### PR TITLE
fix(env): unquote reverses backslash escape

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -115,7 +115,12 @@ function unquote(value: string): string {
     const last = value[value.length - 1];
     if (first === last && (first === '"' || first === "'")) {
       const inner = value.slice(1, -1);
-      return first === '"' ? inner.replace(/\\"/g, '"').replace(/\\n/g, "\n") : inner;
+      // Reverse the escaping done by quoteValue: \\ → \, \" → ", \n → newline.
+      // Single-pass via callback so a literal backslash before n (`\\n` in the
+      // file) decodes to `\n` (two chars) rather than a newline.
+      return first === '"'
+        ? inner.replace(/\\(["\\n])/g, (_, c) => (c === "n" ? "\n" : c))
+        : inner;
     }
   }
   return value;


### PR DESCRIPTION
Closes #3.

## What

`quoteValue` and `unquote` in `src/env.ts` were asymmetric. `saveConfigEnv` escapes `\` → `\\` when serializing, but `loadConfigEnv` → `unquote` only reverses `\"` → `"` and `\n` → newline — it never undoes the `\\`. Every save/load cycle therefore doubled the number of backslashes in any value containing one.

## Before vs after (round-trip)

| Input | Quoted (file) | Before — `unquote` returned | After |
|---|---|---|---|
| `C:\Users\path` | `"C:\\Users\\path"` | `C:\\Users\\path` ✗ | `C:\Users\path` ✓ |
| `API\KEY_X` | `"API\\KEY_X"` | `API\\KEY_X` ✗ | `API\KEY_X` ✓ |
| `with\backslash` | `"with\\backslash"` | `with\\backslash` ✗ | `with\backslash` ✓ |

ASCII-safe values (no special chars), values with `"`, and values with `\n` were unaffected — still round-trip identically.

## Change

```ts
return first === '"'
  ? inner.replace(/\\(["\\n])/g, (_, c) => (c === "n" ? "\n" : c))
  : inner;
```

Single-pass replace with a substitution callback. The alternative — three sequential `.replace()` calls — has an ordering trap: doing `/\\\\/g → \\` first would consume the leading `\\` in `\\n` and produce a stray `\n` token; doing `\n` first would produce a real newline before the `\\` step could see the surrounding context. The callback form covers all three escape sequences in one left-to-right pass.

## Verification

10-case round-trip test (passthrough, spaces, quotes, newlines, single/double/trailing backslashes, Windows paths, combination): **all pass**. Output in the issue body.

## Scope

- One file (`src/env.ts`), one function (`unquote`, 3-line change)
- No public API change, no new deps
- `npm run typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)