### PR TITLE
fix(heartbeat): include file path in JSON parse errors

### DIFF
--- a/src/heartbeat/config.ts
+++ b/src/heartbeat/config.ts
@@ -20,7 +20,12 @@ const FILE = path.join(LISA_HOME, "heartbeat.json");
 export async function loadHeartbeatConfig(): Promise<HeartbeatConfig> {
   if (!(await pathExists(FILE))) return { tasks: [] };
   const raw = await fs.readFile(FILE, "utf8");
-  const parsed = JSON.parse(raw) as HeartbeatConfig;
+  let parsed: HeartbeatConfig;
+  try {
+    parsed = JSON.parse(raw) as HeartbeatConfig;
+  } catch (err) {
+    throw new Error(`failed to parse ${FILE}: ${(err as Error).message}`);
+  }
   return { tasks: parsed.tasks ?? [] };
 }
 


### PR DESCRIPTION
Closes #5.

## What

`loadHeartbeatConfig` was the only user-config loader of the three that didn't tag JSON parse failures with the offending file path:

| Loader | Path | Error wrap |
|---|---|---|
| `mcp/config.ts` | `~/.lisa/mcp.json` | ✅ |
| `channels/config.ts` | `~/.lisa/channels.json` | ✅ |
| `heartbeat/config.ts` | `~/.lisa/heartbeat.json` | ❌ (bare \`JSON.parse\`) |

A user with a typo in `heartbeat.json` got `SyntaxError: Unexpected token …` pointing at compiled `dist/heartbeat/config.js` with no hint that the problem was in their own config.

## Change

Match the existing sibling pattern (same wording, same shape):

```ts
let parsed: HeartbeatConfig;
try {
  parsed = JSON.parse(raw) as HeartbeatConfig;
} catch (err) {
  throw new Error(`failed to parse ${FILE}: ${(err as Error).message}`);
}
```

## Scope

- One file, one function (6-line diff)
- No public API change, no behavior change for valid configs, no new deps
- Only the failure-path message gets better

`npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)