### PR TITLE
chore(completions): add --version / -v to bash, zsh, fish

### DIFF
--- a/completions/_lisa
+++ b/completions/_lisa
@@ -16,6 +16,7 @@ _lisa() {
 
     _arguments -C \
         '(-h --help)'{-h,--help}'[show help]' \
+        '(-v --version)'{-v,--version}'[print version and exit]' \
         '--model[LLM model name]:model:_lisa_models' \
         '--provider[force provider]:provider:(anthropic openai gemini)' \
         '--think[enable adaptive thinking each turn]' \

--- a/completions/lisa.bash
+++ b/completions/lisa.bash
@@ -13,7 +13,7 @@ _lisa_completion() {
     _init_completion -n : 2>/dev/null || _get_comp_words_by_ref -n : cur prev words cword
 
     local subcommands="resume sessions serve heartbeat search birth soul channels skills wishlist status doctor monitor"
-    local global_flags="--model --provider --think --no-reflect --compact --approval --no-mcp --no-plugins --voice --idle --no-idle --help -h"
+    local global_flags="--model --provider --think --no-reflect --compact --approval --no-mcp --no-plugins --voice --idle --no-idle --help -h --version -v"
     local serve_flags="--web --imessage --channels --port"
     local skills_actions="list approve disable enable audit"
     local heartbeat_actions="run install uninstall"

--- a/completions/lisa.fish
+++ b/completions/lisa.fish
@@ -66,6 +66,7 @@ complete -c lisa -n "__lisa_using_subcommand heartbeat" -f -a uninstall -d "remo
 
 # ── global flags ────────────────────────────────────────────────────
 complete -c lisa -l help         -s h -d "show help"
+complete -c lisa -l version      -s v -d "print version and exit"
 complete -c lisa -l think              -d "enable adaptive thinking"
 complete -c lisa -l no-reflect         -d "skip end-of-session reflection"
 complete -c lisa -l compact            -d "enable Anthropic context compaction"


### PR DESCRIPTION
Closes #7.

## What

The `--version` / `-v` flag (added in 84ba4b7) was missing from the three shell completion files, so tab-complete on `lisa --v⇥` returned nothing.

| File | --help / -h | --version / -v (this PR) |
|---|---|---|
| \`completions/lisa.bash\` | ✅ | ✅ added to \`global_flags\` |
| \`completions/_lisa\` (zsh) | ✅ | ✅ paired \`_arguments\` entry under help |
| \`completions/lisa.fish\` | ✅ | ✅ \`complete -l version -s v\` line |

Verified the flag itself works in `dist/cli.js` after rebuild:

```sh
$ lisa --version
0.2.0
$ lisa -v
0.2.0
```

## Scope

- Three files, +3/-1 lines
- Pure completion-shell update, no source/behavior change
- Each file follows its own existing idiom

🤖 Generated with [Claude Code](https://claude.com/claude-code)