### PR TITLE
docs: install requirement reflects 20+ provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ She is yours. The code is open source. **This particular Lisa is sovereign.**
 
 ## Install
 
-Requires Node ≥ 20 and an Anthropic API key.
+Requires Node ≥ 20 and a key for **at least one LLM provider** — Anthropic is the default, but any of the 20+ alternatives listed below works just as well (`--model gpt-4o`, `--model deepseek-chat`, `LISA_BASE_URL=http://localhost:11434/v1` for Ollama, etc.).
 
 ```sh
 git clone https://github.com/oratis/LISA.git
@@ -124,7 +124,7 @@ cd LISA
 npm install
 npm run build
 
-# Configure your key
+# Configure a key — Anthropic is the default model, swap for any provider below
 mkdir -p ~/.lisa
 echo 'ANTHROPIC_API_KEY=sk-ant-...' > ~/.lisa/config.env
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,7 +113,7 @@
 
 ## 安装
 
-要 Node ≥ 20 + Anthropic API key。
+要 Node ≥ 20 + **任一 LLM provider 的 key** —— 默认走 Anthropic，但下面列的 20+ 个 provider 任何一个都行（`--model gpt-4o`、`--model deepseek-chat`、Ollama 走 `LISA_BASE_URL=http://localhost:11434/v1` 等）。
 
 ```sh
 git clone https://github.com/oratis/LISA.git
@@ -121,7 +121,7 @@ cd LISA
 npm install
 npm run build
 
-# 配置 key
+# 配置 key —— 默认模型走 Anthropic；想换 provider 看下面那张表
 mkdir -p ~/.lisa
 echo 'ANTHROPIC_API_KEY=sk-ant-...' > ~/.lisa/config.env
 


### PR DESCRIPTION
Closes #9.

## What

The Install section in both READMEs opened with "Requires Node ≥ 20 and an Anthropic API key" — but the very next paragraph in the same file lists 20+ alternative providers as out-of-the-box. A skimming reader walked away thinking Anthropic was required when it really isn't (the user can `--model gpt-4o`, `--model deepseek-chat`, or set `LISA_BASE_URL=http://localhost:11434/v1` for Ollama, with no Anthropic key at all).

## Change

| File | Before | After |
|---|---|---|
| `README.md` | "Requires Node ≥ 20 and an Anthropic API key." | "Requires Node ≥ 20 and a key for **at least one LLM provider** — Anthropic is the default, but any of the 20+ alternatives listed below works just as well…" |
| `README.zh-CN.md` | "要 Node ≥ 20 + Anthropic API key。" | "要 Node ≥ 20 + **任一 LLM provider 的 key**…" |

Also tweaked the `# Configure your key` comment to point at the provider table below.

## Scope

- Two files (`README.md`, `README.zh-CN.md`)
- Doc-only, no code touched
- No public API change, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)