### PR TITLE
docs: native provider list includes Gemini

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ### LISA = pi-mono + OpenClaw + hermes + claude-code + codex + *something none of them have*
 
-Standing on five of the best open-source agents, LISA ships **the full superset of their capabilities** — streaming agent loop, multi-provider LLMs (Anthropic + OpenAI), MCP client, plugins, hooks, sandboxed bash, sub-agents, session resume, context compaction, voice in/out, six IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), apply-patch, approval modes, TF-IDF over past sessions, pixel-art web UI. ~11k lines of TypeScript, MIT.
+Standing on five of the best open-source agents, LISA ships **the full superset of their capabilities** — streaming agent loop, multi-provider LLMs (Anthropic + OpenAI + Gemini, plus 20+ OpenAI-compatible providers), MCP client, plugins, hooks, sandboxed bash, sub-agents, session resume, context compaction, voice in/out, six IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), apply-patch, approval modes, TF-IDF over past sessions, pixel-art web UI. ~11k lines of TypeScript, MIT.
 
 What none of them have:
 
@@ -349,7 +349,7 @@ LISA was built by studying and synthesizing patterns from five reference agents 
 | Capability | pi-mono | OpenClaw | hermes | claude-code | codex | **LISA** |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|
 | Streaming agent loop | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Multi-provider (Anthropic + OpenAI) | ✅ | ✅ | ✅ | – | partial | ✅ |
+| Multi-provider (Anthropic + OpenAI + Gemini) | ✅ | ✅ | ✅ | – | partial | ✅ |
 | File / shell tools | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Skills (md + frontmatter) | ✅ | ✅ | ✅ | ✅ | – | ✅ |
 | Cross-session memory | – | ✅ | ✅ | partial | – | ✅ |
@@ -462,7 +462,7 @@ src/
 │   ├── store.ts            CRUD + tamper detection
 │   ├── tools.ts            soul_patch / soul_journal / soul_feel / soul_read
 │   ├── paths.ts types.ts
-├── providers/              Anthropic + OpenAI provider abstraction
+├── providers/              Anthropic + OpenAI + Gemini provider abstraction
 ├── tools/                  read/write/edit/apply_patch/bash/grep/ls/task/set_mood + registry
 ├── skills/                 manager + frontmatter parser + skill_manage tool
 ├── memory/                 store + memory tool + TF-IDF index + memory_search

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,7 +13,7 @@
 
 ### LISA = pi-mono + OpenClaw + hermes + claude-code + codex + *它们都没有的东西*
 
-站在五个最好的开源 agent 肩膀上，LISA 实现了**它们全部能力的并集** — 流式 agent loop、双 provider（Anthropic + OpenAI）、MCP client、插件、hooks、沙箱 bash、子 agent、会话恢复、上下文压缩、语音输入输出、六个 IM 通道（Telegram / Discord / Slack / 飞书 / iMessage / Webhook）、apply-patch、审批模式、跨会话 TF-IDF 全文搜、像素艺术 web UI。1.1 万行 TypeScript，MIT。
+站在五个最好的开源 agent 肩膀上，LISA 实现了**它们全部能力的并集** — 流式 agent loop、三 provider 原生支持（Anthropic + OpenAI + Gemini，外加 20+ OpenAI-compatible 提供商）、MCP client、插件、hooks、沙箱 bash、子 agent、会话恢复、上下文压缩、语音输入输出、六个 IM 通道（Telegram / Discord / Slack / 飞书 / iMessage / Webhook）、apply-patch、审批模式、跨会话 TF-IDF 全文搜、像素艺术 web UI。1.1 万行 TypeScript，MIT。
 
 它们都没有的：
 
@@ -361,7 +361,7 @@ LISA 是吃完五个开源 agent（fork 在 `reference/`）合成出来的：
 | 能力 | pi-mono | OpenClaw | hermes | claude-code | codex | **LISA** |
 |---|:-:|:-:|:-:|:-:|:-:|:-:|
 | 流式 agent loop | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| 多 provider（Anthropic + OpenAI） | ✅ | ✅ | ✅ | – | partial | ✅ |
+| 多 provider（Anthropic + OpenAI + Gemini） | ✅ | ✅ | ✅ | – | partial | ✅ |
 | 文件 / shell 工具 | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Skills（md + frontmatter） | ✅ | ✅ | ✅ | ✅ | – | ✅ |
 | 跨会话记忆 | – | ✅ | ✅ | partial | – | ✅ |
@@ -476,7 +476,7 @@ src/
 │   ├── tools.ts            soul_patch / soul_journal / soul_feel / soul_read
 │   ├── paths.ts types.ts
 ├── idle/                   ★ 空闲模式（IdleWatcher 单例 + autonomous-time runner）
-├── providers/              Anthropic + OpenAI 抽象
+├── providers/              Anthropic + OpenAI + Gemini 抽象
 ├── tools/                  read/write/edit/apply_patch/bash/grep/ls/task/set_mood + registry
 ├── skills/                 manager + frontmatter + skill_manage
 ├── memory/                 store + memory tool + TF-IDF 索引 + memory_search


### PR DESCRIPTION
Closes #11.

## What

Three places in each README claimed "Anthropic + OpenAI" as the native provider set. That predated [`622ab87`](https://github.com/oratis/LISA/commit/622ab87) which added a separate `GeminiProvider` class — its own message/tool translation layer to and from Gemini's `Content[]` + `FunctionDeclaration[]` shape, NOT an OpenAI-compat shim. So Gemini belongs in the native list alongside Anthropic and OpenAI, not in the 20+ OpenAI-compat preset table further down.

| File | Spot | Before | After |
|---|---|---|---|
| `README.md` | lead paragraph | "(Anthropic + OpenAI)" | "(Anthropic + OpenAI + Gemini, plus 20+ OpenAI-compatible providers)" |
| `README.md` | capability table row | "Multi-provider (Anthropic + OpenAI)" | "Multi-provider (Anthropic + OpenAI + Gemini)" |
| `README.md` | layout tree comment | "Anthropic + OpenAI provider abstraction" | "Anthropic + OpenAI + Gemini provider abstraction" |
| `README.zh-CN.md` | lead | "双 provider（Anthropic + OpenAI）" | "三 provider 原生支持（Anthropic + OpenAI + Gemini，外加 20+ OpenAI-compatible 提供商）" |
| `README.zh-CN.md` | parity table | "多 provider（Anthropic + OpenAI）" | "多 provider（Anthropic + OpenAI + Gemini）" |
| `README.zh-CN.md` | layout tree | "Anthropic + OpenAI 抽象" | "Anthropic + OpenAI + Gemini 抽象" |

## Scope

- Two files, 6 one-line edits
- Doc-only, no source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)