### PR TITLE
chore(gitignore): ignore .claude/ and *.tsbuildinfo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,11 @@ node_modules/
 dist/
 dist-release/
 *.log
+*.tsbuildinfo
 .DS_Store
 .env
 .env.local
+.claude/
 reference/
 
 # Internal growth/marketing playbook — strategic docs that aren't public-friendly


### PR DESCRIPTION
Closes #13.

## What

Two small additions to `.gitignore`:

| Pattern | Why |
|---|---|
| `.claude/` | Claude Code's per-user state — `settings.local.json` (user-specific permission allowlist) + `scheduled_tasks.lock` (PID file). Currently shows as untracked, so any contributor using Claude Code is one \`git add -A\` away from leaking their personal config. |
| `*.tsbuildinfo` | TypeScript's incremental compilation cache. Not generated today (no \`incremental: true\` in tsconfig), but \`.npmignore\` already lists it defensively — adding it to \`.gitignore\` keeps the two files symmetric and future-proofs against enabling incremental later. |

## Scope

- One file, two lines added
- No source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)