### PR TITLE
chore: remove three unused exports

### DIFF
--- a/src/llm.ts
+++ b/src/llm.ts
@@ -1,13 +1,1 @@
-import Anthropic from "@anthropic-ai/sdk";
-import { proxyAwareFetch } from "./proxy-bootstrap.js";
-
 export const DEFAULT_MODEL = "claude-sonnet-4-6";
-export const DEFAULT_MAX_TOKENS = 16_000;
-
-export function createAnthropicClient(opts: { apiKey?: string; baseURL?: string } = {}): Anthropic {
-  return new Anthropic({
-    apiKey: opts.apiKey,
-    baseURL: opts.baseURL,
-    fetch: proxyAwareFetch,
-  });
-}

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -62,20 +62,6 @@ export class SessionStore {
     await appendLine(this.path, JSON.stringify(entry));
   }
 
-  async readAll(): Promise<{
-    header: SessionHeader;
-    entries: SessionEntry[];
-  }> {
-    const raw = await fs.readFile(this.path, "utf8");
-    const lines = raw.split("\n").filter(Boolean);
-    if (lines.length === 0) throw new Error("empty session file");
-    const header = JSON.parse(lines[0]!) as SessionHeader;
-    const entries = lines
-      .slice(1)
-      .map((line) => JSON.parse(line) as SessionEntry);
-    return { header, entries };
-  }
-
   /**
    * Read a page of message entries (newest-first within the page).
    * page=0 = latest PAGE_SIZE messages, page=1 = older ones, etc.

--- a/src/tools/task.ts
+++ b/src/tools/task.ts
@@ -72,7 +72,3 @@ export function createTaskTool(deps: {
     },
   };
 }
-
-export function readOnlyToolNames(): Set<string> {
-  return new Set(["read", "grep", "ls"]);
-}


### PR DESCRIPTION
Closes #15.

## What

Three exports with zero callers anywhere in `src/`:

| Removed | From | Notes |
|---|---|---|
| `createAnthropicClient()` | `src/llm.ts` | Duplicates the work `AnthropicProvider` already does internally |
| `DEFAULT_MAX_TOKENS` | `src/llm.ts` | Declared but never imported; providers hardcode \`16_000\` inline |
| `readOnlyToolNames()` | `src/tools/task.ts` | Returns a hardcoded \`Set(["read","grep","ls"])\`; never called |
| `SessionStore.readAll()` | `src/sessions/store.ts` | Sibling \`readMessagePage()\` is the one in use (web/server.ts) |

## Bonus

Dropping `SessionStore.readAll` removes a `JSON.parse(line)` path with no try/catch — a single partial JSONL write (e.g. crash mid-append) would have made the whole call throw. The current `readMessagePage` already wraps each parse in try/catch, so the pattern was inconsistent.

Removing `createAnthropicClient` makes the `Anthropic` + `proxyAwareFetch` imports in `src/llm.ts` unused. The whole module collapses to one line: `export const DEFAULT_MODEL = "claude-sonnet-4-6"`.

## Verification

```sh
grep -rn "createAnthropicClient\|DEFAULT_MAX_TOKENS\|readOnlyToolNames\|\.readAll(" src/ --include="*.ts"
```

After the diff: zero hits outside the test grep itself.

`npm run typecheck` clean.

## Scope

- Three files, **−30 lines** net
- Pure deletions, no replacement code
- No public API change (these weren't documented or used externally), no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)