### PR TITLE
chore(issue-template): bug.yml asks for `lisa --version` first

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -34,9 +34,9 @@ body:
   - type: input
     id: lisa-version
     attributes:
-      label: LISA commit / version
-      description: Output of `git rev-parse --short HEAD`
-      placeholder: e.g. ac3a541
+      label: LISA version
+      description: Output of `lisa --version` (or `git rev-parse --short HEAD` if you're running from a clone)
+      placeholder: e.g. 0.2.0
     validations:
       required: true
   - type: dropdown


### PR DESCRIPTION
Closes #17.

## What

The bug-report template's version field told reporters:

> Output of \`git rev-parse --short HEAD\`

That only works for people who cloned the repo. Anyone who installed via npm or homebrew — both documented install paths — has no git checkout, and ends up either typing \"n/a\" or abandoning the report.

Since [`84ba4b7`](https://github.com/oratis/LISA/commit/84ba4b7) shipped \`lisa --version\`, every install surface can report a stable version with one command:

```sh
$ lisa --version
0.2.0
```

## Change

```diff
   - type: input
     id: lisa-version
     attributes:
-      label: LISA commit / version
-      description: Output of \`git rev-parse --short HEAD\`
-      placeholder: e.g. ac3a541
+      label: LISA version
+      description: Output of \`lisa --version\` (or \`git rev-parse --short HEAD\` if you're running from a clone)
+      placeholder: e.g. 0.2.0
```

Dev-checkout reporters who want commit-level precision can still send the git sha — it's mentioned as the fallback.

## Scope

- One file: \`.github/ISSUE_TEMPLATE/bug.yml\`
- Template only, no code, no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)