### PR TITLE
docs(CONTRIBUTING): key requirement reflects 20+ provider support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ npm run build
 npm run typecheck
 ```
 
-You'll need an `ANTHROPIC_API_KEY` to actually run her. Put it in `~/.lisa/config.env`. See [README](./README.md#install).
+You'll need a key for at least one LLM provider to actually run her. Anthropic is the default — but `--model gpt-4o`, `--model deepseek-chat`, or `LISA_BASE_URL=http://localhost:11434/v1` (Ollama) all work for development too. Put your key(s) in `~/.lisa/config.env`. See [README](./README.md#install) and [docs/PROVIDERS.md](./docs/PROVIDERS.md) for the full list.
 
 ## Where to help
 


### PR DESCRIPTION
Closes #19.

## What

`CONTRIBUTING.md:17` had the same Anthropic-only framing as the README install line caught in [#9](https://github.com/oratis/LISA/issues/9) and fixed in [#10](https://github.com/oratis/LISA/pull/10):

> Before: \"You'll need an \`ANTHROPIC_API_KEY\` to actually run her.\"

Contributors with an OpenAI / Gemini / DeepSeek / Ollama setup walked away thinking they had to sign up for Anthropic specifically before they could even start working on the project.

## Change

```diff
- You'll need an \`ANTHROPIC_API_KEY\` to actually run her. Put it in \`~/.lisa/config.env\`. See [README](./README.md#install).
+ You'll need a key for at least one LLM provider to actually run her. Anthropic is the default — but \`--model gpt-4o\`, \`--model deepseek-chat\`, or \`LISA_BASE_URL=http://localhost:11434/v1\` (Ollama) all work for development too. Put your key(s) in \`~/.lisa/config.env\`. See [README](./README.md#install) and [docs/PROVIDERS.md](./docs/PROVIDERS.md) for the full list.
```

## Scope

- One file (\`CONTRIBUTING.md\`), one line edit
- Doc only, mirrors the README fix from #10
- No source touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)