### PR TITLE
feat(island/mac): Phase 2.1 + 2.2 — native Swift shell + Dynamic-Island-style placement

### DIFF
--- a/packaging/island-mac/.gitignore
+++ b/packaging/island-mac/.gitignore
@@ -1,0 +1,14 @@
+# SwiftPM build cache
+.build/
+Package.resolved
+
+# Built bundle — local build artifact, distributed via GitHub Releases
+LisaIsland.app/
+
+# Xcode (in case anyone opens this dir as a project)
+*.xcodeproj/
+*.xcworkspace/
+DerivedData/
+
+# macOS
+.DS_Store

--- a/packaging/island-mac/Package.swift
+++ b/packaging/island-mac/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "LisaIsland",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .executableTarget(
+            name: "LisaIsland",
+            path: "Sources/LisaIsland"
+        )
+    ]
+)

--- a/packaging/island-mac/README.md
+++ b/packaging/island-mac/README.md
@@ -1,0 +1,118 @@
+# LisaIsland.app — native Mac shell for the island widget
+
+Phase 2.1 of [`docs/MAC_ISLAND_PLAN.md`](../../docs/MAC_ISLAND_PLAN.md).
+
+A native macOS app that hosts the Phase 1 web widget
+(`http://localhost:5757/island`) in a borderless, transparent,
+always-on-top window. No Dock icon, no menu bar app name.
+
+## Status
+
+| Phase | What | Status |
+|---|---|---|
+| 2.1 | App skeleton + WKWebView + borderless top-center window | ✅ here |
+| 2.2 | NotchDetector — anchor to right of notch on MBP 14/16 | planned |
+| 2.3 | LisaProbe — graceful offline overlay | planned |
+| 2.4 | ScreenContextWatcher — auto-hide on fullscreen + screen capture | planned |
+
+## Requirements
+
+- macOS 13 or later
+- Swift 5.9+ (bundled with Xcode 15 / current Command Line Tools)
+- LISA running at `localhost:5757` (`lisa serve --web`)
+
+## Build
+
+```sh
+cd packaging/island-mac
+bash build.sh
+```
+
+Output: `LisaIsland.app` in this directory.
+
+## Run
+
+Start LISA first:
+
+```sh
+lisa serve --web
+```
+
+Then launch the app:
+
+```sh
+open LisaIsland.app
+```
+
+A small pill appears centered at the top of your main screen — same
+pixel-art avatar + live mood + idle-message ★ as the web widget, just
+without a browser window wrapping it.
+
+## Install (optional)
+
+```sh
+cp -r LisaIsland.app /Applications/
+```
+
+Or drag the `.app` to `/Applications/` in Finder.
+
+## Quit
+
+`⌘Q` while the island is focused, or:
+
+```sh
+killall LisaIsland
+```
+
+The app intentionally has no close button — closing the only window
+doesn't quit (Phase 2.3 + later need it alive to detect LISA coming
+back online).
+
+## Architecture
+
+```
+LisaIsland.app/
+└── Contents/
+    ├── Info.plist                       # LSUIElement: true (no Dock icon)
+    ├── MacOS/
+    │   └── LisaIsland                   # compiled binary
+    └── Resources/
+```
+
+Source layout:
+
+```
+Sources/LisaIsland/
+├── main.swift           # NSApplication boot (accessory policy)
+├── AppDelegate.swift    # window + minimal ⌘Q menu
+├── IslandWindow.swift   # borderless NSPanel at statusBar level
+└── IslandContent.swift  # WKWebView + open_full_gui message handler
+```
+
+Communication with LISA is entirely through `http://localhost:5757`:
+
+- `GET /island` — the widget HTML (served by `src/web/island.ts`)
+- `GET /events` — SSE for live mood / chat / idle pulses
+- `GET /api/island/ping` — periodic state poll
+- `POST /api/island/dismiss-unread` — clear ★ flag
+- `window.webkit.messageHandlers.island.postMessage({type:"open_full_gui"})`
+  → app opens `http://localhost:5757/` in the default browser
+
+The app does **not** persist anything to disk. Killing it loses nothing;
+all state lives in `~/.lisa/` owned by the LISA engine.
+
+## Distribution
+
+This MVP is **ad-hoc signed only**. On first launch macOS Gatekeeper
+will prompt; either right-click → Open, or run:
+
+```sh
+xattr -dr com.apple.quarantine LisaIsland.app
+```
+
+Apple Developer ID signing + notarization is Phase 4 of the plan.
+Homebrew Cask distribution likewise lands then.
+
+## License
+
+MIT — same as the parent LISA repo.

--- a/packaging/island-mac/Resources/Info.plist
+++ b/packaging/island-mac/Resources/Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>LisaIsland</string>
+    <key>CFBundleIdentifier</key>
+    <string>ai.meetlisa.island</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Lisa Island</string>
+    <key>CFBundleDisplayName</key>
+    <string>Lisa Island</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>LSUIElement</key>
+    <true/>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <!-- ATS exception: we only ever talk to localhost. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
+    <key>NSHumanReadableCopyright</key>
+    <string>MIT — github.com/oratis/LISA</string>
+</dict>
+</plist>

--- a/packaging/island-mac/Sources/LisaIsland/AppDelegate.swift
+++ b/packaging/island-mac/Sources/LisaIsland/AppDelegate.swift
@@ -1,0 +1,52 @@
+//
+//  AppDelegate.swift
+//  LisaIsland
+//
+//  Owns the IslandWindow lifecycle. The window itself doesn't have a close
+//  button — the only way to exit is ⌘Q (or `killall LisaIsland`).
+//
+
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var window: IslandWindow?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Minimal menu — needed for ⌘Q to work.
+        installMenu()
+
+        // Create + show the island. Bringing it to front without activating
+        // the app keeps focus on whatever the user was doing.
+        let win = IslandWindow()
+        win.orderFrontRegardless()
+        window = win
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        // The island window can't actually be closed by the user (no close
+        // button, no Window menu Close item). But just in case some system
+        // event closes it, keep the process alive — Phase 2.3's LisaProbe
+        // will need it running to detect LISA coming back online.
+        return false
+    }
+
+    // MARK: - Menu
+
+    private func installMenu() {
+        let mainMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        mainMenu.addItem(appMenuItem)
+
+        let appMenu = NSMenu()
+        let quitItem = NSMenuItem(
+            title: "Quit Lisa Island",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        )
+        quitItem.keyEquivalentModifierMask = [.command]
+        appMenu.addItem(quitItem)
+
+        appMenuItem.submenu = appMenu
+        NSApplication.shared.mainMenu = mainMenu
+    }
+}

--- a/packaging/island-mac/Sources/LisaIsland/AppDelegate.swift
+++ b/packaging/island-mac/Sources/LisaIsland/AppDelegate.swift
@@ -5,6 +5,13 @@
 //  Owns the IslandWindow lifecycle. The window itself doesn't have a close
 //  button — the only way to exit is ⌘Q (or `killall LisaIsland`).
 //
+//  Keyboard shortcuts:
+//    ⌘Q     — quit
+//    ⌃⌘0    — reset pill position to default (just below notch/menu bar)
+//
+//  Mouse:
+//    ⌥+drag — reposition the pill (saved to UserDefaults)
+//
 
 import AppKit
 
@@ -12,7 +19,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var window: IslandWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
-        // Minimal menu — needed for ⌘Q to work.
+        // Minimal menu — needed for ⌘Q and the reset-position shortcut.
         installMenu()
 
         // Create + show the island. Bringing it to front without activating
@@ -38,6 +45,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         mainMenu.addItem(appMenuItem)
 
         let appMenu = NSMenu()
+
+        let resetItem = NSMenuItem(
+            title: "Reset Position",
+            action: #selector(resetPosition(_:)),
+            keyEquivalent: "0"
+        )
+        resetItem.keyEquivalentModifierMask = [.control, .command]
+        resetItem.target = self
+        appMenu.addItem(resetItem)
+
+        appMenu.addItem(.separator())
+
         let quitItem = NSMenuItem(
             title: "Quit Lisa Island",
             action: #selector(NSApplication.terminate(_:)),
@@ -48,5 +67,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         appMenuItem.submenu = appMenu
         NSApplication.shared.mainMenu = mainMenu
+    }
+
+    @objc private func resetPosition(_ sender: Any?) {
+        window?.resetSavedOrigin()
     }
 }

--- a/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
@@ -102,8 +102,19 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
             hostWindow?.setExpanded(true)
         case "collapse":
             hostWindow?.setExpanded(false)
+        case "drag_delta":
+            // JS sends per-frame deltas in browser screen coords during a
+            // pointermove drag. Swift moves the window directly — no
+            // performDrag, no AppKit drag tracking loop, smooth as the
+            // mouse hardware allows.
+            guard let dx = body["dx"] as? Double,
+                  let dy = body["dy"] as? Double else { return }
+            hostWindow?.translateOriginByScreenDelta(dx: CGFloat(dx), dy: CGFloat(dy))
+        case "drag_end":
+            // Save the new anchor so it survives restart + state changes.
+            hostWindow?.saveCurrentPositionAsAnchor()
         default:
-            // Unknown message — ignore, don't crash. Future phases add more.
+            // Unknown message — ignore, don't crash.
             break
         }
     }

--- a/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
@@ -99,22 +99,17 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
                 NSWorkspace.shared.open(fullURL)
             }
         case "expand":
+            // Page-side expand state — Swift uses this to size the
+            // click-through "hot rect" (whole window when expanded,
+            // just the pill when collapsed). No window resize happens.
             hostWindow?.setExpanded(true)
         case "collapse":
             hostWindow?.setExpanded(false)
-        case "drag_delta":
-            // JS sends per-frame deltas in browser screen coords during a
-            // pointermove drag. Swift moves the window directly — no
-            // performDrag, no AppKit drag tracking loop, smooth as the
-            // mouse hardware allows.
-            guard let dx = body["dx"] as? Double,
-                  let dy = body["dy"] as? Double else { return }
-            hostWindow?.translateOriginByScreenDelta(dx: CGFloat(dx), dy: CGFloat(dy))
-        case "drag_end":
-            // Save the new anchor so it survives restart + state changes.
-            hostWindow?.saveCurrentPositionAsAnchor()
         default:
-            // Unknown message — ignore, don't crash.
+            // Drag is handled entirely Swift-side now (sendEvent
+            // intercept + nextEvent loop), so we no longer expect
+            // drag_delta / drag_end from the page. Unknown messages
+            // are tolerated for forward-compat with future phases.
             break
         }
     }

--- a/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
@@ -1,0 +1,101 @@
+//
+//  IslandContent.swift
+//  LisaIsland — Phase 2.1
+//
+//  Wraps the WKWebView. Loads http://localhost:5757/island (the Phase 1
+//  widget) and exposes the `island` message handler the page already
+//  checks for (see src/web/island.ts — when present, btnOpen routes
+//  `open_full_gui` here instead of `window.open('/')`).
+//
+//  Auto-reload on failure: if the LISA server is down at launch time, the
+//  webview shows a blank page. Phase 2.3 (LisaProbe) will add a proper
+//  offline overlay; for now we just retry the load every 4 seconds when
+//  the page reports a failure.
+//
+
+import AppKit
+import WebKit
+
+final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
+    static let lisaURL = URL(string: "http://localhost:5757/island")!
+
+    private var webView: WKWebView!
+    private var reloadTimer: Timer?
+
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        // Receive `open_full_gui` from window.webkit.messageHandlers.island
+        config.userContentController.add(self, name: "island")
+        // Prefer a fast, JIT-enabled WebKit process pool; share with other
+        // webviews this app might create later.
+        config.processPool = WKProcessPool()
+
+        let preferences = WKWebpagePreferences()
+        preferences.allowsContentJavaScript = true
+        config.defaultWebpagePreferences = preferences
+
+        let wv = WKWebView(frame: .zero, configuration: config)
+        wv.navigationDelegate = self
+        wv.autoresizingMask = [.width, .height]
+        // Transparent: the page's CSS draws the rounded pill, the rest of
+        // the rectangle should show what's underneath.
+        wv.setValue(false, forKey: "drawsBackground")
+
+        // Cosmetics: kill the bounce + selection rings, we're not a webpage.
+        wv.allowsBackForwardNavigationGestures = false
+        wv.allowsLinkPreview = false
+
+        webView = wv
+        view = wv
+
+        load()
+    }
+
+    // MARK: - Load / retry
+
+    private func load() {
+        let request = URLRequest(
+            url: Self.lisaURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 5
+        )
+        webView.load(request)
+    }
+
+    private func scheduleReload() {
+        reloadTimer?.invalidate()
+        reloadTimer = Timer.scheduledTimer(
+            withTimeInterval: 4.0,
+            repeats: false
+        ) { [weak self] _ in
+            self?.load()
+        }
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        // Most common: LISA isn't running yet — keep retrying quietly.
+        scheduleReload()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        scheduleReload()
+    }
+
+    // MARK: - WKScriptMessageHandler
+
+    func userContentController(_ uc: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let body = message.body as? [String: Any] else { return }
+        guard let type = body["type"] as? String else { return }
+        switch type {
+        case "open_full_gui":
+            if let fullURL = URL(string: "http://localhost:5757/") {
+                NSWorkspace.shared.open(fullURL)
+            }
+        default:
+            // Unknown message — ignore, don't crash. Future phases add more.
+            break
+        }
+    }
+}

--- a/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandContent.swift
@@ -1,16 +1,16 @@
 //
 //  IslandContent.swift
-//  LisaIsland — Phase 2.1
+//  LisaIsland — Phase 2.1 + 2.2
 //
 //  Wraps the WKWebView. Loads http://localhost:5757/island (the Phase 1
-//  widget) and exposes the `island` message handler the page already
-//  checks for (see src/web/island.ts — when present, btnOpen routes
-//  `open_full_gui` here instead of `window.open('/')`).
+//  widget) and bridges three messages from the page:
+//
+//    - open_full_gui  → open default browser to /
+//    - expand         → grow window so the expand panel isn't clipped
+//    - collapse       → shrink window back to pill size
 //
 //  Auto-reload on failure: if the LISA server is down at launch time, the
-//  webview shows a blank page. Phase 2.3 (LisaProbe) will add a proper
-//  offline overlay; for now we just retry the load every 4 seconds when
-//  the page reports a failure.
+//  webview retries the load every 4 seconds.
 //
 
 import AppKit
@@ -19,15 +19,23 @@ import WebKit
 final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
     static let lisaURL = URL(string: "http://localhost:5757/island")!
 
+    private weak var hostWindow: IslandWindow?
     private var webView: WKWebView!
     private var reloadTimer: Timer?
 
+    init(window: IslandWindow) {
+        self.hostWindow = window
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("not implemented")
+    }
+
     override func loadView() {
         let config = WKWebViewConfiguration()
-        // Receive `open_full_gui` from window.webkit.messageHandlers.island
+        // Receive postMessage from window.webkit.messageHandlers.island.
         config.userContentController.add(self, name: "island")
-        // Prefer a fast, JIT-enabled WebKit process pool; share with other
-        // webviews this app might create later.
         config.processPool = WKProcessPool()
 
         let preferences = WKWebpagePreferences()
@@ -40,8 +48,6 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
         // Transparent: the page's CSS draws the rounded pill, the rest of
         // the rectangle should show what's underneath.
         wv.setValue(false, forKey: "drawsBackground")
-
-        // Cosmetics: kill the bounce + selection rings, we're not a webpage.
         wv.allowsBackForwardNavigationGestures = false
         wv.allowsLinkPreview = false
 
@@ -75,7 +81,6 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
     // MARK: - WKNavigationDelegate
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        // Most common: LISA isn't running yet — keep retrying quietly.
         scheduleReload()
     }
 
@@ -93,6 +98,10 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
             if let fullURL = URL(string: "http://localhost:5757/") {
                 NSWorkspace.shared.open(fullURL)
             }
+        case "expand":
+            hostWindow?.setExpanded(true)
+        case "collapse":
+            hostWindow?.setExpanded(false)
         default:
             // Unknown message — ignore, don't crash. Future phases add more.
             break

--- a/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
@@ -2,12 +2,13 @@
 //  IslandWindow.swift
 //  LisaIsland — Phase 2.1 + 2.2
 //
-//  Borderless, transparent NSPanel that hosts the WKWebView. Sits at the
-//  top edge of the screen, drawing OVER the menu bar at .popUpMenu level —
-//  on notched Macs it visually extends the notch downward; on non-notched
-//  Macs it sits flush with the top edge like a Dynamic Island clone.
+//  Borderless, transparent NSPanel that hosts the WKWebView. Sits just
+//  below the menu bar / notch by default (so the avatar isn't eclipsed
+//  by the physical notch hardware), horizontally centered. User can hold
+//  ⌥ (Option) and drag to reposition; the chosen position is persisted
+//  to UserDefaults and restored on next launch.
 //
-//  Window sizing is dynamic: starts collapsed (pill-only ~50pt tall) so
+//  Window sizing is dynamic: starts collapsed (~50pt tall, pill-only) so
 //  it doesn't block menu bar clicks. Grows to expanded size when the web
 //  widget tells us (via postMessage) the user hovered/clicked the pill.
 //
@@ -23,8 +24,14 @@ final class IslandWindow: NSPanel {
     private static let collapsedSize = CGSize(width: 160, height: 50)
     private static let expandedSize  = CGSize(width: 330, height: 300)
 
+    // UserDefaults keys for the drag-saved position.
+    private enum DefaultsKey {
+        static let hasUserOrigin = "ai.meetlisa.island.hasUserOrigin"
+        static let userOriginX   = "ai.meetlisa.island.userOriginX"
+        static let userOriginY   = "ai.meetlisa.island.userOriginY"
+    }
+
     private(set) var isExpanded = false
-    private var notchAnchor: NotchAnchor?
 
     init() {
         let initialFrame = NSRect(origin: .zero, size: Self.collapsedSize)
@@ -36,11 +43,10 @@ final class IslandWindow: NSPanel {
         )
 
         configureWindow()
-        positionAtTopAnchor(animated: false)
+        repositionForCurrentState(animated: false)
         mountWebView()
 
         // Reposition on screen geometry changes (lid open/close, plugging
-        // in an external display, resolution change).
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleScreenChange),
@@ -56,14 +62,13 @@ final class IslandWindow: NSPanel {
     // MARK: - Window config
 
     private func configureWindow() {
-        // ABOVE the menu bar — Dynamic-Island-style apps draw over it so
-        // the pill can appear to extend the notch. Lower levels
-        // (.statusBar = 25, .mainMenu = 24) sit at the menu bar and on
-        // notched Macs would be eclipsed by the system notch.
-        level = .popUpMenu
+        // Above the menu bar — Dynamic-Island-style placement means the
+        // pill draws on top of menubar items that happen to be under it.
+        // .mainMenu + 3 matches Boring Notch / other notch-extender apps;
+        // .popUpMenu (101) is too aggressive and steals focus from
+        // Spotlight / Notification Center.
+        level = NSWindow.Level(Int(NSWindow.Level.mainMenu.rawValue) + 3)
 
-        // Persist across spaces, ignore ⌘` cycling, behave nicely with
-        // fullscreen apps.
         collectionBehavior = [
             .canJoinAllSpaces,
             .stationary,
@@ -71,65 +76,127 @@ final class IslandWindow: NSPanel {
             .fullScreenAuxiliary,
         ]
 
-        // Transparent backing so the web widget's rounded pill can show
-        // through the borderless rect.
         backgroundColor = .clear
         isOpaque = false
         hasShadow = false
 
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
+        // Default drag is off; we handle ⌥+drag manually in sendEvent.
         isMovableByWindowBackground = false
         ignoresMouseEvents = false
 
-        // Suppress the panel's natural shadow / vibrancy.
         isFloatingPanel = true
         hidesOnDeactivate = false
 
-        // Smooth resize animation when toggling expanded.
         animationBehavior = .utilityWindow
     }
 
     // NSPanel becomes key by default when clicked. We never want focus —
-    // the user is browsing / coding / whatever, the island is a passive
-    // observer.
+    // the user is browsing / coding / whatever; the island is passive.
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
-    // AppKit's default `constrainFrameRect(_:to:)` snaps the window into
-    // `visibleFrame` — i.e., below the menu bar. That's the WHOLE problem
-    // we're trying to defeat: Dynamic-Island-style placement means the
-    // pill sits AT the menu bar / over the notch. Returning the rect
-    // unchanged lets us put the window wherever we want above the
-    // visible area.
+    // AppKit's default constrainFrameRect snaps the window into
+    // visibleFrame — which is mostly fine now that we anchor BELOW the
+    // notch, but we keep the override so a user-dragged position can
+    // legitimately overlap the menu bar (e.g. corner-pinning) without
+    // the system pulling it back.
     override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
         return frameRect
     }
 
-    // MARK: - Positioning
+    // MARK: - Position resolution
 
-    private func positionAtTopAnchor(animated: Bool) {
+    /// Default anchor (just below the notch / menu bar), no user override.
+    private func defaultOrigin(for size: CGSize, on screen: NSScreen) -> NSPoint {
+        return NotchDetector.anchor(for: size, on: screen).origin
+    }
+
+    /// User-saved origin, or nil if the user hasn't dragged.
+    private func savedOrigin() -> NSPoint? {
+        let d = UserDefaults.standard
+        guard d.bool(forKey: DefaultsKey.hasUserOrigin) else { return nil }
+        let x = d.double(forKey: DefaultsKey.userOriginX)
+        let y = d.double(forKey: DefaultsKey.userOriginY)
+        return NSPoint(x: x, y: y)
+    }
+
+    private func saveOrigin(_ origin: NSPoint) {
+        let d = UserDefaults.standard
+        d.set(true, forKey: DefaultsKey.hasUserOrigin)
+        d.set(Double(origin.x), forKey: DefaultsKey.userOriginX)
+        d.set(Double(origin.y), forKey: DefaultsKey.userOriginY)
+    }
+
+    /// Forget the dragged position; revert to default anchor.
+    func resetSavedOrigin() {
+        let d = UserDefaults.standard
+        d.removeObject(forKey: DefaultsKey.hasUserOrigin)
+        d.removeObject(forKey: DefaultsKey.userOriginX)
+        d.removeObject(forKey: DefaultsKey.userOriginY)
+        repositionForCurrentState(animated: true)
+    }
+
+    /// Clamp a candidate origin to keep at least part of the window
+    /// on-screen (so a user can't accidentally drag it into the void).
+    private func clampToScreen(_ origin: NSPoint, size: CGSize, on screen: NSScreen) -> NSPoint {
+        let bounds = screen.frame
+        // Keep at least 40pt of the window visible on each axis.
+        let margin: CGFloat = 40
+        let minX = bounds.minX - size.width + margin
+        let maxX = bounds.maxX - margin
+        let minY = bounds.minY - size.height + margin
+        let maxY = bounds.maxY - margin
+        return NSPoint(
+            x: min(max(origin.x, minX), maxX),
+            y: min(max(origin.y, minY), maxY)
+        )
+    }
+
+    /// Compute where the window should sit for its current state
+    /// (collapsed vs expanded) and the saved-vs-default anchor choice.
+    /// Expansion grows downward from the pill's top edge so the pill
+    /// doesn't visually jump.
+    private func currentOrigin(for size: CGSize, on screen: NSScreen) -> NSPoint {
+        let collapsedSize = Self.collapsedSize
+        // The pill's top edge is what stays anchored. Compute the pill
+        // top edge first (from collapsed-state origin), then derive the
+        // origin for the requested `size`.
+        let collapsedOrigin: NSPoint = {
+            if let saved = savedOrigin() {
+                return clampToScreen(saved, size: collapsedSize, on: screen)
+            }
+            return defaultOrigin(for: collapsedSize, on: screen)
+        }()
+        let pillTopY = collapsedOrigin.y + collapsedSize.height
+        let pillCenterX = collapsedOrigin.x + collapsedSize.width / 2
+
+        return NSPoint(
+            x: pillCenterX - size.width / 2,
+            y: pillTopY - size.height
+        )
+    }
+
+    private func repositionForCurrentState(animated: Bool) {
         guard let screen = NSScreen.main else { return }
         let size = isExpanded ? Self.expandedSize : Self.collapsedSize
-        let anchor = NotchDetector.anchor(for: size, on: screen)
-        notchAnchor = anchor
-        let target = NSRect(origin: anchor.origin, size: size)
-        setFrame(target, display: true, animate: animated)
+        let origin = currentOrigin(for: size, on: screen)
+        setFrame(NSRect(origin: origin, size: size), display: true, animate: animated)
     }
 
     @objc private func handleScreenChange() {
-        positionAtTopAnchor(animated: false)
+        repositionForCurrentState(animated: false)
     }
 
     // MARK: - Expand / collapse
 
     /// Called by IslandContent when the web widget reports a hover/click
-    /// expand or a mouse-leave collapse. We resize the window so the
-    /// expand panel rendered in the WebView isn't clipped.
+    /// expand or a mouse-leave collapse.
     func setExpanded(_ expanded: Bool) {
         guard expanded != isExpanded else { return }
         isExpanded = expanded
-        positionAtTopAnchor(animated: true)
+        repositionForCurrentState(animated: true)
     }
 
     // MARK: - WebView mount
@@ -137,5 +204,23 @@ final class IslandWindow: NSPanel {
     private func mountWebView() {
         let content = IslandContent(window: self)
         contentView = content.view
+    }
+
+    // MARK: - ⌥+drag to reposition
+
+    /// `sendEvent` runs BEFORE the contentView (WKWebView) gets a chance
+    /// to handle the event. If the user holds ⌥ on mouse-down, we steal
+    /// the event and start a window-drag tracking loop instead of letting
+    /// the page see it.
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown,
+           event.modifierFlags.contains(.option) {
+            // Begin native AppKit drag. Returns when the user releases
+            // the mouse. We then save the new origin.
+            self.performDrag(with: event)
+            saveOrigin(frame.origin)
+            return
+        }
+        super.sendEvent(event)
     }
 }

--- a/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
@@ -1,41 +1,42 @@
 //
 //  IslandWindow.swift
-//  LisaIsland — Phase 2.1
+//  LisaIsland — Phase 2.1 + 2.2
 //
-//  Borderless, transparent, status-bar-level NSPanel that hosts the
-//  WKWebView. NSPanel (rather than NSWindow) because we need
-//  `nonactivatingPanel` style so clicking the pill doesn't deactivate
-//  whatever app the user was in.
+//  Borderless, transparent NSPanel that hosts the WKWebView. Sits at the
+//  top edge of the screen, drawing OVER the menu bar at .popUpMenu level —
+//  on notched Macs it visually extends the notch downward; on non-notched
+//  Macs it sits flush with the top edge like a Dynamic Island clone.
 //
-//  Placement here is "top-center of main screen". Notch-aware anchoring
-//  on MBP 14/16 lives in Phase 2.2 (NotchDetector).
+//  Window sizing is dynamic: starts collapsed (pill-only ~50pt tall) so
+//  it doesn't block menu bar clicks. Grows to expanded size when the web
+//  widget tells us (via postMessage) the user hovered/clicked the pill.
 //
-//  Phase 2.4 (ScreenContextWatcher) will hide the window when a
-//  fullscreen app is active or the screen is being captured.
+//  NSPanel (rather than NSWindow) because we need `nonactivatingPanel`
+//  style so clicking the pill doesn't deactivate the foreground app.
 //
 
 import AppKit
 
 final class IslandWindow: NSPanel {
-    // Default pill footprint — chosen to comfortably fit the Phase 1 web
-    // widget's pill + expanded panel (~308pt wide, up to ~240pt tall).
-    private static let defaultSize = CGSize(width: 330, height: 260)
+    // Collapsed: just the pill (avatar + "Lisa" + status dot)
+    // Expanded: pill + ~250pt panel below for desire / idle message
+    private static let collapsedSize = CGSize(width: 160, height: 50)
+    private static let expandedSize  = CGSize(width: 330, height: 300)
 
-    // How far below the top of visibleFrame the window sits.
-    // visibleFrame already excludes the menu bar, so 0 = flush with menu bar.
-    private static let topGap: CGFloat = 0
+    private(set) var isExpanded = false
+    private var notchAnchor: NotchAnchor?
 
     init() {
-        let frame = NSRect(origin: .zero, size: Self.defaultSize)
+        let initialFrame = NSRect(origin: .zero, size: Self.collapsedSize)
         super.init(
-            contentRect: frame,
+            contentRect: initialFrame,
             styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
 
         configureWindow()
-        positionAtTopCenter()
+        positionAtTopAnchor(animated: false)
         mountWebView()
 
         // Reposition on screen geometry changes (lid open/close, plugging
@@ -55,8 +56,12 @@ final class IslandWindow: NSPanel {
     // MARK: - Window config
 
     private func configureWindow() {
-        // Top z-order: above ordinary windows, below the real menu bar.
-        level = .statusBar
+        // ABOVE the menu bar — Dynamic-Island-style apps draw over it so
+        // the pill can appear to extend the notch. Lower levels
+        // (.statusBar = 25, .mainMenu = 24) sit at the menu bar and on
+        // notched Macs would be eclipsed by the system notch.
+        level = .popUpMenu
+
         // Persist across spaces, ignore ⌘` cycling, behave nicely with
         // fullscreen apps.
         collectionBehavior = [
@@ -75,45 +80,62 @@ final class IslandWindow: NSPanel {
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
         isMovableByWindowBackground = false
-        // The pill responds to clicks; clicks outside the pill (e.g. on the
-        // transparent surrounding area) should pass through to the app below.
-        // CSS `pointer-events: none` on body + `auto` on the pill itself
-        // handles that purely in the webview — the window itself stays
-        // mouse-active so clicks on the pill register.
         ignoresMouseEvents = false
 
         // Suppress the panel's natural shadow / vibrancy.
         isFloatingPanel = true
         hidesOnDeactivate = false
+
+        // Smooth resize animation when toggling expanded.
+        animationBehavior = .utilityWindow
     }
 
     // NSPanel becomes key by default when clicked. We never want focus —
     // the user is browsing / coding / whatever, the island is a passive
-    // observer. Overriding canBecomeKey returning false stops focus theft.
+    // observer.
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
+    // AppKit's default `constrainFrameRect(_:to:)` snaps the window into
+    // `visibleFrame` — i.e., below the menu bar. That's the WHOLE problem
+    // we're trying to defeat: Dynamic-Island-style placement means the
+    // pill sits AT the menu bar / over the notch. Returning the rect
+    // unchanged lets us put the window wherever we want above the
+    // visible area.
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        return frameRect
+    }
+
     // MARK: - Positioning
 
-    private func positionAtTopCenter() {
+    private func positionAtTopAnchor(animated: Bool) {
         guard let screen = NSScreen.main else { return }
-        let visible = screen.visibleFrame
-        let size = frame.size
-        let origin = NSPoint(
-            x: visible.midX - size.width / 2,
-            y: visible.maxY - size.height - Self.topGap
-        )
-        setFrameOrigin(origin)
+        let size = isExpanded ? Self.expandedSize : Self.collapsedSize
+        let anchor = NotchDetector.anchor(for: size, on: screen)
+        notchAnchor = anchor
+        let target = NSRect(origin: anchor.origin, size: size)
+        setFrame(target, display: true, animate: animated)
     }
 
     @objc private func handleScreenChange() {
-        positionAtTopCenter()
+        positionAtTopAnchor(animated: false)
+    }
+
+    // MARK: - Expand / collapse
+
+    /// Called by IslandContent when the web widget reports a hover/click
+    /// expand or a mouse-leave collapse. We resize the window so the
+    /// expand panel rendered in the WebView isn't clipped.
+    func setExpanded(_ expanded: Bool) {
+        guard expanded != isExpanded else { return }
+        isExpanded = expanded
+        positionAtTopAnchor(animated: true)
     }
 
     // MARK: - WebView mount
 
     private func mountWebView() {
-        let content = IslandContent()
+        let content = IslandContent(window: self)
         contentView = content.view
     }
 }

--- a/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
@@ -2,56 +2,69 @@
 //  IslandWindow.swift
 //  LisaIsland — Phase 2.1 + 2.2
 //
-//  Borderless, transparent NSPanel that hosts the WKWebView. Sits just
-//  below the menu bar / notch by default (so the avatar isn't eclipsed
-//  by the physical notch hardware), horizontally centered. User can
-//  click-and-drag anywhere on the pill to reposition. The chosen
-//  position is persisted to UserDefaults and restored at next launch.
+//  Borderless, transparent NSPanel that hosts the WKWebView.
 //
-//  Window sizing is dynamic: starts collapsed (~50pt tall, pill-only)
-//  and grows downward to expanded size when the web widget tells us
-//  (via postMessage) the user clicked/hovered. The resize is INSTANT
-//  (no animation) so the pill's screen position never visually drifts
-//  during state changes; the in-page CSS fade animates the panel's
-//  appearance instead.
+//  Architecture (after the post-flicker rework):
 //
-//  Persisted anchor is normalized to the COLLAPSED-state origin —
-//  regardless of which state the user dragged in, we recover the pill's
-//  top edge and re-derive a fresh origin for any size. This kills the
-//  "click → window jumps 250pt up" drift.
+//   • Window is a CONSTANT 330×300. We never resize it on expand /
+//     collapse — that was the source of the click-flicker.
+//   • The pill renders in the TOP 50pt of the window (CSS aligns it to
+//     flex-start). The bottom 250pt is for the expand panel, hidden via
+//     CSS when collapsed.
+//   • Click-through outside the pill: a polling timer checks the cursor
+//     against the "hot rect" (just the pill when collapsed, the whole
+//     window when expanded) and toggles `ignoresMouseEvents`. So the
+//     250pt transparent area below the pill doesn't steal menu-bar or
+//     content clicks when the user isn't actively engaging with Lisa.
+//   • Drag is Swift-side, not JS: `sendEvent(_:)` intercepts
+//     `.leftMouseDown` and runs a synchronous nextEvent loop tracking
+//     mouseDragged / mouseUp. Movement > 4px ⇒ drag (setFrameOrigin
+//     each tick, no IPC roundtrip). No movement ⇒ click (forward
+//     `pill.click()` into the WKWebView).
+//   • The pill's screen position is persisted as the window origin
+//     (since the window is a fixed size, the origin IS the anchor).
 //
 
 import AppKit
+import WebKit
 
 final class IslandWindow: NSPanel {
-    // Collapsed: just the pill (avatar + "Lisa" + status dot)
-    // Expanded: pill + ~250pt panel below for desire / idle message
-    static let collapsedSize = CGSize(width: 160, height: 50)
-    static let expandedSize  = CGSize(width: 330, height: 300)
+    // Fixed window footprint. Pill renders in the top 50pt; expand
+    // panel renders below (visible only via CSS).
+    static let windowSize = CGSize(width: 330, height: 300)
+    static let pillHeight: CGFloat = 50
 
-    // UserDefaults keys for the drag-saved anchor.
+    // 4pt deadband: cursor must move at least this much before we treat
+    // the mousedown as a drag rather than a click.
+    private static let dragThreshold: CGFloat = 4
+
+    // UserDefaults keys.
     private enum DefaultsKey {
         static let hasUserOrigin = "ai.meetlisa.island.hasUserOrigin"
-        // Anchor is stored as the COLLAPSED-state bottom-left origin,
-        // so the same value reconstructs any size correctly.
         static let userOriginX   = "ai.meetlisa.island.userOriginX"
         static let userOriginY   = "ai.meetlisa.island.userOriginY"
     }
 
-    private(set) var isExpanded = false
+    /// Tracked from CSS expand state via postMessage from island.ts.
+    /// When expanded, the hover-hot-rect is the entire window; when
+    /// collapsed, it's just the pill.
+    private var expandedHot = false
+
+    private var hoverTimer: Timer?
 
     init() {
-        let initialFrame = NSRect(origin: .zero, size: Self.collapsedSize)
+        let frame = NSRect(origin: .zero, size: Self.windowSize)
         super.init(
-            contentRect: initialFrame,
+            contentRect: frame,
             styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
             backing: .buffered,
             defer: false
         )
 
         configureWindow()
-        repositionForCurrentState()
+        repositionWindow()
         mountWebView()
+        startHoverPolling()
 
         NotificationCenter.default.addObserver(
             self,
@@ -62,10 +75,11 @@ final class IslandWindow: NSPanel {
     }
 
     deinit {
+        hoverTimer?.invalidate()
         NotificationCenter.default.removeObserver(self)
     }
 
-    // MARK: - Window config
+    // MARK: - Config
 
     private func configureWindow() {
         level = NSWindow.Level(Int(NSWindow.Level.mainMenu.rawValue) + 3)
@@ -81,7 +95,9 @@ final class IslandWindow: NSPanel {
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
         isMovableByWindowBackground = false
-        ignoresMouseEvents = false
+        // Start in pass-through; hoverPoll will flip this on/off based
+        // on cursor position vs hot-rect.
+        ignoresMouseEvents = true
         isFloatingPanel = true
         hidesOnDeactivate = false
     }
@@ -90,14 +106,12 @@ final class IslandWindow: NSPanel {
     override var canBecomeMain: Bool { false }
 
     override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
-        // Don't snap into visibleFrame — the user is allowed to drag
-        // anywhere, including overlapping menu bar / corners.
         return frameRect
     }
 
-    // MARK: - Anchor persistence (always collapsed-equivalent)
+    // MARK: - Position
 
-    private func savedCollapsedOrigin() -> NSPoint? {
+    private func savedOrigin() -> NSPoint? {
         let d = UserDefaults.standard
         guard d.bool(forKey: DefaultsKey.hasUserOrigin) else { return nil }
         return NSPoint(
@@ -106,25 +120,11 @@ final class IslandWindow: NSPanel {
         )
     }
 
-    private func saveCollapsedOrigin(_ origin: NSPoint) {
+    private func saveCurrentOrigin() {
         let d = UserDefaults.standard
         d.set(true, forKey: DefaultsKey.hasUserOrigin)
-        d.set(Double(origin.x), forKey: DefaultsKey.userOriginX)
-        d.set(Double(origin.y), forKey: DefaultsKey.userOriginY)
-    }
-
-    /// Snapshot the pill's current screen position as a collapsed-state
-    /// origin. Call this after a user drag completes so the next state
-    /// transition (collapse ↔ expand) reconstructs from the same pill
-    /// position rather than the window's current origin.
-    func saveCurrentPositionAsAnchor() {
-        // Pill's top edge = window's top edge (CSS aligns to flex-start)
-        // Pill's center x = window's center x
-        let pillTopY    = frame.maxY
-        let pillCenterX = frame.midX
-        let collapsedX  = pillCenterX - Self.collapsedSize.width / 2
-        let collapsedY  = pillTopY    - Self.collapsedSize.height
-        saveCollapsedOrigin(NSPoint(x: collapsedX, y: collapsedY))
+        d.set(Double(frame.origin.x), forKey: DefaultsKey.userOriginX)
+        d.set(Double(frame.origin.y), forKey: DefaultsKey.userOriginY)
     }
 
     func resetSavedOrigin() {
@@ -132,79 +132,162 @@ final class IslandWindow: NSPanel {
         d.removeObject(forKey: DefaultsKey.hasUserOrigin)
         d.removeObject(forKey: DefaultsKey.userOriginX)
         d.removeObject(forKey: DefaultsKey.userOriginY)
-        repositionForCurrentState()
+        repositionWindow()
     }
 
-    // MARK: - Position resolution
-
-    private func defaultCollapsedOrigin(on screen: NSScreen) -> NSPoint {
-        return NotchDetector.anchor(for: Self.collapsedSize, on: screen).origin
-    }
-
-    /// Compute the window origin for the given size given the current
-    /// state. The pill's top edge stays at the same screen y whether
-    /// collapsed or expanded; the expanded window simply extends
-    /// downward.
-    private func originForCurrentState(size: CGSize, on screen: NSScreen) -> NSPoint {
-        let collapsedOrigin: NSPoint
-        if let saved = savedCollapsedOrigin() {
-            collapsedOrigin = clamp(saved, to: screen)
-        } else {
-            collapsedOrigin = defaultCollapsedOrigin(on: screen)
-        }
-        let pillTopY    = collapsedOrigin.y + Self.collapsedSize.height
-        let pillCenterX = collapsedOrigin.x + Self.collapsedSize.width / 2
+    /// Default: pill's top edge sits at visibleFrame.maxY (just below
+    /// menu bar / notch), horizontally centered on the screen midX.
+    /// Since the pill is in the top 50pt of a 300pt-tall window, the
+    /// window's TOP edge equals visibleFrame.maxY, so origin.y =
+    /// visibleFrame.maxY - windowHeight.
+    private func defaultOrigin(on screen: NSScreen) -> NSPoint {
+        let visible = screen.visibleFrame
         return NSPoint(
-            x: pillCenterX - size.width / 2,
-            y: pillTopY    - size.height
+            x: visible.midX - Self.windowSize.width / 2,
+            y: visible.maxY - Self.windowSize.height
         )
     }
 
-    /// Allow positioning anywhere on screen but keep at least 40pt of
-    /// the COLLAPSED pill on screen so it can't be lost.
-    private func clamp(_ origin: NSPoint, to screen: NSScreen) -> NSPoint {
-        let s = Self.collapsedSize
+    private func clampedOrigin(_ origin: NSPoint, on screen: NSScreen) -> NSPoint {
         let bounds = screen.frame
-        let margin: CGFloat = 40
+        let pillVisibleMargin: CGFloat = 40
+        // Keep at least 40pt of the PILL on screen, so the user can't
+        // lose it. The pill is in the top 50pt of the window.
+        let minX = bounds.minX - Self.windowSize.width + pillVisibleMargin
+        let maxX = bounds.maxX - pillVisibleMargin
+        // Lower bound: pill top must still be inside the screen.
+        // Pill top y in AppKit coords = origin.y + windowHeight.
+        // Need pill top > bounds.minY + pillVisibleMargin → origin.y >
+        // bounds.minY + pillVisibleMargin - windowHeight.
+        let minY = bounds.minY + pillVisibleMargin - Self.windowSize.height
+        // Upper bound: window can sit up to screen-top.
+        let maxY = bounds.maxY - Self.windowSize.height + Self.pillHeight - pillVisibleMargin
         return NSPoint(
-            x: min(max(origin.x, bounds.minX - s.width + margin), bounds.maxX - margin),
-            y: min(max(origin.y, bounds.minY - s.height + margin), bounds.maxY - margin)
+            x: min(max(origin.x, minX), maxX),
+            y: min(max(origin.y, minY), maxY)
         )
     }
 
-    func repositionForCurrentState() {
+    private func repositionWindow() {
         guard let screen = NSScreen.main else { return }
-        let size = isExpanded ? Self.expandedSize : Self.collapsedSize
-        let origin = originForCurrentState(size: size, on: screen)
-        // No animation. The page's CSS fades in the expand panel; the
-        // window itself swaps instantly so the pill never visually
-        // drifts during expand/collapse.
-        setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
+        let origin: NSPoint
+        if let saved = savedOrigin() {
+            origin = clampedOrigin(saved, on: screen)
+        } else {
+            origin = defaultOrigin(on: screen)
+        }
+        setFrame(NSRect(origin: origin, size: Self.windowSize),
+                 display: true,
+                 animate: false)
     }
 
     @objc private func handleScreenChange() {
-        repositionForCurrentState()
+        repositionWindow()
     }
 
-    // MARK: - Expand / collapse
+    // MARK: - Hot rect + click-through polling
 
+    /// Called by IslandContent on receipt of an `expand` / `collapse`
+    /// postMessage from the page. Updates which rect is "hot" for
+    /// click-passthrough decisions.
     func setExpanded(_ expanded: Bool) {
-        guard expanded != isExpanded else { return }
-        isExpanded = expanded
-        repositionForCurrentState()
+        expandedHot = expanded
     }
 
-    // MARK: - Direct origin translation (driven by JS drag)
+    /// Pill rect in screen-space (top 50pt of the window).
+    private var pillScreenRect: NSRect {
+        let top = frame.origin.y + frame.height
+        return NSRect(
+            x: frame.origin.x,
+            y: top - Self.pillHeight,
+            width: frame.width,
+            height: Self.pillHeight
+        )
+    }
 
-    /// Move the window by (dx, dy) in **screen-coordinate deltas** (y
-    /// positive = down, matching browser screenY). Called once per
-    /// pointermove from the JS drag tracker. We invert y to AppKit
-    /// (bottom-left origin where y positive = up).
-    func translateOriginByScreenDelta(dx: CGFloat, dy: CGFloat) {
-        var newOrigin = frame.origin
-        newOrigin.x += dx
-        newOrigin.y -= dy   // screen y → AppKit y
-        setFrameOrigin(newOrigin)
+    private func startHoverPolling() {
+        // 50ms = 20Hz. Cheap. Adequate for "cursor over pill" detection.
+        hoverTimer = Timer.scheduledTimer(
+            withTimeInterval: 0.05,
+            repeats: true
+        ) { [weak self] _ in
+            self?.updateClickPassthrough()
+        }
+    }
+
+    private func updateClickPassthrough() {
+        let mouse = NSEvent.mouseLocation
+        // When expanded, the whole window is hot (so the user can
+        // click buttons in the expand panel). When collapsed, only the
+        // pill rectangle is hot.
+        let hot: NSRect = expandedHot ? frame : pillScreenRect
+        let inHot = NSPointInRect(mouse, hot)
+        let shouldIgnore = !inHot
+        if ignoresMouseEvents != shouldIgnore {
+            ignoresMouseEvents = shouldIgnore
+        }
+    }
+
+    // MARK: - Swift-side drag (mouseDown intercepted at sendEvent)
+
+    override func sendEvent(_ event: NSEvent) {
+        if event.type == .leftMouseDown {
+            handleMouseDown(event)
+            return
+        }
+        super.sendEvent(event)
+    }
+
+    private func handleMouseDown(_ down: NSEvent) {
+        let initialOrigin   = frame.origin
+        let downScreen      = NSEvent.mouseLocation
+        var moved           = false
+
+        while true {
+            // Pull the next mouse-drag-or-up event off the queue.
+            // .eventTracking run loop mode keeps us in the active drag
+            // tracking phase without interleaving non-mouse events.
+            guard let evt = NSApplication.shared.nextEvent(
+                matching: [.leftMouseDragged, .leftMouseUp],
+                until: .distantFuture,
+                inMode: .eventTracking,
+                dequeue: true
+            ) else { return }
+
+            let now = NSEvent.mouseLocation
+            let dx = now.x - downScreen.x
+            let dy = now.y - downScreen.y
+
+            switch evt.type {
+            case .leftMouseDragged:
+                if !moved && (abs(dx) > Self.dragThreshold || abs(dy) > Self.dragThreshold) {
+                    moved = true
+                }
+                if moved {
+                    setFrameOrigin(NSPoint(
+                        x: initialOrigin.x + dx,
+                        y: initialOrigin.y + dy
+                    ))
+                }
+            case .leftMouseUp:
+                if moved {
+                    saveCurrentOrigin()
+                } else {
+                    // It was a click. Synthesize the pill click in JS so
+                    // expand-toggle / button handlers run as normal.
+                    forwardPillClick()
+                }
+                return
+            default:
+                break
+            }
+        }
+    }
+
+    private func forwardPillClick() {
+        guard let wv = contentView as? WKWebView else { return }
+        wv.evaluateJavaScript("document.getElementById('pill')?.click();",
+                              completionHandler: nil)
     }
 
     // MARK: - WebView mount

--- a/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
@@ -1,0 +1,119 @@
+//
+//  IslandWindow.swift
+//  LisaIsland — Phase 2.1
+//
+//  Borderless, transparent, status-bar-level NSPanel that hosts the
+//  WKWebView. NSPanel (rather than NSWindow) because we need
+//  `nonactivatingPanel` style so clicking the pill doesn't deactivate
+//  whatever app the user was in.
+//
+//  Placement here is "top-center of main screen". Notch-aware anchoring
+//  on MBP 14/16 lives in Phase 2.2 (NotchDetector).
+//
+//  Phase 2.4 (ScreenContextWatcher) will hide the window when a
+//  fullscreen app is active or the screen is being captured.
+//
+
+import AppKit
+
+final class IslandWindow: NSPanel {
+    // Default pill footprint — chosen to comfortably fit the Phase 1 web
+    // widget's pill + expanded panel (~308pt wide, up to ~240pt tall).
+    private static let defaultSize = CGSize(width: 330, height: 260)
+
+    // How far below the top of visibleFrame the window sits.
+    // visibleFrame already excludes the menu bar, so 0 = flush with menu bar.
+    private static let topGap: CGFloat = 0
+
+    init() {
+        let frame = NSRect(origin: .zero, size: Self.defaultSize)
+        super.init(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        configureWindow()
+        positionAtTopCenter()
+        mountWebView()
+
+        // Reposition on screen geometry changes (lid open/close, plugging
+        // in an external display, resolution change).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleScreenChange),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Window config
+
+    private func configureWindow() {
+        // Top z-order: above ordinary windows, below the real menu bar.
+        level = .statusBar
+        // Persist across spaces, ignore ⌘` cycling, behave nicely with
+        // fullscreen apps.
+        collectionBehavior = [
+            .canJoinAllSpaces,
+            .stationary,
+            .ignoresCycle,
+            .fullScreenAuxiliary,
+        ]
+
+        // Transparent backing so the web widget's rounded pill can show
+        // through the borderless rect.
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = false
+
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        isMovableByWindowBackground = false
+        // The pill responds to clicks; clicks outside the pill (e.g. on the
+        // transparent surrounding area) should pass through to the app below.
+        // CSS `pointer-events: none` on body + `auto` on the pill itself
+        // handles that purely in the webview — the window itself stays
+        // mouse-active so clicks on the pill register.
+        ignoresMouseEvents = false
+
+        // Suppress the panel's natural shadow / vibrancy.
+        isFloatingPanel = true
+        hidesOnDeactivate = false
+    }
+
+    // NSPanel becomes key by default when clicked. We never want focus —
+    // the user is browsing / coding / whatever, the island is a passive
+    // observer. Overriding canBecomeKey returning false stops focus theft.
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    // MARK: - Positioning
+
+    private func positionAtTopCenter() {
+        guard let screen = NSScreen.main else { return }
+        let visible = screen.visibleFrame
+        let size = frame.size
+        let origin = NSPoint(
+            x: visible.midX - size.width / 2,
+            y: visible.maxY - size.height - Self.topGap
+        )
+        setFrameOrigin(origin)
+    }
+
+    @objc private func handleScreenChange() {
+        positionAtTopCenter()
+    }
+
+    // MARK: - WebView mount
+
+    private func mountWebView() {
+        let content = IslandContent()
+        contentView = content.view
+    }
+}

--- a/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
+++ b/packaging/island-mac/Sources/LisaIsland/IslandWindow.swift
@@ -4,16 +4,21 @@
 //
 //  Borderless, transparent NSPanel that hosts the WKWebView. Sits just
 //  below the menu bar / notch by default (so the avatar isn't eclipsed
-//  by the physical notch hardware), horizontally centered. User can hold
-//  ⌥ (Option) and drag to reposition; the chosen position is persisted
-//  to UserDefaults and restored on next launch.
+//  by the physical notch hardware), horizontally centered. User can
+//  click-and-drag anywhere on the pill to reposition. The chosen
+//  position is persisted to UserDefaults and restored at next launch.
 //
-//  Window sizing is dynamic: starts collapsed (~50pt tall, pill-only) so
-//  it doesn't block menu bar clicks. Grows to expanded size when the web
-//  widget tells us (via postMessage) the user hovered/clicked the pill.
+//  Window sizing is dynamic: starts collapsed (~50pt tall, pill-only)
+//  and grows downward to expanded size when the web widget tells us
+//  (via postMessage) the user clicked/hovered. The resize is INSTANT
+//  (no animation) so the pill's screen position never visually drifts
+//  during state changes; the in-page CSS fade animates the panel's
+//  appearance instead.
 //
-//  NSPanel (rather than NSWindow) because we need `nonactivatingPanel`
-//  style so clicking the pill doesn't deactivate the foreground app.
+//  Persisted anchor is normalized to the COLLAPSED-state origin —
+//  regardless of which state the user dragged in, we recover the pill's
+//  top edge and re-derive a fresh origin for any size. This kills the
+//  "click → window jumps 250pt up" drift.
 //
 
 import AppKit
@@ -21,12 +26,14 @@ import AppKit
 final class IslandWindow: NSPanel {
     // Collapsed: just the pill (avatar + "Lisa" + status dot)
     // Expanded: pill + ~250pt panel below for desire / idle message
-    private static let collapsedSize = CGSize(width: 160, height: 50)
-    private static let expandedSize  = CGSize(width: 330, height: 300)
+    static let collapsedSize = CGSize(width: 160, height: 50)
+    static let expandedSize  = CGSize(width: 330, height: 300)
 
-    // UserDefaults keys for the drag-saved position.
+    // UserDefaults keys for the drag-saved anchor.
     private enum DefaultsKey {
         static let hasUserOrigin = "ai.meetlisa.island.hasUserOrigin"
+        // Anchor is stored as the COLLAPSED-state bottom-left origin,
+        // so the same value reconstructs any size correctly.
         static let userOriginX   = "ai.meetlisa.island.userOriginX"
         static let userOriginY   = "ai.meetlisa.island.userOriginY"
     }
@@ -43,10 +50,9 @@ final class IslandWindow: NSPanel {
         )
 
         configureWindow()
-        repositionForCurrentState(animated: false)
+        repositionForCurrentState()
         mountWebView()
 
-        // Reposition on screen geometry changes (lid open/close, plugging
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(handleScreenChange),
@@ -62,141 +68,143 @@ final class IslandWindow: NSPanel {
     // MARK: - Window config
 
     private func configureWindow() {
-        // Above the menu bar — Dynamic-Island-style placement means the
-        // pill draws on top of menubar items that happen to be under it.
-        // .mainMenu + 3 matches Boring Notch / other notch-extender apps;
-        // .popUpMenu (101) is too aggressive and steals focus from
-        // Spotlight / Notification Center.
         level = NSWindow.Level(Int(NSWindow.Level.mainMenu.rawValue) + 3)
-
         collectionBehavior = [
             .canJoinAllSpaces,
             .stationary,
             .ignoresCycle,
             .fullScreenAuxiliary,
         ]
-
         backgroundColor = .clear
         isOpaque = false
         hasShadow = false
-
         titleVisibility = .hidden
         titlebarAppearsTransparent = true
-        // Default drag is off; we handle ⌥+drag manually in sendEvent.
         isMovableByWindowBackground = false
         ignoresMouseEvents = false
-
         isFloatingPanel = true
         hidesOnDeactivate = false
-
-        animationBehavior = .utilityWindow
     }
 
-    // NSPanel becomes key by default when clicked. We never want focus —
-    // the user is browsing / coding / whatever; the island is passive.
     override var canBecomeKey: Bool { false }
     override var canBecomeMain: Bool { false }
 
-    // AppKit's default constrainFrameRect snaps the window into
-    // visibleFrame — which is mostly fine now that we anchor BELOW the
-    // notch, but we keep the override so a user-dragged position can
-    // legitimately overlap the menu bar (e.g. corner-pinning) without
-    // the system pulling it back.
     override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        // Don't snap into visibleFrame — the user is allowed to drag
+        // anywhere, including overlapping menu bar / corners.
         return frameRect
     }
 
-    // MARK: - Position resolution
+    // MARK: - Anchor persistence (always collapsed-equivalent)
 
-    /// Default anchor (just below the notch / menu bar), no user override.
-    private func defaultOrigin(for size: CGSize, on screen: NSScreen) -> NSPoint {
-        return NotchDetector.anchor(for: size, on: screen).origin
-    }
-
-    /// User-saved origin, or nil if the user hasn't dragged.
-    private func savedOrigin() -> NSPoint? {
+    private func savedCollapsedOrigin() -> NSPoint? {
         let d = UserDefaults.standard
         guard d.bool(forKey: DefaultsKey.hasUserOrigin) else { return nil }
-        let x = d.double(forKey: DefaultsKey.userOriginX)
-        let y = d.double(forKey: DefaultsKey.userOriginY)
-        return NSPoint(x: x, y: y)
+        return NSPoint(
+            x: d.double(forKey: DefaultsKey.userOriginX),
+            y: d.double(forKey: DefaultsKey.userOriginY)
+        )
     }
 
-    private func saveOrigin(_ origin: NSPoint) {
+    private func saveCollapsedOrigin(_ origin: NSPoint) {
         let d = UserDefaults.standard
         d.set(true, forKey: DefaultsKey.hasUserOrigin)
         d.set(Double(origin.x), forKey: DefaultsKey.userOriginX)
         d.set(Double(origin.y), forKey: DefaultsKey.userOriginY)
     }
 
-    /// Forget the dragged position; revert to default anchor.
+    /// Snapshot the pill's current screen position as a collapsed-state
+    /// origin. Call this after a user drag completes so the next state
+    /// transition (collapse ↔ expand) reconstructs from the same pill
+    /// position rather than the window's current origin.
+    func saveCurrentPositionAsAnchor() {
+        // Pill's top edge = window's top edge (CSS aligns to flex-start)
+        // Pill's center x = window's center x
+        let pillTopY    = frame.maxY
+        let pillCenterX = frame.midX
+        let collapsedX  = pillCenterX - Self.collapsedSize.width / 2
+        let collapsedY  = pillTopY    - Self.collapsedSize.height
+        saveCollapsedOrigin(NSPoint(x: collapsedX, y: collapsedY))
+    }
+
     func resetSavedOrigin() {
         let d = UserDefaults.standard
         d.removeObject(forKey: DefaultsKey.hasUserOrigin)
         d.removeObject(forKey: DefaultsKey.userOriginX)
         d.removeObject(forKey: DefaultsKey.userOriginY)
-        repositionForCurrentState(animated: true)
+        repositionForCurrentState()
     }
 
-    /// Clamp a candidate origin to keep at least part of the window
-    /// on-screen (so a user can't accidentally drag it into the void).
-    private func clampToScreen(_ origin: NSPoint, size: CGSize, on screen: NSScreen) -> NSPoint {
-        let bounds = screen.frame
-        // Keep at least 40pt of the window visible on each axis.
-        let margin: CGFloat = 40
-        let minX = bounds.minX - size.width + margin
-        let maxX = bounds.maxX - margin
-        let minY = bounds.minY - size.height + margin
-        let maxY = bounds.maxY - margin
-        return NSPoint(
-            x: min(max(origin.x, minX), maxX),
-            y: min(max(origin.y, minY), maxY)
-        )
+    // MARK: - Position resolution
+
+    private func defaultCollapsedOrigin(on screen: NSScreen) -> NSPoint {
+        return NotchDetector.anchor(for: Self.collapsedSize, on: screen).origin
     }
 
-    /// Compute where the window should sit for its current state
-    /// (collapsed vs expanded) and the saved-vs-default anchor choice.
-    /// Expansion grows downward from the pill's top edge so the pill
-    /// doesn't visually jump.
-    private func currentOrigin(for size: CGSize, on screen: NSScreen) -> NSPoint {
-        let collapsedSize = Self.collapsedSize
-        // The pill's top edge is what stays anchored. Compute the pill
-        // top edge first (from collapsed-state origin), then derive the
-        // origin for the requested `size`.
-        let collapsedOrigin: NSPoint = {
-            if let saved = savedOrigin() {
-                return clampToScreen(saved, size: collapsedSize, on: screen)
-            }
-            return defaultOrigin(for: collapsedSize, on: screen)
-        }()
-        let pillTopY = collapsedOrigin.y + collapsedSize.height
-        let pillCenterX = collapsedOrigin.x + collapsedSize.width / 2
-
+    /// Compute the window origin for the given size given the current
+    /// state. The pill's top edge stays at the same screen y whether
+    /// collapsed or expanded; the expanded window simply extends
+    /// downward.
+    private func originForCurrentState(size: CGSize, on screen: NSScreen) -> NSPoint {
+        let collapsedOrigin: NSPoint
+        if let saved = savedCollapsedOrigin() {
+            collapsedOrigin = clamp(saved, to: screen)
+        } else {
+            collapsedOrigin = defaultCollapsedOrigin(on: screen)
+        }
+        let pillTopY    = collapsedOrigin.y + Self.collapsedSize.height
+        let pillCenterX = collapsedOrigin.x + Self.collapsedSize.width / 2
         return NSPoint(
             x: pillCenterX - size.width / 2,
-            y: pillTopY - size.height
+            y: pillTopY    - size.height
         )
     }
 
-    private func repositionForCurrentState(animated: Bool) {
+    /// Allow positioning anywhere on screen but keep at least 40pt of
+    /// the COLLAPSED pill on screen so it can't be lost.
+    private func clamp(_ origin: NSPoint, to screen: NSScreen) -> NSPoint {
+        let s = Self.collapsedSize
+        let bounds = screen.frame
+        let margin: CGFloat = 40
+        return NSPoint(
+            x: min(max(origin.x, bounds.minX - s.width + margin), bounds.maxX - margin),
+            y: min(max(origin.y, bounds.minY - s.height + margin), bounds.maxY - margin)
+        )
+    }
+
+    func repositionForCurrentState() {
         guard let screen = NSScreen.main else { return }
         let size = isExpanded ? Self.expandedSize : Self.collapsedSize
-        let origin = currentOrigin(for: size, on: screen)
-        setFrame(NSRect(origin: origin, size: size), display: true, animate: animated)
+        let origin = originForCurrentState(size: size, on: screen)
+        // No animation. The page's CSS fades in the expand panel; the
+        // window itself swaps instantly so the pill never visually
+        // drifts during expand/collapse.
+        setFrame(NSRect(origin: origin, size: size), display: true, animate: false)
     }
 
     @objc private func handleScreenChange() {
-        repositionForCurrentState(animated: false)
+        repositionForCurrentState()
     }
 
     // MARK: - Expand / collapse
 
-    /// Called by IslandContent when the web widget reports a hover/click
-    /// expand or a mouse-leave collapse.
     func setExpanded(_ expanded: Bool) {
         guard expanded != isExpanded else { return }
         isExpanded = expanded
-        repositionForCurrentState(animated: true)
+        repositionForCurrentState()
+    }
+
+    // MARK: - Direct origin translation (driven by JS drag)
+
+    /// Move the window by (dx, dy) in **screen-coordinate deltas** (y
+    /// positive = down, matching browser screenY). Called once per
+    /// pointermove from the JS drag tracker. We invert y to AppKit
+    /// (bottom-left origin where y positive = up).
+    func translateOriginByScreenDelta(dx: CGFloat, dy: CGFloat) {
+        var newOrigin = frame.origin
+        newOrigin.x += dx
+        newOrigin.y -= dy   // screen y → AppKit y
+        setFrameOrigin(newOrigin)
     }
 
     // MARK: - WebView mount
@@ -204,23 +212,5 @@ final class IslandWindow: NSPanel {
     private func mountWebView() {
         let content = IslandContent(window: self)
         contentView = content.view
-    }
-
-    // MARK: - ⌥+drag to reposition
-
-    /// `sendEvent` runs BEFORE the contentView (WKWebView) gets a chance
-    /// to handle the event. If the user holds ⌥ on mouse-down, we steal
-    /// the event and start a window-drag tracking loop instead of letting
-    /// the page see it.
-    override func sendEvent(_ event: NSEvent) {
-        if event.type == .leftMouseDown,
-           event.modifierFlags.contains(.option) {
-            // Begin native AppKit drag. Returns when the user releases
-            // the mouse. We then save the new origin.
-            self.performDrag(with: event)
-            saveOrigin(frame.origin)
-            return
-        }
-        super.sendEvent(event)
     }
 }

--- a/packaging/island-mac/Sources/LisaIsland/NotchDetector.swift
+++ b/packaging/island-mac/Sources/LisaIsland/NotchDetector.swift
@@ -1,0 +1,75 @@
+//
+//  NotchDetector.swift
+//  LisaIsland — Phase 2.2 of MAC_ISLAND_PLAN.md
+//
+//  Computes where to anchor the island pill on a given NSScreen so that on
+//  notched Macs (MBP 14"/16" 2021+, MBA 2022+) the pill appears to "extend"
+//  the notch downward, and on non-notched Macs it sits flush with the top
+//  of the screen.
+//
+//  Key macOS 12+ NSScreen APIs:
+//    - safeAreaInsets.top    — height of the menu bar region the notch
+//                              cuts into; 0 on Macs without notch.
+//    - auxiliaryTopLeftArea  — clickable menu bar to the left of the notch;
+//                              nil on Macs without notch.
+//    - auxiliaryTopRightArea — clickable menu bar to the right of the notch.
+//
+//  The notch itself occupies the gap between left and right auxiliary
+//  areas, centered at screen.frame.midX.
+//
+
+import AppKit
+
+struct NotchAnchor {
+    /// Origin (bottom-left in AppKit coordinates) for the window frame.
+    let origin: NSPoint
+    /// Whether this screen has a notch we anchored to.
+    let hasNotch: Bool
+    /// Width of the physical notch (0 if not notched).
+    let notchWidth: CGFloat
+}
+
+enum NotchDetector {
+
+    /// Decide where to place a window of `size` on `screen` so the pill at
+    /// the top of the window sits at the very top edge of the screen —
+    /// overlapping the menu bar on notched Macs, flush with it on others.
+    static func anchor(for size: CGSize, on screen: NSScreen) -> NotchAnchor {
+        let frame = screen.frame  // includes menu bar area
+
+        // Horizontal center: always at screen midX. On notched Macs the
+        // notch itself is centered at midX, so this aligns the pill with
+        // the notch.
+        let x = frame.midX - size.width / 2
+
+        // Vertical: pill's TOP edge at the top of the physical screen.
+        // (AppKit's origin is bottom-left of the window, so we subtract
+        // the window's height from the top of the screen.)
+        let y = frame.maxY - size.height
+
+        let (hasNotch, notchWidth) = detectNotch(on: screen)
+
+        return NotchAnchor(
+            origin: NSPoint(x: x, y: y),
+            hasNotch: hasNotch,
+            notchWidth: notchWidth
+        )
+    }
+
+    /// Returns whether `screen` has a notch and, if so, its width in pts.
+    static func detectNotch(on screen: NSScreen) -> (hasNotch: Bool, width: CGFloat) {
+        if #available(macOS 12.0, *) {
+            // safeAreaInsets.top is non-zero on notched Macs.
+            if screen.safeAreaInsets.top > 0 {
+                // Notch width = gap between auxiliary areas
+                let leftRight = screen.auxiliaryTopRightArea?.minX
+                    ?? screen.frame.midX
+                let rightLeft = screen.auxiliaryTopLeftArea?.maxX
+                    ?? screen.frame.midX
+                let width = max(0, leftRight - rightLeft)
+                return (true, width)
+            }
+        }
+        return (false, 0)
+    }
+}

--- a/packaging/island-mac/Sources/LisaIsland/NotchDetector.swift
+++ b/packaging/island-mac/Sources/LisaIsland/NotchDetector.swift
@@ -2,10 +2,16 @@
 //  NotchDetector.swift
 //  LisaIsland — Phase 2.2 of MAC_ISLAND_PLAN.md
 //
-//  Computes where to anchor the island pill on a given NSScreen so that on
-//  notched Macs (MBP 14"/16" 2021+, MBA 2022+) the pill appears to "extend"
-//  the notch downward, and on non-notched Macs it sits flush with the top
-//  of the screen.
+//  Computes where to anchor the island pill on a given NSScreen.
+//
+//  IMPORTANT: on notched Macs (MBP 14"/16" 2021+, MBA 2022+) the physical
+//  notch is opaque hardware — the camera/sensor cluster — and anything we
+//  draw underneath it is invisible. So the pill's top edge anchors to the
+//  BOTTOM of the safe area (just below the notch / menu bar), not to the
+//  physical top of the screen. That way the avatar is always visible.
+//
+//  Horizontal: centered at screen midX, which on notched Macs aligns with
+//  the notch center so the pill visually "hangs from" the notch.
 //
 //  Key macOS 12+ NSScreen APIs:
 //    - safeAreaInsets.top    — height of the menu bar region the notch
@@ -13,9 +19,6 @@
 //    - auxiliaryTopLeftArea  — clickable menu bar to the left of the notch;
 //                              nil on Macs without notch.
 //    - auxiliaryTopRightArea — clickable menu bar to the right of the notch.
-//
-//  The notch itself occupies the gap between left and right auxiliary
-//  areas, centered at screen.frame.midX.
 //
 
 import AppKit
@@ -32,20 +35,18 @@ struct NotchAnchor {
 enum NotchDetector {
 
     /// Decide where to place a window of `size` on `screen` so the pill at
-    /// the top of the window sits at the very top edge of the screen —
-    /// overlapping the menu bar on notched Macs, flush with it on others.
+    /// the top of the window sits just below the menu bar (and below the
+    /// notch on notched Macs), horizontally centered.
     static func anchor(for size: CGSize, on screen: NSScreen) -> NotchAnchor {
-        let frame = screen.frame  // includes menu bar area
+        // visibleFrame already excludes both the menu bar and the notch
+        // region — so its top edge is exactly where we want the pill's
+        // top edge to be. The pill itself sits at the top of the window
+        // (CSS aligns to flex-start), so window.origin.y must place the
+        // window's TOP edge at visibleFrame.maxY.
+        let visible = screen.visibleFrame
 
-        // Horizontal center: always at screen midX. On notched Macs the
-        // notch itself is centered at midX, so this aligns the pill with
-        // the notch.
-        let x = frame.midX - size.width / 2
-
-        // Vertical: pill's TOP edge at the top of the physical screen.
-        // (AppKit's origin is bottom-left of the window, so we subtract
-        // the window's height from the top of the screen.)
-        let y = frame.maxY - size.height
+        let x = visible.midX - size.width / 2
+        let y = visible.maxY - size.height
 
         let (hasNotch, notchWidth) = detectNotch(on: screen)
 
@@ -61,7 +62,6 @@ enum NotchDetector {
         if #available(macOS 12.0, *) {
             // safeAreaInsets.top is non-zero on notched Macs.
             if screen.safeAreaInsets.top > 0 {
-                // Notch width = gap between auxiliary areas
                 let leftRight = screen.auxiliaryTopRightArea?.minX
                     ?? screen.frame.midX
                 let rightLeft = screen.auxiliaryTopLeftArea?.maxX

--- a/packaging/island-mac/Sources/LisaIsland/main.swift
+++ b/packaging/island-mac/Sources/LisaIsland/main.swift
@@ -1,0 +1,20 @@
+//
+//  main.swift
+//  LisaIsland — Phase 2.1 of MAC_ISLAND_PLAN.md
+//
+//  Boots an accessory-policy NSApplication (no Dock icon, no menu bar app
+//  name) and hands off to AppDelegate which owns the IslandWindow lifecycle.
+//
+//  Why a top-level script entry rather than @main: we explicitly call
+//  setActivationPolicy(.accessory) BEFORE app.run() so the Dock icon never
+//  even appears momentarily. @main attribute would activate the regular
+//  policy briefly.
+//
+
+import AppKit
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.setActivationPolicy(.accessory)
+app.run()

--- a/packaging/island-mac/build.sh
+++ b/packaging/island-mac/build.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Build LisaIsland.app from the SwiftPM target.
+#
+# SwiftPM emits a bare executable; we wrap it in a hand-rolled .app bundle so
+# `open LisaIsland.app` works and LSUIElement (no Dock icon) is honored. No
+# Xcode project required — anyone with Command Line Tools or Xcode installed
+# can build.
+#
+# Output: packaging/island-mac/LisaIsland.app
+#
+# Usage:
+#   bash build.sh           # release build (default)
+#   bash build.sh --debug   # debug build
+#
+set -euo pipefail
+
+CONFIG="release"
+if [ "${1:-}" = "--debug" ]; then
+    CONFIG="debug"
+fi
+
+cd "$(dirname "$0")"
+
+echo "▸ swift build -c $CONFIG"
+# Universal binary: Apple Silicon + Intel. Build script falls back to host
+# arch if cross-build fails (e.g. missing Rosetta SDK on a fresh M-series).
+if ! swift build -c "$CONFIG" --arch arm64 --arch x86_64 2>/dev/null; then
+    echo "  (universal build failed, falling back to host arch)"
+    swift build -c "$CONFIG"
+fi
+
+# SwiftPM's universal output lives in .build/apple/Products/<Config>/;
+# single-arch output in .build/<config>/.
+BIN=""
+for candidate in \
+    ".build/apple/Products/Release/LisaIsland" \
+    ".build/apple/Products/Debug/LisaIsland" \
+    ".build/release/LisaIsland" \
+    ".build/debug/LisaIsland" ; do
+    if [ -x "$candidate" ]; then
+        BIN="$candidate"
+        break
+    fi
+done
+if [ -z "$BIN" ]; then
+    echo "✗ couldn't find compiled binary; check 'swift build' output above" >&2
+    exit 1
+fi
+echo "▸ found binary at $BIN"
+
+APP="LisaIsland.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+mkdir -p "$APP/Contents/Resources"
+
+cp "$BIN" "$APP/Contents/MacOS/LisaIsland"
+chmod +x "$APP/Contents/MacOS/LisaIsland"
+cp Resources/Info.plist "$APP/Contents/Info.plist"
+
+# Ad-hoc sign so Gatekeeper at least doesn't reject the binary outright on
+# first launch. Real signing (Developer ID + notarization) is Phase 4.
+codesign --force --deep --sign - "$APP" >/dev/null 2>&1 || true
+
+echo "✓ built $(pwd)/$APP"
+echo ""
+echo "To launch:    open $APP"
+echo "To install:   cp -r $APP /Applications/"

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -262,8 +262,26 @@ export const ISLAND_HTML = `<!doctype html>
   }
 
   // ── Interaction ────────────────────────────────────────────────────
+  //
+  // Drag vs click resolution: every pill mousedown starts a pointer
+  // capture. If the cursor moves > 4px before release, we treat it as
+  // a drag (post per-frame screen deltas to the native container so it
+  // can move the window). If it releases without moving, we treat it
+  // as a click (toggle expand). The bridge falls back gracefully when
+  // running in a plain browser tab — postMessages are no-ops.
+  //
+  // Why screen coordinates: as the native window moves, the mouse stays
+  // at the same SCREEN position (the user's hand is in screen space),
+  // so deltas of screenX/Y between successive pointermove events give
+  // us the actual physical motion to apply.
+
+  const hasBridge = !!(window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.island);
+  let dragTracking = null;
+  let lastDragEndAt = 0;
+
   let hoverTimer = null;
   pill.addEventListener('mouseenter', () => {
+    if (dragTracking && dragTracking.moved) return;
     clearTimeout(hoverTimer);
     hoverTimer = setTimeout(() => expandPanel(true), 250);
   });
@@ -276,7 +294,71 @@ export const ISLAND_HTML = `<!doctype html>
   });
   expand.addEventListener('mouseleave', () => expandPanel(false));
 
+  pill.addEventListener('pointerdown', (e) => {
+    if (e.button !== 0) return;
+    dragTracking = {
+      pointerId: e.pointerId,
+      startX: e.screenX,
+      startY: e.screenY,
+      lastX: e.screenX,
+      lastY: e.screenY,
+      moved: false,
+    };
+    try { pill.setPointerCapture(e.pointerId); } catch (_) {}
+  });
+
+  pill.addEventListener('pointermove', (e) => {
+    if (!dragTracking || e.pointerId !== dragTracking.pointerId) return;
+    if (!dragTracking.moved) {
+      const totalDx = e.screenX - dragTracking.startX;
+      const totalDy = e.screenY - dragTracking.startY;
+      if (Math.abs(totalDx) > 4 || Math.abs(totalDy) > 4) {
+        dragTracking.moved = true;
+        // Cancel any pending hover-expand so the window doesn't grow
+        // mid-drag.
+        clearTimeout(hoverTimer);
+        expandPanel(false);
+      }
+    }
+    if (dragTracking.moved) {
+      const dx = e.screenX - dragTracking.lastX;
+      const dy = e.screenY - dragTracking.lastY;
+      if (dx !== 0 || dy !== 0) {
+        if (hasBridge) {
+          window.webkit.messageHandlers.island.postMessage({
+            type: 'drag_delta',
+            dx: dx,
+            dy: dy,
+          });
+        }
+        dragTracking.lastX = e.screenX;
+        dragTracking.lastY = e.screenY;
+      }
+    }
+  });
+
+  function endDrag(e) {
+    if (!dragTracking || e.pointerId !== dragTracking.pointerId) return;
+    const wasDrag = dragTracking.moved;
+    try { pill.releasePointerCapture(e.pointerId); } catch (_) {}
+    dragTracking = null;
+    if (wasDrag) {
+      lastDragEndAt = Date.now();
+      if (hasBridge) {
+        window.webkit.messageHandlers.island.postMessage({ type: 'drag_end' });
+      }
+    }
+  }
+  pill.addEventListener('pointerup', endDrag);
+  pill.addEventListener('pointercancel', endDrag);
+
   pill.addEventListener('click', (e) => {
+    // Suppress the click that follows a drag-end.
+    if (Date.now() - lastDragEndAt < 250) {
+      e.preventDefault();
+      e.stopPropagation();
+      return;
+    }
     e.preventDefault();
     expandPanel(!body.classList.contains('expanded'));
   });

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -263,25 +263,21 @@ export const ISLAND_HTML = `<!doctype html>
 
   // ── Interaction ────────────────────────────────────────────────────
   //
-  // Drag vs click resolution: every pill mousedown starts a pointer
-  // capture. If the cursor moves > 4px before release, we treat it as
-  // a drag (post per-frame screen deltas to the native container so it
-  // can move the window). If it releases without moving, we treat it
-  // as a click (toggle expand). The bridge falls back gracefully when
-  // running in a plain browser tab — postMessages are no-ops.
+  // When running inside LisaIsland.app (Phase 2.1+), the native window
+  // owns drag and click-vs-drag resolution: Swift's IslandWindow
+  // intercepts mouseDown in sendEvent and runs a synchronous
+  // mouseDragged loop. If movement > 4px → drag (setFrameOrigin each
+  // tick, no IPC roundtrip). If no movement → Swift synthesizes
+  // pill.click() here so this click handler still fires.
   //
-  // Why screen coordinates: as the native window moves, the mouse stays
-  // at the same SCREEN position (the user's hand is in screen space),
-  // so deltas of screenX/Y between successive pointermove events give
-  // us the actual physical motion to apply.
-
-  const hasBridge = !!(window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.island);
-  let dragTracking = null;
-  let lastDragEndAt = 0;
+  // In a plain browser tab there's no native container — the click
+  // handler runs normally. Hover-to-expand also works in both modes:
+  // when the native window is in "passthrough" state for the
+  // non-pill area, mouseenter still fires on the WKWebView once the
+  // cursor crosses INTO the pill region.
 
   let hoverTimer = null;
   pill.addEventListener('mouseenter', () => {
-    if (dragTracking && dragTracking.moved) return;
     clearTimeout(hoverTimer);
     hoverTimer = setTimeout(() => expandPanel(true), 250);
   });
@@ -294,71 +290,7 @@ export const ISLAND_HTML = `<!doctype html>
   });
   expand.addEventListener('mouseleave', () => expandPanel(false));
 
-  pill.addEventListener('pointerdown', (e) => {
-    if (e.button !== 0) return;
-    dragTracking = {
-      pointerId: e.pointerId,
-      startX: e.screenX,
-      startY: e.screenY,
-      lastX: e.screenX,
-      lastY: e.screenY,
-      moved: false,
-    };
-    try { pill.setPointerCapture(e.pointerId); } catch (_) {}
-  });
-
-  pill.addEventListener('pointermove', (e) => {
-    if (!dragTracking || e.pointerId !== dragTracking.pointerId) return;
-    if (!dragTracking.moved) {
-      const totalDx = e.screenX - dragTracking.startX;
-      const totalDy = e.screenY - dragTracking.startY;
-      if (Math.abs(totalDx) > 4 || Math.abs(totalDy) > 4) {
-        dragTracking.moved = true;
-        // Cancel any pending hover-expand so the window doesn't grow
-        // mid-drag.
-        clearTimeout(hoverTimer);
-        expandPanel(false);
-      }
-    }
-    if (dragTracking.moved) {
-      const dx = e.screenX - dragTracking.lastX;
-      const dy = e.screenY - dragTracking.lastY;
-      if (dx !== 0 || dy !== 0) {
-        if (hasBridge) {
-          window.webkit.messageHandlers.island.postMessage({
-            type: 'drag_delta',
-            dx: dx,
-            dy: dy,
-          });
-        }
-        dragTracking.lastX = e.screenX;
-        dragTracking.lastY = e.screenY;
-      }
-    }
-  });
-
-  function endDrag(e) {
-    if (!dragTracking || e.pointerId !== dragTracking.pointerId) return;
-    const wasDrag = dragTracking.moved;
-    try { pill.releasePointerCapture(e.pointerId); } catch (_) {}
-    dragTracking = null;
-    if (wasDrag) {
-      lastDragEndAt = Date.now();
-      if (hasBridge) {
-        window.webkit.messageHandlers.island.postMessage({ type: 'drag_end' });
-      }
-    }
-  }
-  pill.addEventListener('pointerup', endDrag);
-  pill.addEventListener('pointercancel', endDrag);
-
   pill.addEventListener('click', (e) => {
-    // Suppress the click that follows a drag-end.
-    if (Date.now() - lastDragEndAt < 250) {
-      e.preventDefault();
-      e.stopPropagation();
-      return;
-    }
     e.preventDefault();
     expandPanel(!body.classList.contains('expanded'));
   });

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -248,7 +248,17 @@ export const ISLAND_HTML = `<!doctype html>
   }
 
   function expandPanel(open) {
+    if (body.classList.contains('expanded') === open) return;
     body.classList.toggle('expanded', open);
+    // Tell the native container (LisaIsland.app, Phase 2.2+) so it can
+    // resize its NSWindow — the pill window is sized just for the pill
+    // when collapsed, and grows to host the expand panel on open.
+    // Falls back gracefully when running in a plain browser tab.
+    if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.island) {
+      window.webkit.messageHandlers.island.postMessage({
+        type: open ? 'expand' : 'collapse'
+      });
+    }
   }
 
   // ── Interaction ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #23. First of four Phase 2 PRs per [docs/MAC_ISLAND_PLAN.md](docs/MAC_ISLAND_PLAN.md) §4.

## What this PR delivers

A minimum-viable native macOS app — \`LisaIsland.app\` — that hosts the existing Phase 1 web widget in a chrome-less, always-on-top window. **No Dock icon, no menu bar app name.**

The visual is still 100% the Phase 1 widget (same SSE, same pixel art, same desire/idle/mood). This PR just frees the user from babysitting a browser window.

| Phase | Scope | Status |
|---|---|---|
| **2.1 (this)** | App skeleton, WKWebView, borderless top-center window | ✅ |
| 2.2 | NotchDetector — anchor to right of notch on MBP 14/16 | next |
| 2.3 | LisaProbe — graceful offline overlay | planned |
| 2.4 | ScreenContextWatcher — auto-hide on fullscreen + screen capture | planned |

## Verified locally

✓ Universal binary (arm64 + x86_64) builds via \`bash build.sh\`
✓ No Dock icon (\`LSUIElement: true\`)
✓ Process launches, ad-hoc signed
✓ \`WKWebView\` connects to LISA at \`localhost:5757/island\`:
\`\`\`
com.apple 63147 oratis 12u IPv6 [::1]:59589->[::1]:5757 (ESTABLISHED)
\`\`\`
✓ Window stays on top across Safari / Chrome / Slack
✓ ⌘Q quits cleanly
✓ Reposition on screen geometry change (lid open/close)

## Architecture

Built with **SwiftPM** (no Xcode project) so any contributor can:

\`\`\`sh
cd packaging/island-mac
bash build.sh         # produces LisaIsland.app right here
open LisaIsland.app
\`\`\`

Source layout (5 small Swift files, ~290 LOC total):

\`\`\`
packaging/island-mac/
├── Package.swift
├── Sources/LisaIsland/
│   ├── main.swift           20 LOC  NSApplication boot
│   ├── AppDelegate.swift    52 LOC  window lifecycle + ⌘Q
│   ├── IslandWindow.swift  119 LOC  borderless NSPanel, statusBar level
│   └── IslandContent.swift 101 LOC  WKWebView + auto-retry + message bridge
├── Resources/Info.plist
├── build.sh
└── README.md
\`\`\`

## Key decisions

- **NSPanel, not NSWindow** — needs \`nonactivatingPanel\` style so clicking the pill doesn't deactivate the foreground app (focus theft would be terrible UX for a passive observer).
- **\`canBecomeKey\` / \`canBecomeMain\` return false** — belt-and-suspenders against focus theft.
- **Top-center placement only** — no notch detection here. MBP 14/16 users will see the pill sit ON the notch until PR 2.2 lands; harmless degrade.
- **WKWebView \`drawsBackground = false\`** — transparent so the page's rounded pill CSS shows on top of whatever's underneath.
- **Auto-retry on load failure** — if LISA isn't running at launch, the webview retries every 4s instead of showing a permanent blank.
- **\`open_full_gui\` message handler** — the Phase 1 widget already checks for \`window.webkit.messageHandlers.island\` and falls back to \`window.open('/')\` if absent. When this app is running, clicking "Open chat" in the widget opens the full GUI in the user's default browser via \`NSWorkspace\`, no extra plumbing.

## Out of scope

- **Notch awareness** — PR 2.2 will detect \`NSScreen.auxiliaryTopRightArea\` and reposition. For now MBP 14/16 users see the pill at screen-center top (drawn over the notch); other Macs work perfectly.
- **Offline state** — webview shows a blank surface if LISA is down. Phase 1 widget itself handles its own \`.offline\` CSS state (gray avatar) once the page loads; PR 2.3 will add a proper native offline overlay so users see \`Lisa is asleep — start with \`lisa serve --web\`\` even before the page loads.
- **Fullscreen / screen-share hide** — PR 2.4.
- **Apple Developer ID signing + notarization + Homebrew Cask** — Phase 4.

## Manual review checklist

- [ ] \`bash build.sh\` succeeds in a clean clone
- [ ] \`open LisaIsland.app\` shows a pill at top of main screen
- [ ] No Dock icon
- [ ] Pill stays on top when you switch to Safari / Chrome
- [ ] ⌘Q from focused island quits the app
- [ ] Quitting + relaunching LISA → pill recovers (no manual webview reload)

## Diff stat

| File | LOC |
|---|---|
| \`Sources/LisaIsland/*.swift\` | 292 |
| \`Package.swift\` | 13 |
| \`Resources/Info.plist\` | 40 |
| \`build.sh\` | 68 |
| \`README.md\` | 118 |
| \`.gitignore\` | 14 |
| **Total** | **545** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)