### PR TITLE
feat(mac-client): Lisa.app native Mac client for the chat GUI

### DIFF
--- a/packaging/mac-client/.gitignore
+++ b/packaging/mac-client/.gitignore
@@ -1,0 +1,14 @@
+# SwiftPM
+.build/
+Package.resolved
+
+# Built bundle — local artifact, distributed via GitHub Releases
+Lisa.app/
+
+# Xcode
+*.xcodeproj/
+*.xcworkspace/
+DerivedData/
+
+# macOS
+.DS_Store

--- a/packaging/mac-client/Package.swift
+++ b/packaging/mac-client/Package.swift
@@ -1,0 +1,13 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "Lisa",
+    platforms: [.macOS(.v13)],
+    targets: [
+        .executableTarget(
+            name: "Lisa",
+            path: "Sources/Lisa"
+        )
+    ]
+)

--- a/packaging/mac-client/README.md
+++ b/packaging/mac-client/README.md
@@ -1,0 +1,101 @@
+# Lisa.app — native Mac client
+
+Dockable macOS app hosting the LISA chat GUI. Sibling to
+[`packaging/island-mac/`](../island-mac/) which makes the always-on-top
+pill.
+
+| | LisaIsland.app | **Lisa.app** |
+|---|---|---|
+| What it is | Passive observer (small pill at top of screen) | Active conversation window |
+| Dock icon | no | yes |
+| Window chrome | borderless | standard (titlebar, traffic lights) |
+| Z-order | always on top | normal |
+| Loads | `/island` | `/` (the chat GUI) |
+| When to use | Always running in background | Open when you want to chat |
+
+Two apps; install one, both, or neither. Both talk only to `localhost:5757`.
+
+## Requirements
+
+- macOS 13 or later
+- Swift 5.9+ (bundled with Xcode 15 / current Command Line Tools)
+- LISA running at `localhost:5757` (`lisa serve --web`)
+
+## Build
+
+```sh
+cd packaging/mac-client
+bash build.sh
+```
+
+Output: `Lisa.app` in this directory. App icon is generated at build
+time from `src/web/assets/lisa-mascot.png` via `sips` + `iconutil` —
+no binary blobs committed to git.
+
+## Run
+
+Start LISA first:
+
+```sh
+lisa serve --web
+```
+
+Then:
+
+```sh
+open Lisa.app
+```
+
+A 1200×800 window opens with the chat GUI. Window position + size are
+remembered across launches (via `NSWindow.frameAutosaveName`).
+
+## Install
+
+```sh
+cp -r Lisa.app /Applications/
+```
+
+To launch at login: System Settings → General → Login Items → drag in
+`/Applications/Lisa.app`.
+
+## Keyboard shortcuts
+
+| Shortcut | Action |
+|---|---|
+| `⌘N` | New / show window |
+| `⌘W` | Close window (app stays in Dock) |
+| `⌘R` | Reload chat |
+| `⌘F` | Toggle fullscreen |
+| `⌘M` | Minimize |
+| `⌘H` | Hide |
+| `⌘Q` | Quit |
+
+## Architecture
+
+```
+Sources/Lisa/
+├── main.swift          # NSApplication boot (.regular policy)
+├── AppDelegate.swift   # window lifecycle + standard menu bar
+├── MainWindow.swift    # NSWindow + frame autosave + WebContent VC
+└── WebContent.swift    # WKWebView + auto-retry + external link handler
+```
+
+Communication with LISA is identical to LisaIsland.app — all goes
+through `localhost:5757`. No state stored locally; killing the app
+loses nothing.
+
+## Distribution
+
+Currently **ad-hoc signed only**. First launch on macOS Gatekeeper
+will prompt; right-click → Open the first time, or:
+
+```sh
+xattr -dr com.apple.quarantine Lisa.app
+```
+
+Apple Developer ID signing + notarization + Homebrew Cask are Phase 4
+of [`docs/MAC_ISLAND_PLAN.md`](../../docs/MAC_ISLAND_PLAN.md).
+
+## License
+
+MIT — same as the parent LISA repo.

--- a/packaging/mac-client/Resources/Info.plist
+++ b/packaging/mac-client/Resources/Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>Lisa</string>
+    <key>CFBundleIdentifier</key>
+    <string>ai.meetlisa.app</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>Lisa</string>
+    <key>CFBundleDisplayName</key>
+    <string>Lisa</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>0.1.0</string>
+    <key>CFBundleVersion</key>
+    <string>1</string>
+    <key>CFBundleIconFile</key>
+    <string>AppIcon</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>13.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+    <!-- ATS exception: we only ever talk to localhost. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
+    <!-- Standard supported window features. -->
+    <key>NSSupportsAutomaticTermination</key>
+    <false/>
+    <key>NSSupportsSuddenTermination</key>
+    <false/>
+    <key>NSHumanReadableCopyright</key>
+    <string>MIT — github.com/oratis/LISA</string>
+</dict>
+</plist>

--- a/packaging/mac-client/Sources/Lisa/AppDelegate.swift
+++ b/packaging/mac-client/Sources/Lisa/AppDelegate.swift
@@ -1,0 +1,175 @@
+//
+//  AppDelegate.swift
+//  Lisa
+//
+//  Owns the MainWindow lifecycle and installs the standard Mac menu bar
+//  (App / File / Edit / View / Window / Help).
+//
+//  Behavior:
+//    - Closing the only window keeps the app alive in the Dock (standard
+//      Mac model). Click the Dock icon to bring the window back.
+//    - ⌘Q quits.
+//    - ⌘W closes the front window.
+//    - ⌘R reloads the chat (useful after server restart).
+//
+
+import AppKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var mainWindow: MainWindow?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        installMenu()
+        showMainWindow()
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        // Standard Mac app behavior — keep running so Dock icon click can
+        // reopen. Quit only on explicit ⌘Q.
+        return false
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag {
+            showMainWindow()
+        }
+        return true
+    }
+
+    // MARK: - Window
+
+    private func showMainWindow() {
+        if let win = mainWindow {
+            win.makeKeyAndOrderFront(nil)
+            NSApp.activate(ignoringOtherApps: true)
+            return
+        }
+        let win = MainWindow()
+        win.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+        mainWindow = win
+    }
+
+    @objc func reloadChat(_ sender: Any?) {
+        mainWindow?.reload()
+    }
+
+    @objc func newWindowAction(_ sender: Any?) {
+        // Single-window for now; reuse existing.
+        showMainWindow()
+    }
+
+    // MARK: - Menu
+
+    private func installMenu() {
+        let mainMenu = NSMenu()
+
+        // ── App menu ────────────────────────────────────────────────
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu()
+        appMenu.addItem(NSMenuItem(
+            title: "About Lisa",
+            action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)),
+            keyEquivalent: ""
+        ))
+        appMenu.addItem(.separator())
+        appMenu.addItem(NSMenuItem(
+            title: "Hide Lisa",
+            action: #selector(NSApplication.hide(_:)),
+            keyEquivalent: "h"
+        ))
+        let hideOthers = NSMenuItem(
+            title: "Hide Others",
+            action: #selector(NSApplication.hideOtherApplications(_:)),
+            keyEquivalent: "h"
+        )
+        hideOthers.keyEquivalentModifierMask = [.command, .option]
+        appMenu.addItem(hideOthers)
+        appMenu.addItem(NSMenuItem(
+            title: "Show All",
+            action: #selector(NSApplication.unhideAllApplications(_:)),
+            keyEquivalent: ""
+        ))
+        appMenu.addItem(.separator())
+        appMenu.addItem(NSMenuItem(
+            title: "Quit Lisa",
+            action: #selector(NSApplication.terminate(_:)),
+            keyEquivalent: "q"
+        ))
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
+
+        // ── File menu ───────────────────────────────────────────────
+        let fileItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
+        let fileMenu = NSMenu(title: "File")
+        fileMenu.addItem(NSMenuItem(
+            title: "New Window",
+            action: #selector(newWindowAction(_:)),
+            keyEquivalent: "n"
+        ))
+        fileMenu.addItem(NSMenuItem(
+            title: "Close Window",
+            action: #selector(NSWindow.performClose(_:)),
+            keyEquivalent: "w"
+        ))
+        fileItem.submenu = fileMenu
+        mainMenu.addItem(fileItem)
+
+        // ── Edit menu (standard responder chain — copy/paste etc.) ──
+        let editItem = NSMenuItem(title: "Edit", action: nil, keyEquivalent: "")
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(NSMenuItem(title: "Undo", action: Selector(("undo:")), keyEquivalent: "z"))
+        let redo = NSMenuItem(title: "Redo", action: Selector(("redo:")), keyEquivalent: "z")
+        redo.keyEquivalentModifierMask = [.command, .shift]
+        editMenu.addItem(redo)
+        editMenu.addItem(.separator())
+        editMenu.addItem(NSMenuItem(title: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x"))
+        editMenu.addItem(NSMenuItem(title: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c"))
+        editMenu.addItem(NSMenuItem(title: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v"))
+        editMenu.addItem(NSMenuItem(title: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a"))
+        editItem.submenu = editMenu
+        mainMenu.addItem(editItem)
+
+        // ── View menu ───────────────────────────────────────────────
+        let viewItem = NSMenuItem(title: "View", action: nil, keyEquivalent: "")
+        let viewMenu = NSMenu(title: "View")
+        viewMenu.addItem(NSMenuItem(
+            title: "Reload Chat",
+            action: #selector(reloadChat(_:)),
+            keyEquivalent: "r"
+        ))
+        viewMenu.addItem(.separator())
+        viewMenu.addItem(NSMenuItem(
+            title: "Enter Full Screen",
+            action: #selector(NSWindow.toggleFullScreen(_:)),
+            keyEquivalent: "f"
+        ))
+        viewItem.submenu = viewMenu
+        mainMenu.addItem(viewItem)
+
+        // ── Window menu (standard) ──────────────────────────────────
+        let windowItem = NSMenuItem(title: "Window", action: nil, keyEquivalent: "")
+        let windowMenu = NSMenu(title: "Window")
+        windowMenu.addItem(NSMenuItem(
+            title: "Minimize",
+            action: #selector(NSWindow.performMiniaturize(_:)),
+            keyEquivalent: "m"
+        ))
+        windowMenu.addItem(NSMenuItem(
+            title: "Zoom",
+            action: #selector(NSWindow.performZoom(_:)),
+            keyEquivalent: ""
+        ))
+        windowMenu.addItem(.separator())
+        windowMenu.addItem(NSMenuItem(
+            title: "Bring All to Front",
+            action: #selector(NSApplication.arrangeInFront(_:)),
+            keyEquivalent: ""
+        ))
+        windowItem.submenu = windowMenu
+        mainMenu.addItem(windowItem)
+        NSApp.windowsMenu = windowMenu
+
+        NSApplication.shared.mainMenu = mainMenu
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/MainWindow.swift
+++ b/packaging/mac-client/Sources/Lisa/MainWindow.swift
@@ -1,0 +1,55 @@
+//
+//  MainWindow.swift
+//  Lisa
+//
+//  Standard Mac window hosting the chat WKWebView. Remembers position +
+//  size across launches via NSWindow's frameAutosaveName.
+//
+
+import AppKit
+
+final class MainWindow: NSWindow {
+    private static let defaultSize = CGSize(width: 1200, height: 800)
+    private static let minSize     = CGSize(width: 600, height: 500)
+
+    private let content = WebContent()
+
+    convenience init() {
+        let frame = NSRect(origin: .zero, size: Self.defaultSize)
+        self.init(
+            contentRect: frame,
+            styleMask: [
+                .titled,
+                .closable,
+                .miniaturizable,
+                .resizable,
+                .fullSizeContentView,
+            ],
+            backing: .buffered,
+            defer: false
+        )
+
+        title = "Lisa"
+        minSize = Self.minSize
+        // Title bar transparent so the chat's pixel-art background can extend
+        // edge-to-edge underneath the traffic lights.
+        titlebarAppearsTransparent = true
+        toolbarStyle = .unified
+        isReleasedWhenClosed = false   // AppDelegate keeps a strong reference
+
+        // Persist last frame across launches. The name is namespaced so we
+        // don't clash with anything else the user has in defaults.
+        setFrameAutosaveName("ai.meetlisa.app.MainWindow")
+
+        // Center on first launch (autosave restores subsequent launches).
+        if !setFrameUsingName("ai.meetlisa.app.MainWindow") {
+            center()
+        }
+
+        contentViewController = content
+    }
+
+    func reload() {
+        content.reload()
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/WebContent.swift
+++ b/packaging/mac-client/Sources/Lisa/WebContent.swift
@@ -1,0 +1,94 @@
+//
+//  WebContent.swift
+//  Lisa
+//
+//  Hosts a WKWebView loading http://localhost:5757/ — the canonical LISA
+//  chat GUI. Auto-retries on failed load (e.g. if the user opens this app
+//  before starting `lisa serve --web`).
+//
+
+import AppKit
+import WebKit
+
+final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
+    static let lisaURL = URL(string: "http://localhost:5757/")!
+
+    private var webView: WKWebView!
+    private var reloadTimer: Timer?
+
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        config.processPool = WKProcessPool()
+
+        let preferences = WKWebpagePreferences()
+        preferences.allowsContentJavaScript = true
+        config.defaultWebpagePreferences = preferences
+
+        let wv = WKWebView(frame: .zero, configuration: config)
+        wv.navigationDelegate = self
+        wv.uiDelegate = self
+        wv.autoresizingMask = [.width, .height]
+        wv.allowsBackForwardNavigationGestures = false
+        wv.allowsLinkPreview = false
+        // Custom user agent so the LISA server can recognize the client.
+        // Cosmetic — useful in server logs and (eventually) for serving a
+        // slightly different layout to native containers.
+        wv.customUserAgent = "Mozilla/5.0 (Macintosh) Lisa-MacClient/0.1"
+
+        webView = wv
+        view = wv
+
+        load()
+    }
+
+    // MARK: - Load / retry
+
+    func load() {
+        let request = URLRequest(
+            url: Self.lisaURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 5
+        )
+        webView.load(request)
+    }
+
+    func reload() {
+        webView.reloadFromOrigin()
+    }
+
+    private func scheduleReload() {
+        reloadTimer?.invalidate()
+        reloadTimer = Timer.scheduledTimer(
+            withTimeInterval: 4.0,
+            repeats: false
+        ) { [weak self] _ in
+            self?.load()
+        }
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        scheduleReload()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        scheduleReload()
+    }
+
+    // MARK: - WKUIDelegate
+
+    // Open target=_blank links in the user's default browser, not in a new
+    // WebView (we don't have new-window infrastructure).
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        if let url = navigationAction.request.url {
+            NSWorkspace.shared.open(url)
+        }
+        return nil
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/main.swift
+++ b/packaging/mac-client/Sources/Lisa/main.swift
@@ -1,0 +1,19 @@
+//
+//  main.swift
+//  Lisa — native Mac client for the LISA chat GUI.
+//
+//  Boots a regular NSApplication (regular activation policy, Dock icon
+//  visible) and hands off to AppDelegate which owns the MainWindow.
+//
+//  Sibling to LisaIsland.app (the passive observer pill). Both apps wrap
+//  the same LISA web server at localhost:5757; this one points at `/`
+//  for the full chat experience, LisaIsland points at `/island`.
+//
+
+import AppKit
+
+let app = NSApplication.shared
+let delegate = AppDelegate()
+app.delegate = delegate
+app.setActivationPolicy(.regular)
+app.run()

--- a/packaging/mac-client/build.sh
+++ b/packaging/mac-client/build.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Build Lisa.app — native Mac client hosting the full chat GUI.
+#
+# Phases:
+#   1. swift build -c release  (universal binary, falls back to host arch)
+#   2. iconset → .icns from src/web/assets/lisa-mascot.png (1024x1024)
+#   3. assemble Lisa.app bundle (Contents/MacOS, Resources, Info.plist)
+#   4. ad-hoc codesign so Gatekeeper at least doesn't reject outright
+#
+# Output: packaging/mac-client/Lisa.app
+#
+# Usage:
+#   bash build.sh           # release (default)
+#   bash build.sh --debug   # debug
+#
+set -euo pipefail
+
+CONFIG="release"
+if [ "${1:-}" = "--debug" ]; then
+    CONFIG="debug"
+fi
+
+cd "$(dirname "$0")"
+REPO_ROOT="$(cd ../.. && pwd)"
+MASCOT="$REPO_ROOT/src/web/assets/lisa-mascot.png"
+
+if [ ! -f "$MASCOT" ]; then
+    echo "✗ mascot PNG not found at $MASCOT" >&2
+    echo "  (this script expects to be run from packaging/mac-client/ inside the LISA repo)" >&2
+    exit 1
+fi
+
+# ── 1. compile ──────────────────────────────────────────────────────
+echo "▸ swift build -c $CONFIG"
+if ! swift build -c "$CONFIG" --arch arm64 --arch x86_64 2>/dev/null; then
+    echo "  (universal build failed, falling back to host arch)"
+    swift build -c "$CONFIG"
+fi
+
+BIN=""
+for candidate in \
+    ".build/apple/Products/Release/Lisa" \
+    ".build/apple/Products/Debug/Lisa" \
+    ".build/release/Lisa" \
+    ".build/debug/Lisa" ; do
+    if [ -x "$candidate" ]; then
+        BIN="$candidate"
+        break
+    fi
+done
+if [ -z "$BIN" ]; then
+    echo "✗ couldn't find compiled binary; check 'swift build' output above" >&2
+    exit 1
+fi
+echo "▸ found binary at $BIN"
+
+# ── 2. icon ─────────────────────────────────────────────────────────
+echo "▸ generating .icns from $MASCOT"
+ICONSET=".build/AppIcon.iconset"
+rm -rf "$ICONSET"
+mkdir -p "$ICONSET"
+
+# Apple's iconutil expects these specific filenames + sizes.
+declare -a SIZES=(
+    "16:icon_16x16.png"
+    "32:icon_16x16@2x.png"
+    "32:icon_32x32.png"
+    "64:icon_32x32@2x.png"
+    "128:icon_128x128.png"
+    "256:icon_128x128@2x.png"
+    "256:icon_256x256.png"
+    "512:icon_256x256@2x.png"
+    "512:icon_512x512.png"
+    "1024:icon_512x512@2x.png"
+)
+for entry in "${SIZES[@]}"; do
+    SIZE="${entry%%:*}"
+    NAME="${entry##*:}"
+    sips -z "$SIZE" "$SIZE" "$MASCOT" --out "$ICONSET/$NAME" >/dev/null
+done
+
+ICNS=".build/AppIcon.icns"
+iconutil -c icns "$ICONSET" -o "$ICNS"
+echo "▸ icon: $ICNS"
+
+# ── 3. assemble bundle ──────────────────────────────────────────────
+APP="Lisa.app"
+rm -rf "$APP"
+mkdir -p "$APP/Contents/MacOS"
+mkdir -p "$APP/Contents/Resources"
+
+cp "$BIN" "$APP/Contents/MacOS/Lisa"
+chmod +x "$APP/Contents/MacOS/Lisa"
+cp Resources/Info.plist "$APP/Contents/Info.plist"
+cp "$ICNS" "$APP/Contents/Resources/AppIcon.icns"
+
+# ── 4. ad-hoc sign ──────────────────────────────────────────────────
+# Proper signing (Developer ID + notarization) is Phase 4.
+codesign --force --deep --sign - "$APP" >/dev/null 2>&1 || true
+
+# Force Finder/Dock to pick up the new icon (the system caches by bundle path).
+touch "$APP" "$APP/Contents/Info.plist"
+
+echo ""
+echo "✓ built $(pwd)/$APP"
+echo ""
+echo "To launch:    open $APP"
+echo "To install:   cp -r $APP /Applications/"


### PR DESCRIPTION
Closes #25. Sibling to [LisaIsland.app](https://github.com/oratis/LISA/pull/24) — same WKWebView wrapper pattern, but for the **full** chat GUI rather than the always-on-top pill.

## Why a separate app

|  | LisaIsland.app | **Lisa.app** (this PR) |
|---|---|---|
| What it is | Passive observer | Active conversation |
| Dock icon | ✗ | ✓ (mascot) |
| Window chrome | borderless, transparent | standard (titlebar, traffic lights) |
| Z-order | always on top | normal; ⌘Tab works |
| Loads | \`/island\` | \`/\` (chat GUI) |
| When to use | Always running in background | Open when you want to chat |
| Activation policy | \`.accessory\` | \`.regular\` |

Install one, both, or neither. Both just hit \`localhost:5757\`; neither knows about the other.

## What's in this PR

\`packaging/mac-client/\` — a SwiftPM target that produces \`Lisa.app\`:

\`\`\`
Sources/Lisa/
├── main.swift          19 LOC  NSApplication boot (.regular policy)
├── AppDelegate.swift  175 LOC  window lifecycle + standard menu bar
├── MainWindow.swift    55 LOC  NSWindow + frame autosave
└── WebContent.swift    94 LOC  WKWebView + auto-retry + external links
```

### App icon generated at build time

\`build.sh\` runs \`sips\` + \`iconutil\` against the existing
\`src/web/assets/lisa-mascot.png\` (1024×1024) to produce the
\`.iconset\` then \`.icns\`. No binary blobs committed; the icon stays
in sync if the mascot changes.

### Standard menu bar

| Shortcut | Action |
|---|---|
| ⌘N | New / show window |
| ⌘W | Close window (app stays in Dock) |
| ⌘R | Reload chat |
| ⌘F | Toggle fullscreen |
| ⌘M | Minimize |
| ⌘H | Hide |
| ⌘Q | Quit |

### Frame autosave

NSWindow's \`frameAutosaveName\` is set to \`ai.meetlisa.app.MainWindow\`,
so window position + size persist across launches. Defaults to 1200×800
centered on first run.

### External links

\`target=_blank\` links inside the chat (e.g. someone shares a URL)
open in the user's default browser via \`NSWorkspace.shared.open\`
rather than spawning a new in-app WebView.

## Verified locally

✓ \`bash build.sh\` succeeds; produces universal binary (arm64 + x86_64)
✓ \`Lisa.app/Contents/Resources/AppIcon.icns\` generated (~1 MB)
✓ App launches; mascot icon appears in Dock
✓ Two ESTABLISHED connections to localhost:5757 (page + \`/events\` SSE)
✓ \`⌘W\` closes window; \`⌘Q\` quits; Dock click reopens after \`⌘W\`
✓ \`⌘R\` reloads
✓ Runs simultaneously with LisaIsland.app — both reach LISA independently

## Verification

\`\`\`sh
lisa serve --web
cd packaging/mac-client
bash build.sh
open Lisa.app
\`\`\`

## Out of scope

- Multi-window — single window for now
- URL scheme integration with LisaIsland (\`open_full_gui\` could deep-link to Lisa.app instead of opening Safari) — separate small PR if/when desired
- Native menu commands talking to LISA's REST endpoints — separate small PRs (\`⌘N\` → \`POST /api/birth\` for new soul, etc.)
- Apple Developer ID signing + notarization + Homebrew Cask — Phase 4 of MAC_ISLAND_PLAN

## Diff stat

| File | LOC |
|---|---|
| \`Sources/Lisa/*.swift\` | 343 |
| \`Package.swift\` | 13 |
| \`Resources/Info.plist\` | 45 |
| \`build.sh\` | 109 |
| \`README.md\` | 101 |
| \`.gitignore\` | 14 |
| **Total** | **625** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)