### PR TITLE
feat(claude-code): Phase 1 + 2 + 3 — watcher + state parser + notifications + history trail

### DIFF
--- a/src/integrations/claude-code/parser.ts
+++ b/src/integrations/claude-code/parser.ts
@@ -1,0 +1,196 @@
+/**
+ * Claude Code session state parser — Phase 2 of issue #27.
+ *
+ * Reads the TAIL of a session jsonl (last 32KB max) to derive whether
+ * Claude Code is currently:
+ *
+ *   - "working"  — Claude is mid-turn (tool call in flight, or assistant
+ *                  streaming, or user just sent something)
+ *   - "waiting"  — Claude finished (stopReason: end_turn) and is now
+ *                  awaiting the next user message; OR Claude requested a
+ *                  tool that needs permission
+ *   - "error"    — most recent meaningful line has is_error: true,
+ *                  hookErrors > 0, or an explicit error envelope
+ *   - "unknown"  — couldn't decide (file empty, malformed, only meta
+ *                  entries)
+ *
+ * ── PRIVACY CONTRACT (extends watcher.ts) ──────────────────────────
+ *
+ *   We DO read jsonl in this module — necessary to derive state —
+ *   but we ONLY ever inspect structural / metadata fields:
+ *
+ *     • type
+ *     • stopReason
+ *     • is_error / error
+ *     • hookErrors / hookCount
+ *     • subtype
+ *
+ *   We NEVER read, log, transmit, or persist `content`, `text`,
+ *   `message.content`, prompts, or replies. The parser destructures
+ *   only the fields above and discards the rest. A reviewer can audit
+ *   the entire module in 60 seconds — search for `content` or `text`
+ *   should produce zero hits except in comments like this one.
+ *
+ * ── ROBUSTNESS ──────────────────────────────────────────────────────
+ *
+ *   Claude Code's jsonl format may change between versions. Unknown
+ *   shapes return "unknown" rather than throwing. Malformed JSON lines
+ *   are skipped. Partial writes during streaming are tolerated (we
+ *   take the LAST complete line). File deletion mid-parse returns
+ *   "unknown".
+ */
+
+import fsp from "node:fs/promises";
+
+export type ClaudeSessionState = "working" | "waiting" | "error" | "unknown";
+
+export interface SessionStateInfo {
+  state: ClaudeSessionState;
+  /** Short label for tooltips / debugging — never user content. */
+  reason: string;
+}
+
+const META_TYPES = new Set([
+  "ai-title",
+  "custom-title",
+  "last-prompt",
+  "queue-operation",
+  "attachment",
+]);
+
+const TAIL_BYTES = 32 * 1024;
+
+export async function parseSessionState(filePath: string): Promise<SessionStateInfo> {
+  let size: number;
+  try {
+    const st = await fsp.stat(filePath);
+    if (!st.isFile()) return { state: "unknown", reason: "not-a-file" };
+    size = st.size;
+  } catch {
+    return { state: "unknown", reason: "stat-failed" };
+  }
+  if (size === 0) return { state: "unknown", reason: "empty" };
+
+  let tail: string;
+  try {
+    const fd = await fsp.open(filePath, "r");
+    try {
+      const length = Math.min(TAIL_BYTES, size);
+      const buf = Buffer.alloc(length);
+      await fd.read(buf, 0, length, size - length);
+      tail = buf.toString("utf8");
+    } finally {
+      await fd.close();
+    }
+  } catch {
+    return { state: "unknown", reason: "read-failed" };
+  }
+
+  // Drop the first partial line if we didn't read from the very start —
+  // it might be truncated mid-record. (Doesn't matter for our purposes
+  // since we walk from the bottom anyway, but cheap insurance.)
+  const lines = tail.split("\n").filter(Boolean);
+  if (size > TAIL_BYTES && lines.length > 0) lines.shift();
+
+  // Walk bottom-up, skip meta entries, decide on the first real one.
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const decision = decide(lines[i]!);
+    if (decision !== null) return decision;
+  }
+  return { state: "unknown", reason: "only-meta" };
+}
+
+/**
+ * Parse one jsonl line and decide whether it carries enough info to
+ * declare a state. Returns null to mean "keep walking" (meta or
+ * unparseable).
+ *
+ * Destructures only metadata fields. Never touches content / text /
+ * message bodies.
+ */
+function decide(line: string): SessionStateInfo | null {
+  let entry: unknown;
+  try {
+    entry = JSON.parse(line);
+  } catch {
+    return null;
+  }
+  if (!entry || typeof entry !== "object") return null;
+  const e = entry as Record<string, unknown>;
+
+  const type = readString(e.type);
+  if (!type) return null;
+  if (META_TYPES.has(type)) return null;
+
+  // Privacy: from this point on we only ever read metadata fields.
+  // Real Claude Code jsonl puts stop_reason nested under .message —
+  // we read it via a typed accessor that never touches .message.content.
+  const stopReason = readNestedStopReason(e);
+  const subtype = readString(e.subtype);
+  const isError = e.is_error === true || e.error === true;
+  const hookErrors = typeof e.hookErrors === "number" && (e.hookErrors as number) > 0;
+
+  if (isError || hookErrors) {
+    return { state: "error", reason: "is_error" };
+  }
+
+  if (type === "assistant") {
+    // `end_turn` = Claude finished talking, waiting for user reply
+    // `tool_use` = Claude wants to run a tool. In Claude Code this is
+    //              usually mid-loop (tool runs, result comes back,
+    //              Claude continues) — so we report "working" unless
+    //              the tool requires permission, which surfaces as a
+    //              separate system entry we'd see later.
+    if (stopReason === "end_turn")      return { state: "waiting", reason: "end_turn" };
+    if (stopReason === "tool_use")      return { state: "working", reason: "tool_use" };
+    if (stopReason === "max_tokens")    return { state: "waiting", reason: "max_tokens" };
+    if (stopReason === "stop_sequence") return { state: "waiting", reason: "stop_sequence" };
+    // Unknown / no stop_reason yet — likely streaming in progress.
+    return { state: "working", reason: "assistant" };
+  }
+
+  if (type === "user") {
+    // The user just typed — Claude is about to (or already) respond.
+    return { state: "working", reason: "user" };
+  }
+
+  if (type === "tool_use") {
+    return { state: "working", reason: "tool_use" };
+  }
+
+  if (type === "system") {
+    // Permission prompts often come as system entries with a
+    // subtype like "permission_request" / "tool_permission". Treat
+    // them as "waiting" (user needs to approve).
+    if (subtype && /permission/i.test(subtype)) {
+      return { state: "waiting", reason: "permission" };
+    }
+    // Other system entries are transient — keep walking.
+    return null;
+  }
+
+  // Unknown but non-meta type — keep walking; if everything above
+  // turns out to be unknown, the caller's loop will fall through to
+  // "unknown" anyway.
+  return null;
+}
+
+function readString(v: unknown): string | undefined {
+  return typeof v === "string" ? v : undefined;
+}
+
+/**
+ * Claude Code stores stop_reason nested under `.message.stop_reason`
+ * (snake_case). We extract ONLY that one field; `.message.content`,
+ * `.message.text`, etc. are deliberately never touched.
+ */
+function readNestedStopReason(e: Record<string, unknown>): string | undefined {
+  const direct = readString(e.stopReason) ?? readString(e.stop_reason);
+  if (direct) return direct;
+  const msg = e.message;
+  if (msg && typeof msg === "object") {
+    const m = msg as Record<string, unknown>;
+    return readString(m.stop_reason) ?? readString(m.stopReason);
+  }
+  return undefined;
+}

--- a/src/integrations/claude-code/watcher.ts
+++ b/src/integrations/claude-code/watcher.ts
@@ -1,0 +1,279 @@
+/**
+ * Claude Code session monitor — Phase 1.
+ *
+ * Watches ~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl for activity
+ * from Claude Code's CLI / IDE clients. Emits an `update` event whenever
+ * a session jsonl appears (new) or grows (message). LISA's web server
+ * subscribes and broadcasts to /events SSE so the island widget and other
+ * surfaces can render a "Claude is busy" indicator.
+ *
+ * ── PRIVACY CONTRACT ────────────────────────────────────────────────
+ *
+ *   This module NEVER reads the jsonl message contents. Only:
+ *     - filename / directory name (= encoded cwd)
+ *     - mtime
+ *     - size in bytes
+ *
+ *   The user's prompts and Claude's replies stay in their files. We do
+ *   not parse, log, or transmit them anywhere. Phase 2 might add an
+ *   opt-in parser to detect "waiting for permission" semantics — that
+ *   will be a separate, explicit decision.
+ *
+ * ── DEPENDENCIES ────────────────────────────────────────────────────
+ *
+ *   None added. Uses only `node:fs` (`fs.watch` with `recursive: true`
+ *   works on macOS 10.5+ and Windows 10+ — perfect for our target).
+ *
+ * ── EVENT SEMANTICS ─────────────────────────────────────────────────
+ *
+ *   - "new"     — a session jsonl appeared we hadn't seen before
+ *   - "message" — an existing session jsonl grew (debounced 200ms so a
+ *                 fast token stream doesn't fire a flood)
+ *   - (Phase 2) "waiting" / "completed" / "error" — needs jsonl parse
+ *
+ *   Active = mtime within ACTIVE_WINDOW_MS (30 min). listActive()
+ *   returns sessions sorted newest-first, capped at MAX_LISTED.
+ */
+
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { EventEmitter } from "node:events";
+
+const CLAUDE_HOME       = process.env.CLAUDE_HOME ?? path.join(os.homedir(), ".claude");
+const PROJECTS_DIR      = path.join(CLAUDE_HOME, "projects");
+const DEBOUNCE_MS       = 200;
+const ACTIVE_WINDOW_MS  = 30 * 60_000;
+const MAX_LISTED        = 10;
+
+/**
+ * One row in the in-memory session map. We hold mtime + size only —
+ * never any jsonl content.
+ */
+export interface ClaudeSessionInfo {
+  /** Encoded form, e.g. "-Users-oratis-Projects-Adex" */
+  projectEncoded: string;
+  /** Best-effort display label, e.g. "Adex" */
+  projectLabel: string;
+  /** UUID (.jsonl basename without extension) */
+  sessionId: string;
+  /** Last modification time (epoch ms) */
+  lastMtime: number;
+  /** Size in bytes (rough indicator of message volume) */
+  size: number;
+}
+
+export interface ClaudeSessionUpdate {
+  event: "new" | "message";
+  projectEncoded: string;
+  projectLabel: string;
+  sessionId: string;
+  ts: string; // ISO
+}
+
+type Log = (msg: string) => void;
+
+export class ClaudeCodeWatcher extends EventEmitter {
+  private sessions = new Map<string, ClaudeSessionInfo>(); // key = full path
+  private watcher: fs.FSWatcher | null = null;
+  private retryTimer: NodeJS.Timeout | null = null;
+  private pendingChanges = new Map<string, NodeJS.Timeout>();
+  private readonly log: Log;
+  private started = false;
+
+  constructor(opts: { log?: Log } = {}) {
+    super();
+    this.log = opts.log ?? (() => {});
+    this.setMaxListeners(32);
+  }
+
+  /** Begin watching. Idempotent. Survives ~/.claude/projects not existing yet. */
+  async start(): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    await this.initialScan();
+    await this.attachWatcher();
+  }
+
+  stop(): void {
+    this.started = false;
+    this.watcher?.close();
+    this.watcher = null;
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+    for (const t of this.pendingChanges.values()) clearTimeout(t);
+    this.pendingChanges.clear();
+  }
+
+  /** Sessions modified in the last 30 min, newest first, capped. */
+  listActive(): ClaudeSessionInfo[] {
+    const cutoff = Date.now() - ACTIVE_WINDOW_MS;
+    return [...this.sessions.values()]
+      .filter((s) => s.lastMtime >= cutoff)
+      .sort((a, b) => b.lastMtime - a.lastMtime)
+      .slice(0, MAX_LISTED);
+  }
+
+  // ── Internals ────────────────────────────────────────────────────
+
+  private async initialScan(): Promise<void> {
+    let projectDirs: string[];
+    try {
+      projectDirs = await fsp.readdir(PROJECTS_DIR);
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      if (e.code !== "ENOENT") {
+        this.log(`[claude-code] initial scan failed: ${e.message}`);
+      }
+      return;
+    }
+
+    for (const dir of projectDirs) {
+      if (dir.startsWith(".")) continue;
+      const projectPath = path.join(PROJECTS_DIR, dir);
+      let sessionFiles: string[] = [];
+      try {
+        sessionFiles = await fsp.readdir(projectPath);
+      } catch {
+        continue;
+      }
+      for (const f of sessionFiles) {
+        if (!f.endsWith(".jsonl")) continue;
+        const full = path.join(projectPath, f);
+        await this.recordExisting(full);
+      }
+    }
+    this.log(`[claude-code] initial scan: ${this.sessions.size} session(s) seen`);
+  }
+
+  private async recordExisting(filePath: string): Promise<void> {
+    try {
+      const st = await fsp.stat(filePath);
+      if (!st.isFile()) return;
+      const info = this.makeInfo(filePath, st.mtimeMs, st.size);
+      this.sessions.set(filePath, info);
+    } catch {
+      // ignore — file disappeared between readdir and stat
+    }
+  }
+
+  private async attachWatcher(): Promise<void> {
+    try {
+      await fsp.access(PROJECTS_DIR);
+    } catch {
+      // Directory doesn't exist (user hasn't run Claude Code yet).
+      // Poll every 30s for its appearance; once it shows up, attach.
+      this.scheduleRetry();
+      return;
+    }
+    try {
+      this.watcher = fs.watch(
+        PROJECTS_DIR,
+        { recursive: true, persistent: false },
+        (_eventType, filename) => {
+          if (filename) this.handleFsEvent(filename);
+        },
+      );
+      this.watcher.on("error", (err) => {
+        this.log(`[claude-code] watcher error: ${err.message}; will retry`);
+        this.watcher?.close();
+        this.watcher = null;
+        this.scheduleRetry();
+      });
+      this.log(`[claude-code] watching ${PROJECTS_DIR}`);
+    } catch (err) {
+      this.log(`[claude-code] failed to attach: ${(err as Error).message}; retrying`);
+      this.scheduleRetry();
+    }
+  }
+
+  private scheduleRetry(): void {
+    if (this.retryTimer || !this.started) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      void this.attachWatcher();
+    }, 30_000);
+  }
+
+  /**
+   * fs.watch fires the relative path of the changed entry. We debounce
+   * to coalesce rapid streaming writes into one `message` event per
+   * burst.
+   */
+  private handleFsEvent(filename: string): void {
+    if (!filename.endsWith(".jsonl")) return;
+    const full = path.join(PROJECTS_DIR, filename);
+    const existing = this.pendingChanges.get(full);
+    if (existing) clearTimeout(existing);
+    this.pendingChanges.set(
+      full,
+      setTimeout(() => {
+        this.pendingChanges.delete(full);
+        void this.diff(full);
+      }, DEBOUNCE_MS),
+    );
+  }
+
+  private async diff(fullPath: string): Promise<void> {
+    let st: fs.Stats;
+    try {
+      st = await fsp.stat(fullPath);
+    } catch {
+      // file was deleted — drop from map silently (no `ended` event in Phase 1)
+      this.sessions.delete(fullPath);
+      return;
+    }
+    if (!st.isFile()) return;
+
+    const prev = this.sessions.get(fullPath);
+    const info = this.makeInfo(fullPath, st.mtimeMs, st.size);
+    this.sessions.set(fullPath, info);
+
+    if (!prev) {
+      this.emitUpdate("new", info);
+      return;
+    }
+    if (st.size !== prev.size || st.mtimeMs !== prev.lastMtime) {
+      this.emitUpdate("message", info);
+    }
+  }
+
+  private emitUpdate(event: "new" | "message", info: ClaudeSessionInfo): void {
+    const payload: ClaudeSessionUpdate = {
+      event,
+      projectEncoded: info.projectEncoded,
+      projectLabel: info.projectLabel,
+      sessionId: info.sessionId,
+      ts: new Date().toISOString(),
+    };
+    this.emit("update", payload);
+  }
+
+  private makeInfo(filePath: string, mtimeMs: number, size: number): ClaudeSessionInfo {
+    const sessionId = path.basename(filePath, ".jsonl");
+    const projectEncoded = path.basename(path.dirname(filePath));
+    return {
+      projectEncoded,
+      projectLabel: decodeProjectLabel(projectEncoded),
+      sessionId,
+      lastMtime: mtimeMs,
+      size,
+    };
+  }
+}
+
+/**
+ * `~/.claude/projects/-Users-oratis-Projects-Adex` → "Adex".
+ * Heuristic: strip a leading dash, replace remaining dashes with slashes,
+ * take the basename. Falls back to the raw encoded form if the result
+ * looks broken (no `/`, suspiciously empty).
+ */
+export function decodeProjectLabel(encoded: string): string {
+  if (!encoded.startsWith("-")) return encoded;
+  const asPath = "/" + encoded.slice(1).replace(/-/g, "/");
+  const base = path.basename(asPath);
+  if (!base || base === "/") return encoded;
+  return base;
+}
+
+export const CLAUDE_PROJECTS_DIR = PROJECTS_DIR;

--- a/src/integrations/claude-code/watcher.ts
+++ b/src/integrations/claude-code/watcher.ts
@@ -40,6 +40,7 @@ import fsp from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { EventEmitter } from "node:events";
+import { parseSessionState, type ClaudeSessionState } from "./parser.js";
 
 const CLAUDE_HOME       = process.env.CLAUDE_HOME ?? path.join(os.homedir(), ".claude");
 const PROJECTS_DIR      = path.join(CLAUDE_HOME, "projects");
@@ -62,13 +63,19 @@ export interface ClaudeSessionInfo {
   lastMtime: number;
   /** Size in bytes (rough indicator of message volume) */
   size: number;
+  /** Derived state — Phase 2; see parser.ts. */
+  state: ClaudeSessionState;
+  /** Short reason label for the derived state (debugging / tooltip). */
+  stateReason: string;
 }
 
 export interface ClaudeSessionUpdate {
-  event: "new" | "message";
+  event: "new" | "message" | "state_changed";
   projectEncoded: string;
   projectLabel: string;
   sessionId: string;
+  state: ClaudeSessionState;
+  stateReason: string;
   ts: string; // ISO
 }
 
@@ -150,7 +157,8 @@ export class ClaudeCodeWatcher extends EventEmitter {
     try {
       const st = await fsp.stat(filePath);
       if (!st.isFile()) return;
-      const info = this.makeInfo(filePath, st.mtimeMs, st.size);
+      const { state, reason } = await parseSessionState(filePath);
+      const info = this.makeInfo(filePath, st.mtimeMs, st.size, state, reason);
       this.sessions.set(filePath, info);
     } catch {
       // ignore — file disappeared between readdir and stat
@@ -226,30 +234,46 @@ export class ClaudeCodeWatcher extends EventEmitter {
     if (!st.isFile()) return;
 
     const prev = this.sessions.get(fullPath);
-    const info = this.makeInfo(fullPath, st.mtimeMs, st.size);
+    const { state, reason } = await parseSessionState(fullPath);
+    const info = this.makeInfo(fullPath, st.mtimeMs, st.size, state, reason);
     this.sessions.set(fullPath, info);
 
     if (!prev) {
       this.emitUpdate("new", info);
       return;
     }
-    if (st.size !== prev.size || st.mtimeMs !== prev.lastMtime) {
+    const grew = st.size !== prev.size || st.mtimeMs !== prev.lastMtime;
+    const stateChanged = prev.state !== info.state;
+    if (grew) {
+      // A "message" event implicitly reports the new state too.
       this.emitUpdate("message", info);
+    } else if (stateChanged) {
+      // Rare path: file mtime/size unchanged but parse derived a
+      // different state. Emit a state-only event so the UI can react.
+      this.emitUpdate("state_changed", info);
     }
   }
 
-  private emitUpdate(event: "new" | "message", info: ClaudeSessionInfo): void {
+  private emitUpdate(event: "new" | "message" | "state_changed", info: ClaudeSessionInfo): void {
     const payload: ClaudeSessionUpdate = {
       event,
       projectEncoded: info.projectEncoded,
       projectLabel: info.projectLabel,
       sessionId: info.sessionId,
+      state: info.state,
+      stateReason: info.stateReason,
       ts: new Date().toISOString(),
     };
     this.emit("update", payload);
   }
 
-  private makeInfo(filePath: string, mtimeMs: number, size: number): ClaudeSessionInfo {
+  private makeInfo(
+    filePath: string,
+    mtimeMs: number,
+    size: number,
+    state: ClaudeSessionState,
+    stateReason: string,
+  ): ClaudeSessionInfo {
     const sessionId = path.basename(filePath, ".jsonl");
     const projectEncoded = path.basename(path.dirname(filePath));
     return {
@@ -258,6 +282,8 @@ export class ClaudeCodeWatcher extends EventEmitter {
       sessionId,
       lastMtime: mtimeMs,
       size,
+      state,
+      stateReason,
     };
   }
 }

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -92,11 +92,15 @@ export const ISLAND_HTML = `<!doctype html>
     background: transparent;
     flex-shrink: 0;
   }
-  #dot.thinking      { background: var(--accent);        animation: pulse 1.2s ease-in-out infinite; }
-  #dot.dreaming      { background: var(--accent-dream);  animation: pulse 2.4s ease-in-out infinite; }
-  #dot.unread        { background: var(--accent-warm); }
-  #dot.claude-active { background: var(--accent-claude); animation: pulse 1.8s ease-in-out infinite; }
-  #dot.offline       { background: var(--fg-faint); }
+  #dot.thinking       { background: var(--accent);         animation: pulse 1.2s ease-in-out infinite; }
+  #dot.dreaming       { background: var(--accent-dream);   animation: pulse 2.4s ease-in-out infinite; }
+  #dot.unread         { background: var(--accent-warm); }
+  /* Phase 2: pill dot reflects the strongest signal across all
+     Claude sessions. */
+  #dot.claude-working { background: var(--accent-claude);  animation: pulse 1.8s ease-in-out infinite; }
+  #dot.claude-waiting { background: var(--accent-claude); }  /* solid — "needs you" */
+  #dot.claude-error   { background: #ff5577;               animation: pulse 0.8s ease-in-out infinite; }
+  #dot.offline        { background: var(--fg-faint); }
 
   @keyframes pulse {
     0%, 100% { opacity: 0.35; }
@@ -186,6 +190,20 @@ export const ISLAND_HTML = `<!doctype html>
   #claude-list .when { color: var(--fg-dim); flex-shrink: 0; font-variant-numeric: tabular-nums; }
   #claude-list .empty { padding: 6px 10px; color: var(--fg-faint); font-style: italic; }
 
+  /* Phase 2 — per-session state pip prefix */
+  #claude-list .pip {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: var(--fg-faint);
+    margin-right: 2px;
+  }
+  #claude-list .pip.working { background: var(--accent-claude); animation: pulse 1.8s ease-in-out infinite; }
+  #claude-list .pip.waiting { background: var(--accent-claude); }
+  #claude-list .pip.error   { background: #ff5577; }
+  #claude-list .pip.unknown { background: var(--fg-faint); }
+
   #actions {
     display: flex;
     gap: 6px;
@@ -264,10 +282,26 @@ export const ISLAND_HTML = `<!doctype html>
 
   // 30-min activity window matches the watcher's ACTIVE_WINDOW_MS.
   const CLAUDE_ACTIVE_WINDOW_MS = 30 * 60 * 1000;
-  function isClaudeActive() {
-    return state.claudeSessions.some((s) =>
-      Date.now() - new Date(s.lastMtime).getTime() < CLAUDE_ACTIVE_WINDOW_MS
+  function recentSessions() {
+    const cutoff = Date.now() - CLAUDE_ACTIVE_WINDOW_MS;
+    return state.claudeSessions.filter(
+      (s) => new Date(s.lastMtime).getTime() >= cutoff
     );
+  }
+  /**
+   * Phase 2: aggregate Claude state for the pill dot. Priority is
+   * "loudest signal wins": an error anywhere dominates everything;
+   * otherwise a "waiting" session beats a "working" session (because
+   * "waiting" means Claude needs the user — more attention-worthy
+   * than "working" which is passive observing).
+   */
+  function aggregateClaudeState() {
+    const recent = recentSessions();
+    if (recent.length === 0) return null;
+    if (recent.some((s) => s.state === 'error'))   return 'error';
+    if (recent.some((s) => s.state === 'waiting')) return 'waiting';
+    if (recent.some((s) => s.state === 'working')) return 'working';
+    return null;
   }
 
   function setAvatar(slug) {
@@ -280,12 +314,15 @@ export const ISLAND_HTML = `<!doctype html>
     dot.className = '';
     // Priority: LISA's own state (offline / thinking / dreaming / unread)
     // always wins over the Claude-Code-monitor indicator — the pill is
-    // primarily about her, the orange dot is a quieter "by the way".
-    if (!state.online)             { dot.classList.add('offline');       return; }
-    if (state.thinking)            { dot.classList.add('thinking');      return; }
-    if (state.dreaming)            { dot.classList.add('dreaming');      return; }
-    if (state.unread)              { dot.classList.add('unread');        return; }
-    if (isClaudeActive())          { dot.classList.add('claude-active'); return; }
+    // primarily about her, the Claude dot is a quieter "by the way".
+    if (!state.online)  { dot.classList.add('offline');  return; }
+    if (state.thinking) { dot.classList.add('thinking'); return; }
+    if (state.dreaming) { dot.classList.add('dreaming'); return; }
+    if (state.unread)   { dot.classList.add('unread');   return; }
+    const claude = aggregateClaudeState();
+    if (claude === 'error')   { dot.classList.add('claude-error');   return; }
+    if (claude === 'waiting') { dot.classList.add('claude-waiting'); return; }
+    if (claude === 'working') { dot.classList.add('claude-working'); return; }
   }
 
   function refreshPanel() {
@@ -308,35 +345,42 @@ export const ISLAND_HTML = `<!doctype html>
   }
 
   function renderClaudeList() {
-    const n = state.claudeSessions.length;
-    claudeCount.textContent = String(n);
+    const recent = recentSessions();
+    claudeCount.textContent = String(recent.length);
     while (claudeList.firstChild) claudeList.removeChild(claudeList.firstChild);
-    if (n === 0) {
+    if (recent.length === 0) {
       const li = document.createElement('li');
       li.className = 'empty';
       li.textContent = '(idle)';
       claudeList.appendChild(li);
       return;
     }
-    // Sort newest first, cap at 5.
-    const rows = state.claudeSessions
-      .slice()
-      .sort((a, b) => new Date(b.lastMtime).getTime() - new Date(a.lastMtime).getTime())
-      .slice(0, 5);
+    // Sort: errors first, then waiting, then working, then by mtime.
+    const stateRank = { error: 0, waiting: 1, working: 2, unknown: 3 };
+    const rows = recent.slice().sort((a, b) => {
+      const ra = stateRank[a.state] ?? 9;
+      const rb = stateRank[b.state] ?? 9;
+      if (ra !== rb) return ra - rb;
+      return new Date(b.lastMtime).getTime() - new Date(a.lastMtime).getTime();
+    }).slice(0, 5);
     for (const s of rows) {
       const li = document.createElement('li');
+      const pip = document.createElement('span');
+      pip.className = 'pip ' + (s.state || 'unknown');
       const proj = document.createElement('span');
       proj.className = 'proj';
       proj.textContent = s.project;
       const when = document.createElement('span');
       when.className = 'when';
       when.textContent = relativeTime(s.lastMtime);
+      li.appendChild(pip);
       li.appendChild(proj);
       li.appendChild(when);
-      li.title = s.sessionId;
+      li.title = s.state + (s.stateReason ? ' (' + s.stateReason + ')' : '')
+               + ' · ' + s.sessionId;
       li.addEventListener('click', async () => {
-        // Phase 1: copy session id to clipboard. Phase 2 will add a
-        // URL-scheme handoff for "open in iTerm at this session".
+        // Phase 2 still copies sessionId; Phase 3 will URL-scheme handoff
+        // to iTerm / Warp at the right pane.
         try { await navigator.clipboard.writeText(s.sessionId); } catch (_) {}
       });
       claudeList.appendChild(li);
@@ -458,14 +502,15 @@ export const ISLAND_HTML = `<!doctype html>
           break;
         case 'claude_session_update':
           // Watcher noticed activity in ~/.claude/projects/. Splice the
-          // updated session into our local list and re-render. The list
-          // is kept short — we cap on render — so unbounded growth isn't
-          // a concern, but we still drop stale entries from time to time.
+          // updated session into our local list (with its newly-derived
+          // state) and re-render.
           upsertClaudeSession({
             project: m.projectLabel,
             projectEncoded: m.projectEncoded,
             sessionId: m.sessionId,
             lastMtime: m.ts,
+            state: m.state || 'unknown',
+            stateReason: m.stateReason || '',
           });
           refreshDot();
           refreshPanel();
@@ -510,6 +555,8 @@ export const ISLAND_HTML = `<!doctype html>
           projectEncoded: s.projectEncoded,
           sessionId: s.sessionId,
           lastMtime: s.lastMtime,
+          state: s.state || 'unknown',
+          stateReason: s.stateReason || '',
         }));
       }
     } catch (_) {

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -204,6 +204,49 @@ export const ISLAND_HTML = `<!doctype html>
   #claude-list .pip.error   { background: #ff5577; }
   #claude-list .pip.unknown { background: var(--fg-faint); }
 
+  /* Phase 3 — state transition trail, shown below the row when its
+     parent <li> has the .expanded class. */
+  #claude-list .trail {
+    display: none;
+    margin: 4px 0 0 14px;
+    padding: 4px 0 0;
+    border-top: 1px dashed rgba(255, 140, 66, 0.18);
+    font-size: 10px;
+    color: var(--fg-faint);
+    line-height: 1.6;
+  }
+  #claude-list li.row-open .trail { display: block; }
+  #claude-list .trail .tdot {
+    display: inline-block;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    margin-right: 4px;
+    vertical-align: 0;
+    background: var(--fg-faint);
+  }
+  #claude-list .trail .tdot.working { background: var(--accent-claude); }
+  #claude-list .trail .tdot.waiting { background: var(--accent-claude); opacity: 0.7; }
+  #claude-list .trail .tdot.error   { background: #ff5577; }
+  #claude-list li > .head { display: contents; }
+
+  /* Phase 3 — notification opt-in chip */
+  #notify-cta {
+    display: none;
+    margin-top: 8px;
+    padding: 6px 10px;
+    border-radius: 8px;
+    background: rgba(255, 140, 66, 0.12);
+    border: 1px solid rgba(255, 140, 66, 0.30);
+    font-size: 10.5px;
+    color: var(--fg);
+    text-align: center;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+  #notify-cta:hover { background: rgba(255, 140, 66, 0.18); }
+  body.notify-default #notify-cta { display: block; }
+
   #actions {
     display: flex;
     gap: 6px;
@@ -248,6 +291,7 @@ export const ISLAND_HTML = `<!doctype html>
     <div id="claude-section">
       <div class="section-label">claude code · <span id="claude-count">0</span> active</div>
       <ul id="claude-list"></ul>
+      <div id="notify-cta" role="button" tabindex="0">🔔 Notify me when Claude is waiting</div>
     </div>
     <div id="actions">
       <button id="btn-open">Open chat</button>
@@ -265,6 +309,7 @@ export const ISLAND_HTML = `<!doctype html>
   const idleBody     = document.getElementById('idle-body');
   const claudeList   = document.getElementById('claude-list');
   const claudeCount  = document.getElementById('claude-count');
+  const notifyCta    = document.getElementById('notify-cta');
   const btnOpen      = document.getElementById('btn-open');
   const btnDismiss   = document.getElementById('btn-dismiss');
   const body         = document.body;
@@ -282,6 +327,80 @@ export const ISLAND_HTML = `<!doctype html>
 
   // 30-min activity window matches the watcher's ACTIVE_WINDOW_MS.
   const CLAUDE_ACTIVE_WINDOW_MS = 30 * 60 * 1000;
+
+  // Phase 3 — in-memory state transition history per session.
+  // Map<sessionId, [{state, reason, ts}, …]> capped at MAX_HISTORY.
+  // Pure UI memory; not persisted, not transmitted.
+  const stateHistory = new Map();
+  const MAX_HISTORY = 8;
+  // Per-session opened-state for the inline trail in the expand list.
+  const rowOpen = new Set();
+
+  function recordStateHistory(sessionId, info) {
+    let h = stateHistory.get(sessionId);
+    if (!h) { h = []; stateHistory.set(sessionId, h); }
+    const last = h[h.length - 1];
+    if (last && last.state === info.state && last.reason === info.reason) {
+      // Same state, just refresh timestamp — collapse repeats.
+      last.ts = info.lastMtime;
+      return false;
+    }
+    h.push({ state: info.state, reason: info.reason, ts: info.lastMtime });
+    while (h.length > MAX_HISTORY) h.shift();
+    return true; // transition happened
+  }
+
+  // ── Phase 3 — Notification API ───────────────────────────────────
+  // Fires "Claude needs you in <project>" notifications when a session
+  // transitions INTO waiting (i.e., Claude finished and the user is
+  // expected to respond). Throttled per session so a flaky tool that
+  // bounces between waiting/working doesn't spam. Permission opt-in
+  // via the chip in the expand panel.
+  const NOTIFY_THROTTLE_MS = 60_000;
+  const lastNotifyAt = new Map();
+
+  function notifPermission() {
+    return ('Notification' in window) ? Notification.permission : 'unsupported';
+  }
+
+  function refreshNotifyCta() {
+    body.classList.toggle('notify-default', notifPermission() === 'default');
+  }
+
+  function requestNotificationPermission() {
+    if (!('Notification' in window) || Notification.permission !== 'default') {
+      refreshNotifyCta();
+      return;
+    }
+    Notification.requestPermission().then(() => refreshNotifyCta()).catch(() => {});
+  }
+
+  function maybeNotifyWaiting(prevState, info) {
+    if (info.state !== 'waiting') return;
+    if (prevState === 'waiting') return;     // already in this state
+    if (notifPermission() !== 'granted') return;
+    const last = lastNotifyAt.get(info.sessionId) || 0;
+    if (Date.now() - last < NOTIFY_THROTTLE_MS) return;
+    lastNotifyAt.set(info.sessionId, Date.now());
+    try {
+      const reasonLabel = info.reason === 'permission' ? 'needs permission' : 'is waiting';
+      const n = new Notification('Claude ' + reasonLabel + ' in ' + info.project, {
+        body: info.sessionId.slice(0, 8) + ' · click to open Lisa',
+        tag: 'lisa-claude-' + info.sessionId, // replaces older for same session
+        icon: '/assets/lisa-mascot.png',
+        silent: false,
+      });
+      n.onclick = () => {
+        window.focus();
+        if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.island) {
+          window.webkit.messageHandlers.island.postMessage({ type: 'open_full_gui' });
+        } else {
+          window.open('/', '_blank');
+        }
+        n.close();
+      };
+    } catch (_) { /* unsupported, ignore */ }
+  }
   function recentSessions() {
     const cutoff = Date.now() - CLAUDE_ACTIVE_WINDOW_MS;
     return state.claudeSessions.filter(
@@ -365,6 +484,7 @@ export const ISLAND_HTML = `<!doctype html>
     }).slice(0, 5);
     for (const s of rows) {
       const li = document.createElement('li');
+      if (rowOpen.has(s.sessionId)) li.classList.add('row-open');
       const pip = document.createElement('span');
       pip.className = 'pip ' + (s.state || 'unknown');
       const proj = document.createElement('span');
@@ -376,14 +496,51 @@ export const ISLAND_HTML = `<!doctype html>
       li.appendChild(pip);
       li.appendChild(proj);
       li.appendChild(when);
+
+      // Phase 3 — collapsible state-transition trail
+      const trail = document.createElement('div');
+      trail.className = 'trail';
+      renderTrail(trail, s);
+      li.appendChild(trail);
+
       li.title = s.state + (s.stateReason ? ' (' + s.stateReason + ')' : '')
-               + ' · ' + s.sessionId;
-      li.addEventListener('click', async () => {
-        // Phase 2 still copies sessionId; Phase 3 will URL-scheme handoff
-        // to iTerm / Warp at the right pane.
+               + ' · ' + s.sessionId
+               + '\nclick: expand timeline · double-click: copy sessionId';
+      li.addEventListener('click', () => {
+        if (rowOpen.has(s.sessionId)) rowOpen.delete(s.sessionId);
+        else rowOpen.add(s.sessionId);
+        renderClaudeList();
+      });
+      li.addEventListener('dblclick', async (ev) => {
+        ev.stopPropagation();
         try { await navigator.clipboard.writeText(s.sessionId); } catch (_) {}
       });
       claudeList.appendChild(li);
+    }
+  }
+
+  function renderTrail(container, s) {
+    const h = stateHistory.get(s.sessionId) || [];
+    if (h.length === 0) {
+      container.textContent = '(no transitions recorded yet)';
+      return;
+    }
+    // Render newest first so the right-most reads as "right now".
+    const ordered = h.slice();
+    for (let i = 0; i < ordered.length; i++) {
+      const entry = ordered[i];
+      const tdot = document.createElement('span');
+      tdot.className = 'tdot ' + (entry.state || 'unknown');
+      container.appendChild(tdot);
+      const span = document.createElement('span');
+      span.textContent = entry.state + ' · ' + relativeTime(entry.ts);
+      container.appendChild(span);
+      if (i < ordered.length - 1) {
+        const sep = document.createElement('span');
+        sep.textContent = '  →  ';
+        sep.style.color = 'rgba(255,255,255,0.15)';
+        container.appendChild(sep);
+      }
     }
   }
 
@@ -532,9 +689,18 @@ export const ISLAND_HTML = `<!doctype html>
     const idx = state.claudeSessions.findIndex(
       (x) => x.sessionId === s.sessionId
     );
+    const prevState = idx >= 0 ? state.claudeSessions[idx].state : null;
     if (idx >= 0) state.claudeSessions[idx] = s;
     else state.claudeSessions.push(s);
     pruneClaudeSessions();
+
+    // Phase 3 — record transition + maybe notify on entering "waiting".
+    const transitioned = recordStateHistory(s.sessionId, {
+      state: s.state,
+      reason: s.stateReason,
+      lastMtime: s.lastMtime,
+    });
+    if (transitioned) maybeNotifyWaiting(prevState, s);
   }
 
   function pruneClaudeSessions() {
@@ -558,17 +724,38 @@ export const ISLAND_HTML = `<!doctype html>
           state: s.state || 'unknown',
           stateReason: s.stateReason || '',
         }));
+        // Phase 3 — seed each session's history with its current state
+        // so the trail isn't empty on first open. Doesn't notify (no
+        // transition implied by initial load).
+        for (const s of state.claudeSessions) {
+          recordStateHistory(s.sessionId, {
+            state: s.state,
+            reason: s.stateReason,
+            lastMtime: s.lastMtime,
+          });
+        }
       }
     } catch (_) {
       // server might not yet have the endpoint (older LISA) — silent
     }
   }
 
+  // Phase 3 — notification permission opt-in. The CTA is only visible
+  // when permission is in the default (un-asked) state.
+  notifyCta.addEventListener('click', (e) => {
+    e.stopPropagation();
+    requestNotificationPermission();
+  });
+  notifyCta.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') requestNotificationPermission();
+  });
+
   // ── Bootstrap ──────────────────────────────────────────────────────
   setAvatar('neutral');
   pollPing();
   fetchClaudeSessions().then(() => { refreshDot(); refreshPanel(); });
   subscribe();
+  refreshNotifyCta();
   // Lightweight resync — covers cases where SSE silently disconnected
   // (laptop sleep, network blip) and we need to refresh state.
   setInterval(pollPing, 30_000);

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -27,6 +27,7 @@ export const ISLAND_HTML = `<!doctype html>
     --accent: #6ad4ff;
     --accent-warm: #ffd066;
     --accent-dream: #b487ff;
+    --accent-claude: #ff8c42;
     --border: rgba(255, 255, 255, 0.06);
   }
   html, body {
@@ -91,10 +92,11 @@ export const ISLAND_HTML = `<!doctype html>
     background: transparent;
     flex-shrink: 0;
   }
-  #dot.thinking { background: var(--accent);     animation: pulse 1.2s ease-in-out infinite; }
-  #dot.dreaming { background: var(--accent-dream); animation: pulse 2.4s ease-in-out infinite; }
-  #dot.unread   { background: var(--accent-warm); }
-  #dot.offline  { background: var(--fg-faint); }
+  #dot.thinking      { background: var(--accent);        animation: pulse 1.2s ease-in-out infinite; }
+  #dot.dreaming      { background: var(--accent-dream);  animation: pulse 2.4s ease-in-out infinite; }
+  #dot.unread        { background: var(--accent-warm); }
+  #dot.claude-active { background: var(--accent-claude); animation: pulse 1.8s ease-in-out infinite; }
+  #dot.offline       { background: var(--fg-faint); }
 
   @keyframes pulse {
     0%, 100% { opacity: 0.35; }
@@ -155,6 +157,35 @@ export const ISLAND_HTML = `<!doctype html>
     white-space: pre-wrap;
   }
 
+  /* Claude Code section — appears when there's active Claude Code activity */
+  #claude-section { display: none; }
+  body.has-claude #claude-section { display: block; }
+  #claude-section .section-label { color: var(--accent-claude); }
+  #claude-list {
+    list-style: none;
+    padding: 0;
+    margin: 0 0 10px;
+    border-left: 2px solid var(--accent-claude);
+    background: rgba(255, 140, 66, 0.06);
+    border-radius: 4px;
+    overflow: hidden;
+  }
+  #claude-list li {
+    padding: 5px 10px;
+    color: var(--fg);
+    font-size: 11px;
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    cursor: pointer;
+    transition: background 120ms ease;
+  }
+  #claude-list li:hover { background: rgba(255, 140, 66, 0.10); }
+  #claude-list li + li { border-top: 1px solid rgba(255, 140, 66, 0.10); }
+  #claude-list .proj { font-weight: 600; flex: 1; min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  #claude-list .when { color: var(--fg-dim); flex-shrink: 0; font-variant-numeric: tabular-nums; }
+  #claude-list .empty { padding: 6px 10px; color: var(--fg-faint); font-style: italic; }
+
   #actions {
     display: flex;
     gap: 6px;
@@ -196,6 +227,10 @@ export const ISLAND_HTML = `<!doctype html>
       <div class="section-label">★ while you were away</div>
       <div id="idle-body"></div>
     </div>
+    <div id="claude-section">
+      <div class="section-label">claude code · <span id="claude-count">0</span> active</div>
+      <ul id="claude-list"></ul>
+    </div>
     <div id="actions">
       <button id="btn-open">Open chat</button>
       <button id="btn-dismiss" class="muted">Dismiss ★</button>
@@ -204,15 +239,17 @@ export const ISLAND_HTML = `<!doctype html>
 
 <script>
 (() => {
-  const pill        = document.getElementById('pill');
-  const avatar      = document.getElementById('avatar');
-  const dot         = document.getElementById('dot');
-  const expand      = document.getElementById('expand');
-  const desireBody  = document.getElementById('desire-body');
-  const idleBody    = document.getElementById('idle-body');
-  const btnOpen     = document.getElementById('btn-open');
-  const btnDismiss  = document.getElementById('btn-dismiss');
-  const body        = document.body;
+  const pill         = document.getElementById('pill');
+  const avatar       = document.getElementById('avatar');
+  const dot          = document.getElementById('dot');
+  const expand       = document.getElementById('expand');
+  const desireBody   = document.getElementById('desire-body');
+  const idleBody     = document.getElementById('idle-body');
+  const claudeList   = document.getElementById('claude-list');
+  const claudeCount  = document.getElementById('claude-count');
+  const btnOpen      = document.getElementById('btn-open');
+  const btnDismiss   = document.getElementById('btn-dismiss');
+  const body         = document.body;
 
   const state = {
     mood: 'neutral',
@@ -222,7 +259,16 @@ export const ISLAND_HTML = `<!doctype html>
     desire: null,
     thinking: false,
     dreaming: false,
+    claudeSessions: [],  // [{project, sessionId, lastMtime}, …]
   };
+
+  // 30-min activity window matches the watcher's ACTIVE_WINDOW_MS.
+  const CLAUDE_ACTIVE_WINDOW_MS = 30 * 60 * 1000;
+  function isClaudeActive() {
+    return state.claudeSessions.some((s) =>
+      Date.now() - new Date(s.lastMtime).getTime() < CLAUDE_ACTIVE_WINDOW_MS
+    );
+  }
 
   function setAvatar(slug) {
     if (!slug) return;
@@ -232,19 +278,69 @@ export const ISLAND_HTML = `<!doctype html>
 
   function refreshDot() {
     dot.className = '';
-    if (!state.online)      { dot.classList.add('offline');  return; }
-    if (state.thinking)     { dot.classList.add('thinking'); return; }
-    if (state.dreaming)     { dot.classList.add('dreaming'); return; }
-    if (state.unread)       { dot.classList.add('unread');   return; }
+    // Priority: LISA's own state (offline / thinking / dreaming / unread)
+    // always wins over the Claude-Code-monitor indicator — the pill is
+    // primarily about her, the orange dot is a quieter "by the way".
+    if (!state.online)             { dot.classList.add('offline');       return; }
+    if (state.thinking)            { dot.classList.add('thinking');      return; }
+    if (state.dreaming)            { dot.classList.add('dreaming');      return; }
+    if (state.unread)              { dot.classList.add('unread');        return; }
+    if (isClaudeActive())          { dot.classList.add('claude-active'); return; }
   }
 
   function refreshPanel() {
     body.classList.toggle('offline',   !state.online);
     body.classList.toggle('has-unread', state.unread);
+    body.classList.toggle('has-claude', state.claudeSessions.length > 0);
     desireBody.textContent = state.desire || '(nothing actively pursued)';
     idleBody.textContent   = state.idleText || '';
     btnDismiss.classList.toggle('muted', !state.unread);
     btnDismiss.disabled = !state.unread;
+    renderClaudeList();
+  }
+
+  function relativeTime(iso) {
+    const ms = Date.now() - new Date(iso).getTime();
+    if (ms < 30_000)             return 'just now';
+    if (ms < 60_000)             return Math.round(ms / 1000) + 's ago';
+    if (ms < 3600_000)           return Math.round(ms / 60_000) + 'm ago';
+    return Math.round(ms / 3600_000) + 'h ago';
+  }
+
+  function renderClaudeList() {
+    const n = state.claudeSessions.length;
+    claudeCount.textContent = String(n);
+    while (claudeList.firstChild) claudeList.removeChild(claudeList.firstChild);
+    if (n === 0) {
+      const li = document.createElement('li');
+      li.className = 'empty';
+      li.textContent = '(idle)';
+      claudeList.appendChild(li);
+      return;
+    }
+    // Sort newest first, cap at 5.
+    const rows = state.claudeSessions
+      .slice()
+      .sort((a, b) => new Date(b.lastMtime).getTime() - new Date(a.lastMtime).getTime())
+      .slice(0, 5);
+    for (const s of rows) {
+      const li = document.createElement('li');
+      const proj = document.createElement('span');
+      proj.className = 'proj';
+      proj.textContent = s.project;
+      const when = document.createElement('span');
+      when.className = 'when';
+      when.textContent = relativeTime(s.lastMtime);
+      li.appendChild(proj);
+      li.appendChild(when);
+      li.title = s.sessionId;
+      li.addEventListener('click', async () => {
+        // Phase 1: copy session id to clipboard. Phase 2 will add a
+        // URL-scheme handoff for "open in iTerm at this session".
+        try { await navigator.clipboard.writeText(s.sessionId); } catch (_) {}
+      });
+      claudeList.appendChild(li);
+    }
   }
 
   function expandPanel(open) {
@@ -360,6 +456,20 @@ export const ISLAND_HTML = `<!doctype html>
             { duration: 600, iterations: 2 },
           );
           break;
+        case 'claude_session_update':
+          // Watcher noticed activity in ~/.claude/projects/. Splice the
+          // updated session into our local list and re-render. The list
+          // is kept short — we cap on render — so unbounded growth isn't
+          // a concern, but we still drop stale entries from time to time.
+          upsertClaudeSession({
+            project: m.projectLabel,
+            projectEncoded: m.projectEncoded,
+            sessionId: m.sessionId,
+            lastMtime: m.ts,
+          });
+          refreshDot();
+          refreshPanel();
+          break;
       }
     });
     es.addEventListener('error', () => {
@@ -371,13 +481,58 @@ export const ISLAND_HTML = `<!doctype html>
     });
   }
 
+  // ── Claude Code session helpers ────────────────────────────────────
+
+  function upsertClaudeSession(s) {
+    const idx = state.claudeSessions.findIndex(
+      (x) => x.sessionId === s.sessionId
+    );
+    if (idx >= 0) state.claudeSessions[idx] = s;
+    else state.claudeSessions.push(s);
+    pruneClaudeSessions();
+  }
+
+  function pruneClaudeSessions() {
+    const cutoff = Date.now() - CLAUDE_ACTIVE_WINDOW_MS;
+    state.claudeSessions = state.claudeSessions.filter(
+      (s) => new Date(s.lastMtime).getTime() >= cutoff
+    );
+  }
+
+  async function fetchClaudeSessions() {
+    try {
+      const r = await fetch('/api/claude/sessions', { cache: 'no-store' });
+      if (!r.ok) return;
+      const j = await r.json();
+      if (Array.isArray(j.sessions)) {
+        state.claudeSessions = j.sessions.map((s) => ({
+          project: s.project,
+          projectEncoded: s.projectEncoded,
+          sessionId: s.sessionId,
+          lastMtime: s.lastMtime,
+        }));
+      }
+    } catch (_) {
+      // server might not yet have the endpoint (older LISA) — silent
+    }
+  }
+
   // ── Bootstrap ──────────────────────────────────────────────────────
   setAvatar('neutral');
   pollPing();
+  fetchClaudeSessions().then(() => { refreshDot(); refreshPanel(); });
   subscribe();
   // Lightweight resync — covers cases where SSE silently disconnected
   // (laptop sleep, network blip) and we need to refresh state.
   setInterval(pollPing, 30_000);
+  setInterval(fetchClaudeSessions, 60_000);
+  // Re-render every 15s so "Xs ago" / "Xm ago" labels stay fresh and
+  // stale sessions fall off the list without a fresh update event.
+  setInterval(() => {
+    pruneClaudeSessions();
+    refreshDot();
+    refreshPanel();
+  }, 15_000);
 })();
 </script>
 </body>

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1844,7 +1844,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     }
 
     // Claude Code session monitoring (issue #27). Returns sessions
-    // with activity in the last 30 minutes.
+    // with activity in the last 30 minutes plus their derived state
+    // (Phase 2: working / waiting / error / unknown).
     if (req.method === "GET" && url === "/api/claude/sessions") {
       const sessions = claudeWatcher.listActive().map((s) => ({
         project: s.projectLabel,
@@ -1852,6 +1853,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         sessionId: s.sessionId,
         lastMtime: new Date(s.lastMtime).toISOString(),
         size: s.size,
+        state: s.state,
+        stateReason: s.stateReason,
       }));
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ sessions }));

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -18,6 +18,7 @@ import { SessionStore } from "../sessions/store.js";
 import { reflectOnSession } from "../reflect.js";
 import { listDesires } from "../soul/store.js";
 import { ISLAND_HTML } from "./island.js";
+import { ClaudeCodeWatcher } from "../integrations/claude-code/watcher.js";
 import type { ToolDefinition, StoredMessage } from "../types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -1724,6 +1725,18 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   moodBus.on("chat_start", () => broadcast({ type: "chat_start" }));
   moodBus.on("chat_end", () => broadcast({ type: "chat_end" }));
 
+  // ── Claude Code session monitoring (issue #27) ──────────────────────
+  // Watches ~/.claude/projects/ for jsonl activity and forwards updates
+  // to the same /events SSE. Privacy: only mtime + size + filename, never
+  // message contents (see src/integrations/claude-code/watcher.ts).
+  const claudeWatcher = new ClaudeCodeWatcher({
+    log: (msg) => console.error(msg),
+  });
+  claudeWatcher.on("update", (payload) => {
+    broadcast({ type: "claude_session_update", ...payload });
+  });
+  void claudeWatcher.start();
+
   // ── Island unread tracking (Phase 1 of MAC_ISLAND_PLAN) ─────────────
   // The island widget caches "last idle_message" so a fresh tab opening
   // mid-conversation knows there's something to read. Cleared via
@@ -1827,6 +1840,21 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       lastIdleMessage = null;
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    // Claude Code session monitoring (issue #27). Returns sessions
+    // with activity in the last 30 minutes.
+    if (req.method === "GET" && url === "/api/claude/sessions") {
+      const sessions = claudeWatcher.listActive().map((s) => ({
+        project: s.projectLabel,
+        projectEncoded: s.projectEncoded,
+        sessionId: s.sessionId,
+        lastMtime: new Date(s.lastMtime).toISOString(),
+        size: s.size,
+      }));
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ sessions }));
       return;
     }
 


### PR DESCRIPTION
Closes #27. First phase of the Claude Code integration discussed in PR #24's comments. Phase 2 (parse jsonl to know if a session is waiting / completed / errored) and Phase 3 (macOS notifications) will be separate PRs.

## What this PR delivers

LISA now notices when Claude Code (the CLI) is active and surfaces it through the existing \`/events\` SSE + island widget.

| Layer | Change |
|---|---|
| Backend | New \`src/integrations/claude-code/watcher.ts\` — recursive \`fs.watch\` on \`~/.claude/projects/\`, debounced 200ms, no new dependencies |
| Server | Watcher hooked into \`startWebServer\`; broadcasts on existing \`/events\` SSE; new \`GET /api/claude/sessions\` endpoint |
| UI | New orange "claude-active" status dot + new "CLAUDE CODE · N ACTIVE" section in the island's expand panel |

## Privacy contract

**Never reads jsonl message contents.** Only filename, mtime, and size are observed. Stated as a top-of-file comment in \`watcher.ts\` for anyone reviewing.

## Event semantics

\`\`\`json
{
  "type": "claude_session_update",
  "event": "new" | "message",
  "projectEncoded": "-Users-oratis-Projects-Adex",
  "projectLabel": "Adex",
  "sessionId": "780606aa-d2ee-4eac-87c6-21c23fee6a43",
  "ts": "2026-05-28T04:12:13.441Z"
}
\`\`\`

\"Active\" = mtime within the last 30 minutes.

Phase 2 will add \`waiting\` / \`completed\` / \`error\` events that require jsonl parsing.

## Dot priority

LISA-state always wins over Claude-monitor visualization:

\`\`\`
offline  >  thinking  >  dreaming  >  unread ★  >  claude-active  >  (idle)
\`\`\`

The pill is primarily about her; the orange Claude dot is a quieter "by the way".

## Verified end-to-end

Real activity captured by the watcher while developing this PR — Claude Code was writing to the LISA project's session jsonl as I worked, and the SSE listener picked it up:

\`\`\`
[claude-code] initial scan: 263 session(s) seen
[claude-code] watching /Users/oratis/.claude/projects

$ curl -s -N http://localhost:5757/events
data: {"type":"claude_session_update","event":"message",
       "projectEncoded":"-Users-oratis-Projects-LISA",
       "projectLabel":"LISA","sessionId":"d94ed434…",
       "ts":"2026-05-28T04:12:13.441Z"}
\`\`\`

REST endpoint also verified:

\`\`\`
$ curl -s http://localhost:5757/api/claude/sessions
{
  "sessions": [
    { "project": "LISA",     "sessionId": "d94ed434…", "lastMtime": "…", "size": 18044268 },
    { "project": "DeepCode", "sessionId": "66aa0251…", "lastMtime": "…", "size": 13123578 },
    { "project": "e30551",   "sessionId": "fe899172…", "lastMtime": "…", "size": 4378763 },
    …
  ]
}
\`\`\`

Project labels decode correctly from the \`-Users-oratis-Projects-Foo\` encoding macOS Claude Code uses for cwd hashing.

## Files

| File | LOC |
|---|---|
| \`src/integrations/claude-code/watcher.ts\` (new) | 279 |
| \`src/web/server.ts\` (additions) | +28 |
| \`src/web/island.ts\` (CSS + DOM + JS additions) | +172 |
| **Total** | **+479 / -17** |

## Out of scope (later)

- Phase 2 — parse jsonl tail to determine session state (\`waiting_for_user\` vs \`active\` vs \`completed\`)
- Phase 3 — macOS \`UNUserNotificationCenter\` notification when a session transitions to "waiting"
- URL-scheme handoff to open a specific session in iTerm/Warp; currently the row click copies sessionId to clipboard
- iTerm2 / Warp / Ghostty integration to "show me which terminal pane this session is in"

🤖 Generated with [Claude Code](https://claude.com/claude-code)