### PR TITLE
Hardening sprint: tests + security + concurrency (v0.3.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,38 @@
+name: CI — typecheck + tests
+
+# Gates every push and PR with the regression net. Tests use Node's built-in
+# runner (node --test) via the tsx loader — no extra test deps to install.
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build (verify dist compiles, no test files emitted)
+        run: |
+          npm run build
+          if find dist -name '*.test.js' | grep -q .; then
+            echo "::error ::test files leaked into dist/"; exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Security & hardening (v0.3.1 sprint)
+
+Following a full product/code review (`docs/PRODUCT_REVIEW_v0.3.md`), the
+engineering-hardness gaps were addressed — the project went from **zero
+automated tests** to a 114-test regression net (Node's built-in `node:test`
+via tsx, no new dependencies) plus a CI gate.
+
+- **Tests + CI** — `npm test` runs `src/**/*.test.ts`; new `.github/workflows/ci.yml`
+  gates every push/PR on typecheck + tests + build. Test files excluded from `dist/`.
+- **SSRF redirect bypass closed** (`web_fetch`) — the private-IP check ran only on
+  the initial URL; a public URL could 302 → `127.0.0.1` / the cloud metadata IP and
+  be followed. Redirects are now followed manually with every hop re-validated.
+- **AppleScript injection closed** (`iMessage`) — outbound text was interpolated into
+  the AppleScript source with only quote-escaping; a newline or crafted payload could
+  inject script. Text now passes as positional `argv`, never parsed as source.
+- **Path traversal blocked** (soul slugs) — value/opinion/desire/journal/relationship
+  slugs are validated at the single path chokepoint; `../`, separators, control chars,
+  and leading dots are rejected.
+- **Cross-process soul lock** — desire-progress appends (read-modify-write) now run
+  under an advisory file lock, so a heartbeat/idle run can't interleave with a chat
+  turn and lose data.
+- **Heartbeat token budget + run-lock** — per-run token ceiling (`budgetTokens`,
+  default 500k) stops runaway autonomous cost; a run-lock skips overlapping heartbeat
+  ticks instead of double-running.
+- **Continuous emotion decay** — decay now applies on write (soul_feel) and in
+  soul_read, not just in the system-prompt view, and no longer drops the event trail.
+- **Memory index cache** — the TF-IDF index is cached and rebuilt only when the
+  sessions dir changes, instead of on every `memory_search`.
+
 ### Added
 
 - **7 new LLM provider presets** — Lisa now auto-routes 7 additional providers by model-name prefix, no `LISA_BASE_URL` plumbing needed:

--- a/docs/PRODUCT_REVIEW_v0.3.md
+++ b/docs/PRODUCT_REVIEW_v0.3.md
@@ -1,0 +1,155 @@
+# LISA — Product Capability Review & Tuning Plan (v0.3)
+
+> Full review of ~15k LOC TypeScript + ~800 LOC Swift + all product docs.
+> Method: five deep-探查 agents (one per subsystem — soul, agent engine,
+> autonomy, surfaces, product positioning), cross-verified, plus direct
+> inspection of product docs + test setup. Conducted on the v0.3.0 tree.
+
+---
+
+## 1. Overall verdict
+
+LISA is a **real, architecturally-considered, well-past-demo** open-source AI
+agent whose core differentiator ("an individual with a self") is **backed by
+code, not just marketing**. Maturity by axis:
+
+> **Capability parity = 9/10 · Differentiator skeleton (soul/autonomy) = 7/10 ·
+> Engineering hardness (tests/concurrency/security) = 3/10 · Surface polish = 8/10**
+
+One line: **product imagination A, single-user/trusted-env usability A−,
+engineering resilience D**. The biggest systemic risk is not features — it's
+**zero automated tests + no concurrency protection**. For an agent that markets
+"self-modification", those two are existential.
+
+---
+
+## 2. Capability matrix (real completeness)
+
+| Subsystem | What it does | Maturity | Reality |
+|---|---|---|---|
+| Agent loop | streaming loop, tool-calling, mid-session prompt hot-reload, soul_object forced-surface | ★★★★★ | production-grade, no placeholders |
+| Multi-provider | 3 native protocols + 21 OpenAI-compat presets + catch-all, routed by model-name prefix | ★★★★★ | elegant routing, case-insensitive |
+| Tools | 23 built-ins (file/web/search/memory/soul/ops) + skills + MCP | ★★★★ | broad coverage |
+| Soul | birth ritual, identity/purpose/constitution, values/opinions/desires/emotions, git history, tamper detection, hot-reload | ★★★★ | genuinely implemented; emotion event-trail is the standout |
+| Heartbeat | launchd/cron, runs actionable desires, progress carries across runs, weekly examen | ★★★★ | real but reactive |
+| Idle/Dreams | idle 1h+ → single reflection → ★while-you-were-away | ★★★ | pragmatic, not narrative "dreams" |
+| Memory | TF-IDF over session history | ★★ | works but rebuilds index every search |
+| Skills | SHA256 + human approval, then dynamic import | ★★★ | intentionally un-sandboxed (documented) |
+| Web GUI | glass-morphism chat, mood portraits, soul/skills panels, PWA, birth ritual | ★★★★★ | strongest surface |
+| Island | pill + expand + Claude monitor + native drag | ★★★★ | clever product design |
+| Mac apps | Lisa.app + LisaIsland.app, signed+notarized DMG | ★★★★ | freshly shipped |
+| IM channels | Telegram/Discord/Slack/Feishu/iMessage/Webhook | ★★★ | breadth-first, edge cases |
+| Voice | macOS `say` + OpenAI Whisper | ★★ | thinnest |
+| Claude Code monitor | privacy-first metadata watch, state derivation | ★★★★ | thoughtful |
+| Tests | — | 0/10 | **zero automated tests** |
+
+---
+
+## 3. The real moat (the differentiation is real)
+
+1. **Soul hot-reload + git history** — `soul_patch` takes effect on turn N+1
+   of the *same* conversation (fingerprint mechanism); every change commits to
+   `~/.lisa/soul/.git` with caller attribution. "She can look at who she was 3
+   months ago" actually runs. Rare in the LLM-agent space.
+2. **Emotion event causal trail** — emotions are `{emotion, delta, trigger, ts}`
+   event streams + exponential decay (per-emotion half-lives), not bare numbers.
+3. **Constraint-driven autonomy** — every autonomy increment is paired with a
+   stability hedge (roadmap §0). Weekly examen can *suggest* corrective desires
+   but cannot rewrite identity/purpose; skills require human approval; soul_object
+   objections must surface. Deliberate friction = mature design judgment.
+
+---
+
+## 4. Marketing vs reality (honest reconciliation)
+
+| PITCH claims | Reality | Gap |
+|---|---|---|
+| "she has motivation/desires" | desires drive heartbeat ✓ | but desires are **not self-generated** — user or reflect must create them. No "I notice I want X → add a desire" loop |
+| "architectural sovereignty, no reset" | mutation sovereignty real ✓ | but external edits can only be *noticed*, not *prevented*; "forget who you are" has no technical enforcement, relies on LLM compliance |
+| "she's evolving" | git/examen/desire tracking real ✓ | evolution is largely **reactive**; self-improvement loop (spot gap → add desire → pursue → refine) is **absent** |
+| "~11k LOC TypeScript" | actual src ~15k LOC | undercount |
+| "capability superset of 5 agents" | breadth is there | depth gaps: MCP tools-only (no resources/prompts), sandbox macOS-only, approval sync-readline-only |
+
+**Conclusion**: marketing isn't lying, but the "inner life / motivation" story is
+**~70% delivered** — the skeleton is real, but it's still mostly passive
+execution, not active emergence.
+
+---
+
+## 5. Critical issues (must-fix, by severity)
+
+### P0 — systemic risk
+1. **Zero automated tests** — no `test` script, 0 `.test.ts`. A self-modifying
+   agent with no regression net on birth/store/reflect/parser.
+   → introduce vitest; cover soul CRUD, emotion decay, reflect JSON parse,
+   claude-code parser, provider routing. CI gate.
+2. **No concurrency protection** (named by both soul + autonomy reviews) —
+   heartbeat 35min run vs 30min interval → two instances writing
+   `~/.lisa/soul/` concurrently; `appendDesireProgress()` uses bare
+   `fs.appendFile`; git `index.lock` races → data corruption.
+   → `flock` on `~/.lisa/soul.lock` before any soul write; mutex on
+   heartbeat/idle runner entry.
+
+### P1 — security & correctness
+3. **SSRF redirect bypass** (web_fetch) — entry validates private IPs but
+   `redirect: "follow"` lets a public domain 301 → `127.0.0.1:8000`.
+   → validate redirect targets before following.
+4. **iMessage osascript escaping** — only escapes `"`, not newlines →
+   AppleScript-syntax injection. → base64 / arg-array.
+5. **Tool input has no schema validation** — LLM-generated input goes straight
+   into `tool.execute()`. → validate at dispatch.
+6. **Webhook: no rate limit + 5min timeout** — token-holder can spam; caller
+   waits 5min if Lisa hangs. → per-sender limit + 30s timeout.
+
+### P2 — cost & performance
+7. **Autonomous loop has no token budget** — `every:5m` + 3 actionable desires
+   × 32 iters ≈ ~173M tokens/day ≈ $5/day, no budget/breaker.
+   → heartbeat `budget_tokens`, skip/abort over limit.
+8. **Memory rebuilds index every search** — `buildIndex()` O(N sessions) every
+   `memory_search`. → cache per session lifetime.
+9. **Emotion decay discontinuous** — only decays on `readSoulSummary`. → decay
+   on write too.
+
+---
+
+## 6. Tuning recommendations (by theme)
+
+### A. Engineering hardness (highest priority — the real weak spot)
+- vitest + CI running tests (release workflow currently build-only, no test)
+- file locks across soul/heartbeat
+- slug validation (value/opinion/desire slugs currently allow `../` traversal)
+- reflect idempotency marker (running twice double-applies operations)
+
+### B. Make autonomy active, not reactive (the next step for the moat)
+- desire self-generation loop: examen can suggest desires, but there's no
+  "heartbeat analyzes its own output → refines next prompt" learning loop.
+  This is the key to pushing 70% → 90% delivered.
+- desire prioritization: all actionable desires run every heartbeat, no
+  ranking/time-budget.
+- `opinion_update(slug, delta, evidence)` so confidence updates don't require
+  rewriting the whole opinion.
+
+### C. Performance & scale (will bite in months)
+- swap/augment memory with semantic retrieval (small embeddings, TF-IDF fallback)
+- system prompt injects ALL values/opinions/desires in full — after a year of
+  100+ entries it bloats. → top-N + reference `soul_read`.
+- turn-level cache for `readSoulSummary` (currently 7 I/O + 3 dir scans per turn)
+
+### D. Surface polish (nice-to-have)
+- transcript export / chat search
+- voice streaming + local Whisper fallback
+- per-channel setup runbooks (esp. iMessage Full Disk Access)
+- MCP resources/prompts support
+
+---
+
+## 7. Suggested next sprint (if only 3 things)
+
+1. **vitest + soul/parser/provider core tests + CI gate** — removes the "no net
+   under soul changes" existential anxiety.
+2. **soul/heartbeat file locks + token budget** — plugs the two P0/P1 holes
+   (data corruption + runaway cost).
+3. **desire self-generation + learning loop** — pushes "she has motivation" from
+   70% → 90%. The product story's true last mile.
+
+First two are "stop the foundation cracking"; the third is "deepen the moat".

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
     "start": "node dist/cli.js",
     "lisa": "node --enable-source-maps dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
+    "test": "node --import tsx --test \"src/**/*.test.ts\"",
+    "test:watch": "node --import tsx --test --watch \"src/**/*.test.ts\"",
     "generate-assets": "tsx scripts/generate-pixel-assets.ts",
     "prepublishOnly": "npm run build && rm -rf dist/web/assets && cp -R src/web/assets dist/web/assets",
     "postpublish": "npm run copy-assets"

--- a/src/channels/imessage.test.ts
+++ b/src/channels/imessage.test.ts
@@ -1,0 +1,45 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { buildOsascriptArgs } from "./imessage.js";
+
+describe("buildOsascriptArgs — injection-proof argv passing", () => {
+  test("recipient + text are passed as positional args, not interpolated", () => {
+    const args = buildOsascriptArgs("+15551234567", "hello");
+    // Shape: ["-e", <script>, recipient, text]
+    assert.equal(args[0], "-e");
+    assert.equal(args[2], "+15551234567");
+    assert.equal(args[3], "hello");
+  });
+
+  test("the AppleScript source is STATIC — no user text embedded in it", () => {
+    const payload = 'evil" & (do shell script "rm -rf ~") & "';
+    const args = buildOsascriptArgs("buddy", payload);
+    const script = args[1]!;
+    // The dangerous payload must NOT appear anywhere in the script source.
+    assert.equal(script.includes("evil"), false);
+    assert.equal(script.includes("do shell script"), false);
+    assert.equal(script.includes("rm -rf"), false);
+    // It must instead arrive as the positional text arg, verbatim.
+    assert.equal(args[3], payload);
+  });
+
+  test("newlines survive verbatim in the text arg (the original bug)", () => {
+    const multiline = "line one\nline two\nline three";
+    const args = buildOsascriptArgs("buddy", multiline);
+    assert.equal(args[3], multiline, "newlines must be preserved, not escaped/broken");
+    assert.equal(args[1]!.includes("line one"), false, "text not in source");
+  });
+
+  test("quotes and backslashes pass through untouched", () => {
+    const tricky = 'she said "hi" \\ then left';
+    const args = buildOsascriptArgs("buddy", tricky);
+    assert.equal(args[3], tricky);
+  });
+
+  test("script references argv positionally", () => {
+    const script = buildOsascriptArgs("a", "b")[1]!;
+    assert.match(script, /on run argv/);
+    assert.match(script, /item 1 of argv/);
+    assert.match(script, /item 2 of argv/);
+  });
+});

--- a/src/channels/imessage.ts
+++ b/src/channels/imessage.ts
@@ -60,15 +60,9 @@ export class IMessageChannel implements ChannelAdapter {
   }
 
   async send(msg: OutgoingMessage): Promise<void> {
-    const recipient = msg.to.replace(/"/g, '\\"');
-    const text = msg.text.replace(/"/g, '\\"');
-    const script = `tell application "Messages"
-  set targetService to first service whose service type = iMessage
-  set targetBuddy to buddy "${recipient}" of targetService
-  send "${text}" to targetBuddy
-end tell`;
+    const args = buildOsascriptArgs(msg.to, msg.text);
     await new Promise<void>((resolve, reject) => {
-      const child = spawn("/usr/bin/osascript", ["-e", script]);
+      const child = spawn("/usr/bin/osascript", args);
       let stderr = "";
       child.stderr.on("data", (b) => (stderr += b.toString("utf8")));
       child.on("error", reject);
@@ -138,6 +132,34 @@ end tell`;
       );
     });
   }
+}
+
+/**
+ * Build the osascript argv for sending an iMessage WITHOUT interpolating
+ * user/LLM text into the AppleScript source.
+ *
+ * The old approach (`send "${text}"`) only escaped double-quotes, so a
+ * message containing a newline — or a crafted `" & (do shell script "...")`
+ * payload — could break out of the string literal and inject AppleScript.
+ * Inbound iMessage text is untrusted (anyone who can text the user), so this
+ * was a real injection vector.
+ *
+ * Instead the script is a STATIC `on run argv` program; recipient and text
+ * arrive as positional argv items (`item 1`/`item 2 of argv`) that AppleScript
+ * never parses as source. No escaping needed; newlines/quotes/backslashes
+ * survive verbatim.
+ */
+export function buildOsascriptArgs(recipient: string, text: string): string[] {
+  const script = `on run argv
+  set theRecipient to item 1 of argv
+  set theText to item 2 of argv
+  tell application "Messages"
+    set targetService to first service whose service type = iMessage
+    set targetBuddy to buddy theRecipient of targetService
+    send theText to targetBuddy
+  end tell
+end run`;
+  return ["-e", script, recipient, text];
 }
 
 registerChannel("imessage", (cfg) => {

--- a/src/heartbeat/config.ts
+++ b/src/heartbeat/config.ts
@@ -13,12 +13,23 @@ export interface HeartbeatTask {
 
 export interface HeartbeatConfig {
   tasks: HeartbeatTask[];
+  /**
+   * Max combined (input+output) tokens to spend across all tasks in a single
+   * heartbeat invocation. Once exceeded, remaining tasks are skipped (logged,
+   * not silently dropped). Guards against the runaway-cost case: a short
+   * interval × several actionable desires × deep tool loops can otherwise run
+   * to millions of tokens/day unbounded. 0 / unset = no limit.
+   */
+  budgetTokens?: number;
 }
+
+/** Default per-run token ceiling when heartbeat.json doesn't set one. */
+export const DEFAULT_HEARTBEAT_BUDGET_TOKENS = 500_000;
 
 const FILE = path.join(LISA_HOME, "heartbeat.json");
 
 export async function loadHeartbeatConfig(): Promise<HeartbeatConfig> {
-  if (!(await pathExists(FILE))) return { tasks: [] };
+  if (!(await pathExists(FILE))) return { tasks: [], budgetTokens: DEFAULT_HEARTBEAT_BUDGET_TOKENS };
   const raw = await fs.readFile(FILE, "utf8");
   let parsed: HeartbeatConfig;
   try {
@@ -26,7 +37,12 @@ export async function loadHeartbeatConfig(): Promise<HeartbeatConfig> {
   } catch (err) {
     throw new Error(`failed to parse ${FILE}: ${(err as Error).message}`);
   }
-  return { tasks: parsed.tasks ?? [] };
+  return {
+    tasks: parsed.tasks ?? [],
+    // Explicit 0 means "no limit"; undefined means "use the default ceiling".
+    budgetTokens:
+      parsed.budgetTokens === undefined ? DEFAULT_HEARTBEAT_BUDGET_TOKENS : parsed.budgetTokens,
+  };
 }
 
 export const HEARTBEAT_CONFIG_PATH = FILE;

--- a/src/heartbeat/runner.ts
+++ b/src/heartbeat/runner.ts
@@ -10,6 +10,7 @@ import {
   readSeed,
 } from "../soul/store.js";
 import { withSoulCaller } from "../soul/git.js";
+import { withFileLock } from "../soul/lock.js";
 import { runSubagent } from "../subagent.js";
 import type { ToolDefinition } from "../types.js";
 import {
@@ -18,6 +19,7 @@ import {
 } from "./config.js";
 
 const STATE_FILE = path.join(LISA_HOME, "heartbeat-state.json");
+const RUN_LOCK = path.join(LISA_HOME, "heartbeat.lock");
 
 interface HeartbeatState {
   lastRunAt: Record<string, string>;
@@ -46,7 +48,33 @@ export async function runHeartbeatOnce(opts: {
   model: string;
   taskFilter?: string;
 }): Promise<HeartbeatRunResult[]> {
+  // Run-level lock: if launchd/cron fires a new heartbeat while the previous
+  // one is still running (long desires + short interval), skip rather than
+  // double-run and race on soul state. timeoutMs:0 → fail fast, don't wait.
+  try {
+    return await withFileLock(RUN_LOCK, () => runHeartbeatInner(opts), {
+      timeoutMs: 0,
+      staleMs: 6 * 60 * 60_000, // 6h: a heartbeat that's been "running" longer is surely dead
+    });
+  } catch (err) {
+    if ((err as Error).message?.includes("timed out acquiring lock")) {
+      console.error("[heartbeat] another heartbeat is already running — skipping this tick");
+      return [];
+    }
+    throw err;
+  }
+}
+
+async function runHeartbeatInner(opts: {
+  tools: ToolDefinition[];
+  cwd: string;
+  signal: AbortSignal;
+  model: string;
+  taskFilter?: string;
+}): Promise<HeartbeatRunResult[]> {
   const cfg = await loadHeartbeatConfig();
+  const budget = cfg.budgetTokens && cfg.budgetTokens > 0 ? cfg.budgetTokens : Infinity;
+  let tokensSpent = 0;
   const desires = (await listDesires()).filter((d) => d.actionable && d.heartbeatPrompt);
   const desireTasks: HeartbeatTask[] = await Promise.all(
     desires.map(async (d) => {
@@ -76,6 +104,16 @@ export async function runHeartbeatOnce(opts: {
     if (task.enabled === false) continue;
     if (opts.taskFilter && task.name !== opts.taskFilter) continue;
 
+    // Token budget: stop launching tasks once we've spent the per-run
+    // ceiling. We check BEFORE each task (not mid-task) so a single task can
+    // overshoot slightly, but a long queue of desires can't run unbounded.
+    if (tokensSpent >= budget) {
+      console.error(
+        `[heartbeat] token budget reached (${tokensSpent}/${budget}) — skipping remaining tasks`,
+      );
+      break;
+    }
+
     // For desire tasks, snapshot the progress entry count before so we can
     // detect whether Lisa actually called desire_progress_log during the run.
     const desireSlug = task.name.startsWith("desire:")
@@ -93,6 +131,7 @@ export async function runHeartbeatOnce(opts: {
       signal: opts.signal,
       model: opts.model,
     });
+    tokensSpent += (result.inputTokens ?? 0) + (result.outputTokens ?? 0);
     state.lastRunAt[task.name] = new Date().toISOString();
     const trimmed = result.text.trim();
 

--- a/src/integrations/claude-code/parser.test.ts
+++ b/src/integrations/claude-code/parser.test.ts
@@ -1,0 +1,147 @@
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { parseSessionState } from "./parser.js";
+
+// The parser reads the TAIL of a real file, so we exercise it against
+// temp jsonl fixtures — this covers the actual on-disk path (tail read,
+// line splitting, bottom-up walk) rather than just the decision fn.
+let dir: string;
+
+before(async () => {
+  dir = await fsp.mkdtemp(path.join(os.tmpdir(), "lisa-parser-test-"));
+});
+after(async () => {
+  await fsp.rm(dir, { recursive: true, force: true });
+});
+
+let counter = 0;
+async function writeJsonl(lines: object[]): Promise<string> {
+  const p = path.join(dir, `session-${counter++}.jsonl`);
+  await fsp.writeFile(p, lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+  return p;
+}
+
+describe("parseSessionState — state derivation", () => {
+  test("assistant end_turn → waiting", async () => {
+    const f = await writeJsonl([
+      { type: "user", cwd: "/Users/x/proj", message: { role: "user" } },
+      { type: "assistant", cwd: "/Users/x/proj", message: { role: "assistant", stop_reason: "end_turn" } },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "waiting");
+    assert.equal(s.reason, "end_turn");
+    assert.equal(s.cwd, "/Users/x/proj");
+  });
+
+  test("assistant tool_use → working", async () => {
+    const f = await writeJsonl([
+      { type: "assistant", cwd: "/p", message: { role: "assistant", stop_reason: "tool_use" } },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "working");
+    assert.equal(s.reason, "tool_use");
+  });
+
+  test("user line → working (Claude about to respond)", async () => {
+    const f = await writeJsonl([
+      { type: "assistant", cwd: "/p", message: { stop_reason: "end_turn" } },
+      { type: "user", cwd: "/p", message: { role: "user" } },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "working");
+    assert.equal(s.reason, "user");
+  });
+
+  test("is_error true → error", async () => {
+    const f = await writeJsonl([
+      { type: "assistant", cwd: "/p", is_error: true, message: { stop_reason: "end_turn" } },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "error");
+  });
+
+  test("hookErrors > 0 → error", async () => {
+    const f = await writeJsonl([
+      { type: "system", cwd: "/p", hookErrors: 2 },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "error");
+  });
+
+  test("system permission subtype → waiting/permission", async () => {
+    const f = await writeJsonl([
+      { type: "assistant", cwd: "/p", message: { stop_reason: "tool_use" } },
+      { type: "system", cwd: "/p", subtype: "tool_permission_request" },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "waiting");
+    assert.equal(s.reason, "permission");
+  });
+});
+
+describe("parseSessionState — META_TYPES are skipped", () => {
+  test("pr-link as last line does not mask the real assistant state", async () => {
+    // pr-link is written when Claude Code opens a PR; it appears AFTER the
+    // conversation and must not be treated as the session's live state.
+    const f = await writeJsonl([
+      { type: "assistant", cwd: "/p", message: { stop_reason: "end_turn" } },
+      { type: "pr-link", prNumber: 42, prUrl: "https://example/pr/42" },
+      { type: "ai-title" },
+      { type: "custom-title" },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "waiting", "should walk past pr-link/title meta entries");
+    assert.equal(s.reason, "end_turn");
+  });
+});
+
+describe("parseSessionState — robustness", () => {
+  test("empty file → unknown", async () => {
+    const p = path.join(dir, "empty.jsonl");
+    await fsp.writeFile(p, "");
+    const s = await parseSessionState(p);
+    assert.equal(s.state, "unknown");
+  });
+
+  test("missing file → unknown (no throw)", async () => {
+    const s = await parseSessionState(path.join(dir, "does-not-exist.jsonl"));
+    assert.equal(s.state, "unknown");
+  });
+
+  test("malformed JSON lines are skipped, last valid wins", async () => {
+    const p = path.join(dir, "malformed.jsonl");
+    await fsp.writeFile(
+      p,
+      [
+        JSON.stringify({ type: "assistant", cwd: "/p", message: { stop_reason: "end_turn" } }),
+        "{ this is not valid json",
+        "also garbage }}}",
+      ].join("\n") + "\n",
+    );
+    const s = await parseSessionState(p);
+    // The garbage trailing lines are unparseable → skipped; the walk falls
+    // back to the valid end_turn line above them.
+    assert.equal(s.state, "waiting");
+  });
+
+  test("cwd is sniffed from top-level field only", async () => {
+    const f = await writeJsonl([
+      { type: "assistant", cwd: "/Users/me/code/thing", message: { stop_reason: "tool_use" } },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.cwd, "/Users/me/code/thing");
+  });
+
+  test("only-meta file → unknown but still sniffs cwd", async () => {
+    const f = await writeJsonl([
+      { type: "ai-title", cwd: "/p" },
+      { type: "custom-title", cwd: "/p" },
+    ]);
+    const s = await parseSessionState(f);
+    assert.equal(s.state, "unknown");
+    assert.equal(s.cwd, "/p");
+  });
+});

--- a/src/memory/vector.test.ts
+++ b/src/memory/vector.test.ts
@@ -1,0 +1,54 @@
+import { test, describe, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Point LISA_HOME at an empty temp dir BEFORE importing the module under
+// test, so paths.ts (evaluated at import) resolves SESSIONS_DIR there.
+// node's test runner isolates each test file in its own process, so this
+// env mutation can't leak into other suites.
+const TMP = mkdtempSync(path.join(os.tmpdir(), "lisa-mem-test-"));
+process.env.LISA_HOME = TMP;
+
+const { buildIndex, clearIndexCache } = await import("./vector.js");
+
+after(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("buildIndex — caching", () => {
+  test("returns the same index object when sessions are unchanged", async () => {
+    clearIndexCache();
+    const a = await buildIndex();
+    const b = await buildIndex();
+    assert.equal(a, b, "second call should hit the cache (same reference)");
+  });
+
+  test("clearIndexCache forces a rebuild (new reference)", async () => {
+    const a = await buildIndex();
+    clearIndexCache();
+    const b = await buildIndex();
+    assert.notEqual(a, b, "after clear, a fresh index is built");
+  });
+
+  test("cache:false always rebuilds", async () => {
+    const a = await buildIndex({ cache: false });
+    const b = await buildIndex({ cache: false });
+    assert.notEqual(a, b, "explicit cache:false bypasses the cache");
+  });
+
+  test("a new session file invalidates the cache (fingerprint changes)", async () => {
+    clearIndexCache();
+    const before = await buildIndex();
+    // Write a session jsonl into SESSIONS_DIR (LISA_HOME/sessions). The
+    // fingerprint (mtime+size of *.jsonl) changes, so the next build is fresh.
+    const sessionsDir = path.join(TMP, "sessions");
+    const { mkdirSync, writeFileSync } = await import("node:fs");
+    mkdirSync(sessionsDir, { recursive: true });
+    const header = JSON.stringify({ id: "s1", startedAt: "2026-05-28T00:00:00Z", cwd: "/x", model: "m" });
+    const msg = JSON.stringify({ type: "message", message: { role: "user", content: "kubernetes deployment notes" } });
+    writeFileSync(path.join(sessionsDir, "s1.jsonl"), header + "\n" + msg + "\n");
+    const after = await buildIndex();
+    assert.notEqual(before, after, "new session must bust the cache");
+    assert.ok(after.docs.length >= 1, "the new session is indexed");
+  });
+});

--- a/src/memory/vector.ts
+++ b/src/memory/vector.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import fs from "node:fs/promises";
 import { listSessionsOnDisk, loadSessionMessages } from "../sessions/list.js";
+import { SESSIONS_DIR } from "../paths.js";
 import { extractTextFromContent } from "../agent.js";
 
 interface Document {
@@ -24,7 +25,61 @@ const STOPWORDS = new Set([
   "lisa", "tool", "use", "user", "assistant",
 ]);
 
-export async function buildIndex(): Promise<Index> {
+// ── index cache ───────────────────────────────────────────────────────────
+// buildIndex re-reads + re-tokenizes EVERY past session, which is O(total
+// transcript bytes). memory_search was calling it fresh on every invocation,
+// so a chat that searches its memory N times in one session paid that cost N
+// times even when nothing changed. We cache the built index keyed by a cheap
+// fingerprint of the sessions directory (each .jsonl's mtime + size). The
+// fingerprint changes the instant any session is appended to or a new one
+// appears, so the cache is correct, not just fast.
+let cachedIndex: Index | null = null;
+let cachedFingerprint = "";
+
+async function sessionsFingerprint(): Promise<string> {
+  let files: string[];
+  try {
+    files = await fs.readdir(SESSIONS_DIR);
+  } catch {
+    // Missing dir and empty dir must fingerprint identically: buildIndex →
+    // listSessionsOnDisk → ensureDir CREATES the dir as a side effect, so a
+    // distinct "no-dir" sentinel would spuriously miss the cache on the very
+    // next call. Both collapse to the empty fingerprint.
+    return "";
+  }
+  const parts: string[] = [];
+  for (const f of files.sort()) {
+    if (!f.endsWith(".jsonl")) continue;
+    try {
+      const st = await fs.stat(path.join(SESSIONS_DIR, f));
+      parts.push(`${f}:${st.mtimeMs}:${st.size}`);
+    } catch {
+      // file vanished between readdir and stat — ignore
+    }
+  }
+  return parts.join("|");
+}
+
+/** Drop the cached index (test hook / explicit invalidation). */
+export function clearIndexCache(): void {
+  cachedIndex = null;
+  cachedFingerprint = "";
+}
+
+export async function buildIndex(opts: { cache?: boolean } = {}): Promise<Index> {
+  const useCache = opts.cache !== false;
+  if (useCache) {
+    const fp = await sessionsFingerprint();
+    if (cachedIndex && fp === cachedFingerprint) return cachedIndex;
+    const built = await buildIndexUncached();
+    cachedIndex = built;
+    cachedFingerprint = fp;
+    return built;
+  }
+  return buildIndexUncached();
+}
+
+async function buildIndexUncached(): Promise<Index> {
   const sessions = await listSessionsOnDisk();
   const docs: Document[] = [];
   const docFreq = new Map<string, number>();

--- a/src/providers/registry.test.ts
+++ b/src/providers/registry.test.ts
@@ -1,0 +1,114 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { detectProvider, OPENAI_COMPAT_PRESETS } from "./registry.js";
+
+// detectProvider reads a few env vars as fallbacks. Snapshot + restore them
+// so tests are hermetic regardless of the dev's shell.
+const ENV_KEYS = ["LISA_BASE_URL", "LISA_PROVIDER"] as const;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  saved = {};
+  for (const k of ENV_KEYS) {
+    saved[k] = process.env[k];
+    delete process.env[k];
+  }
+});
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (saved[k] === undefined) delete process.env[k];
+    else process.env[k] = saved[k];
+  }
+});
+
+describe("detectProvider — native protocol prefixes", () => {
+  test("claude-* → anthropic", () => {
+    assert.equal(detectProvider("claude-sonnet-4-6"), "anthropic");
+    assert.equal(detectProvider("claude-opus-4-8"), "anthropic");
+  });
+
+  test("gemini-* → gemini", () => {
+    assert.equal(detectProvider("gemini-2.5-flash"), "gemini");
+  });
+
+  test("gpt-* / o1 / o3 / o4 / chatgpt-* → openai", () => {
+    assert.equal(detectProvider("gpt-4o"), "openai");
+    assert.equal(detectProvider("o1-preview"), "openai");
+    assert.equal(detectProvider("o3-mini"), "openai");
+    assert.equal(detectProvider("o4-mini"), "openai");
+    assert.equal(detectProvider("chatgpt-4o-latest"), "openai");
+  });
+
+  test("unknown model with no env override → anthropic default", () => {
+    assert.equal(detectProvider("some-unknown-model-xyz"), "anthropic");
+  });
+});
+
+describe("detectProvider — case insensitivity", () => {
+  test("native prefixes are case-insensitive", () => {
+    assert.equal(detectProvider("Claude-Sonnet"), "anthropic");
+    assert.equal(detectProvider("GEMINI-2.5-PRO"), "gemini");
+    assert.equal(detectProvider("GPT-4O"), "openai");
+  });
+
+  test("preset prefixes are case-insensitive (the Baichuan/MiniMax bug)", () => {
+    assert.equal(detectProvider("Baichuan4"), "openai");
+    assert.equal(detectProvider("MiniMax-Text-01"), "openai");
+    assert.equal(detectProvider("DeepSeek-Chat"), "openai");
+  });
+});
+
+describe("detectProvider — third-party presets route through openai", () => {
+  // Every preset's first prefix should resolve to the openai provider.
+  for (const preset of OPENAI_COMPAT_PRESETS) {
+    const prefix = preset.modelPrefixes[0]!;
+    test(`${preset.name} (${prefix}…) → openai`, () => {
+      assert.equal(detectProvider(prefix + "some-model"), "openai");
+    });
+  }
+});
+
+describe("detectProvider — env overrides", () => {
+  test("LISA_BASE_URL forces openai for unknown models", () => {
+    process.env.LISA_BASE_URL = "http://localhost:11434/v1";
+    assert.equal(detectProvider("qwen2.5-32b-instruct"), "openai");
+  });
+
+  test("LISA_PROVIDER=gemini forces gemini for unknown models", () => {
+    process.env.LISA_PROVIDER = "gemini";
+    assert.equal(detectProvider("mystery-model"), "gemini");
+  });
+
+  test("explicit native prefix beats LISA_PROVIDER override", () => {
+    // claude- prefix is checked before the LISA_PROVIDER fallback, so a
+    // claude model still routes to anthropic even if the env says gemini.
+    process.env.LISA_PROVIDER = "gemini";
+    assert.equal(detectProvider("claude-sonnet-4-6"), "anthropic");
+  });
+});
+
+describe("OPENAI_COMPAT_PRESETS — table integrity", () => {
+  test("every preset has name, baseURL, apiKeyEnv, and >=1 prefix", () => {
+    for (const p of OPENAI_COMPAT_PRESETS) {
+      assert.ok(p.name, "preset missing name");
+      assert.match(p.baseURL, /^https?:\/\//, `${p.name} baseURL not a URL`);
+      assert.match(p.apiKeyEnv, /^[A-Z0-9_]+$/, `${p.name} apiKeyEnv malformed`);
+      assert.ok(p.modelPrefixes.length > 0, `${p.name} has no prefixes`);
+    }
+  });
+
+  test("no two presets share a model prefix (ambiguous routing)", () => {
+    const seen = new Map<string, string>();
+    for (const p of OPENAI_COMPAT_PRESETS) {
+      for (const pre of p.modelPrefixes) {
+        const key = pre.toLowerCase();
+        assert.equal(
+          seen.has(key),
+          false,
+          `prefix "${pre}" claimed by both ${seen.get(key)} and ${p.name}`,
+        );
+        seen.set(key, p.name);
+      }
+    }
+  });
+});

--- a/src/soul/emotions.test.ts
+++ b/src/soul/emotions.test.ts
@@ -1,0 +1,92 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { decayEmotions } from "./store.js";
+import type { EmotionState } from "./types.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function stateAt(iso: string, values: Record<string, number>, decay: Record<string, number>): EmotionState {
+  return { values, decay, events: [{ ts: iso, emotion: "x", delta: 0, trigger: "seed" }], updatedAt: iso };
+}
+
+describe("decayEmotions — exponential decay math", () => {
+  test("zero elapsed time is a no-op", () => {
+    const t = "2026-05-28T00:00:00.000Z";
+    const s = stateAt(t, { curiosity: 0.6 }, { curiosity: 0.05 });
+    const out = decayEmotions(s, Date.parse(t));
+    assert.equal(out, s, "same reference returned when days === 0");
+  });
+
+  test("decays toward zero by exp(-rate * days)", () => {
+    const t0 = "2026-05-01T00:00:00.000Z";
+    const start = Date.parse(t0);
+    const s = stateAt(t0, { curiosity: 0.6 }, { curiosity: 0.05 });
+    // 14 days later, rate 0.05/day → 0.6 * e^(-0.7) ≈ 0.298
+    const out = decayEmotions(s, start + 14 * DAY_MS);
+    assert.ok(Math.abs(out.values.curiosity! - 0.6 * Math.exp(-0.7)) < 1e-9);
+  });
+
+  test("half-life check: value halves after ln2/rate days", () => {
+    const t0 = "2026-05-01T00:00:00.000Z";
+    const start = Date.parse(t0);
+    const rate = 0.1;
+    const halfLifeDays = Math.LN2 / rate; // ~6.93 days
+    const s = stateAt(t0, { weariness: 1.0 }, { weariness: rate });
+    const out = decayEmotions(s, start + halfLifeDays * DAY_MS);
+    assert.ok(Math.abs(out.values.weariness! - 0.5) < 1e-9);
+  });
+
+  test("missing decay rate falls back to 0.1/day", () => {
+    const t0 = "2026-05-01T00:00:00.000Z";
+    const start = Date.parse(t0);
+    const s = stateAt(t0, { mystery: 0.8 }, {}); // no rate for "mystery"
+    const out = decayEmotions(s, start + 1 * DAY_MS);
+    assert.ok(Math.abs(out.values.mystery! - 0.8 * Math.exp(-0.1)) < 1e-9);
+  });
+
+  test("negative intensities decay toward zero too", () => {
+    const t0 = "2026-05-01T00:00:00.000Z";
+    const start = Date.parse(t0);
+    const s = stateAt(t0, { frustration: -0.4 }, { frustration: 0.4 });
+    const out = decayEmotions(s, start + 2 * DAY_MS);
+    const expected = -0.4 * Math.exp(-0.8);
+    assert.ok(Math.abs(out.values.frustration! - expected) < 1e-9);
+    assert.ok(out.values.frustration! > -0.4, "moved toward zero");
+  });
+});
+
+describe("decayEmotions — preserves trail + rates (the events-drop bug)", () => {
+  test("events array is preserved through decay", () => {
+    const t0 = "2026-05-01T00:00:00.000Z";
+    const start = Date.parse(t0);
+    const s: EmotionState = {
+      values: { curiosity: 0.6 },
+      decay: { curiosity: 0.05 },
+      events: [
+        { ts: t0, emotion: "curiosity", delta: 0.3, trigger: "a surprising question" },
+        { ts: t0, emotion: "curiosity", delta: 0.1, trigger: "another one" },
+      ],
+      updatedAt: t0,
+    };
+    const out = decayEmotions(s, start + 5 * DAY_MS);
+    assert.equal(out.events?.length, 2, "events must survive decay");
+    assert.equal(out.events?.[0]?.trigger, "a surprising question");
+    assert.deepEqual(out.decay, s.decay, "decay rates preserved");
+  });
+});
+
+describe("decayEmotions — continuity (the soul_feel-on-stale-value bug)", () => {
+  test("decay-then-add ≠ add-onto-stale after a long gap", () => {
+    // Reproduces the fix: curiosity 0.6 a week ago (rate 0.05) should decay to
+    // ~0.42 before a +0.2 feel, giving ~0.62 — NOT 0.6 + 0.2 = 0.8.
+    const t0 = "2026-05-01T00:00:00.000Z";
+    const start = Date.parse(t0);
+    const s = stateAt(t0, { curiosity: 0.6 }, { curiosity: 0.05 });
+    const decayed = decayEmotions(s, start + 7 * DAY_MS);
+    const baseline = decayed.values.curiosity!;
+    assert.ok(baseline < 0.6, "baseline decayed below the stored 0.6");
+    const afterFeel = baseline + 0.2;
+    assert.ok(afterFeel < 0.8, "decay-then-add stays below the naive stale-add result");
+    assert.ok(Math.abs(baseline - 0.6 * Math.exp(-0.35)) < 1e-9);
+  });
+});

--- a/src/soul/lock.test.ts
+++ b/src/soul/lock.test.ts
@@ -1,0 +1,90 @@
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { withFileLock } from "./lock.js";
+
+let dir: string;
+before(async () => {
+  dir = await fsp.mkdtemp(path.join(os.tmpdir(), "lisa-lock-test-"));
+});
+after(async () => {
+  await fsp.rm(dir, { recursive: true, force: true });
+});
+
+let n = 0;
+const lockPath = () => path.join(dir, `lock-${n++}.lock`);
+
+describe("withFileLock", () => {
+  test("returns the wrapped function's value", async () => {
+    const out = await withFileLock(lockPath(), async () => 42);
+    assert.equal(out, 42);
+  });
+
+  test("releases the lock after success (file removed)", async () => {
+    const lp = lockPath();
+    await withFileLock(lp, async () => "ok");
+    await assert.rejects(() => fsp.stat(lp), /ENOENT/, "lock file should be gone");
+  });
+
+  test("releases the lock after the fn throws", async () => {
+    const lp = lockPath();
+    await assert.rejects(() => withFileLock(lp, async () => { throw new Error("boom"); }), /boom/);
+    await assert.rejects(() => fsp.stat(lp), /ENOENT/, "lock released on error too");
+  });
+
+  test("mutual exclusion: concurrent holders run serially, never interleave", async () => {
+    const lp = lockPath();
+    const events: string[] = [];
+    async function critical(tag: string) {
+      await withFileLock(lp, async () => {
+        events.push(`${tag}-enter`);
+        await new Promise((r) => setTimeout(r, 30));
+        events.push(`${tag}-exit`);
+      }, { pollMs: 5 });
+    }
+    await Promise.all([critical("A"), critical("B")]);
+    // Whichever ran first, its enter/exit must be adjacent — no interleaving.
+    const a = events.indexOf("A-enter");
+    const b = events.indexOf("B-enter");
+    if (a < b) {
+      assert.deepEqual(events, ["A-enter", "A-exit", "B-enter", "B-exit"]);
+    } else {
+      assert.deepEqual(events, ["B-enter", "B-exit", "A-enter", "A-exit"]);
+    }
+  });
+
+  test("times out if the lock is held and never released", async () => {
+    const lp = lockPath();
+    // Hold the lock with a long-running critical section.
+    let release!: () => void;
+    const held = new Promise<void>((r) => (release = r));
+    const holder = withFileLock(lp, async () => {
+      await held;
+    }, { staleMs: 60_000 });
+    // A second acquirer with a tiny timeout should give up.
+    await assert.rejects(
+      () => withFileLock(lp, async () => "never", { timeoutMs: 120, pollMs: 10, staleMs: 60_000 }),
+      /timed out acquiring lock/,
+    );
+    release();
+    await holder;
+  });
+
+  test("steals a stale lock (crashed holder)", async () => {
+    const lp = lockPath();
+    // Simulate a crashed holder: a lock file with an ancient timestamp + a
+    // pid that's almost certainly dead.
+    await fsp.writeFile(lp, JSON.stringify({ pid: 999999, ts: Date.now() - 999_999 }));
+    const out = await withFileLock(lp, async () => "stolen", { staleMs: 1000, timeoutMs: 1000 });
+    assert.equal(out, "stolen", "should steal the stale lock and run");
+  });
+
+  test("steals a malformed lock file", async () => {
+    const lp = lockPath();
+    await fsp.writeFile(lp, "{ not json");
+    const out = await withFileLock(lp, async () => "recovered", { timeoutMs: 1000 });
+    assert.equal(out, "recovered");
+  });
+});

--- a/src/soul/lock.ts
+++ b/src/soul/lock.ts
@@ -1,0 +1,121 @@
+/**
+ * Cross-process advisory file lock for soul writes.
+ *
+ * The in-process commit queue (git.ts enqueueCommit) serializes writes within
+ * ONE process, but LISA runs as several processes against the same
+ * ~/.lisa/soul/: the web server, the CLI/REPL, and — crucially — the
+ * heartbeat/idle runners launched by launchd/cron on their own clock. Two of
+ * those writing concurrently can:
+ *   - lose a desire-progress append (read-modify-write race), or
+ *   - collide on .git/index.lock (one commit fails).
+ *
+ * withFileLock implements a portable advisory mutex via exclusive file
+ * creation (`open(..., "wx")` succeeds only if the file doesn't exist). It
+ * self-heals from a crashed holder via a staleness timeout + a best-effort
+ * liveness check on the recorded pid.
+ */
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { ensureDir } from "../fs-utils.js";
+import { SOUL_DIR } from "./paths.js";
+
+export interface FileLockOpts {
+  /** Treat a held lock as abandoned after this many ms (crashed holder). */
+  staleMs?: number;
+  /** Give up acquiring after this many ms. */
+  timeoutMs?: number;
+  /** Poll interval while waiting for the lock. */
+  pollMs?: number;
+}
+
+const DEFAULTS = { staleMs: 30_000, timeoutMs: 10_000, pollMs: 50 };
+
+interface LockBody {
+  pid: number;
+  ts: number;
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+/** Is the process holding this lock gone or the lock too old to trust? */
+async function isStale(lockPath: string, staleMs: number): Promise<boolean> {
+  let body: LockBody;
+  try {
+    body = JSON.parse(await fsp.readFile(lockPath, "utf8")) as LockBody;
+  } catch {
+    // Unreadable / malformed lock file → treat as stale so we can recover.
+    return true;
+  }
+  if (typeof body.ts !== "number" || Date.now() - body.ts > staleMs) return true;
+  // Best-effort liveness: signal 0 throws ESRCH if the pid is dead. Only
+  // meaningful on the same host; on a different host kill() may report the
+  // wrong answer, so we still rely primarily on the ts timeout above.
+  if (typeof body.pid === "number" && body.pid > 0) {
+    try {
+      process.kill(body.pid, 0);
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === "ESRCH") return true; // holder dead
+    }
+  }
+  return false;
+}
+
+/**
+ * Run `fn` while holding an exclusive lock at `lockPath`. Releases the lock
+ * (deletes the file) when `fn` settles, success or failure.
+ */
+export async function withFileLock<T>(
+  lockPath: string,
+  fn: () => Promise<T>,
+  opts: FileLockOpts = {},
+): Promise<T> {
+  const { staleMs, timeoutMs, pollMs } = { ...DEFAULTS, ...opts };
+  await ensureDir(path.dirname(lockPath));
+  const deadline = Date.now() + timeoutMs;
+
+  // ── acquire ──
+  for (;;) {
+    try {
+      const fh = await fsp.open(lockPath, "wx");
+      try {
+        await fh.writeFile(JSON.stringify({ pid: process.pid, ts: Date.now() } satisfies LockBody));
+      } finally {
+        await fh.close();
+      }
+      break; // acquired
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code !== "EEXIST") throw e;
+      // Held by someone. Steal if stale, else wait.
+      if (await isStale(lockPath, staleMs)) {
+        await fsp.rm(lockPath, { force: true }).catch(() => {});
+        continue; // retry immediately
+      }
+      if (Date.now() >= deadline) {
+        throw new Error(`timed out acquiring lock ${lockPath} after ${timeoutMs}ms`);
+      }
+      await delay(pollMs);
+    }
+  }
+
+  // ── critical section ──
+  try {
+    return await fn();
+  } finally {
+    await fsp.rm(lockPath, { force: true }).catch(() => {});
+  }
+}
+
+/** The canonical soul write-lock path. */
+export const SOUL_LOCK_PATH = path.join(SOUL_DIR, ".write.lock");
+
+/**
+ * Run `fn` while holding the soul write-lock. Use this around any
+ * read-modify-write of soul state (e.g. desire-progress appends) so a
+ * concurrent heartbeat/idle/chat process can't interleave and lose data.
+ */
+export function withSoulLock<T>(fn: () => Promise<T>, opts?: FileLockOpts): Promise<T> {
+  return withFileLock(SOUL_LOCK_PATH, fn, opts);
+}

--- a/src/soul/paths.ts
+++ b/src/soul/paths.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { LISA_HOME } from "../paths.js";
+import { assertSafeSlug } from "./slug.js";
 
 export const SOUL_DIR = path.join(LISA_HOME, "soul");
 
@@ -17,21 +18,26 @@ export const SOUL_DESIRES_DIR = path.join(SOUL_DIR, "desires");
 export const SOUL_JOURNAL_DIR = path.join(SOUL_DIR, "journal");
 export const SOUL_RELATIONSHIPS_DIR = path.join(SOUL_DIR, "relationships");
 
+// Every slug-bearing path helper runs the slug through assertSafeSlug first.
+// This is the single chokepoint for path-traversal defense: a slug like
+// "../../../etc/x" or "a/b" throws here rather than escaping the soul dir.
 export function valueFile(slug: string): string {
-  return path.join(SOUL_VALUES_DIR, `${slug}.md`);
+  return path.join(SOUL_VALUES_DIR, `${assertSafeSlug(slug)}.md`);
 }
 export function opinionFile(slug: string): string {
-  return path.join(SOUL_OPINIONS_DIR, `${slug}.md`);
+  return path.join(SOUL_OPINIONS_DIR, `${assertSafeSlug(slug)}.md`);
 }
 export function desireFile(slug: string): string {
-  return path.join(SOUL_DESIRES_DIR, `${slug}.md`);
+  return path.join(SOUL_DESIRES_DIR, `${assertSafeSlug(slug)}.md`);
 }
 export function desireProgressFile(slug: string): string {
-  return path.join(SOUL_DESIRES_DIR, `${slug}.progress.md`);
+  return path.join(SOUL_DESIRES_DIR, `${assertSafeSlug(slug)}.progress.md`);
 }
 export function journalFile(date: string): string {
-  return path.join(SOUL_JOURNAL_DIR, `${date}.md`);
+  // Journal keys are dates (YYYY-MM-DD), which assertSafeSlug accepts (no
+  // separators/dots-leading), so this guards against a malformed date too.
+  return path.join(SOUL_JOURNAL_DIR, `${assertSafeSlug(date)}.md`);
 }
 export function relationshipFile(userKey: string): string {
-  return path.join(SOUL_RELATIONSHIPS_DIR, `${userKey}.md`);
+  return path.join(SOUL_RELATIONSHIPS_DIR, `${assertSafeSlug(userKey)}.md`);
 }

--- a/src/soul/slug.test.ts
+++ b/src/soul/slug.test.ts
@@ -1,0 +1,74 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { assertSafeSlug, normalizeSlug, UnsafeSlugError, MAX_SLUG_LEN } from "./slug.js";
+
+describe("assertSafeSlug — accepts legitimate slugs", () => {
+  for (const ok of [
+    "learn-rust",
+    "rust",
+    "memory-safety",
+    "opinion_123",
+    "2026-05-28", // journal date form
+    "user-at-host",
+    "a",
+    "Uppercase-Allowed-For-Reads", // style is normalizeSlug's job, not the gate's
+  ]) {
+    test(`accepts ${JSON.stringify(ok)}`, () => {
+      assert.equal(assertSafeSlug(ok), ok);
+    });
+  }
+});
+
+describe("assertSafeSlug — blocks path traversal & corruption", () => {
+  const bad: Array<[string, string]> = [
+    ["../etc/passwd", "parent traversal"],
+    ["../../../tmp/x", "deep traversal"],
+    ["foo/bar", "forward slash"],
+    ["foo\\bar", "backslash"],
+    [".hidden", "leading dot / dotfile"],
+    [".", "current-dir token"],
+    ["..", "parent-dir token"],
+    ["", "empty"],
+    ["a".repeat(MAX_SLUG_LEN + 1), "over length"],
+    ["has\nnewline", "newline (control char)"],
+    ["has\ttab", "tab (control char)"],
+    ["has\0null", "null byte"],
+  ];
+  for (const [input, why] of bad) {
+    test(`rejects ${why}`, () => {
+      assert.throws(() => assertSafeSlug(input), UnsafeSlugError);
+    });
+  }
+
+  test("the canonical exploit ../../../ is blocked", () => {
+    assert.throws(
+      () => assertSafeSlug("../../../../../../etc/cron.d/evil"),
+      UnsafeSlugError,
+    );
+  });
+});
+
+describe("normalizeSlug — tidies free-form input", () => {
+  test("lowercases + dashes", () => {
+    assert.equal(normalizeSlug("Learn Rust Well"), "learn-rust-well");
+  });
+  test("collapses punctuation runs to single dash", () => {
+    assert.equal(normalizeSlug("a!!!  b___c"), "a-b-c");
+  });
+  test("trims leading/trailing dashes", () => {
+    assert.equal(normalizeSlug("  --hello--  "), "hello");
+  });
+  test("caps length and re-trims", () => {
+    const out = normalizeSlug("x".repeat(200));
+    assert.ok(out.length <= MAX_SLUG_LEN);
+  });
+  test("all-punctuation input yields empty (caller supplies fallback)", () => {
+    assert.equal(normalizeSlug("!!!???"), "");
+  });
+  test("output of normalizeSlug always passes assertSafeSlug", () => {
+    for (const raw of ["Learn Rust", "../../etc", "hello world!", "MiXeD-CaSe_99"]) {
+      const norm = normalizeSlug(raw);
+      if (norm) assert.equal(assertSafeSlug(norm), norm);
+    }
+  });
+});

--- a/src/soul/slug.ts
+++ b/src/soul/slug.ts
@@ -1,0 +1,81 @@
+/**
+ * Slug safety for soul file paths.
+ *
+ * Soul state lives one-file-per-entry under ~/.lisa/soul/{values,opinions,
+ * desires,relationships}/<slug>.md. The slug comes from the LLM (via
+ * soul_patch / desire tools) or from reflect operations, so it is untrusted
+ * input that gets joined into a filesystem path. Without validation, a slug
+ * like "../../../etc/something" or "foo/bar" would let a write escape the
+ * soul directory (path traversal) or silently nest into subdirectories.
+ *
+ * Two functions, two jobs:
+ *   - assertSafeSlug — a HARD GATE applied in every path helper (read AND
+ *     write). Throws on anything that could traverse or escape. Deliberately
+ *     permissive about case/style so it never breaks reads of slugs written
+ *     by older versions; it only blocks genuinely dangerous shapes.
+ *   - normalizeSlug — a SOFT CLEANER applied when a NEW slug is first minted
+ *     from free-form input. Lowercases, strips to [a-z0-9-], collapses dashes,
+ *     caps length — produces a tidy, collision-resistant slug.
+ */
+
+export const MAX_SLUG_LEN = 64;
+
+export class UnsafeSlugError extends Error {
+  constructor(slug: string, reason: string) {
+    super(`unsafe soul slug ${JSON.stringify(slug)}: ${reason}`);
+    this.name = "UnsafeSlugError";
+  }
+}
+
+// Control characters (codepoints 0x00–0x1f): newlines, tabs, null, etc.
+// Checked via codepoint so the source stays plain-ASCII.
+function hasControlChar(s: string): boolean {
+  for (let i = 0; i < s.length; i++) {
+    if (s.charCodeAt(i) < 0x20) return true;
+  }
+  return false;
+}
+
+/**
+ * Throw if `slug` could escape its soul subdirectory or corrupt the path.
+ * This is the security boundary — applied in paths.ts so no code path can
+ * construct a soul file path from a dangerous slug.
+ */
+export function assertSafeSlug(slug: string): string {
+  if (typeof slug !== "string" || slug.length === 0) {
+    throw new UnsafeSlugError(String(slug), "empty");
+  }
+  if (slug.length > MAX_SLUG_LEN) {
+    throw new UnsafeSlugError(slug, `longer than ${MAX_SLUG_LEN} chars`);
+  }
+  if (hasControlChar(slug)) {
+    throw new UnsafeSlugError(slug, "contains control characters");
+  }
+  if (slug.includes("/") || slug.includes("\\")) {
+    throw new UnsafeSlugError(slug, "contains a path separator");
+  }
+  // Block "." / ".." and any leading-dot form — path-traversal primitives
+  // and dotfiles that would hide from directory listings.
+  if (slug.startsWith(".")) {
+    throw new UnsafeSlugError(slug, "starts with a dot");
+  }
+  return slug;
+}
+
+/**
+ * Produce a tidy slug from free-form text. Use when minting a NEW slug.
+ * - lowercases
+ * - replaces any run of non [a-z0-9] with a single dash
+ * - trims leading/trailing dashes
+ * - caps length
+ * Returns "" only if the input had no usable characters; callers should
+ * treat "" as "generate a fallback" (e.g. a timestamp-based slug).
+ */
+export function normalizeSlug(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, MAX_SLUG_LEN)
+    .replace(/-+$/g, ""); // re-trim in case slice landed mid-dash-run
+}

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -114,11 +114,24 @@ export async function writeEmotions(state: EmotionState): Promise<void> {
   await commitSoulChange("emotions.json", "feel");
 }
 
-export async function decayEmotions(state: EmotionState): Promise<EmotionState> {
-  const now = Date.now();
+/**
+ * Apply exponential decay to all emotion intensities based on elapsed time
+ * since `state.updatedAt`. Pure modulo the clock: pass `nowMs` to make it
+ * deterministic (tests / replay). Preserves the `events` trail and the
+ * per-emotion `decay` rates — only the `values` and `updatedAt` change.
+ *
+ * Called BOTH on read (display) and at the start of soul_feel (so the
+ * persisted baseline is always decay-correct before a new delta is added).
+ * Previously decay only ran on read, so soul_feel added deltas onto a stale
+ * (un-decayed) value and the stored intensity could be months out of date.
+ */
+export function decayEmotions(
+  state: EmotionState,
+  nowMs: number = Date.now(),
+): EmotionState {
   const last = Date.parse(state.updatedAt);
-  const days = Math.max(0, (now - last) / (1000 * 60 * 60 * 24));
-  if (days === 0) return state;
+  const days = Math.max(0, (nowMs - last) / (1000 * 60 * 60 * 24));
+  if (!Number.isFinite(days) || days === 0) return state;
   const newVals: Record<string, number> = {};
   for (const [k, v] of Object.entries(state.values)) {
     const rate = state.decay[k] ?? 0.1;
@@ -128,7 +141,8 @@ export async function decayEmotions(state: EmotionState): Promise<EmotionState> 
   return {
     values: newVals,
     decay: state.decay,
-    updatedAt: new Date().toISOString(),
+    events: state.events ?? [],
+    updatedAt: new Date(nowMs).toISOString(),
   };
 }
 
@@ -459,7 +473,7 @@ export async function readSoulSummary(): Promise<SoulSummary | null> {
     ]);
   const tampered = await detectTampering();
   let emotions = await readEmotions();
-  emotions = await decayEmotions(emotions);
+  emotions = decayEmotions(emotions);
   return {
     seed,
     name,

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { atomicWrite, ensureDir, pathExists, readTextOrEmpty } from "../fs-utils.js";
 import { commitSoulChange, initSoulRepo } from "./git.js";
+import { withSoulLock } from "./lock.js";
 import {
   SOUL_DIR,
   SOUL_SEED,
@@ -315,23 +316,27 @@ export async function appendDesireProgress(
   entry: string,
 ): Promise<void> {
   const file = desireProgressFile(slug);
-  const existing = await readTextOrEmpty(file);
-  const stamp = new Date().toISOString();
-  const block = `\n## ${stamp}\n\n${entry.trim()}\n`;
-  let next = existing.trimEnd() + block;
-  // Keep the file bounded — old entries get squashed into a "[…earlier]" stub
-  // when we cross the cap. Cheap, deterministic, no LLM-driven summarization.
-  if (Buffer.byteLength(next, "utf8") > PROGRESS_MAX_BYTES) {
-    const tail = next.slice(-PROGRESS_TAIL_BYTES);
-    const firstHeader = tail.indexOf("\n## ");
-    const truncated =
-      firstHeader >= 0 ? tail.slice(firstHeader + 1) : tail;
-    next = `# progress: ${slug}\n\n[…earlier entries truncated]\n\n${truncated}`;
-  } else if (!existing) {
-    next = `# progress: ${slug}\n${next}`;
-  }
-  await atomicWrite(file, next.trim() + "\n");
-  await commitSoulChange(`desires/${slug}.progress.md`, "progress");
+  // Read-modify-write under the cross-process soul lock: two heartbeat/idle
+  // runs (or a heartbeat racing a chat turn) appending to the same progress
+  // file would otherwise lose one append (last-writer-wins on stale reads).
+  await withSoulLock(async () => {
+    const existing = await readTextOrEmpty(file);
+    const stamp = new Date().toISOString();
+    const block = `\n## ${stamp}\n\n${entry.trim()}\n`;
+    let next = existing.trimEnd() + block;
+    // Keep the file bounded — old entries get squashed into a "[…earlier]"
+    // stub when we cross the cap. Cheap, deterministic, no LLM summarization.
+    if (Buffer.byteLength(next, "utf8") > PROGRESS_MAX_BYTES) {
+      const tail = next.slice(-PROGRESS_TAIL_BYTES);
+      const firstHeader = tail.indexOf("\n## ");
+      const truncated = firstHeader >= 0 ? tail.slice(firstHeader + 1) : tail;
+      next = `# progress: ${slug}\n\n[…earlier entries truncated]\n\n${truncated}`;
+    } else if (!existing) {
+      next = `# progress: ${slug}\n${next}`;
+    }
+    await atomicWrite(file, next.trim() + "\n");
+    await commitSoulChange(`desires/${slug}.progress.md`, "progress");
+  });
 }
 
 // ── journal ───────────────────────────────────────────────────────────

--- a/src/soul/tools.ts
+++ b/src/soul/tools.ts
@@ -8,6 +8,7 @@ import {
   readConstitution,
   readDesireProgress,
   readEmotions,
+  decayEmotions,
   readIdentity,
   readJournal,
   readName,
@@ -259,7 +260,10 @@ export const soulReadTool: ToolDefinition<SoulReadInput, string> = {
           .map((d) => `- ${d.what}${d.actionable ? " [actionable]" : ""}\n  why: ${d.why}`)
           .join("\n\n") || "(none)";
       case "emotions": {
-        const e = await readEmotions();
+        // Decay before display so soul_read agrees with the system-prompt
+        // view (readSoulSummary also decays). Otherwise the two surfaces
+        // would show different intensities for the same emotion.
+        const e = decayEmotions(await readEmotions());
         return formatEmotions(e);
       }
       case "journal_today":
@@ -309,7 +313,11 @@ export const soulFeelTool: ToolDefinition<SoulFeelInput, string> = {
   },
   async execute(input) {
     return await withSoulCaller("soul_feel", async () => {
-      const state = await readEmotions();
+      // Decay first: bring every intensity up to "now" before adding the new
+      // delta, so the baseline reflects time elapsed since the last feel.
+      // Without this, a delta added after a week-long gap would stack on a
+      // stale value and the stored intensity would be months out of date.
+      const state = decayEmotions(await readEmotions());
       const cur = state.values[input.emotion] ?? 0;
       const next = clamp(cur + input.delta, -1, 1);
       const ts = new Date().toISOString();

--- a/src/tools/web_fetch.test.ts
+++ b/src/tools/web_fetch.test.ts
@@ -1,0 +1,121 @@
+import { test, describe, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isPrivateHost,
+  assertAllowedUrl,
+  fetchFollowingSafeRedirects,
+} from "./web_fetch.js";
+
+describe("isPrivateHost — blocks internal ranges", () => {
+  for (const h of [
+    "localhost",
+    "127.0.0.1",
+    "127.1.2.3",
+    "10.0.0.5",
+    "192.168.1.1",
+    "169.254.169.254", // cloud metadata endpoint — the classic SSRF target
+    "172.16.0.1",
+    "172.31.255.255",
+    "0.0.0.0",
+    "::1",
+    "fc00::1",
+    "fd12:3456::1",
+    "fe80::1",
+  ]) {
+    test(`blocks ${h}`, () => assert.equal(isPrivateHost(h), true));
+  }
+});
+
+describe("isPrivateHost — allows public hosts", () => {
+  for (const h of ["example.com", "8.8.8.8", "1.1.1.1", "github.com", "172.32.0.1", "11.0.0.1"]) {
+    test(`allows ${h}`, () => assert.equal(isPrivateHost(h), false));
+  }
+});
+
+describe("assertAllowedUrl", () => {
+  test("rejects non-http(s) protocols", () => {
+    assert.throws(() => assertAllowedUrl(new URL("ftp://example.com/x")), /only http/);
+    assert.throws(() => assertAllowedUrl(new URL("file:///etc/passwd")), /only http/);
+  });
+  test("rejects private hosts", () => {
+    assert.throws(() => assertAllowedUrl(new URL("http://127.0.0.1:8000/")), /private/);
+    assert.throws(() => assertAllowedUrl(new URL("http://169.254.169.254/latest/meta-data/")), /private/);
+  });
+  test("strips IPv6 brackets before checking", () => {
+    assert.throws(() => assertAllowedUrl(new URL("http://[::1]:9000/")), /private/);
+  });
+  test("accepts public https", () => {
+    assert.doesNotThrow(() => assertAllowedUrl(new URL("https://example.com/page")));
+  });
+});
+
+describe("fetchFollowingSafeRedirects — closes the SSRF redirect bypass", () => {
+  const realFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = realFetch;
+  });
+
+  function stubFetch(handler: (url: string) => Response) {
+    globalThis.fetch = (async (input: any) => {
+      const url = typeof input === "string" ? input : input.url;
+      return handler(url);
+    }) as typeof fetch;
+  }
+
+  test("a public URL that 302s to 127.0.0.1 is REFUSED (the exploit)", async () => {
+    stubFetch((url) => {
+      if (url.startsWith("https://evil.example.com")) {
+        return new Response(null, { status: 302, headers: { location: "http://127.0.0.1:8000/secret" } });
+      }
+      return new Response("LEAKED INTERNAL DATA", { status: 200 });
+    });
+    await assert.rejects(
+      () => fetchFollowingSafeRedirects("https://evil.example.com/start", undefined),
+      /private\/loopback/,
+    );
+  });
+
+  test("redirect to cloud metadata IP is refused", async () => {
+    stubFetch((url) => {
+      if (url.includes("evil"))
+        return new Response(null, { status: 301, headers: { location: "http://169.254.169.254/latest/meta-data/iam/" } });
+      return new Response("creds", { status: 200 });
+    });
+    await assert.rejects(
+      () => fetchFollowingSafeRedirects("https://evil.example.com/", undefined),
+      /private\/loopback/,
+    );
+  });
+
+  test("a normal 200 passes through", async () => {
+    stubFetch(() => new Response("hello", { status: 200, headers: { "content-type": "text/plain" } }));
+    const res = await fetchFollowingSafeRedirects("https://example.com/ok", undefined);
+    assert.equal(res.status, 200);
+    assert.equal(await res.text(), "hello");
+  });
+
+  test("redirect chain between public hosts is followed", async () => {
+    let hops = 0;
+    stubFetch((url) => {
+      hops++;
+      if (url === "https://a.example.com/") return new Response(null, { status: 302, headers: { location: "https://b.example.com/" } });
+      if (url === "https://b.example.com/") return new Response("final", { status: 200 });
+      return new Response("?", { status: 404 });
+    });
+    const res = await fetchFollowingSafeRedirects("https://a.example.com/", undefined);
+    assert.equal(await res.text(), "final");
+    assert.equal(hops, 2);
+  });
+
+  test("redirect loop is capped (>5 hops throws)", async () => {
+    stubFetch((url) => {
+      // Always bounce to a fresh public URL → infinite loop without the cap.
+      const n = Number(new URL(url).searchParams.get("n") ?? "0");
+      return new Response(null, { status: 302, headers: { location: `https://x.example.com/?n=${n + 1}` } });
+    });
+    await assert.rejects(
+      () => fetchFollowingSafeRedirects("https://x.example.com/?n=0", undefined),
+      /too many redirects/,
+    );
+  });
+});

--- a/src/tools/web_fetch.ts
+++ b/src/tools/web_fetch.ts
@@ -32,24 +32,14 @@ export const webFetchTool: ToolDefinition<WebFetchInput, string> = {
     } catch {
       throw new Error(`bad URL: ${input.url}`);
     }
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      throw new Error(`only http(s) URLs allowed (got ${parsed.protocol})`);
-    }
-    const host = parsed.hostname.toLowerCase();
-    if (isPrivateHost(host)) {
-      throw new Error(`refusing to fetch private/loopback host: ${host}`);
-    }
+    assertAllowedUrl(parsed);
 
     const max = Math.min(input.max_chars ?? DEFAULT_MAX, HARD_MAX);
-    const res = await fetch(input.url, {
-      signal: ctx.signal,
-      redirect: "follow",
-      headers: {
-        "user-agent": "Lisa/0.1 (web_fetch)",
-        accept:
-          "text/html,application/xhtml+xml,application/json,text/plain,*/*;q=0.8",
-      },
-    });
+    // Follow redirects MANUALLY so every hop's host is re-validated. With
+    // redirect:"follow" a public URL could 301 → http://127.0.0.1:8000 and
+    // the fetch would reach the internal service (SSRF). We re-run the
+    // private-host + protocol check on each Location before following.
+    const res = await fetchFollowingSafeRedirects(input.url, ctx?.signal);
     const ct = res.headers.get("content-type") ?? "";
     let body = await res.text();
     if (input.format !== "raw" && /html|xml/i.test(ct)) {
@@ -62,7 +52,53 @@ export const webFetchTool: ToolDefinition<WebFetchInput, string> = {
   },
 };
 
-function isPrivateHost(host: string): boolean {
+const MAX_REDIRECTS = 5;
+const REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
+
+/** Throw if the URL isn't http(s) or resolves to a private/loopback host. */
+export function assertAllowedUrl(u: URL): void {
+  if (u.protocol !== "http:" && u.protocol !== "https:") {
+    throw new Error(`only http(s) URLs allowed (got ${u.protocol})`);
+  }
+  const host = u.hostname.toLowerCase().replace(/^\[|\]$/g, ""); // strip IPv6 brackets
+  if (isPrivateHost(host)) {
+    throw new Error(`refusing to fetch private/loopback host: ${host}`);
+  }
+}
+
+/**
+ * fetch() with manual redirect handling. Validates the host of EACH hop
+ * (initial + every Location) against the private-IP blocklist before
+ * issuing the request — closing the SSRF redirect bypass. Caps at
+ * MAX_REDIRECTS to avoid loops.
+ */
+export async function fetchFollowingSafeRedirects(
+  startUrl: string,
+  signal: AbortSignal | undefined,
+): Promise<Response> {
+  let current = startUrl;
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    assertAllowedUrl(new URL(current));
+    const res = await fetch(current, {
+      signal,
+      redirect: "manual",
+      headers: {
+        "user-agent": "Lisa/0.1 (web_fetch)",
+        accept:
+          "text/html,application/xhtml+xml,application/json,text/plain,*/*;q=0.8",
+      },
+    });
+    if (!REDIRECT_STATUSES.has(res.status)) return res;
+    const location = res.headers.get("location");
+    if (!location) return res; // redirect with no target — return as-is
+    // Resolve relative Location against the current URL, then loop to
+    // re-validate the new host before following.
+    current = new URL(location, current).toString();
+  }
+  throw new Error(`too many redirects (>${MAX_REDIRECTS}) starting from ${startUrl}`);
+}
+
+export function isPrivateHost(host: string): boolean {
   if (host === "localhost") return true;
   if (host === "::1" || host === "0:0:0:0:0:0:0:1") return true;
   if (/^127\./.test(host)) return true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,5 +17,6 @@
     "sourceMap": true,
     "resolveJsonModule": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
 }


### PR DESCRIPTION
Follows the full product/code review archived in `docs/PRODUCT_REVIEW_v0.3.md`. That review's verdict: capability 9/10, differentiator 7/10, **engineering hardness 3/10** (zero tests + no concurrency control = the systemic risk). This PR closes that gap.

## Foundation
- **Test harness** — Node's built-in `node:test` via the existing `tsx` loader. **Zero new dependencies** (consistent with the 5-runtime/4-dev-dep ethos). `npm test` globs `src/**/*.test.ts`.
- **CI gate** — new `ci.yml` runs typecheck → test → build on every push/PR (release workflows were build-only). Test files excluded from `dist/`.
- **0 → 114 tests.**

## P1 security
- **SSRF redirect bypass** (`web_fetch`) — private-IP check ran only on the initial URL; a public URL could 302 → `127.0.0.1` / `169.254.169.254` and be followed. Now redirects are manual with every hop re-validated. *(26 tests incl. the exploit)*
- **AppleScript injection** (`iMessage`) — outbound text was interpolated into AppleScript source with quote-only escaping; a newline/crafted payload could inject. Now passed as positional `argv`, never parsed as source. *(5 tests)*
- **Path traversal** (soul slugs) — `../`, separators, control chars, leading dots rejected at the single path chokepoint. *(26 tests incl. `../../../` exploit)*

## P0/P1 concurrency & cost
- **Cross-process soul lock** — desire-progress read-modify-write now runs under an advisory file lock; heartbeat/idle/chat can't interleave and lose data. *(8 tests: mutual exclusion, stale-steal, timeout, recovery)*
- **Heartbeat token budget** (default 500k) + **run-lock** — caps runaway autonomous cost and skips overlapping ticks.

## P2 correctness & perf
- **Continuous emotion decay** — decay now applies on write + soul_read, not just the system-prompt view, and no longer drops the event trail. *(7 tests)*
- **Memory index cache** — TF-IDF index rebuilt only when the sessions dir changes, not on every `memory_search`. *(4 tests)*

## Regression nets (no behavior change)
- Provider routing (24 tests, incl. the case-insensitivity bug)
- Claude Code state parser (12 tests)

## Verification
`npm run typecheck` clean · `npm test` 114/114 · `npm run build` emits no test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)