### PR TITLE
Voice: record audio → LISA transcribes + summarizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.6.0] — 2026-05-30
+
+**LISA can listen.** Record audio in the chat → she transcribes it and
+summarizes in her own voice. Full notes: `docs/RELEASE_v0.6.0.md`.
+
+### Added — Voice recording
+
+- **🎙 composer button** toggles a browser `MediaRecorder` (pulsing ⏹ while
+  live). On stop, the clip is transcribed and handed to Lisa with a
+  "summarize this" framing — she replies with key points / decisions / action
+  items as a normal, persisted chat turn.
+- **`POST /api/voice/transcribe`** `{data(base64), mediaType}` → `{transcript}`;
+  writes a temp file, runs the existing Whisper transcriber, deletes the temp.
+  Summarization is the model's job via the normal chat (no special endpoint),
+  so it inherits soul/memory/context. Clear error if `OPENAI_API_KEY` is unset.
+- Privacy: nothing recorded until 🎙 pressed; clip leaves the machine only for
+  transcription on stop; temp deleted immediately.
+
+### Requirements
+
+- `OPENAI_API_KEY` (Whisper) for transcription.
+
 ## [0.5.0] — 2026-05-30
 
 **LISA can see.** Hand her a screenshot and talk about it — from anywhere, one

--- a/docs/RELEASE_v0.6.0.md
+++ b/docs/RELEASE_v0.6.0.md
@@ -1,0 +1,42 @@
+## What's new in v0.6.0 — LISA can listen
+
+LISA gets **ears**. Record audio right in the chat and she transcribes it and
+gives you a summary — in her own voice, persisted and discussable.
+
+### Record → transcribe → summary
+
+- **🎙 button** in the composer toggles recording (turns into a pulsing ⏹
+  while live). Press it again to stop.
+- On stop, the clip is transcribed (OpenAI Whisper, server-side) and the
+  transcript is handed to Lisa with a "summarize this" framing — so she replies
+  with a clear summary (key points, decisions, action items) **in her own
+  voice**, as a normal chat turn you can ask follow-ups about.
+
+### How it works
+
+- Recording happens in the browser via the standard `MediaRecorder` API (no
+  native dependency), so it works in Lisa.app and any browser tab. First use
+  prompts for microphone permission.
+- A new `POST /api/voice/transcribe` endpoint takes the base64 clip, writes a
+  temp file, runs the existing Whisper transcriber, returns the transcript, and
+  deletes the temp. Summarization is the model's job through the normal chat —
+  no special endpoint — so it inherits LISA's soul, memory, and context.
+- Privacy: nothing is recorded until you press 🎙, the clip only leaves the
+  machine for transcription when you stop, and the temp file is deleted
+  immediately after.
+
+### Requirements
+
+- **`OPENAI_API_KEY`** (Whisper). Set it in `~/.lisa/config.env`. Without it the
+  recorder shows a clear error instead of failing silently.
+
+### Upgrade
+
+```sh
+npm install -g @oratis/lisa            # 0.6.0
+# or
+brew update && brew upgrade lisa
+# or grab the signed + notarized Lisa-Suite-v0.6.0.dmg below
+```
+
+Test suite: **170 passing**. Still zero new runtime dependencies.

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -607,12 +607,12 @@ export const MAIN_HTML = `<!doctype html>
     -webkit-backdrop-filter: blur(30px);
     border-top: 1px solid var(--border-new);
     display: grid;
-    grid-template-columns: 36px 36px 1fr 96px;
+    grid-template-columns: 36px 36px 36px 1fr 96px;
     gap: 10px;
     align-items: end;
   }
 
-  #attachBtn, #captureBtn {
+  #attachBtn, #captureBtn, #recordBtn {
     align-self: stretch;
     display: flex;
     align-items: center;
@@ -627,8 +627,15 @@ export const MAIN_HTML = `<!doctype html>
     min-height: 44px;
     padding: 0;
   }
-  #attachBtn:hover, #captureBtn:hover { background: var(--bg-card); color: var(--fg); }
+  #attachBtn:hover, #captureBtn:hover, #recordBtn:hover { background: var(--bg-card); color: var(--fg); }
   #captureBtn.flash { background: var(--accent); color: var(--bg-deep); }
+  /* Pulsing red while recording. */
+  #recordBtn.recording {
+    background: var(--err-color);
+    color: #fff;
+    animation: rec-pulse 1.1s ease-in-out infinite;
+  }
+  @keyframes rec-pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.55; } }
   /* Off-screen the file input instead of display:none. WKWebView's
      implicit <label>→<input type=file> click forward doesn't fire on a
      fully display:none input — the OS file picker silently no-ops.
@@ -708,7 +715,7 @@ export const MAIN_HTML = `<!doctype html>
       gap: 14px;
     }
     #form {
-      grid-template-columns: 36px 36px 1fr 84px;
+      grid-template-columns: 36px 36px 36px 1fr 84px;
       padding: 10px 14px 14px;
     }
     #input { font-size: 16px; /* prevents iOS Safari auto-zoom */ }
@@ -1139,6 +1146,7 @@ export const MAIN_HTML = `<!doctype html>
         📎
       </label>
       <button type="button" id="captureBtn" title="Screenshot for Lisa (⌃⌥S anywhere)">📷</button>
+      <button type="button" id="recordBtn" title="Record audio — Lisa will transcribe + summarize it">🎙</button>
       <textarea id="input" placeholder="Talk to Lisa…  (Enter to send · Shift+Enter for newline)" autofocus></textarea>
       <button type="submit" id="sendBtn">
         <img src="/assets/icon-send.png" alt="">
@@ -1319,6 +1327,105 @@ fileInput.addEventListener('change', async () => {
 const captureBtnEl = document.getElementById('captureBtn');
 if (captureBtnEl) {
   captureBtnEl.addEventListener('click', () => { void window.lisaCaptureAndAttach('interactive'); });
+}
+
+// ── Audio recording → transcribe → Lisa summarizes ─────────────────
+// 🎙 toggles a MediaRecorder. On stop: POST the clip to /api/voice/transcribe
+// (server-side Whisper), then send the transcript into the normal chat with a
+// "summarize this" framing — so Lisa produces the summary in her own voice and
+// it's persisted + discussable like any turn. First click prompts mic
+// permission (browser-native).
+const recordBtnEl = document.getElementById('recordBtn');
+let mediaRecorder = null;
+let recordedChunks = [];
+let recordStream = null;
+
+function pickAudioMime() {
+  const prefs = ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/ogg'];
+  for (const m of prefs) {
+    try { if (window.MediaRecorder && MediaRecorder.isTypeSupported(m)) return m; } catch (_) {}
+  }
+  return '';
+}
+
+async function startRecording() {
+  if (!navigator.mediaDevices || !window.MediaRecorder) {
+    el('div', 'err', '[voice] recording not supported in this browser');
+    return;
+  }
+  try {
+    recordStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+  } catch (err) {
+    el('div', 'err', '[voice] microphone access denied or unavailable');
+    return;
+  }
+  const mimeType = pickAudioMime();
+  recordedChunks = [];
+  mediaRecorder = mimeType ? new MediaRecorder(recordStream, { mimeType }) : new MediaRecorder(recordStream);
+  mediaRecorder.addEventListener('dataavailable', (e) => { if (e.data && e.data.size > 0) recordedChunks.push(e.data); });
+  mediaRecorder.addEventListener('stop', () => { void finishRecording(); });
+  mediaRecorder.start();
+  if (recordBtnEl) { recordBtnEl.classList.add('recording'); recordBtnEl.textContent = '⏹'; recordBtnEl.title = 'Stop recording'; }
+}
+
+function stopRecordingTracks() {
+  if (recordStream) { recordStream.getTracks().forEach((t) => t.stop()); recordStream = null; }
+  if (recordBtnEl) { recordBtnEl.classList.remove('recording'); recordBtnEl.textContent = '🎙'; recordBtnEl.title = 'Record audio — Lisa will transcribe + summarize it'; }
+}
+
+async function finishRecording() {
+  const mime = (mediaRecorder && mediaRecorder.mimeType) || 'audio/webm';
+  stopRecordingTracks();
+  const blob = new Blob(recordedChunks, { type: mime });
+  recordedChunks = [];
+  if (blob.size === 0) return;
+  // Show a transient "transcribing…" line in the log.
+  const pending = el('div', 'thinking', '⋯ transcribing recording');
+  try {
+    const data = await blobToBase64(blob);
+    const res = await fetch('/api/voice/transcribe', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ data, mediaType: mime }),
+    });
+    const out = await res.json();
+    if (pending) pending.remove();
+    if (!res.ok || out.error) {
+      el('div', 'err', '[voice] ' + (out.error || ('HTTP ' + res.status)));
+      return;
+    }
+    const transcript = (out.transcript || '').trim();
+    if (!transcript) { el('div', 'err', '[voice] (empty transcript)'); return; }
+    // Hand the transcript to Lisa with a summarize framing. send() handles the
+    // chat turn, persistence, and her response in her own voice.
+    const framed =
+      "I just recorded some audio. Here's the transcript — please give me a clear, " +
+      "useful summary (key points, decisions, action items if any), then I might ask follow-ups.\n\n" +
+      "--- transcript ---\n" + transcript;
+    send(framed);
+  } catch (err) {
+    if (pending) pending.remove();
+    el('div', 'err', '[voice] ' + (err && err.message ? err.message : 'transcription failed'));
+  }
+}
+
+function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result).split(',')[1] || '');
+    reader.onerror = reject;
+    reader.readAsDataURL(blob);
+  });
+}
+
+if (recordBtnEl) {
+  recordBtnEl.addEventListener('click', () => {
+    if (mediaRecorder && mediaRecorder.state === 'recording') {
+      mediaRecorder.stop();
+    } else {
+      void startRecording();
+    }
+  });
 }
 
 const attachBtnEl = document.getElementById('attachBtn');

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -24,6 +24,8 @@ import { setCurrentHub } from "../integrations/current-hub.js";
 import { advise, formatDigest } from "../advisor/engine.js";
 import type { AgentSession } from "../integrations/types.js";
 import { captureScreenshot, captureSupported, type CaptureMode } from "../vision/capture.js";
+import { transcribeAudio } from "../voice/transcribe.js";
+import os from "node:os";
 import { LISA_HOME } from "../paths.js";
 import type { ToolDefinition, StoredMessage } from "../types.js";
 
@@ -317,6 +319,55 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       } catch (err) {
         res.writeHead(500, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: (err as Error).message }));
+      }
+      return;
+    }
+
+    // Voice: transcribe an audio clip recorded in the browser. Body is JSON
+    // { data: <base64>, mediaType?: string }. Writes a temp file, runs the
+    // existing Whisper transcriber, returns { transcript } and deletes the
+    // temp. The browser records via MediaRecorder; LISA then summarizes the
+    // transcript through the normal chat flow (server-side summarization is
+    // the model's job, not a special endpoint). 400 on missing data; the
+    // transcriber itself errors clearly if OPENAI_API_KEY is unset.
+    if (req.method === "POST" && url === "/api/voice/transcribe") {
+      let voiceBody = "";
+      for await (const chunk of req) voiceBody += chunk.toString("utf8");
+      let payload: { data?: string; mediaType?: string };
+      try {
+        payload = JSON.parse(voiceBody || "{}");
+      } catch {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "invalid JSON body" }));
+        return;
+      }
+      if (!payload.data) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "missing audio data" }));
+        return;
+      }
+      // Pick an extension Whisper accepts based on the recorder's mimeType.
+      const mt = payload.mediaType ?? "audio/webm";
+      const ext = mt.includes("mp4") || mt.includes("m4a")
+        ? "m4a"
+        : mt.includes("ogg")
+          ? "ogg"
+          : mt.includes("wav")
+            ? "wav"
+            : "webm";
+      const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
+      const tmp = path.join(os.tmpdir(), `lisa-rec-${stamp}-${process.pid}.${ext}`);
+      try {
+        await fs.writeFile(tmp, Buffer.from(payload.data, "base64"));
+        console.error(`[voice] transcribing ${Buffer.from(payload.data, "base64").length} bytes (${ext})`);
+        const transcript = await transcribeAudio({ audioPath: tmp });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ transcript }));
+      } catch (err) {
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: (err as Error).message }));
+      } finally {
+        await fs.rm(tmp, { force: true }).catch(() => {});
       }
       return;
     }


### PR DESCRIPTION
LISA gets ears. Record audio in the chat → she transcribes it and summarizes in her own voice.

## What landed
- **🎙 composer button** toggles a browser `MediaRecorder` (no native dep; pulsing ⏹ while recording, mic-permission + unsupported-browser handled). On stop → POST clip → transcribe → the transcript is handed to Lisa with a "summarize this" framing via the normal `send()`/`/chat` path, so the summary is in her own voice, persisted, and follow-up-able.
- **`POST /api/voice/transcribe`** `{data(base64), mediaType}` → `{transcript}` | `{error}`. Picks a Whisper-friendly extension from the recorder mimeType, writes a temp file, runs the existing Whisper transcriber, always deletes the temp. Clear error if `OPENAI_API_KEY` unset.
- 5-column composer grid (📎 📷 🎙 input send), desktop + mobile.

Reuses the entire existing image/chat infrastructure — the only new server code is the thin transcribe endpoint; summarization is the model's job through normal chat (inherits soul/memory/context).

## Verification
`npm run typecheck` clean · `npm test` **170/170** · build clean. **Live-verified end-to-end**: generated a 290KB real audio clip with `say`, POSTed it → endpoint wrote the temp, invoked the transcriber, returned its graceful no-key error (`OPENAI_API_KEY` not set here), `[voice] transcribing 297872 bytes` logged, temp file cleaned up. With the key set, that same path returns the transcript → flows into the summary.

Privacy: nothing recorded until 🎙 pressed; clip leaves the machine only for transcription on stop; temp deleted immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)