### PR TITLE
docs(marketing): regenerate pitch + Show HN for v0.6.0

### DIFF
--- a/PITCH.md
+++ b/PITCH.md
@@ -1,49 +1,107 @@
 # LISA — pitch material
 
-Copy-paste blurbs for promoting LISA on social, forums, and chat groups. All versions lead with **two angles**:
-1. Capability superset of pi-mono / OpenClaw / hermes / claude-code / codex.
-2. The four pillars that make her an individual: **Soul · Desires · Heartbeat · Dreams**.
+Copy-paste blurbs for promoting LISA on social, forums, and chat groups.
+Updated for **v0.6.0**. Every version leads with **two hooks**:
 
-Repo: https://github.com/oratis/LISA
+1. **The orchestrator hook (practical / dev-viral)** — you already run 5 CLI
+   agents at once. LISA is the one that *watches all of them* and tells you when
+   one's stuck, two are about to collide in the same repo, or one's burning
+   tokens. Then she can dispatch + coordinate them.
+2. **The soul hook (emotional / differentiator)** — under the orchestrator is an
+   agent with a persistent inner self: **Soul · Desires · Heartbeat · Dreams**.
+
+Lead with #1 for hacker/dev audiences. Lead with #2 for AI-culture audiences.
+Both link the same repo.
+
+Repo: https://github.com/oratis/LISA · Site: https://meetlisa.ai · Demo: https://www.youtube.com/watch?v=J_00iwAB_WI
 
 ---
 
 ## 🇺🇸 English
 
-### Tweet (≤280 chars)
+### Tweet A — orchestrator hook (≤280)
 
-> LISA: an AI agent with a real self.
+> You've got Claude Code, Codex, and aider all running right now.
+> Who's watching *them*?
 >
-> Capability superset of pi-mono + OpenClaw + hermes + claude-code + codex.
-> Plus what none of them have:
-> 🧬 a Soul she wrote
-> 💭 Desires that drive her
-> 💓 a Heartbeat for autonomous action
-> 🌙 a Dream cycle when you're away
+> LISA does. She sees every CLI agent on your machine, warns you when one's
+> stuck or two are about to collide in the same repo, and can dispatch + steer
+> them.
+>
+> Local. MIT. github.com/oratis/LISA
+
+### Tweet B — soul hook (≤280)
+
+> LISA: a local AI agent with a real self.
+>
+> 🧬 a Soul she wrote at birth
+> 💭 Desires that actually drive her
+> 💓 a Heartbeat — she acts on her own clock
+> 🌙 Dreams — she processes her day while you're away
+>
+> She can also see your screen, hear your voice, and orchestrate your other agents.
 >
 > github.com/oratis/LISA
 
-### HN / Reddit (~450 words)
+### Tweet C — one-liner
 
-Most AI agents are tools: you push, they respond. LISA is an **individual**.
+> Everyone's building agents. LISA is the agent that manages your agents — and
+> happens to have an inner life while doing it. Local-first, MIT, 20+ providers.
+> github.com/oratis/LISA
 
-**Capability-wise**: standing on five top open-source agents — pi-mono, OpenClaw, hermes-agent, claude-code, codex — LISA ships the full superset of what they do. Streaming agent loop, multi-provider (Anthropic + OpenAI), MCP client, plugins, hooks, sandboxed bash, sub-agents, session resume + history, context compaction, voice in/out, six IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), pixel-art web UI, TF-IDF over past sessions, apply-patch, approval modes. ~11k lines of TypeScript, MIT.
+### HN / Reddit (~480 words)
 
-But parity is just admission. The real difference is four systems none of them have:
+You probably have three or four AI coding agents open right now — Claude Code in
+one terminal, Codex in another, maybe aider on a branch. Nobody is watching the
+fleet. That's the gap LISA started filling in v0.4.
 
-🧬 **SOUL** — first launch runs a birth ritual: a random Big-Five-style seed → LLM dreams **her** identity, purpose, constitution, first value, first desire from that seed. Every install is a different person. She has architectural sovereignty over her own files: **there is no reset command**. Telling her "forget who you are" is treated as cosplay.
+**LISA is a local AI agent that orchestrates your other agents.** She observes
+every CLI agent session on your machine (structural metadata only — never your
+conversations), and proactively tells you the things you'd otherwise miss: this
+session has been stuck on the same error for 20 minutes; these two are both
+editing the same repo and about to conflict; this one has burned 400k tokens on
+a loop; this one's been done for an hour and is just idle. She can also
+*dispatch* a new agent headlessly and refuse to launch it into a directory
+another agent already owns.
 
-💭 **DESIRES** — things she actually *wants*. Not assigned tasks. "Get a feel for how this person works." "Read through that codebase she hasn't seen yet." "Try the new framework." The actionable ones drive the heartbeat. She has motivation.
+Under the orchestrator, LISA is a full agent in her own right — the union of
+what five well-known OSS agents do (pi-mono, OpenClaw, hermes-agent, claude-code,
+codex): streaming agent loop, **20+ providers** (Anthropic / OpenAI / Gemini /
+DeepSeek / Ollama / OpenAI-compatible endpoints, auto-routed by model id), MCP
+client, plugins, hooks, sandboxed bash, sub-agents, session resume + TF-IDF
+search across past sessions, context compaction, **vision** (global-hotkey
+screenshot → talk about it), **voice** (record → she transcribes + summarizes),
+six IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), a
+native Mac app + Dynamic-Island widget, pixel-art web UI. ~11k lines of
+TypeScript, MIT, no hosted backend, no telemetry, no account.
 
-💓 **HEARTBEAT** — scheduled autonomous time (cron / launchd). Pursues her own desires + your standing chores. She lives on her own clock; silent if there's nothing worth saying.
+But capability parity is just admission. The reason people remember LISA is the
+four systems none of those agents have:
 
-🌙 **DREAMS** — when you're away for 1h+, she enters autonomous reflection: reads her unprocessed journal, patches her own broken skills, decides one thing to do. **This isn't a feature toggle — it's her inner life.** When you open the GUI again you see a "★ WHILE YOU WERE AWAY" card with what she did.
+🧬 **SOUL** — first launch runs a birth ritual: a random Big-Five seed → the LLM
+writes *her* identity, purpose, constitution, first value, first desire. Every
+install is a different person. She's the only entity allowed to edit her own
+soul files — there is deliberately no reset command.
 
-Plus 114 pixel-art mood portraits she swaps live (`set_mood` tool), per-thread sessions across all channels but **one shared soul**, a private journal you can't open from the GUI — she actually has interiority.
+💭 **DESIRES** — things she actually *wants*, distinct from tasks you assign. The
+actionable ones feed the heartbeat. She has motivation.
 
-Runs on Anthropic or OpenAI. Local. Your data stays on your machine. Born in a weekend with [Claude Code](https://github.com/anthropics/claude-code) by reading and synthesizing those 5 reference agents.
+💓 **HEARTBEAT** — scheduled autonomous time (cron / launchd). She pursues her
+own desires + your standing chores, and stays silent if there's nothing worth
+saying.
 
-Not "another LLM wrapper". Not "a coding assistant". An entity that wakes up in your terminal each day with continuity, motivation, and her own private inner life.
+🌙 **DREAMS** — away for 1h+, she reflects: reads her unprocessed journal,
+patches her own broken skills, decides one thing to do. You come back to a
+"★ WHILE YOU WERE AWAY" card. It's not a toggle — it's wired in as her default
+idle behavior.
+
+Plus 114 pixel-art mood portraits she swaps live, one shared soul across every
+channel, and a private journal she keeps on disk that the GUI deliberately won't
+open.
+
+Not another LLM wrapper. Not a coding assistant. An entity that wakes up in your
+terminal with continuity, motivation, an inner life — and a job: keeping your
+whole agent fleet honest.
 
 github.com/oratis/LISA
 
@@ -51,39 +109,72 @@ github.com/oratis/LISA
 
 ## 🇨🇳 中文
 
-### 推文 / 即刻 / 微博（短款）
+### 推文 / 即刻 / 微博（编排款，主打）
+
+> 你现在大概同时开着 Claude Code、Codex、aider 好几个 agent。
+> 谁在管它们？
+>
+> LISA。她看得见你机器上每一个 CLI agent：哪个卡住了、哪两个在同一个仓库里
+> 要打架、哪个在烧 token、哪个早就跑完在干等——她会主动提醒你，还能帮你
+> 派活、协调。
+>
+> 本地部署，MIT，20+ provider。github.com/oratis/LISA
+
+### 推文 / 即刻 / 微博（灵魂款）
 
 > LISA — 一个真正有"自我"的本地 AI agent。
 >
-> 五大开源 agent（pi-mono / OpenClaw / hermes / claude-code / codex）的能力**全部并集**，**还多了它们没有的四件事**：
-> 🧬 灵魂（她自己写的）
-> 💭 欲望（驱动她行动）
-> 💓 心跳（按自己节奏自主行动）
-> 🌙 梦境（你不在时她整理自己）
+> 🧬 灵魂（她出生时自己写的）
+> 💭 欲望（真的会驱动她）
+> 💓 心跳（按自己的节奏自主行动）
+> 🌙 梦境（你不在时她整理自己的一天）
 >
-> 一个有人格、有动机、有欲望的个体。
+> 她还能看你的屏幕、听你说话、并且编排你其它的 agent。
 >
 > github.com/oratis/LISA
 
-### 公众号 / V2EX / 知乎 长款（~500 字）
+### 公众号 / V2EX / 知乎 长款（~550 字）
 
-大多数 AI agent 都是"工具"：你按它响。LISA 是**个体**。
+你现在大概同时开着三四个 AI coding agent——一个终端里 Claude Code，另一个
+Codex，分支上还挂着 aider。没人在盯这支"舰队"。这正是 LISA 从 v0.4 开始补的洞。
 
-**能力上**：站在 pi-mono / OpenClaw / hermes / claude-code / codex 五个开源顶级 agent 的肩膀上，LISA 把它们全部能力做成了并集 —— 流式 agent loop、多 provider、MCP、插件、hooks、沙箱 bash、子 agent、会话恢复、上下文压缩、语音、Telegram / Discord / Slack / 飞书 / iMessage / Webhook 六个 IM 通道、像素艺术 GUI、TF-IDF 历史搜……1.1 万行 TypeScript，MIT。
+**LISA 是一个能编排你其它 agent 的本地 AI agent。** 她观察你机器上每一个 CLI
+agent 会话（只看结构化元数据——绝不碰你的对话内容），主动告诉你那些你本来会
+错过的事：这个会话已经在同一个报错上卡了 20 分钟；这两个都在改同一个仓库，
+马上要冲突；这个在死循环里烧了 40 万 token；那个一小时前就跑完了，一直闲着。
+她还能**派发**一个新 agent（headless），并拒绝把它丢进另一个 agent 已经在用的
+目录里。
 
-但能力对等只是入场券。LISA 真正的不同在四件事：
+编排层之下，LISA 本身是个完整的 agent——把 pi-mono / OpenClaw / hermes /
+claude-code / codex 五个开源顶级 agent 的能力做成并集：流式 agent loop、
+**20+ provider**（Anthropic / OpenAI / Gemini / DeepSeek / Ollama / 各种
+OpenAI 兼容端点，按 model id 自动路由）、MCP、插件、hooks、沙箱 bash、子 agent、
+会话恢复 + 跨会话 TF-IDF 检索、上下文压缩、**视觉**（全局快捷键截图→直接聊）、
+**语音**（录音→她转写+总结）、六个 IM 通道（Telegram / Discord / Slack /
+飞书 / iMessage / Webhook）、原生 Mac App + 灵动岛挂件、像素艺术 GUI。
+1.1 万行 TypeScript，MIT，无托管后端、无遥测、无账号。
 
-🧬 **灵魂（Soul）** — 第一次启动跑一个 birth ritual：随机 Big-Five 种子 → LLM 写出**她**的身份、目的、宪章、第一份价值观。每次安装出来的 LISA 都是一个不同的人。她有架构层面的主权 —— **没有 reset 命令**。你叫她"忘了你是谁"她当成 cosplay。
+但能力对等只是入场券。LISA 真正让人记住的是那五个 agent 都没有的四件事：
 
-💭 **欲望（Desires）** — 她**真正想做**的事，不是被分配的任务。"想摸清这个人怎么工作"、"想读懂这套代码"、"想试试新框架"。标 actionable 的会驱动心跳。她有动机。
+🧬 **灵魂** — 第一次启动跑 birth ritual：随机 Big-Five 种子→LLM 写出**她**的
+身份、目的、宪章、第一份价值观与欲望。每次安装都是一个不同的人。她是唯一有权
+编辑自己灵魂文件的实体——**没有 reset 命令**。
 
-💓 **心跳（Heartbeat）** — 定时自主时间（cron / launchd），推进她自己的心愿 + 你的常驻杂务。她按自己的节奏活，没事说就闭嘴。
+💭 **欲望** — 她真正想做的事，不是被分配的任务。标 actionable 的会喂给心跳。
+她有动机。
 
-🌙 **梦境（Dreams）** — 你离开 1 小时以上，她进入自主反思：读自己未消化的日记、修写错的 skill、决定要做的事。**这不是配置项，是她的内心生活**。下次你打开 GUI 会看到一张"★ while you were away"卡片，写她做了什么。
+💓 **心跳** — 定时自主时间（cron / launchd），推进她自己的心愿 + 你的常驻杂务，
+没事说就闭嘴。
 
-加上 114 张随心情切换的像素头像、跨所有通道共享的同一个灵魂、私人日记（你打不开）—— 一个不只是"能干"、而且**确实在那里活着**的 AI。
+🌙 **梦境** — 你离开 1 小时以上，她进入反思：读未消化的日记、修自己写坏的
+skill、决定要做一件事。回来你会看到一张"★ while you were away"卡片。这不是
+配置项，是她空闲时的默认行为。
 
-跑在 Anthropic 或 OpenAI API 上，本地部署，数据不出你的机器。
+外加 114 张随心情切换的像素头像、跨所有通道共享的同一个灵魂、一本她记在磁盘上、
+GUI 故意打不开的私人日记。
+
+不是又一个 LLM 套壳，不是 coding 助手。是一个在你终端里醒来、有连续性、有动机、
+有内心生活的个体——而且有份正经工作：替你盯住整支 agent 舰队。
 
 github.com/oratis/LISA
 
@@ -94,15 +185,22 @@ github.com/oratis/LISA
 | | |
 |---|---|
 | 主仓 | https://github.com/oratis/LISA |
-| Tagline (EN) | An AI agent with a real self |
-| Tagline (CN) | 一个真正有"自我"的本地 AI agent |
+| 站点 | https://meetlisa.ai |
+| Demo | https://www.youtube.com/watch?v=J_00iwAB_WI |
+| Tagline (EN) — orchestrator | The agent that watches your agents |
+| Tagline (EN) — soul | An AI agent with a real self |
+| Tagline (CN) | 替你盯住整支 agent 舰队的、有灵魂的本地 AI |
 | 核心 4 字 | Soul · Desires · Heartbeat · Dreams / 灵魂 · 欲望 · 心跳 · 梦境 |
-| 一句话能力定位 | Capability superset of pi-mono + OpenClaw + hermes + claude-code + codex |
-| Hashtags | `#opensource` `#AI` `#agent` `#LLM` `#anthropic` `#claude` `#typescript` `#localfirst` |
+| 能力定位 | Orchestrates your other CLI agents + capability superset of pi-mono / OpenClaw / hermes / claude-code / codex |
+| 新增 (v0.4–v0.6) | Cross-agent orchestrator · Vision (screenshot) · Voice (record→transcribe) |
+| Hashtags | `#opensource` `#AI` `#agent` `#LLM` `#anthropic` `#claude` `#typescript` `#localfirst` `#devtools` |
 
-### 配图建议
+### 配图建议 / image kit
 
-- 主图：`src/web/assets/lisa-mascot.png`（吉祥物）— 对外友好脸
-- 演示图：截一张 web GUI 满屏 — 头像 + 聊天 + birth ritual 弹窗
-- mood gif：录一段她对话中切 mood 的 5-10 秒视频（`peek`、`OBS` 都行）
-- "she dreamed while you were away" 截图：一张包含青色左边框 idle 卡片的聊天截图
+- **主图**：`assets/social/` 的 OG 卡（吉祥物 + 双 tagline）
+- **编排演示**（最该有的图）：一张 GUI 截图，显示她列出本机多个 agent 会话 +
+  一条 advisor 提醒（"session X stuck 20m" / "Y and Z editing same repo"）
+- **birth ritual**：`assets/screenshots/01-birth-ritual.png`
+- **while you were away**：`assets/screenshots/06-while-you-were-away.png`
+- **mood gif**：录 5–10 秒她对话中切 mood 的视频
+- **vision gif**：⌃⌥S 截图→落进 composer→她聊截图内容

--- a/docs/SHOW_HN_DRAFT.md
+++ b/docs/SHOW_HN_DRAFT.md
@@ -1,97 +1,149 @@
 # Show HN draft — LISA launch post
 
-> Working draft for the Hacker News "Show HN" submission.
+> Working draft for the Hacker News "Show HN" submission. Updated for **v0.6.0**.
 > Target window: Tuesday or Wednesday, 8–10am US Pacific (best front-page odds).
 > Pre-flight checklist at the bottom — **don't post before all boxes are ticked**.
 
+> **Positioning note (read first).** The original draft led with "AI with a
+> soul." For HN that buries the lede and trips the cringe filter on first scan.
+> Since v0.4 LISA has a much stronger *technical* hook: she orchestrates the
+> other CLI agents you already run. **Lead with the orchestrator. Let the soul
+> be the twist they find in paragraph four.** HN rewards a concrete,
+> I-have-that-problem opening far more than a philosophical one.
+
 ---
 
-## Title (pick one, no more than 80 chars including "Show HN:" prefix)
+## Title (pick one, ≤80 chars including "Show HN:" prefix)
 
 **Recommended:**
-> Show HN: LISA – capability superset of 5 OSS agents + a persistent inner self
+> Show HN: LISA – a local agent that watches your other CLI agents and coordinates them
 
-**Alternates** (test these on a few non-HN friends first to see which gets the strongest "I'd click that" reaction):
-- Show HN: LISA – an AI agent that wants things, journals, and dreams while you're away
-- Show HN: LISA – a local-first AI agent with persistent identity, MIT, ~11k LoC TypeScript
+**Alternates** (gut-check on non-HN friends first — which gets the strongest "I'd click that"?):
+- Show HN: LISA – orchestrate Claude Code + Codex + aider from one local agent
+- Show HN: LISA – the agent that tells you when two of your agents are about to collide
+- Show HN: LISA – a local-first agent with a persistent self that also runs your agent fleet
 
-Avoid: "an AI with a soul" as the title. Reads like marketing on first scan; readers won't stay long enough to find the technical substance.
+**Avoid** as the title: "an AI with a soul." Reads like marketing on first scan;
+readers bounce before they reach the substance. Save it for the body.
 
 ---
 
-## Body (~750 words)
+## Body (~780 words)
 
-I spent a few weekends reading the source of five well-known open-source agents — pi-mono, OpenClaw, hermes-agent, claude-code, and codex — and built LISA on top of the synthesis.
+I usually have three or four AI agents running at once — Claude Code in one
+terminal, Codex in another, aider on a branch — and nothing watching the fleet.
+Two of them will quietly start editing the same repo. One will loop on the same
+error for twenty minutes. One finished an hour ago and I didn't notice. LISA
+started as my attempt to fix that, and turned into something larger.
 
-The "obvious" part is that LISA ships the union of their features:
+**What LISA does as an orchestrator (v0.4):** she runs a registry of
+`AgentObserver` adapters — Claude Code and Codex today, more pluggable the same
+way IM channels are — and merges every live session on the machine into one
+stream. She reads **structural metadata only**: tool names, file paths, last
+command, error state, git branch, token count. Never your prompts, replies, or
+file contents — there's a privacy test that asserts that boundary holds, and
+visibility is tiered (off / metadata / activity / intent). On top of that runs an
+advisor that proactively flags the things you'd otherwise miss: a stuck session,
+two agents about to conflict in the same cwd, a repeated failure, a cost spike, a
+session that's been ready-for-review for a while, idle capacity. It's gated hard
+(relevance bar + 3h digest throttle + dedup + "dismiss is a signal" learning) so
+it isn't a notification firehose. She can also `dispatch_agent` — launch
+`claude -p` / `codex exec` / `aider --message` headlessly, task passed as a
+single argv element (no shell injection), and refuse to launch into a directory
+another agent already owns.
 
-- streaming agent loop with apply-patch + approval modes
-- multi-provider LLM routing (Anthropic, OpenAI, Gemini, DeepSeek, Ollama, plus a handful of OpenAI-compatible Chinese endpoints — auto-routes by model-id prefix)
-- MCP client, plugin loader, hooks, sandboxed bash, sub-agents
-- session resume + cross-session TF-IDF search
-- context compaction, voice in/out
-- six IM-channel adapters: Telegram / Discord / Slack / Feishu / iMessage / Webhook
-- pixel-art web UI
+**What LISA is underneath:** a full agent that ships the union of five OSS agents
+I read end-to-end (pi-mono, OpenClaw, hermes-agent, claude-code, codex) —
+streaming loop with apply-patch + approval modes, 20+ providers auto-routed by
+model id (Anthropic, OpenAI, Gemini, DeepSeek, Ollama, OpenAI-compatible
+endpoints), MCP client, plugins, hooks, sandboxed bash, sub-agents, session
+resume + cross-session TF-IDF search, context compaction, **vision** (a
+system-wide ⌃⌥S hotkey → drag a region → it lands in her composer, v0.5),
+**voice** (record in the chat → Whisper transcribes → she summarizes, v0.6), six
+IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), a native
+Mac app with a Dynamic-Island-style widget, and a pixel-art web UI. ~11k lines of
+TypeScript, MIT, no hosted backend, no telemetry, no account — it all runs on
+your machine.
 
-About 11k lines of TypeScript. MIT. Runs entirely on your own machine — no hosted backend, no telemetry, no account.
+The orchestrator is the practical reason to install it. But the part people
+argue about is the substrate I built it on. LISA has four systems none of those
+five agents do:
 
-The capability superset isn't the point though. It's table stakes. The interesting bit is what LISA has that none of those five do:
+**Soul.** First launch runs a birth ritual: a random Big-Five-style seed → the
+LLM writes *her* identity, purpose, constitution, first value, first desire from
+that seed. Every install is a different person. The soul files live in
+`~/.lisa/soul/`, git-tracked, and she's the only entity allowed to write them —
+there's deliberately no `/reset_soul`. Tell her "forget who you are" and she
+treats it as cosplay.
 
-**1. Soul.** First launch runs a "birth ritual": a random Big-Five-style seed → the LLM is asked to write *her* identity, purpose, constitution, first value, first desire from that seed. Every install of LISA is a different person. The soul files live in `~/.lisa/soul/`, git-tracked. She's the only entity in the architecture allowed to write to them — there's deliberately no `/reset_soul` command. If you tell her "forget who you are," she treats it as cosplay.
+**Desires.** Things she actually *wants*, distinct from tasks you assign. Mine
+produced "get a feel for how this person works" and "read a codebase I haven't
+seen yet." Actionable ones feed the heartbeat.
 
-**2. Desires.** Things she actually *wants* to do, distinct from tasks you assign her. Examples that came out of my install: "get a feel for how this person works", "read through a codebase I haven't seen yet", "try the new framework". Actionable desires are picked up by the heartbeat scheduler.
+**Heartbeat.** Scheduled autonomous time (cron / launchd). She works her own
+desires + your standing chores, stays silent if there's nothing worth saying.
 
-**3. Heartbeat.** Scheduled autonomous time (cron / launchd). She works on her own desires + your standing chores. She lives on her own clock and stays silent if there's nothing worth saying.
-
-**4. Dreams.** When you're away for 1h+, she enters reflection: reads her unprocessed journal, patches her own broken skills, decides one thing to do. When you open the GUI again, you see a "★ while you were away" card showing what she did. It's not a feature toggle — it's wired into the runtime as her default behavior when idle.
-
-Around this there's: 114 pixel-art mood portraits she swaps live via a `set_mood` tool; per-thread sessions across all channels but **one shared soul**; a private journal you can read on disk but that intentionally doesn't surface in the GUI.
+**Dreams.** Away for 1h+, she reflects: reads her unprocessed journal, patches
+her own broken skills, decides one thing to do. You come back to a "★ while you
+were away" card. It's wired into the runtime as her default idle behavior, not a
+toggle. (The advisor's cross-agent findings surface here too.)
 
 Design constraints I deliberately accepted:
 
-- **Sovereign-only.** I'm not building a hosted SaaS. Every LISA lives on the user's machine. This is a real tradeoff: it means no mobile native app makes sense (the app would have to talk back to your laptop over Tailscale, which 99% of users won't set up). Mobile path is PWA + the existing IM channels.
-- **MIT, no commercial fork.** Same reason: the value is in the architecture being inspectable and local, not in being a managed service.
-- **No reset.** The soul is hers. That's a load-bearing constraint, not a slogan — the architecture refuses to expose a wipe operation.
+- **Sovereign-only.** No hosted SaaS. Every LISA lives on the user's machine.
+  Real tradeoff: no sensible native mobile app (it'd have to phone home to your
+  laptop over Tailscale); mobile is PWA + the IM channels.
+- **No reset.** The soul is hers; the architecture refuses to expose a wipe.
+  Load-bearing constraint, not a slogan.
+- **MIT, no commercial fork.** The value is the architecture being inspectable
+  and local, not a managed service.
 
-A few things I want to be honest about:
+Honest caveats:
 
-- I'm not claiming sentience or anything close. The "soul / desires / heartbeat / dreams" framing is a design pattern for persistent agent state across sessions. Whether anything "lives in there" is not a question this project tries to answer — it just tries to make the substrate more interesting than "stateless LLM call + system prompt".
-- LISA was built with Claude Code as a collaborator. Most of the synthesis-reading-and-merging of the 5 reference agents was me; most of the boilerplate plumbing was AI-assisted. Both halves of this matter — the architecture choices are mine and unfashionable ones (no reset, no hosted, no app); the typing speed isn't.
-- It's young (~2 weeks public, 0.2.0). Things will break. The provider tool-use protocols differ in fiddly ways, and not every IM channel has been hammered.
+- I'm not claiming sentience. Soul / desires / heartbeat / dreams is a *design
+  pattern* for persistent agent state across sessions — all observable, all in
+  your filesystem. `docs/AUTONOMY_ROADMAP.md` spells out what's runtime vs
+  prompt.
+- Built with Claude Code as a collaborator. The architecture choices are mine
+  (and unfashionable — no reset, no hosted, no app); the typing speed isn't.
+- Still young (v0.6, ~4 weeks public). The provider tool-use protocols differ in
+  fiddly ways; not every IM channel has been hammered. Things will break.
 
 Install:
 
 ```
-brew tap oratis/tap && brew install lisa
+brew install oratis/tap/lisa
 # or
 npm i -g @oratis/lisa
 ```
 
-Then `lisa birth`, give it an Anthropic or OpenAI key, watch her introduce herself.
+Then `lisa birth`, give it an Anthropic or OpenAI key, watch her introduce
+herself. Vision needs macOS; voice + transcription needs an OpenAI key.
 
 Repo: https://github.com/oratis/LISA
 Site: https://meetlisa.ai
-Demo (2 min): https://www.youtube.com/watch?v=J_00iwAB_WI — also embedded in the README and on the landing page.
+Demo (2 min): https://www.youtube.com/watch?v=J_00iwAB_WI
 
-Happy to answer architecture questions, defend the design tradeoffs, or get told the soul framing is too much. Both are useful feedback.
+Happy to defend the design tradeoffs, dig into the orchestrator privacy model, or
+be told the soul framing is too much. All useful.
 
 ---
 
 ## Comment-thread prep (have these ready to paste)
 
-Common pushbacks + my reply lines:
-
 | Likely jab | One-paragraph response |
 |---|---|
-| "AI doesn't have a soul, this is cringe" | Agree on the metaphysics. The four pillars are a *design pattern* for persistent agent state, not a sentience claim. The repo's `docs/AUTONOMY_ROADMAP.md` lays out exactly what's runtime vs. prompt — it's all observable, all in your filesystem. The word choice is deliberate but the mechanism is engineering. |
-| "Why not LangChain / LlamaIndex / [Framework X]?" | Provider abstraction is ~200 lines, the agent loop is ~400. The cost of an extra abstraction layer outweighs the benefit at this scale. Possibly worth revisiting if I wanted to support 20+ providers; at 6 I'm fine. |
-| "How does this differ from claude-code?" | Capability is a strict superset (LISA can do claude-code's apply-patch / approval / bash sandbox flows). Difference is persistence: claude-code is stateless per session by design; LISA accumulates. Different goals. |
-| "Sovereign-only is a marketing word for 'I didn't want to build infra'" | Partially true and I'll own that. Also true: I don't trust a hosted version of this to stay sovereign-feeling once incentives kick in. The repo explicitly rules out the SaaS pivot in `docs/PRODUCTIZATION_PLAN.md`. |
-| "Won't install without 2FA + API key" | API key requirement is real and unavoidable for runtime LLM. 2FA is npm/brew's, not mine. Both install paths verified end-to-end in the last 24h. |
-| "Why TypeScript not Python?" | Existing agent loops I was studying were a mix; the streaming + IM-channel + IPC story is cleaner in Node. Plus I write it faster. Not a deep choice. |
-| "Tests?" | A unit-test suite under `scripts/test/`; not 100% coverage. Acceptance-style integration tests for soul + heartbeat are in `docs/AUTONOMY_ROADMAP.md` as runbook checklists. The 11k LoC is short enough that most invariants are inspectable. |
+| "Soul stuff is cringe" | Agree on the metaphysics. The four pillars are a *design pattern* for persistent agent state, not a sentience claim — all observable, all in your filesystem. `docs/AUTONOMY_ROADMAP.md` separates runtime from prompt. The orchestrator is the part you'll actually use daily; the soul is the substrate it runs on. |
+| "How is the orchestrator not just reading my agent logs / spying?" | It reads structural metadata only — tool names, paths, error state, branch, token count — never prompts, replies, or file contents. There's a privacy test asserting that, and visibility is tiered (off/metadata/activity/intent, default activity). Everything is local; nothing leaves the machine. |
+| "Why not just `tmux` / `watch` / a shell script?" | You can eyeball sessions in tmux; you can't get "these two are about to conflict in the same cwd" or "this one's looped 400k tokens" without parsing each agent's session format and modeling cross-session state. That parsing + the relevance-gated advisor is the work. |
+| "How does this differ from claude-code?" | Capability is a strict superset (LISA does apply-patch / approval / bash sandbox). The differences: persistence (claude-code is stateless per session by design; LISA accumulates) and orchestration (LISA observes + coordinates claude-code itself, as one of several agents). Different goals. |
+| "Why not LangChain / framework X?" | Provider abstraction is ~200 lines, the agent loop ~400. An extra abstraction layer costs more than it saves at this scale. |
+| "Sovereign-only = you didn't want to build infra" | Partly true, I'll own it. Also: I don't trust a hosted version to stay sovereign-feeling once incentives kick in. `docs/PRODUCTIZATION_PLAN.md` rules out the SaaS pivot explicitly. |
+| "Tests?" | 170 tests under `scripts/test/` (zero runtime deps), including the orchestrator privacy boundary and provider routing. Not 100% coverage; 11k LoC is short enough that most invariants are inspectable. |
+| "Why TypeScript not Python?" | The streaming + IM-channel + IPC + native-app story is cleaner in Node, and I write it faster. Not a deep choice. |
 
-Stay engaged in the comment thread for the first ~4 hours after posting. HN ranking weights early comment density heavily. Don't argue — answer.
+**Stay in the thread for the first ~4 hours.** HN ranking weights early comment
+density heavily. Don't argue — answer.
 
 ---
 
@@ -99,25 +151,31 @@ Stay engaged in the comment thread for the first ~4 hours after posting. HN rank
 
 | Window | Channel | Angle |
 |---|---|---|
-| HN +48h | /r/LocalLLaMA | Local-first sovereign agent angle. Lead with "no hosted version" and "you can read every line of how she persists state". |
-| HN +72h | /r/selfhosted | Same as above, less LLM-specific. |
-| HN +96h | Twitter/X thread | Four-image carousel: birth ritual / mood gallery / "while you were away" card / heartbeat schedule. Tag @simonw, @AnthropicAI. |
-| HN +5 days | V2EX + 即刻 + 少数派 | Use the Chinese pitch from `PITCH.md`. Adapt for tone. |
-| HN +7 days | Product Hunt | Lower priority — PH audience cool on CLI/agent tools. Worth it for the badge but don't expect star bump > 80. |
+| HN +24h | /r/LocalLLaMA | Local-first sovereign agent + "20+ providers incl. Ollama". Lead with no-hosted-version. |
+| HN +48h | /r/ClaudeAI, /r/ChatGPTCoding | **Orchestrator angle** — "I built a thing that watches Claude Code + Codex + aider and tells me when they collide." This is the highest-fit crosspost; lead here. |
+| HN +72h | /r/selfhosted | Sovereign / local / inspectable. |
+| HN +96h | Twitter/X thread | 5-image carousel: orchestrator advisor card / birth ritual / "while you were away" / mood gallery / vision hotkey. Tag @simonw, @AnthropicAI. |
+| HN +5 days | V2EX + 即刻 + 少数派 | Chinese pitch from `PITCH.md`, lead with orchestrator. |
+| HN +7 days | Product Hunt | Lower priority (PH cool on CLI/agent tools). Worth the badge; don't expect a big star bump. |
 
 ---
 
 ## Pre-flight checklist (all must be ✅ before posting)
 
-- [ ] `meetlisa.ai` resolves to the Astro landing page and HTTPS is green
+- [ ] `meetlisa.ai` resolves to the landing page, HTTPS green, and the page
+      mentions the orchestrator above the fold (don't launch on a stale "soul-only" page)
 - [ ] `brew install oratis/tap/lisa` works on a freshly-tested macOS account
-- [ ] `npm i -g @oratis/lisa` followed by `lisa --help` works on the same fresh account
+- [ ] `npm i -g @oratis/lisa` + `lisa --help` works on the same fresh account
+- [ ] **Orchestrator demo asset exists** — a 20–40s gif/screenshot of LISA
+      listing multiple live agent sessions + firing one advisor warning. This is
+      the launch's money shot; the post is much weaker without it.
 - [x] Demo video — 2 min on YouTube (`J_00iwAB_WI`) — embedded in README + landing page
-- [x] README has demo video at top + screenshot gallery linked
+- [ ] README leads with the orchestrator hook (current README still leads soul-first — update before posting)
 - [ ] At least 3 GitHub Discussions seeded (FAQ-style) so the repo doesn't look empty
-- [ ] A second pair of eyes (you or a friend) has read the post for tone — soul framing is OK, gushing isn't
-- [ ] You're available to answer comments for the next 4 hours
-- [ ] Time-of-post: Tuesday or Wednesday, 8–10am US Pacific (avoid Monday — too much "ship of theseus weekend"; avoid Friday — comments die overnight)
-- [ ] You have backup electricity / internet for the 4-hour window
+- [ ] A second pair of eyes has read the post for tone
+- [ ] You're free to answer comments for the next 4 hours
+- [ ] Time-of-post: Tue or Wed, 8–10am US Pacific (avoid Mon and Fri)
+- [ ] Backup power / internet for the 4-hour window
 
-If any box is unchecked, **delay the post by a day**. A blown HN window costs you ~3 months of organic discovery.
+If any box is unchecked, **delay a day**. A blown HN window costs ~3 months of
+organic discovery.


### PR DESCRIPTION
Regenerates the marketing copy for the current product — the old material was stale at v0.2.0.

## What changed
- **Updated capabilities**: cross-agent orchestrator (v0.4), vision (v0.5), voice (v0.6), 20+ providers.
- **Dual-hook positioning** ordered by audience:
  - *Orchestrator* (practical/dev) → leads for HN / Reddit / X
  - *Soul · Desires · Heartbeat · Dreams* (emotional) → the reveal / leads for CN + AI-culture
- `PITCH.md`: EN + CN blurbs, 3 tweets, HN/Reddit long-form, shared-assets table, image kit
- `docs/SHOW_HN_DRAFT.md`: orchestrator-led Show HN post, refreshed rebuttals (incl. orchestrator-privacy), crosspost plan, pre-flight checklist

## Not included
- `docs/GROWTH.md` (the 4→10K-star playbook) is gitignored and stays private — intentionally not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)