### PR TITLE
Orchestrator O5: signal_agent (list + cancel dispatched agents) + register the dead orchestration tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — `signal_agent` tool (orchestrator O5: active control)
+
+- **`signal_agent`** completes the dispatch loop: `action:"list"` shows the
+  agents LISA launched via `dispatch_agent` that are still running (id, agent,
+  pid, uptime, cwd, task); `action:"cancel"` stops one — SIGTERM to its process
+  *group*, escalating to SIGKILL after a grace period (`force:true` kills
+  immediately). It can only target agents LISA herself dispatched (the ledger
+  holds their pids); the user's own sessions carry no pid and are unreachable.
+- **Dispatch ledger** (`~/.lisa/dispatches.json`) — `dispatch_agent` now records
+  each launch so it can be controlled from a later turn or after a restart
+  (detached agents outlive the spawning turn's handle). Dead pids are pruned on
+  read.
+
+### Fixed
+
+- **`advise_now` and `dispatch_agent` were never registered.** Both were
+  imported into the tool registry but never added to the tool array (and
+  `tsconfig` has no `noUnusedLocals` to catch it), so the model could not call
+  either one — `dispatch_agent` shipped dead in v0.4.0. Both are now wired up,
+  with a registry regression test asserting all three orchestration tools are
+  present.
+
 ## [0.6.1] — 2026-05-31
 
 **Release hardening — fully notarized + stapled Mac apps.** No app/runtime

--- a/src/integrations/dispatch-ledger.test.ts
+++ b/src/integrations/dispatch-ledger.test.ts
@@ -1,0 +1,120 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Isolate the ledger to a throwaway dir. dispatch-ledger reads LISA_HOME
+// lazily (at call time), so setting it here — before any function runs — is
+// enough; this test file runs in its own process.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-ledger-"));
+process.env.LISA_HOME = TMP;
+const LEDGER = path.join(TMP, "dispatches.json");
+
+const {
+  recordDispatch,
+  loadLedger,
+  listLiveDispatches,
+  findDispatch,
+  removeDispatch,
+  isAlive,
+} = await import("./dispatch-ledger.js");
+
+/** A pid that is essentially never a running process. */
+const DEAD_PID = 2_000_000_000;
+
+beforeEach(() => {
+  fs.rmSync(LEDGER, { force: true });
+});
+
+describe("isAlive", () => {
+  test("our own pid is alive", () => {
+    assert.equal(isAlive(process.pid), true);
+  });
+  test("a bogus high pid is dead", () => {
+    assert.equal(isAlive(DEAD_PID), false);
+  });
+  test("pid <= 1 is treated as not-ours / dead", () => {
+    assert.equal(isAlive(1), false);
+    assert.equal(isAlive(0), false);
+    assert.equal(isAlive(-5), false);
+  });
+});
+
+describe("recordDispatch / loadLedger", () => {
+  test("round-trips an entry with a deterministic id", () => {
+    const e = recordDispatch({
+      agent: "codex",
+      pid: process.pid,
+      cwd: "/tmp/x",
+      task: "fix the thing",
+      now: 1000,
+    });
+    assert.equal(e.id, `${process.pid}-${(1000).toString(36)}`);
+    assert.equal(e.agent, "codex");
+    const all = loadLedger();
+    assert.equal(all.length, 1);
+    assert.deepEqual(all[0], e);
+  });
+
+  test("task is truncated to 200 chars", () => {
+    const e = recordDispatch({
+      agent: "claude",
+      pid: process.pid,
+      cwd: "/x",
+      task: "z".repeat(500),
+    });
+    assert.equal(e.task.length, 200);
+  });
+
+  test("re-recording the same pid replaces the stale entry (recycled pid)", () => {
+    recordDispatch({ agent: "claude", pid: process.pid, cwd: "/a", task: "first", now: 1 });
+    recordDispatch({ agent: "codex", pid: process.pid, cwd: "/b", task: "second", now: 2 });
+    const all = loadLedger();
+    assert.equal(all.length, 1);
+    assert.equal(all[0].agent, "codex");
+    assert.equal(all[0].cwd, "/b");
+  });
+
+  test("missing file → empty ledger", () => {
+    assert.deepEqual(loadLedger(), []);
+  });
+
+  test("corrupt JSON → empty ledger (no throw)", () => {
+    fs.writeFileSync(LEDGER, "{not json");
+    assert.deepEqual(loadLedger(), []);
+  });
+});
+
+describe("listLiveDispatches", () => {
+  test("prunes dead entries and rewrites the file", () => {
+    // One live (our pid), one dead — written straight to disk.
+    fs.writeFileSync(
+      LEDGER,
+      JSON.stringify([
+        { id: "live", agent: "claude", pid: process.pid, cwd: "/a", task: "t", startedAt: 1 },
+        { id: "dead", agent: "codex", pid: DEAD_PID, cwd: "/b", task: "t", startedAt: 2 },
+      ]),
+    );
+    const live = listLiveDispatches();
+    assert.equal(live.length, 1);
+    assert.equal(live[0].id, "live");
+    // The dead one was pruned from disk too.
+    assert.equal(loadLedger().length, 1);
+  });
+});
+
+describe("findDispatch / removeDispatch", () => {
+  test("finds a live entry by id and by pid string", () => {
+    const e = recordDispatch({ agent: "claude", pid: process.pid, cwd: "/a", task: "t" });
+    assert.equal(findDispatch(e.id)?.id, e.id);
+    assert.equal(findDispatch(String(process.pid))?.id, e.id);
+    assert.equal(findDispatch("nope"), null);
+  });
+
+  test("removeDispatch drops the entry", () => {
+    const e = recordDispatch({ agent: "claude", pid: process.pid, cwd: "/a", task: "t" });
+    removeDispatch(e.id);
+    assert.deepEqual(loadLedger(), []);
+  });
+});

--- a/src/integrations/dispatch-ledger.ts
+++ b/src/integrations/dispatch-ledger.ts
@@ -1,0 +1,131 @@
+/**
+ * Dispatch ledger (L3 DISPATCH) — a small persistent record of the CLI agents
+ * LISA has launched via dispatch_agent, so she can later signal them
+ * (list / cancel) from a *different* turn, or even after a restart.
+ *
+ * dispatch_agent spawns agents **detached**, so they outlive LISA's own
+ * process and the transient child handle is gone by the next turn. This ledger
+ * persists the (pid, agent, cwd, task, startedAt) tuple to
+ * `~/.lisa/dispatches.json` so the orchestrator can reconnect observed work to
+ * a controllable process.
+ *
+ * SAFETY: the ledger only ever holds agents LISA *herself* dispatched — never
+ * the user's own manually-started sessions (those are discovered via session
+ * files and have no associated pid). signal_agent can therefore only stop work
+ * LISA started, never an arbitrary user process.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface DispatchEntry {
+  /** Stable handle, `${pid}-${startedAt.toString(36)}`. */
+  id: string;
+  agent: string;
+  pid: number;
+  cwd: string;
+  /** Task snippet (first 200 chars) — for display only. */
+  task: string;
+  /** Epoch ms when dispatched. */
+  startedAt: number;
+}
+
+/** Resolved lazily (reads env at call time) so tests can point LISA_HOME at a tmp dir. */
+function ledgerPath(): string {
+  const home = process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+  return path.join(home, "dispatches.json");
+}
+
+/** Read the ledger; tolerant of a missing or corrupt file (returns []). */
+export function loadLedger(): DispatchEntry[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(ledgerPath(), "utf8");
+  } catch {
+    return []; // no file yet
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is DispatchEntry =>
+        !!e &&
+        typeof (e as DispatchEntry).pid === "number" &&
+        typeof (e as DispatchEntry).id === "string",
+    );
+  } catch {
+    return []; // corrupt JSON — treat as empty rather than throwing
+  }
+}
+
+function saveLedger(entries: DispatchEntry[]): void {
+  const file = ledgerPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(entries, null, 2));
+}
+
+/**
+ * Is a process still alive? Signal 0 probes for existence without delivering a
+ * signal. EPERM means the process exists but is owned by another user (still
+ * "alive"); ESRCH means it's gone.
+ */
+export function isAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 1) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/** Record a freshly dispatched agent. Returns the stored entry. */
+export function recordDispatch(d: {
+  agent: string;
+  pid: number;
+  cwd: string;
+  task: string;
+  /** Override the clock (tests). */
+  now?: number;
+}): DispatchEntry {
+  const startedAt = d.now ?? Date.now();
+  const entry: DispatchEntry = {
+    id: `${d.pid}-${startedAt.toString(36)}`,
+    agent: d.agent,
+    pid: d.pid,
+    cwd: d.cwd,
+    task: d.task.slice(0, 200),
+    startedAt,
+  };
+  // Drop any stale entry that reused this pid before appending.
+  const entries = loadLedger().filter((e) => e.pid !== d.pid);
+  entries.push(entry);
+  saveLedger(entries);
+  return entry;
+}
+
+/** Live dispatched agents, pruning any that have since exited. */
+export function listLiveDispatches(): DispatchEntry[] {
+  const all = loadLedger();
+  const live = all.filter((e) => isAlive(e.pid));
+  if (live.length !== all.length) saveLedger(live); // prune the dead
+  return live;
+}
+
+/** Find a *live* dispatch by id or by pid (as a string). Null if absent/dead. */
+export function findDispatch(target: string): DispatchEntry | null {
+  const live = listLiveDispatches();
+  return (
+    live.find((e) => e.id === target) ??
+    live.find((e) => String(e.pid) === target) ??
+    null
+  );
+}
+
+/** Drop an entry from the ledger by id. */
+export function removeDispatch(id: string): void {
+  const entries = loadLedger();
+  const next = entries.filter((e) => e.id !== id);
+  if (next.length !== entries.length) saveLedger(next);
+}

--- a/src/tools/dispatch_agent.ts
+++ b/src/tools/dispatch_agent.ts
@@ -24,6 +24,7 @@
 import { spawn } from "node:child_process";
 import type { ToolDefinition } from "../types.js";
 import { getCurrentHub } from "../integrations/current-hub.js";
+import { recordDispatch } from "../integrations/dispatch-ledger.js";
 
 interface DispatchInput {
   agent: "claude" | "codex" | "opencode" | "aider";
@@ -161,11 +162,23 @@ export const dispatchAgentTool: ToolDefinition<DispatchInput, string> = {
 
     const pid = child.pid;
     child.unref(); // don't keep LISA's event loop alive for it
+
+    // Record it so signal_agent can list/cancel it from a later turn (the
+    // detached child outlives this turn's handle). Never fatal to the dispatch.
+    if (typeof pid === "number") {
+      try {
+        recordDispatch({ agent: input.agent, pid, cwd, task: input.task });
+      } catch (err) {
+        ctx.log(`[dispatch] ledger write failed (non-fatal): ${(err as Error).message}`);
+      }
+    }
+
     ctx.log(`[dispatch] launched ${input.agent} (pid ${pid}) in ${cwd}: ${input.task.slice(0, 80)}`);
     return (
       `Launched ${input.agent} (pid ${pid}) in ${cwd}.\n` +
       `It's running autonomously and will appear in the agent session monitor. ` +
-      `I won't block on it — ask me "what's running?" (advise_now) to check progress.`
+      `I won't block on it — ask me "what's running?" (advise_now) to check progress, ` +
+      `or signal_agent to list/cancel it.`
     );
   },
 };

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -1,0 +1,31 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { buildToolRegistry } from "./registry.js";
+
+describe("buildToolRegistry", () => {
+  test("registers the orchestration tools (regression: they were imported but unwired)", () => {
+    // advise_now + dispatch_agent + signal_agent were once imported into the
+    // registry but never pushed into the array, so the model couldn't call
+    // them. tsconfig has no noUnusedLocals to catch that, so guard it here.
+    const names = new Set(buildToolRegistry().map((t) => t.name));
+    for (const required of ["advise_now", "dispatch_agent", "signal_agent"]) {
+      assert.ok(names.has(required), `${required} must be registered`);
+    }
+  });
+
+  test("includeVoice gates the voice tools", () => {
+    const without = new Set(buildToolRegistry().map((t) => t.name));
+    assert.equal(without.has("speak"), false);
+    const withVoice = new Set(
+      buildToolRegistry({ includeVoice: true }).map((t) => t.name),
+    );
+    assert.ok(withVoice.has("speak"));
+    assert.ok(withVoice.has("transcribe"));
+  });
+
+  test("tools are returned sorted by name", () => {
+    const names = buildToolRegistry().map((t) => t.name);
+    const sorted = [...names].sort((a, b) => a.localeCompare(b));
+    assert.deepEqual(names, sorted);
+  });
+});

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,6 +3,7 @@ import { memoryTool } from "../memory/tool.js";
 import { memorySearchTool } from "../memory/search_tool.js";
 import { adviseNowTool } from "./advise_now.js";
 import { dispatchAgentTool } from "./dispatch_agent.js";
+import { signalAgentTool } from "./signal_agent.js";
 import { skillManageTool } from "../skills/tool.js";
 import {
   desireCloseTool,
@@ -64,6 +65,10 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     webFetchTool as ToolDefinition,
     webSearchTool as ToolDefinition,
     redeployTool as ToolDefinition,
+    // Orchestration (docs/ORCHESTRATOR_PLAN.md): observe → advise → dispatch → control.
+    adviseNowTool as ToolDefinition,
+    dispatchAgentTool as ToolDefinition,
+    signalAgentTool as ToolDefinition,
   ];
   if (opts.includeVoice) {
     tools.push(speakTool as ToolDefinition, transcribeTool as ToolDefinition);

--- a/src/tools/signal_agent.test.ts
+++ b/src/tools/signal_agent.test.ts
@@ -1,0 +1,105 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { spawn } from "node:child_process";
+import type { ToolContext } from "../types.js";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-signal-"));
+process.env.LISA_HOME = TMP;
+const LEDGER = path.join(TMP, "dispatches.json");
+
+const { signalAgentTool, formatUptime, formatDispatchLine } = await import("./signal_agent.js");
+const { recordDispatch, loadLedger, isAlive } = await import(
+  "../integrations/dispatch-ledger.js"
+);
+
+function ctx(): ToolContext {
+  return { cwd: TMP, signal: new AbortController().signal, log: () => {} };
+}
+
+beforeEach(() => {
+  fs.rmSync(LEDGER, { force: true });
+});
+
+describe("formatUptime", () => {
+  test("seconds / minutes / hours", () => {
+    assert.equal(formatUptime(8_000), "8s");
+    assert.equal(formatUptime(3 * 60_000), "3m");
+    assert.equal(formatUptime((2 * 60 + 5) * 60_000), "2h 5m");
+    assert.equal(formatUptime(-100), "0s");
+  });
+});
+
+describe("formatDispatchLine", () => {
+  test("renders id, agent, pid, cwd and a truncated task", () => {
+    const line = formatDispatchLine(
+      { id: "abc", agent: "codex", pid: 1234, cwd: "/proj", task: "do a thing", startedAt: 0 },
+      8_000,
+    );
+    assert.match(line, /abc/);
+    assert.match(line, /codex/);
+    assert.match(line, /pid 1234/);
+    assert.match(line, /\/proj/);
+    assert.match(line, /do a thing/);
+  });
+});
+
+describe("signal_agent — list", () => {
+  test("empty ledger reports nothing running", async () => {
+    const out = await signalAgentTool.execute({ action: "list" }, ctx());
+    assert.match(out, /No agents dispatched by LISA/i);
+  });
+
+  test("lists a live dispatched agent", async () => {
+    recordDispatch({ agent: "claude", pid: process.pid, cwd: "/here", task: "build it" });
+    const out = await signalAgentTool.execute({ action: "list" }, ctx());
+    assert.match(out, /1 dispatched agent running/);
+    assert.match(out, /claude/);
+    assert.match(out, /build it/);
+  });
+});
+
+describe("signal_agent — cancel guards", () => {
+  test("cancel without a target asks for one", async () => {
+    const out = await signalAgentTool.execute({ action: "cancel" }, ctx());
+    assert.match(out, /needs a target/i);
+  });
+
+  test("cancel of an unknown target explains and lists what's running", async () => {
+    const out = await signalAgentTool.execute(
+      { action: "cancel", target: "ghost" },
+      ctx(),
+    );
+    assert.match(out, /No running dispatched agent matches/i);
+  });
+});
+
+describe("signal_agent — cancel actually kills the process", () => {
+  test("force-cancel terminates a dispatched process and clears the ledger", async () => {
+    // A real, long-lived child as its own process-group leader (detached),
+    // mirroring how dispatch_agent spawns agents.
+    const child = spawn("sleep", ["30"], { detached: true, stdio: "ignore" });
+    assert.ok(typeof child.pid === "number", "spawned with a pid");
+    const pid = child.pid;
+    child.unref();
+    const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
+
+    const entry = recordDispatch({ agent: "claude", pid, cwd: TMP, task: "long-running" });
+    assert.equal(isAlive(pid), true);
+
+    const out = await signalAgentTool.execute(
+      { action: "cancel", target: entry.id, force: true },
+      ctx(),
+    );
+    assert.match(out, /Cancelled/);
+
+    await exited; // libuv reaps the child once it dies under SIGKILL
+    assert.equal(
+      loadLedger().find((e) => e.id === entry.id),
+      undefined,
+      "entry removed from ledger after cancel",
+    );
+  });
+});

--- a/src/tools/signal_agent.test.ts
+++ b/src/tools/signal_agent.test.ts
@@ -77,29 +77,40 @@ describe("signal_agent — cancel guards", () => {
 });
 
 describe("signal_agent — cancel actually kills the process", () => {
-  test("force-cancel terminates a dispatched process and clears the ledger", async () => {
+  test("force-cancel terminates a dispatched process and clears the ledger", { timeout: 10_000 }, async () => {
     // A real, long-lived child as its own process-group leader (detached),
-    // mirroring how dispatch_agent spawns agents.
+    // mirroring how dispatch_agent spawns agents. NOTE: we deliberately do NOT
+    // unref() it — the live handle keeps the event loop alive until the 'exit'
+    // event fires, so the runner can't drain and cancel this test mid-await
+    // (which is racy in CI). libuv reaps the child on exit.
     const child = spawn("sleep", ["30"], { detached: true, stdio: "ignore" });
     assert.ok(typeof child.pid === "number", "spawned with a pid");
     const pid = child.pid;
-    child.unref();
     const exited = new Promise<void>((resolve) => child.once("exit", () => resolve()));
 
     const entry = recordDispatch({ agent: "claude", pid, cwd: TMP, task: "long-running" });
     assert.equal(isAlive(pid), true);
 
-    const out = await signalAgentTool.execute(
-      { action: "cancel", target: entry.id, force: true },
-      ctx(),
-    );
-    assert.match(out, /Cancelled/);
+    try {
+      const out = await signalAgentTool.execute(
+        { action: "cancel", target: entry.id, force: true },
+        ctx(),
+      );
+      assert.match(out, /Cancelled/);
 
-    await exited; // libuv reaps the child once it dies under SIGKILL
-    assert.equal(
-      loadLedger().find((e) => e.id === entry.id),
-      undefined,
-      "entry removed from ledger after cancel",
-    );
+      await exited; // resolves once the SIGKILL'd child dies and is reaped
+      assert.equal(
+        loadLedger().find((e) => e.id === entry.id),
+        undefined,
+        "entry removed from ledger after cancel",
+      );
+    } finally {
+      // Safety net: if the cancel path failed, don't leave a stray process.
+      try {
+        process.kill(-pid, "SIGKILL");
+      } catch {
+        /* already gone */
+      }
+    }
   });
 });

--- a/src/tools/signal_agent.ts
+++ b/src/tools/signal_agent.ts
@@ -1,0 +1,168 @@
+/**
+ * signal_agent (L3/O5 DISPATCH — active control) — the other half of
+ * dispatch_agent. Once LISA has launched CLI agents she should be able to act
+ * on what she observes: see which of her dispatched agents are still running
+ * and stop one that's stuck, conflicting, or burning tokens.
+ *
+ * Scope & safety:
+ *   - It only ever targets agents recorded in the dispatch ledger — i.e. ones
+ *     LISA *herself* launched via dispatch_agent. The user's own manually
+ *     started sessions are observed via session files, carry no pid, and are
+ *     therefore unreachable here. LISA cannot kill an arbitrary process.
+ *   - `cancel` terminates an autonomous process the host already approved
+ *     LISA to spawn; it's the inverse of that approval. It sends SIGTERM to the
+ *     whole process *group* (dispatch spawns detached group leaders, so the
+ *     agent's child processes die with it), then escalates to SIGKILL after a
+ *     short grace period if the group is still alive.
+ *
+ * Composes with the advisor: "codex looks stuck in ~/p — cancel it?" →
+ * signal_agent({action:"cancel", target:"<id>"}).
+ */
+
+import type { ToolDefinition } from "../types.js";
+import {
+  findDispatch,
+  listLiveDispatches,
+  removeDispatch,
+  isAlive,
+  type DispatchEntry,
+} from "../integrations/dispatch-ledger.js";
+
+interface SignalInput {
+  action: "list" | "cancel";
+  /** For cancel: the dispatch id (preferred) or pid of the agent to stop. */
+  target?: string;
+  /** Skip the graceful SIGTERM and SIGKILL the group immediately. */
+  force?: boolean;
+}
+
+/** Human-friendly elapsed time, e.g. "3m", "2h 5m", "8s". */
+export function formatUptime(ms: number): string {
+  if (ms < 0) ms = 0;
+  const s = Math.floor(ms / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+/** One ledger entry → a readable line. Pure, for display + tests. */
+export function formatDispatchLine(e: DispatchEntry, now: number): string {
+  const up = formatUptime(now - e.startedAt);
+  const task = e.task.length > 70 ? e.task.slice(0, 67) + "…" : e.task;
+  return `• ${e.id}  ${e.agent} (pid ${e.pid}, up ${up})  ${e.cwd}\n    "${task}"`;
+}
+
+/**
+ * Send `signal` to the process group led by `pid`, falling back to the lone
+ * process if the group send fails. Returns true if either delivery succeeded.
+ */
+function signalGroup(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(-pid, signal); // negative pid → whole process group
+    return true;
+  } catch {
+    try {
+      process.kill(pid, signal);
+      return true;
+    } catch {
+      return false; // already gone, or not permitted
+    }
+  }
+}
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+export const signalAgentTool: ToolDefinition<SignalInput, string> = {
+  name: "signal_agent",
+  description:
+    "List or stop the CLI agents LISA dispatched. action:'list' shows the still-running " +
+    "agents LISA launched via dispatch_agent (id, agent, pid, uptime, cwd, task). " +
+    "action:'cancel' (needs target = the id or pid from the list) stops one: SIGTERM to " +
+    "its process group, escalating to SIGKILL after a grace period (or pass force:true to " +
+    "kill immediately). Use when a dispatched agent is stuck, conflicting, or running away. " +
+    "Only agents LISA herself dispatched can be targeted — never the user's own sessions.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: ["list", "cancel"],
+        description: "'list' the running dispatched agents, or 'cancel' one.",
+      },
+      target: {
+        type: "string",
+        description:
+          "For cancel: the dispatch id (preferred) or the pid of the agent to stop. From action:'list'.",
+      },
+      force: {
+        type: "boolean",
+        description:
+          "Cancel only: skip graceful SIGTERM and SIGKILL the process group immediately (default false).",
+      },
+    },
+    required: ["action"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx) {
+    const now = Date.now();
+
+    if (input.action === "list") {
+      const live = listLiveDispatches();
+      if (live.length === 0) {
+        return "No agents dispatched by LISA are currently running. (Only agents launched via dispatch_agent are tracked here.)";
+      }
+      const lines = live
+        .sort((a, b) => a.startedAt - b.startedAt)
+        .map((e) => formatDispatchLine(e, now))
+        .join("\n");
+      return `${live.length} dispatched agent${live.length === 1 ? "" : "s"} running:\n${lines}\n\nCancel one with signal_agent({action:"cancel", target:"<id>"}).`;
+    }
+
+    // action === "cancel"
+    const target = (input.target ?? "").trim();
+    if (!target) {
+      return 'cancel needs a target — the dispatch id or pid from signal_agent({action:"list"}).';
+    }
+
+    const entry = findDispatch(target);
+    if (!entry) {
+      const live = listLiveDispatches();
+      const hint =
+        live.length > 0
+          ? ` Currently running: ${live.map((e) => `${e.id} (${e.agent}, pid ${e.pid})`).join(", ")}.`
+          : " No dispatched agents are running.";
+      return `No running dispatched agent matches "${target}".${hint}`;
+    }
+
+    const sig: NodeJS.Signals = input.force ? "SIGKILL" : "SIGTERM";
+    const delivered = signalGroup(entry.pid, sig);
+    if (!delivered && !isAlive(entry.pid)) {
+      // It exited on its own between the lookup and the signal — clean up.
+      removeDispatch(entry.id);
+      return `${entry.agent} (pid ${entry.pid}) had already exited; removed it from the ledger.`;
+    }
+
+    let escalated = false;
+    if (!input.force) {
+      // Give it a moment to shut down gracefully, then SIGKILL if it clings on.
+      await sleep(1500);
+      if (isAlive(entry.pid)) {
+        escalated = signalGroup(entry.pid, "SIGKILL");
+      }
+    }
+
+    removeDispatch(entry.id);
+    ctx.log(
+      `[signal] cancelled ${entry.agent} (pid ${entry.pid}) in ${entry.cwd}${escalated ? " [SIGKILL]" : ""}`,
+    );
+
+    const how = input.force
+      ? "SIGKILL"
+      : escalated
+        ? "SIGTERM then SIGKILL"
+        : "SIGTERM";
+    return `Cancelled ${entry.agent} (pid ${entry.pid}) in ${entry.cwd} via ${how}. Removed from the dispatch ledger.`;
+  },
+};


### PR DESCRIPTION
Completes the **DISPATCH** layer (O5 "active control") of `docs/ORCHESTRATOR_PLAN.md`. LISA could already *launch* CLI agents (`dispatch_agent`) and *observe* + *advise* on them — but she had no way to **act** on what she saw. `signal_agent` closes that loop.

## What's new

**`signal_agent` tool**
- `action:"list"` → the agents LISA dispatched that are still running (id, agent, pid, uptime, cwd, task).
- `action:"cancel"` (target = id or pid) → stops one: SIGTERM to its process **group** (dispatch spawns detached group leaders, so the agent's children die with it), escalating to SIGKILL after a 1.5s grace period. `force:true` SIGKILLs immediately.
- Composes with the advisor: *"codex looks stuck in ~/p — cancel it?"* → `signal_agent({action:"cancel", target})`.

**Dispatch ledger** (`src/integrations/dispatch-ledger.ts` → `~/.lisa/dispatches.json`)
- `dispatch_agent` records every launch. Detached agents outlive the spawning turn (the child handle is gone next turn) and even survive a LISA restart, so the pid is persisted. Dead pids are pruned on read.

### Safety / scope
The ledger only ever holds agents **LISA herself dispatched** — the user's own manually-started sessions are discovered via session files and carry no pid, so they're unreachable here. LISA can never SIGKILL an arbitrary user process. `cancel` is the inverse of the approval the host already granted to spawn the agent.

## Bug found + fixed along the way 🐛
`advise_now` and `dispatch_agent` were **imported into the tool registry but never added to the tool array** — and `tsconfig` has no `noUnusedLocals`, so it compiled silently. The model could never actually call either one: **`dispatch_agent` shipped dead in v0.4.0**. Both are now registered, with a `registry.test.ts` regression guard asserting all three orchestration tools are present.

## Tests
`npm run typecheck` clean · build clean · **170 → 191** tests:
- `dispatch-ledger.test.ts` — record/load/prune/find/remove, `isAlive` edge cases, recycled-pid dedup, corrupt-file tolerance.
- `signal_agent.test.ts` — list/cancel guards + **a real `spawn("sleep")` → force-cancel → asserts the process actually dies** and the ledger is cleared.
- `registry.test.ts` — orchestration tools registered, voice gating, sorted order.

Zero new runtime dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)