### PR TITLE
feat(autostart): run the backend from login (lisa autostart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — login autostart
+
+- **`lisa autostart install`** keeps the backend (`lisa serve --web`) running
+  from login onward, so the Mac apps / island / channels find it already up.
+  On macOS it writes a `ai.lisa.autostart` LaunchAgent with `RunAtLoad` +
+  `KeepAlive` (starts at login, restarts on crash) and loads it immediately
+  (`--no-load` to only write it). Flags pass through: `--port N`,
+  `--channels <list>`, `--imessage`. On Linux it prints a ready-to-paste
+  `systemd --user` unit (hands-off, like the heartbeat's crontab stance).
+- **`lisa autostart status`** / **`lisa autostart uninstall`** to inspect and
+  remove it. Logs at `~/.lisa/autostart.log`.
+
+### Fixed
+
+- **`heartbeat install --load` / `--every` threw `unknown flag`.** The arg
+  parser validated unknown `--flags` globally before subcommand args were split
+  out, so the heartbeat installer's own flags never reached its handler. Flags
+  after a raw-args subcommand (`heartbeat`, `autostart`) are now collected
+  verbatim. Shared launchd helpers extracted to `src/launchd.ts`.
+
 ## [0.7.0] — 2026-05-31
 
 **LISA can stop the agents she starts.** Completes the orchestrator's DISPATCH

--- a/src/autostart/install.test.ts
+++ b/src/autostart/install.test.ts
@@ -1,0 +1,62 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { renderPlist, serveArgs } from "./install.js";
+
+describe("autostart serveArgs", () => {
+  test("defaults to `serve --web` with no port (uses the default 5757)", () => {
+    assert.deepEqual(serveArgs({}), ["serve", "--web"]);
+    assert.deepEqual(serveArgs({ port: 5757 }), ["serve", "--web"]);
+  });
+
+  test("appends a non-default port", () => {
+    assert.deepEqual(serveArgs({ port: 6000 }), ["serve", "--web", "--port", "6000"]);
+  });
+
+  test("imessage shortcut maps to --channels imessage", () => {
+    assert.deepEqual(serveArgs({ imessage: true }), ["serve", "--web", "--channels", "imessage"]);
+  });
+
+  test("channels list is joined", () => {
+    assert.deepEqual(serveArgs({ channels: ["telegram", "discord"] }), [
+      "serve",
+      "--web",
+      "--channels",
+      "telegram,discord",
+    ]);
+  });
+});
+
+describe("autostart renderPlist", () => {
+  const plist = renderPlist({
+    label: "ai.lisa.autostart",
+    argv: ["/usr/local/bin/lisa", "serve", "--web"],
+    logPath: "/Users/x/.lisa/autostart.log",
+  });
+
+  test("is a login agent: RunAtLoad + KeepAlive both true", () => {
+    // The two keys that make it start at login and survive a crash. A
+    // regression on either silently breaks "auto" start.
+    assert.match(plist, /<key>RunAtLoad<\/key>\s*<true\/>/);
+    assert.match(plist, /<key>KeepAlive<\/key>\s*<true\/>/);
+    // It must NOT carry the heartbeat's StartInterval (that would re-spawn
+    // a second server every N seconds).
+    assert.doesNotMatch(plist, /StartInterval/);
+  });
+
+  test("carries the label and the serve --web argv", () => {
+    assert.match(plist, /<string>ai\.lisa\.autostart<\/string>/);
+    assert.match(plist, /<string>serve<\/string>/);
+    assert.match(plist, /<string>--web<\/string>/);
+    assert.match(plist, /<string>\/usr\/local\/bin\/lisa<\/string>/);
+  });
+
+  test("escapes XML metacharacters in argv", () => {
+    const p = renderPlist({
+      label: "ai.lisa.autostart",
+      argv: ["/path/a&b", "serve"],
+      logPath: "/l",
+    });
+    assert.match(p, /a&amp;b/);
+    assert.doesNotMatch(p, /a&b/);
+  });
+});

--- a/src/autostart/install.ts
+++ b/src/autostart/install.ts
@@ -1,0 +1,201 @@
+/**
+ * Login autostart — keep the LISA backend (`lisa serve --web`) running from
+ * login onward, so the Mac apps / island / channels find it already up.
+ *
+ * macOS: a LaunchAgent with RunAtLoad + KeepAlive (starts at login, restarts
+ * on crash). Linux/WSL: print a systemd --user unit the user installs manually
+ * (we don't touch their unit files automatically, mirroring the heartbeat
+ * installer's hands-off stance on crontab).
+ */
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { atomicWrite } from "../fs-utils.js";
+import { LISA_HOME } from "../paths.js";
+import { escapeXml, resolveLisaArgv, resolveLisaBin, runCmd } from "../launchd.js";
+
+export interface AutostartOptions {
+  /** Web UI port. Default 5757 (the port the Mac apps load). */
+  port?: number;
+  /** Channel adapters to also start (comma-list or "all"). */
+  channels?: string[];
+  /** Shortcut for channels:["imessage"] (macOS). */
+  imessage?: boolean;
+  /** Path to the `lisa` binary; auto-detected if omitted. */
+  binPath?: string;
+  /** macOS only: load the agent immediately (don't wait for next login). */
+  load?: boolean;
+}
+
+const PLIST_LABEL = "ai.lisa.autostart";
+const PLIST_PATH = path.join(
+  os.homedir(),
+  "Library",
+  "LaunchAgents",
+  `${PLIST_LABEL}.plist`,
+);
+const AUTOSTART_LOG = path.join(LISA_HOME, "autostart.log");
+
+/** The `serve …` argv tail that the agent launches. Exported for testing. */
+export function serveArgs(opts: AutostartOptions): string[] {
+  const args = ["serve", "--web"];
+  if (opts.port && opts.port !== 5757) args.push("--port", String(opts.port));
+  const channels = opts.imessage ? ["imessage"] : opts.channels ?? [];
+  if (channels.length) args.push("--channels", channels.join(","));
+  return args;
+}
+
+export async function installAutostart(
+  opts: AutostartOptions = {},
+): Promise<{ platform: string; instructions: string; written?: string }> {
+  const platform = process.platform;
+  const binPath = opts.binPath ?? (await resolveLisaBin());
+  const tail = serveArgs(opts);
+
+  if (platform === "darwin") {
+    const programArgv = [...(await resolveLisaArgv(binPath)), ...tail];
+    const plist = renderPlist({
+      label: PLIST_LABEL,
+      argv: programArgv,
+      logPath: AUTOSTART_LOG,
+    });
+    await fs.mkdir(path.dirname(PLIST_PATH), { recursive: true });
+    await atomicWrite(PLIST_PATH, plist);
+    let loadResult = "";
+    if (opts.load) {
+      try {
+        await runCmd("launchctl", ["unload", PLIST_PATH]);
+      } catch {}
+      try {
+        await runCmd("launchctl", ["load", "-w", PLIST_PATH]);
+        loadResult = `\nLoaded into launchd — Lisa is starting now and at every login.\nTo stop: launchctl unload ${PLIST_PATH}`;
+      } catch (err) {
+        loadResult = `\nWrote plist but failed to load: ${(err as Error).message}`;
+      }
+    }
+    return {
+      platform,
+      written: PLIST_PATH,
+      instructions: [
+        `Wrote launchd agent: ${PLIST_PATH}`,
+        `  runs:  ${[binPath, ...tail].join(" ")}`,
+        `  log:   ${AUTOSTART_LOG}`,
+        `  when:  at login + restarts if it exits (KeepAlive)`,
+        ``,
+        opts.load
+          ? loadResult.trim()
+          : `To start now (and every login): launchctl load -w ${PLIST_PATH}\nTo stop / disable:              launchctl unload ${PLIST_PATH}`,
+      ].join("\n"),
+    };
+  }
+
+  // Linux / WSL → systemd --user unit snippet (hands-off; we don't write it).
+  const cmd = `${binPath} ${tail.join(" ")}`;
+  const unitPath = "~/.config/systemd/user/lisa.service";
+  const unit = [
+    `[Unit]`,
+    `Description=LISA backend (web UI + channels)`,
+    `After=network-online.target`,
+    ``,
+    `[Service]`,
+    `ExecStart=${cmd}`,
+    `Restart=on-failure`,
+    `RestartSec=5`,
+    ``,
+    `[Install]`,
+    `WantedBy=default.target`,
+  ].join("\n");
+  const instructions = [
+    `Lisa doesn't edit your systemd units automatically. To autostart at login:`,
+    ``,
+    `  mkdir -p ~/.config/systemd/user`,
+    `  cat > ${unitPath} <<'EOF'`,
+    unit,
+    `EOF`,
+    `  systemctl --user daemon-reload`,
+    `  systemctl --user enable --now lisa.service`,
+    ``,
+    `  # so it runs without you being logged in (optional):`,
+    `  loginctl enable-linger "$USER"`,
+    ``,
+    `Logs:   journalctl --user -u lisa.service -f`,
+    `Disable: systemctl --user disable --now lisa.service`,
+  ].join("\n");
+  return { platform, instructions };
+}
+
+export async function uninstallAutostart(): Promise<string> {
+  if (process.platform !== "darwin") {
+    return "Auto-uninstall only supported on macOS. Run: systemctl --user disable --now lisa.service";
+  }
+  try {
+    await runCmd("launchctl", ["unload", PLIST_PATH]);
+  } catch {}
+  try {
+    await fs.unlink(PLIST_PATH);
+    return `Removed ${PLIST_PATH} — Lisa will no longer start at login.`;
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    if (e.code === "ENOENT") return "Autostart was not installed (nothing to remove).";
+    return `Could not remove ${PLIST_PATH}: ${e.message}`;
+  }
+}
+
+export async function autostartStatus(): Promise<string> {
+  if (process.platform !== "darwin") {
+    return "Status check only supported on macOS. Try: systemctl --user status lisa.service";
+  }
+  let installed = false;
+  try {
+    await fs.access(PLIST_PATH);
+    installed = true;
+  } catch {}
+  if (!installed) return "Autostart: not installed. Enable with `lisa autostart install --load`.";
+  let loaded = false;
+  try {
+    const out = await runCmd("launchctl", ["list"]);
+    loaded = out.includes(PLIST_LABEL);
+  } catch {}
+  return [
+    `Autostart: installed (${PLIST_PATH})`,
+    `  loaded in launchd: ${loaded ? "yes — running / will run at login" : "no — run `launchctl load -w " + PLIST_PATH + "`"}`,
+    `  log: ${AUTOSTART_LOG}`,
+  ].join("\n");
+}
+
+/** Render the macOS LaunchAgent plist. Exported for testing. */
+export function renderPlist(opts: {
+  label: string;
+  argv: string[];
+  logPath: string;
+}): string {
+  const argvXml = opts.argv
+    .map((a) => `        <string>${escapeXml(a)}</string>`)
+    .join("\n");
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>${opts.label}</string>
+    <key>ProgramArguments</key>
+    <array>
+${argvXml}
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>KeepAlive</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>${opts.logPath}</string>
+    <key>StandardErrorPath</key>
+    <string>${opts.logPath}</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+    </dict>
+</dict>
+</plist>
+`;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,6 +60,13 @@ LIFECYCLE
                                Install macOS launchd plist (or print cron line).
   lisa heartbeat uninstall     Remove the launchd plist (macOS).
 
+AUTOSTART (run the backend from login)
+  lisa autostart install [--no-load] [--port N] [--channels <list>] [--imessage]
+                               Keep \`serve --web\` running at login + on crash
+                               (macOS LaunchAgent; Linux prints a systemd unit).
+  lisa autostart status        Show whether autostart is installed / loaded.
+  lisa autostart uninstall     Stop starting Lisa at login.
+
 SERVE (long-lived)
   lisa serve --web [--port N]  Start the web UI (default port 5757).
   lisa serve --channels <list> Start IM channel adapters (comma-separated, or "all").
@@ -127,6 +134,7 @@ interface ParsedArgs {
     | "sessions"
     | "serve"
     | "heartbeat"
+    | "autostart"
     | "search"
     | "birth"
     | "soul"
@@ -143,6 +151,9 @@ interface ParsedArgs {
   port: number;
   prompt: string | null;
 }
+
+/** Subcommands whose trailing flags are command-specific, not global. */
+const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart"]);
 
 function parseArgs(argv: string[]): ParsedArgs {
   const out: ParsedArgs = {
@@ -208,7 +219,15 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === "--port") {
       out.port = parseInt(mustNext(argv, ++i, "--port"), 10);
     } else if (arg.startsWith("--")) {
-      throw new Error(`unknown flag: ${arg}`);
+      // Flags after a raw-args subcommand (heartbeat/autostart) are
+      // command-specific, not global — collect them verbatim instead of
+      // rejecting. (Without this, `heartbeat install --load` threw before
+      // its handler ever saw the flag.)
+      if (positional.some((p) => RAW_SUBCOMMANDS.has(p))) {
+        positional.push(arg);
+      } else {
+        throw new Error(`unknown flag: ${arg}`);
+      }
     } else {
       positional.push(arg);
     }
@@ -220,6 +239,7 @@ function parseArgs(argv: string[]): ParsedArgs {
       first === "sessions" ||
       first === "serve" ||
       first === "heartbeat" ||
+      first === "autostart" ||
       first === "search" ||
       first === "birth" ||
       first === "soul" ||
@@ -328,6 +348,38 @@ async function main(): Promise<void> {
   if (args.subcommand === "skills") {
     await handleSkillsSubcommand(args.subargs);
     return;
+  }
+
+  if (args.subcommand === "autostart") {
+    const sub = args.subargs[0];
+    if (sub === "install") {
+      const { installAutostart } = await import("./autostart/install.js");
+      // Default to loading immediately — the point of autostart is "running
+      // now and at every login". `--no-load` writes the agent without starting.
+      const load = !args.subargs.includes("--no-load");
+      const result = await installAutostart({
+        load,
+        port: args.port,
+        channels: args.serveChannels,
+        imessage: args.serveImessage,
+      });
+      console.log(`platform: ${result.platform}\n${result.instructions}`);
+      return;
+    }
+    if (sub === "uninstall") {
+      const { uninstallAutostart } = await import("./autostart/install.js");
+      console.log(await uninstallAutostart());
+      return;
+    }
+    if (sub === "status") {
+      const { autostartStatus } = await import("./autostart/install.js");
+      console.log(await autostartStatus());
+      return;
+    }
+    console.error(
+      "usage: lisa autostart <install|uninstall|status> [--no-load] [--port N] [--channels <list>] [--imessage]",
+    );
+    process.exit(2);
   }
 
   if (args.subcommand === "wishlist") {

--- a/src/heartbeat/install.ts
+++ b/src/heartbeat/install.ts
@@ -1,9 +1,9 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { spawn } from "node:child_process";
 import { atomicWrite } from "../fs-utils.js";
 import { LISA_HOME } from "../paths.js";
+import { escapeXml, resolveLisaArgv, resolveLisaBin, runCmd } from "../launchd.js";
 
 export interface InstallOptions {
   /** Cron-like spec: "*\/30 * * * *" or shorthand like "every:30m". Default: every 30 min. */
@@ -129,12 +129,6 @@ ${argvXml}
 `;
 }
 
-function escapeXml(s: string): string {
-  return s.replace(/[<>&"']/g, (c) =>
-    ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&apos;" }[c]!),
-  );
-}
-
 export async function uninstallHeartbeat(): Promise<string> {
   if (process.platform !== "darwin") {
     return "Auto-uninstall only supported on macOS. Edit your crontab manually.";
@@ -248,43 +242,3 @@ function formatSec(sec: number): string {
   return `${sec} seconds`;
 }
 
-async function resolveLisaBin(): Promise<string> {
-  // Used for the human-readable `instructions` line + the cron snippet.
-  try {
-    const out = await runCmd("which", ["lisa"]);
-    const trimmed = out.trim();
-    if (trimmed) return trimmed;
-  } catch {}
-  const here = path.resolve(process.cwd(), "dist", "cli.js");
-  try {
-    await fs.access(here);
-    return `node ${here}`;
-  } catch {}
-  return "lisa";
-}
-
-/** Returns argv elements for launchd plist (one entry per array slot). */
-async function resolveLisaArgv(displayedBin: string): Promise<string[]> {
-  // If displayedBin starts with "node ", split it.
-  if (displayedBin.startsWith("node ")) {
-    const nodePath = (await runCmd("which", ["node"]).catch(() => "node")).trim() || "node";
-    return [nodePath, displayedBin.slice("node ".length)];
-  }
-  return [displayedBin];
-}
-
-function runCmd(cmd: string, args: string[]): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args);
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (b) => (stdout += b.toString("utf8")));
-    child.stderr.on("data", (b) => (stderr += b.toString("utf8")));
-    child.on("error", reject);
-    child.on("close", (code) =>
-      code === 0
-        ? resolve(stdout)
-        : reject(new Error(`${cmd} exited ${code}: ${stderr.trim()}`)),
-    );
-  });
-}

--- a/src/launchd.ts
+++ b/src/launchd.ts
@@ -1,0 +1,65 @@
+/**
+ * Shared launchd / process helpers used by both the heartbeat scheduler and
+ * the login autostart installer. Kept dependency-free (node built-ins only).
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { spawn } from "node:child_process";
+
+/** Escape a string for inclusion as XML text/attribute content in a plist. */
+export function escapeXml(s: string): string {
+  return s.replace(/[<>&"']/g, (c) =>
+    ({ "<": "&lt;", ">": "&gt;", "&": "&amp;", '"': "&quot;", "'": "&apos;" }[c]!),
+  );
+}
+
+/** Run a command, resolving stdout on exit 0 and rejecting otherwise. */
+export function runCmd(cmd: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args);
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (b) => (stdout += b.toString("utf8")));
+    child.stderr.on("data", (b) => (stderr += b.toString("utf8")));
+    child.on("error", reject);
+    child.on("close", (code) =>
+      code === 0
+        ? resolve(stdout)
+        : reject(new Error(`${cmd} exited ${code}: ${stderr.trim()}`)),
+    );
+  });
+}
+
+/**
+ * Best-effort path to the `lisa` binary, used for the human-readable
+ * instructions line and the Linux service snippet. May return a "node <path>"
+ * form when only the local dist build is available.
+ */
+export async function resolveLisaBin(): Promise<string> {
+  try {
+    const out = await runCmd("which", ["lisa"]);
+    const trimmed = out.trim();
+    if (trimmed) return trimmed;
+  } catch {}
+  const here = path.resolve(process.cwd(), "dist", "cli.js");
+  try {
+    await fs.access(here);
+    return `node ${here}`;
+  } catch {}
+  return "lisa";
+}
+
+/**
+ * Resolve the displayed binary into launchd ProgramArguments slots (one argv
+ * element per array entry). A "node <path>" form is split into two slots with
+ * an absolute node path so launchd — which has no shell and a minimal PATH —
+ * can exec it.
+ */
+export async function resolveLisaArgv(displayedBin: string): Promise<string[]> {
+  if (displayedBin.startsWith("node ")) {
+    const nodePath =
+      (await runCmd("which", ["node"]).catch(() => "node")).trim() || "node";
+    return [nodePath, displayedBin.slice("node ".length)];
+  }
+  return [displayedBin];
+}


### PR DESCRIPTION
Adds login-autostart so the LISA backend (`serve --web`) is already up when the Mac apps / island / channels need it.

## New commands
- `lisa autostart install [--no-load] [--port N] [--channels <list>] [--imessage]`
  - **macOS**: writes a `ai.lisa.autostart` LaunchAgent with `RunAtLoad` + `KeepAlive` (starts at login, restarts on crash) and loads it immediately. `--no-load` writes without starting.
  - **Linux/WSL**: prints a ready-to-paste `systemd --user` unit (hands-off, mirroring the heartbeat's crontab stance).
  - Logs to `~/.lisa/autostart.log`. Needs no API key (early command path).
- `lisa autostart status` — installed? loaded?
- `lisa autostart uninstall` — stop starting at login.

## Refactor + bonus fix
- Extracted shared launchd helpers (`escapeXml` / `runCmd` / `resolveLisaBin` / `resolveLisaArgv`) into `src/launchd.ts`; the heartbeat installer imports them now (was duplicated).
- **Fixed a latent parser bug**: unknown `--flags` were validated globally *before* subcommand args were split out, so `heartbeat install --load` / `--every` threw `unknown flag` and never reached their handler. Flags after a raw-args subcommand (`heartbeat`/`autostart`) are now collected verbatim.

## Verification
- typecheck clean; full suite **198** green (7 new: `serveArgs` composition + plist `RunAtLoad`/`KeepAlive`/no-`StartInterval`/XML escaping).
- Ran the full install→status→uninstall lifecycle against an isolated `$HOME` — correct plist, **no real `~/Library/LaunchAgents` touched**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)