### PR TITLE
feat(mac): build Lisa Island into Lisa.app, toggled from the menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — Lisa Island built into Lisa.app
+
+- The notch pill is now a **feature of Lisa.app**, not a separate
+  `LisaIsland.app` you launch by hand. Toggle it from **View ▸ Show Lisa
+  Island** (⌘⇧I); the choice persists across launches (off by default), and
+  **Reset Island Position** re-centres it. The island's "open full chat" now
+  brings the in-process chat window forward instead of launching another app.
+  (The standalone `LisaIsland.app` still ships for now; it can be retired
+  later.)
+
 ### Changed — app icon
 
 - **New Lisa.app icon**: a cute chibi catgirl avatar (Lisa's signature cyan

--- a/packaging/mac-client/Sources/Lisa/AppDelegate.swift
+++ b/packaging/mac-client/Sources/Lisa/AppDelegate.swift
@@ -15,7 +15,7 @@
 
 import AppKit
 
-final class AppDelegate: NSObject, NSApplicationDelegate {
+final class AppDelegate: NSObject, NSApplicationDelegate, NSMenuItemValidation {
     private var mainWindow: MainWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -34,6 +34,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         HotkeyManager.shared.register { [weak self] in
             self?.captureForLisa(nil)
         }
+
+        // Lisa Island — the notch pill, now a feature of this app rather than
+        // a separate LisaIsland.app. Toggle it from View ▸ Show Lisa Island;
+        // the on/off choice is remembered across launches.
+        IslandController.shared.applyInitialState()
+        // The island's "open full chat" bridge posts this so we can bring the
+        // chat window forward in-process.
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleShowMainWindow),
+            name: IslandContent.showMainWindowNotification,
+            object: nil
+        )
+    }
+
+    @objc private func handleShowMainWindow() {
+        showMainWindow()
     }
 
     @objc func captureForLisa(_ sender: Any?) {
@@ -104,6 +121,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     @objc func reloadChat(_ sender: Any?) {
         mainWindow?.reload()
+    }
+
+    // MARK: - Lisa Island
+
+    @objc func toggleIsland(_ sender: Any?) {
+        IslandController.shared.toggle()
+    }
+
+    @objc func resetIslandPosition(_ sender: Any?) {
+        IslandController.shared.resetPosition()
+    }
+
+    /// Tick the "Show Lisa Island" item when the island is on, and disable
+    /// "Reset Island Position" while it's off (nothing to reset).
+    func validateMenuItem(_ item: NSMenuItem) -> Bool {
+        if item.action == #selector(toggleIsland(_:)) {
+            item.state = IslandController.shared.isEnabled ? .on : .off
+        } else if item.action == #selector(resetIslandPosition(_:)) {
+            return IslandController.shared.isEnabled
+        }
+        return true
     }
 
     @objc func newWindowAction(_ sender: Any?) {
@@ -198,6 +236,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         captureItem.keyEquivalentModifierMask = [.control, .option]
         viewMenu.addItem(captureItem)
+
+        // ── Lisa Island toggle (the in-app notch pill) ──────────────
+        viewMenu.addItem(.separator())
+        let islandItem = NSMenuItem(
+            title: "Show Lisa Island",
+            action: #selector(toggleIsland(_:)),
+            keyEquivalent: "i"
+        )
+        islandItem.keyEquivalentModifierMask = [.command, .shift]
+        islandItem.target = self
+        viewMenu.addItem(islandItem)
+        let resetIslandItem = NSMenuItem(
+            title: "Reset Island Position",
+            action: #selector(resetIslandPosition(_:)),
+            keyEquivalent: ""
+        )
+        resetIslandItem.target = self
+        viewMenu.addItem(resetIslandItem)
+
         viewMenu.addItem(.separator())
         viewMenu.addItem(NSMenuItem(
             title: "Enter Full Screen",

--- a/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
@@ -1,0 +1,204 @@
+//
+//  IslandContent.swift
+//  LisaIsland — Phase 2.1 + 2.2
+//
+//  Wraps the WKWebView. Loads http://localhost:5757/island (the Phase 1
+//  widget) and bridges three messages from the page:
+//
+//    - open_full_gui  → open default browser to /
+//    - expand         → grow window so the expand panel isn't clipped
+//    - collapse       → shrink window back to pill size
+//
+//  Auto-reload on failure: if the LISA server is down at launch time, the
+//  webview retries the load every 4 seconds.
+//
+
+import AppKit
+import WebKit
+
+final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessageHandler {
+    static let lisaURL = URL(string: "http://localhost:5757/island")!
+
+    private weak var hostWindow: IslandWindow?
+    private var webView: WKWebView!
+    private var reloadTimer: Timer?
+
+    init(window: IslandWindow) {
+        self.hostWindow = window
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("not implemented")
+    }
+
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        // Receive postMessage from window.webkit.messageHandlers.island.
+        config.userContentController.add(self, name: "island")
+        config.processPool = WKProcessPool()
+
+        let preferences = WKWebpagePreferences()
+        preferences.allowsContentJavaScript = true
+        config.defaultWebpagePreferences = preferences
+
+        let wv = WKWebView(frame: .zero, configuration: config)
+        wv.navigationDelegate = self
+        wv.autoresizingMask = [.width, .height]
+        // Transparent: the page's CSS draws the rounded pill, the rest of
+        // the rectangle should show what's underneath.
+        wv.setValue(false, forKey: "drawsBackground")
+        wv.allowsBackForwardNavigationGestures = false
+        wv.allowsLinkPreview = false
+        // Enable right-click → Inspect Element on macOS 13.3+ so we can
+        // debug runtime issues without a separate browser session.
+        if #available(macOS 13.3, *) {
+            wv.isInspectable = true
+        }
+
+        webView = wv
+        view = wv
+
+        load()
+    }
+
+    // MARK: - Load / retry
+
+    private func load() {
+        let request = URLRequest(
+            url: Self.lisaURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 5
+        )
+        webView.load(request)
+    }
+
+    private func scheduleReload() {
+        reloadTimer?.invalidate()
+        reloadTimer = Timer.scheduledTimer(
+            withTimeInterval: 4.0,
+            repeats: false
+        ) { [weak self] _ in
+            self?.load()
+        }
+    }
+
+    // MARK: - WKNavigationDelegate
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        loadOfflineSplash()
+        scheduleReload()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        loadOfflineSplash()
+        scheduleReload()
+    }
+
+    /// Pill-sized "offline" placeholder shown when localhost:5757 is
+    /// unreachable. Visually consistent with the real pill so users
+    /// understand at a glance that the app's alive but the backend isn't.
+    /// Replaced atomically the next time the real page loads.
+    private func loadOfflineSplash() {
+        let html = """
+        <!doctype html><html><head><meta charset=\"utf-8\"><style>
+          html, body { margin: 0; padding: 0; background: transparent;
+            font-family: -apple-system, BlinkMacSystemFont, \"SF Pro Text\", system-ui, sans-serif;
+            color: #e4e4e6; -webkit-font-smoothing: antialiased; user-select: none; }
+          body { display: flex; flex-direction: column; align-items: center;
+                 padding: 4px 8px; }
+          .pill { display: inline-flex; align-items: center; gap: 8px;
+            background: rgba(8, 12, 24, 0.92);
+            border: 1px solid rgba(255, 255, 255, 0.06);
+            border-radius: 22px; padding: 5px 14px 5px 5px;
+            backdrop-filter: blur(20px);
+            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4); }
+          /* No avatar image — baseURL is nil on the offline splash, so
+             relative URLs don't resolve. A muted circle with a "Z" mark
+             ("she's sleeping") communicates offline without a broken icon. */
+          .av { width: 36px; height: 36px; border-radius: 50%;
+                background: #15192a; opacity: 0.55;
+                border: 1px solid rgba(255, 255, 255, 0.10);
+                display: grid; place-items: center;
+                color: #6b7280; font-size: 16px; font-weight: 700; }
+          .label { font-size: 13px; font-weight: 600; color: #9ba3b8;
+                   letter-spacing: 0.02em; }
+          .dot { width: 7px; height: 7px; border-radius: 50%;
+                 background: #6b7280; flex-shrink: 0; }
+        </style></head><body>
+          <div class=\"pill\" title=\"LISA backend offline — start: lisa serve --web\">
+            <div class=\"av\">z</div>
+            <div class=\"label\">offline</div>
+            <div class=\"dot\"></div>
+          </div>
+        </body></html>
+        """
+        webView.loadHTMLString(html, baseURL: nil)
+    }
+
+    // MARK: - Open the full chat
+
+    /// In-app island: the chat window lives in THIS process, so just ask the
+    /// AppDelegate to bring it forward (rather than launching a separate app).
+    static let showMainWindowNotification = Notification.Name("ai.meetlisa.showMainWindow")
+
+    private func openLisaAppOrBrowser() {
+        NotificationCenter.default.post(name: Self.showMainWindowNotification, object: nil)
+    }
+
+    // MARK: - WKScriptMessageHandler
+
+    func userContentController(_ uc: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let body = message.body as? [String: Any] else { return }
+        guard let type = body["type"] as? String else { return }
+        switch type {
+        case "open_full_gui":
+            // Prefer launching the native Lisa.app (bundle id
+            // ai.meetlisa.app) if it's installed. Falls back to the
+            // browser at http://localhost:5757/ when the app isn't
+            // present — keeps the island useful for users who only
+            // run the web widget.
+            openLisaAppOrBrowser()
+        case "expand":
+            // Page-side expand state — Swift uses this to size the
+            // click-through "hot rect" (whole window when expanded,
+            // just the pill when collapsed). No window resize happens.
+            hostWindow?.setExpanded(true)
+        case "collapse":
+            hostWindow?.setExpanded(false)
+        case "ensure_notify_permission":
+            // Page is asking us to request macOS notification
+            // permission (idempotent; system handles repeats).
+            Task { @MainActor in
+                Notifier.shared.ensurePermission()
+            }
+        case "notify":
+            // Page detected a Claude session transitioning to
+            // waiting/error/etc. and wants to surface it as a native
+            // notification. Title + body are constructed page-side
+            // from projectLabel + sessionId — never message content.
+            guard let title = body["title"] as? String,
+                  let bodyText = body["body"] as? String else { return }
+            let sessionId = (body["sessionId"] as? String) ?? ""
+            Task { @MainActor in
+                Notifier.shared.notify(title: title, body: bodyText, sessionId: sessionId)
+            }
+        case "open_path":
+            // Open a Finder window at the cwd of a Claude session
+            // (Phase 3.5 B). Path is page-supplied; we restrict to
+            // absolute paths under the user's home for safety.
+            guard let raw = body["path"] as? String else { return }
+            let path = (raw as NSString).expandingTildeInPath
+            if path.hasPrefix("/") {
+                let url = URL(fileURLWithPath: path, isDirectory: true)
+                NSWorkspace.shared.open(url)
+            }
+        default:
+            // Drag is handled entirely Swift-side now (sendEvent
+            // intercept + nextEvent loop), so we no longer expect
+            // drag_delta / drag_end from the page. Unknown messages
+            // are tolerated for forward-compat with future phases.
+            break
+        }
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/Island/IslandController.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/IslandController.swift
@@ -1,0 +1,66 @@
+//
+//  IslandController.swift
+//  Lisa
+//
+//  Owns the in-app Lisa Island — the notch pill that used to be a separate
+//  LisaIsland.app. It's now a feature of Lisa.app, toggled from the menu
+//  ("View ▸ Show Lisa Island") and remembered across launches in UserDefaults.
+//
+//  The window itself (IslandWindow) is identical to the standalone app's; this
+//  controller just gates its lifecycle on the `enabled` preference.
+//
+
+import AppKit
+
+// Not @MainActor: every caller is already a main-thread AppKit context
+// (app launch + menu actions), and that keeps it callable from the
+// nonisolated @objc menu selectors without hops.
+final class IslandController {
+    static let shared = IslandController()
+    private init() {}
+
+    private static let enabledKey = "ai.meetlisa.island.enabled"
+    private var window: IslandWindow?
+
+    /// Whether the island is switched on. Persisted; default off.
+    var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: Self.enabledKey)
+    }
+
+    /// Show the island at launch if the user left it enabled.
+    func applyInitialState() {
+        if isEnabled { show() }
+    }
+
+    func setEnabled(_ on: Bool) {
+        UserDefaults.standard.set(on, forKey: Self.enabledKey)
+        if on { show() } else { hide() }
+    }
+
+    func toggle() {
+        setEnabled(!isEnabled)
+    }
+
+    func resetPosition() {
+        window?.resetSavedOrigin()
+    }
+
+    // MARK: - Window lifecycle
+
+    private func show() {
+        if window == nil {
+            window = IslandWindow()
+        }
+        // orderFrontRegardless: surface the pill without stealing focus from
+        // whatever the user is doing (the island is a passive observer).
+        window?.orderFrontRegardless()
+    }
+
+    private func hide() {
+        // Fully tear down so the window's hover-polling timer stops (deinit
+        // invalidates it). The saved origin lives in UserDefaults, so the pill
+        // returns to the same spot when re-enabled.
+        window?.orderOut(nil)
+        window = nil
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/Island/IslandWindow.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/IslandWindow.swift
@@ -1,0 +1,323 @@
+//
+//  IslandWindow.swift
+//  LisaIsland — Phase 2.1 + 2.2
+//
+//  Borderless, transparent NSPanel that hosts the WKWebView.
+//
+//  Architecture (after the post-flicker rework):
+//
+//   • Window is a CONSTANT 330×300. We never resize it on expand /
+//     collapse — that was the source of the click-flicker.
+//   • The pill renders in the TOP 50pt of the window (CSS aligns it to
+//     flex-start). The bottom 250pt is for the expand panel, hidden via
+//     CSS when collapsed.
+//   • Click-through outside the pill: a polling timer checks the cursor
+//     against the "hot rect" (just the pill when collapsed, the whole
+//     window when expanded) and toggles `ignoresMouseEvents`. So the
+//     250pt transparent area below the pill doesn't steal menu-bar or
+//     content clicks when the user isn't actively engaging with Lisa.
+//   • Drag is Swift-side, not JS: `sendEvent(_:)` intercepts
+//     `.leftMouseDown` and runs a synchronous nextEvent loop tracking
+//     mouseDragged / mouseUp. Movement > 4px ⇒ drag (setFrameOrigin
+//     each tick, no IPC roundtrip). No movement ⇒ click (forward
+//     `pill.click()` into the WKWebView).
+//   • The pill's screen position is persisted as the window origin
+//     (since the window is a fixed size, the origin IS the anchor).
+//
+
+import AppKit
+import WebKit
+
+final class IslandWindow: NSPanel {
+    // Fixed window footprint. Pill renders in the top 50pt; expand
+    // panel renders below (visible only via CSS). Sized to comfortably
+    // fit 5 Claude session rows + desire text + actions without
+    // clipping — the architecture comment above explains why the
+    // window stays constant rather than resizing on expand/collapse.
+    static let windowSize = CGSize(width: 360, height: 440)
+    static let pillHeight: CGFloat = 50
+
+    // 4pt deadband: cursor must move at least this much before we treat
+    // the mousedown as a drag rather than a click.
+    private static let dragThreshold: CGFloat = 4
+
+    // UserDefaults keys.
+    private enum DefaultsKey {
+        static let hasUserOrigin = "ai.meetlisa.island.hasUserOrigin"
+        static let userOriginX   = "ai.meetlisa.island.userOriginX"
+        static let userOriginY   = "ai.meetlisa.island.userOriginY"
+    }
+
+    /// Tracked from CSS expand state via postMessage from island.ts.
+    /// When expanded, the hover-hot-rect is the entire window; when
+    /// collapsed, it's just the pill.
+    private var expandedHot = false
+
+    private var hoverTimer: Timer?
+
+    init() {
+        let frame = NSRect(origin: .zero, size: Self.windowSize)
+        super.init(
+            contentRect: frame,
+            styleMask: [.borderless, .nonactivatingPanel, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+
+        configureWindow()
+        repositionWindow()
+        mountWebView()
+        startHoverPolling()
+
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleScreenChange),
+            name: NSApplication.didChangeScreenParametersNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        hoverTimer?.invalidate()
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    // MARK: - Config
+
+    private func configureWindow() {
+        level = NSWindow.Level(Int(NSWindow.Level.mainMenu.rawValue) + 3)
+        collectionBehavior = [
+            .canJoinAllSpaces,
+            .stationary,
+            .ignoresCycle,
+            .fullScreenAuxiliary,
+        ]
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        isMovableByWindowBackground = false
+        // Start in pass-through; hoverPoll will flip this on/off based
+        // on cursor position vs hot-rect.
+        ignoresMouseEvents = true
+        isFloatingPanel = true
+        hidesOnDeactivate = false
+    }
+
+    override var canBecomeKey: Bool { false }
+    override var canBecomeMain: Bool { false }
+
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        return frameRect
+    }
+
+    // MARK: - Position
+
+    private func savedOrigin() -> NSPoint? {
+        let d = UserDefaults.standard
+        guard d.bool(forKey: DefaultsKey.hasUserOrigin) else { return nil }
+        return NSPoint(
+            x: d.double(forKey: DefaultsKey.userOriginX),
+            y: d.double(forKey: DefaultsKey.userOriginY)
+        )
+    }
+
+    private func saveCurrentOrigin() {
+        let d = UserDefaults.standard
+        d.set(true, forKey: DefaultsKey.hasUserOrigin)
+        d.set(Double(frame.origin.x), forKey: DefaultsKey.userOriginX)
+        d.set(Double(frame.origin.y), forKey: DefaultsKey.userOriginY)
+    }
+
+    func resetSavedOrigin() {
+        let d = UserDefaults.standard
+        d.removeObject(forKey: DefaultsKey.hasUserOrigin)
+        d.removeObject(forKey: DefaultsKey.userOriginX)
+        d.removeObject(forKey: DefaultsKey.userOriginY)
+        repositionWindow()
+    }
+
+    /// Default: pill's top edge sits at visibleFrame.maxY (just below
+    /// menu bar / notch), horizontally centered on the screen midX.
+    /// Since the pill is in the top 50pt of a 300pt-tall window, the
+    /// window's TOP edge equals visibleFrame.maxY, so origin.y =
+    /// visibleFrame.maxY - windowHeight.
+    private func defaultOrigin(on screen: NSScreen) -> NSPoint {
+        let visible = screen.visibleFrame
+        return NSPoint(
+            x: visible.midX - Self.windowSize.width / 2,
+            y: visible.maxY - Self.windowSize.height
+        )
+    }
+
+    private func clampedOrigin(_ origin: NSPoint, on screen: NSScreen) -> NSPoint {
+        let bounds = screen.frame
+        let pillVisibleMargin: CGFloat = 40
+        // Keep at least 40pt of the PILL on screen, so the user can't
+        // lose it. The pill is in the top 50pt of the window.
+        let minX = bounds.minX - Self.windowSize.width + pillVisibleMargin
+        let maxX = bounds.maxX - pillVisibleMargin
+        // Lower bound: pill top must still be inside the screen.
+        // Pill top y in AppKit coords = origin.y + windowHeight.
+        // Need pill top > bounds.minY + pillVisibleMargin → origin.y >
+        // bounds.minY + pillVisibleMargin - windowHeight.
+        let minY = bounds.minY + pillVisibleMargin - Self.windowSize.height
+        // Upper bound: window can sit up to screen-top.
+        let maxY = bounds.maxY - Self.windowSize.height + Self.pillHeight - pillVisibleMargin
+        return NSPoint(
+            x: min(max(origin.x, minX), maxX),
+            y: min(max(origin.y, minY), maxY)
+        )
+    }
+
+    private func repositionWindow() {
+        guard let screen = NSScreen.main else { return }
+        let origin: NSPoint
+        if let saved = savedOrigin() {
+            origin = clampedOrigin(saved, on: screen)
+        } else {
+            origin = defaultOrigin(on: screen)
+        }
+        setFrame(NSRect(origin: origin, size: Self.windowSize),
+                 display: true,
+                 animate: false)
+    }
+
+    @objc private func handleScreenChange() {
+        repositionWindow()
+    }
+
+    // MARK: - Hot rect + click-through polling
+
+    /// Called by IslandContent on receipt of an `expand` / `collapse`
+    /// postMessage from the page. Updates which rect is "hot" for
+    /// click-passthrough decisions.
+    func setExpanded(_ expanded: Bool) {
+        expandedHot = expanded
+    }
+
+    /// Pill rect in screen-space (top 50pt of the window).
+    private var pillScreenRect: NSRect {
+        let top = frame.origin.y + frame.height
+        return NSRect(
+            x: frame.origin.x,
+            y: top - Self.pillHeight,
+            width: frame.width,
+            height: Self.pillHeight
+        )
+    }
+
+    private func startHoverPolling() {
+        // 50ms = 20Hz. Cheap. Adequate for "cursor over pill" detection.
+        hoverTimer = Timer.scheduledTimer(
+            withTimeInterval: 0.05,
+            repeats: true
+        ) { [weak self] _ in
+            self?.updateClickPassthrough()
+        }
+    }
+
+    private func updateClickPassthrough() {
+        let mouse = NSEvent.mouseLocation
+        // When expanded, the whole window is hot (so the user can
+        // click buttons in the expand panel). When collapsed, only the
+        // pill rectangle is hot.
+        let hot: NSRect = expandedHot ? frame : pillScreenRect
+        let inHot = NSPointInRect(mouse, hot)
+        let shouldIgnore = !inHot
+        if ignoresMouseEvents != shouldIgnore {
+            ignoresMouseEvents = shouldIgnore
+        }
+    }
+
+    // MARK: - Swift-side drag (mouseDown intercepted at sendEvent)
+
+    override func sendEvent(_ event: NSEvent) {
+        // Only intercept clicks that land on the pill rect. Clicks
+        // elsewhere (expand panel: Open chat / Dismiss / Claude rows /
+        // Open in Finder / Copy resume / notify CTA) need to reach the
+        // WKWebView so their JS click handlers fire normally. Without
+        // this hit-test every click was being rewritten into a
+        // pill.click() — which just toggled the expand panel,
+        // appearing to do nothing.
+        if event.type == .leftMouseDown {
+            let mouse = NSEvent.mouseLocation
+            if NSPointInRect(mouse, pillScreenRect) {
+                handleMouseDown(event)
+                return
+            }
+        }
+        super.sendEvent(event)
+    }
+
+    private func handleMouseDown(_ down: NSEvent) {
+        let initialOrigin   = frame.origin
+        let downScreen      = NSEvent.mouseLocation
+        var moved           = false
+
+        while true {
+            // Pull the next mouse-drag-or-up event off the queue.
+            // .eventTracking run loop mode keeps us in the active drag
+            // tracking phase without interleaving non-mouse events.
+            guard let evt = NSApplication.shared.nextEvent(
+                matching: [.leftMouseDragged, .leftMouseUp],
+                until: .distantFuture,
+                inMode: .eventTracking,
+                dequeue: true
+            ) else { return }
+
+            let now = NSEvent.mouseLocation
+            let dx = now.x - downScreen.x
+            let dy = now.y - downScreen.y
+
+            switch evt.type {
+            case .leftMouseDragged:
+                if !moved && (abs(dx) > Self.dragThreshold || abs(dy) > Self.dragThreshold) {
+                    moved = true
+                }
+                if moved {
+                    setFrameOrigin(NSPoint(
+                        x: initialOrigin.x + dx,
+                        y: initialOrigin.y + dy
+                    ))
+                }
+            case .leftMouseUp:
+                if moved {
+                    saveCurrentOrigin()
+                } else {
+                    // It was a click. Synthesize the pill click in JS so
+                    // expand-toggle / button handlers run as normal.
+                    forwardPillClick()
+                }
+                return
+            default:
+                break
+            }
+        }
+    }
+
+    private func forwardPillClick() {
+        guard let wv = contentView as? WKWebView else {
+            FileHandle.standardError.write(
+                Data("[island] forwardPillClick: contentView not WKWebView\n".utf8)
+            )
+            return
+        }
+        FileHandle.standardError.write(Data("[island] forwarding click\n".utf8))
+        wv.evaluateJavaScript("document.getElementById('pill')?.click();") { _, err in
+            if let err = err {
+                FileHandle.standardError.write(
+                    Data("[island] evalJS error: \(err)\n".utf8)
+                )
+            }
+        }
+    }
+
+    // MARK: - WebView mount
+
+    private func mountWebView() {
+        let content = IslandContent(window: self)
+        contentView = content.view
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/Island/Notifier.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/Notifier.swift
@@ -1,0 +1,108 @@
+//
+//  Notifier.swift
+//  LisaIsland — Phase 3.5 of issue #29
+//
+//  Thin wrapper around UNUserNotificationCenter for surfacing
+//  "Claude is waiting" alerts as macOS-native notifications. Called
+//  from IslandContent in response to a `notify` postMessage from the
+//  page — the page is the source of truth for *when* to notify (it
+//  knows about state transitions), this module just owns the *how*.
+//
+//  The browser fallback (Notification API in island.ts) still works
+//  when the page is loaded in a plain browser tab. When running
+//  inside LisaIsland.app, the page detects the native bridge and
+//  defers to us instead.
+//
+
+import AppKit
+import UserNotifications
+
+@MainActor
+final class Notifier: NSObject, @preconcurrency UNUserNotificationCenterDelegate {
+    static let shared = Notifier()
+
+    /// Track per-session throttle independently of the page so even if
+    /// the page reloads we still rate-limit cleanly. Same 60s window
+    /// as the JS-side throttle.
+    private var lastFireAt: [String: Date] = [:]
+    private static let throttleSeconds: TimeInterval = 60
+    private var permissionRequested = false
+
+    override init() {
+        super.init()
+        UNUserNotificationCenter.current().delegate = self
+    }
+
+    /// Ask the user for notification permission. Idempotent — calling
+    /// repeatedly after the first decision is a no-op.
+    func ensurePermission() {
+        guard !permissionRequested else { return }
+        permissionRequested = true
+        UNUserNotificationCenter.current().requestAuthorization(
+            options: [.alert, .sound]
+        ) { _, _ in
+            // Result is best-effort; system handles denial silently.
+        }
+    }
+
+    /// Post a notification. Title + body come from the page; we add
+    /// throttling, identifier-based replace-not-stack behavior, and a
+    /// click action that asks the host app to open the full chat GUI.
+    ///
+    /// Privacy: title/body strings are constructed by the page from
+    /// `projectLabel` and `sessionId` only — never message content.
+    /// This module never reads jsonl.
+    func notify(title: String, body: String, sessionId: String) {
+        let key = sessionId.isEmpty ? "_default" : sessionId
+        let now = Date()
+        if let prev = lastFireAt[key], now.timeIntervalSince(prev) < Self.throttleSeconds {
+            return
+        }
+        lastFireAt[key] = now
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body  = body
+        content.sound = .default
+        // `threadIdentifier` makes macOS visually group same-session
+        // notifications. `identifier` (on the request) makes a new
+        // alert REPLACE a previous one for the same session rather
+        // than stack.
+        content.threadIdentifier = "lisa.claude.\(key)"
+        content.userInfo = ["sessionId": sessionId]
+
+        let request = UNNotificationRequest(
+            identifier: "lisa.claude.\(key)",
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { _ in
+            // Best-effort. macOS may quietly drop if Focus is on.
+        }
+    }
+
+    // MARK: - UNUserNotificationCenterDelegate
+
+    /// Show banners even when the app is "foreground" (it's an
+    /// .accessory app so there's no real foreground; this keeps
+    /// banners visible regardless).
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    /// Click on a notification → open the full LISA chat GUI.
+    func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        defer { completionHandler() }
+        if let url = URL(string: "http://localhost:5757/") {
+            NSWorkspace.shared.open(url)
+        }
+    }
+}


### PR DESCRIPTION
Folds the notch pill into the main **Lisa.app** so it's a setting you toggle, not a separate `LisaIsland.app` you launch by hand (per request).

## What
- Island sources moved into the Lisa target under `Sources/Lisa/Island/` (`IslandWindow`, `IslandContent`, `Notifier` — copied; `NotchDetector` wasn't referenced).
- `IslandController` owns the window lifecycle + an `ai.meetlisa.island.enabled` `UserDefaults` flag (default **off**, restored at launch).
- **View ▸ Show Lisa Island** (⌘⇧I, checkable) toggles it; **Reset Island Position** re-centres it (disabled while off).
- The island's "open full chat" bridge now posts a notification so `AppDelegate` brings the in-process chat window forward (instead of launching a separate app/browser).

## Verification
- `swift build` ✅ and full `build.sh` ✅ (Lisa.app assembles with the island + new icon).
- ⚠️ Runtime notch placement / drag / click-through still needs a **GUI smoke test** — can't exercise that headlessly.

## Note
The standalone `LisaIsland.app` is left in place for now (still built into the DMG); it can be retired in a follow-up once the in-app island is confirmed good.

🤖 Generated with [Claude Code](https://claude.com/claude-code)