### PR TITLE
fix(web): repair SyntaxError that killed ALL GUI JavaScript since v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,15 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Fixed
 
+- **The entire web GUI's JavaScript was dead since v0.6.0.** The voice
+  feature's transcript-framing string was written with `\n` *inside the page's
+  outer template literal*, so it expanded to a raw newline inside a
+  double-quoted JS string in the served HTML — a `SyntaxError` that made the
+  browser discard the page's single `<script>` wholesale. Result: no chat send,
+  no SSE mood/idle updates, and the Claude-Code monitor stuck at "0 / idle"
+  even with active sessions. Fixed the escaping (`\\n`), and added a
+  compile-only test (`html-syntax.test.ts`) that parses both inline scripts so
+  this class of break can't ship again.
 - **`heartbeat install --load` / `--every` threw `unknown flag`.** The arg
   parser validated unknown `--flags` globally before subcommand args were split
   out, so the heartbeat installer's own flags never reached its handler. Flags

--- a/src/web/html-syntax.test.ts
+++ b/src/web/html-syntax.test.ts
@@ -1,0 +1,42 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import { MAIN_HTML } from "./lisa-html.js";
+import { ISLAND_HTML } from "./island.js";
+
+/**
+ * Regression guard: the whole GUI/island is one big inline <script>. A single
+ * syntax error there (e.g. a raw newline inside a JS string literal — which is
+ * exactly what a `\n` written inside the outer TS template literal expands to)
+ * makes the browser discard the ENTIRE script, silently killing all page JS:
+ * chat send, SSE mood/idle, the Claude monitor, vision, voice. typecheck can't
+ * see inside a template-literal string, so we compile the emitted scripts here.
+ *
+ * vm.Script compiles (parses) without running, so missing browser globals
+ * (document/window/fetch/EventSource) don't matter — only syntax is checked.
+ */
+function inlineScripts(html: string): string[] {
+  const out: string[] = [];
+  const re = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/gi;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(html)) !== null) out.push(m[1]!);
+  return out;
+}
+
+describe("inline page <script> blocks are syntactically valid JS", () => {
+  for (const [name, html] of [
+    ["MAIN_HTML", MAIN_HTML],
+    ["ISLAND_HTML", ISLAND_HTML],
+  ] as const) {
+    test(`${name} parses`, () => {
+      const blocks = inlineScripts(html);
+      assert.ok(blocks.length > 0, `${name} should contain an inline <script>`);
+      blocks.forEach((code, i) => {
+        assert.doesNotThrow(
+          () => new vm.Script(code),
+          `${name} inline script #${i} has a syntax error`,
+        );
+      });
+    });
+  }
+});

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -1400,8 +1400,8 @@ async function finishRecording() {
     // chat turn, persistence, and her response in her own voice.
     const framed =
       "I just recorded some audio. Here's the transcript — please give me a clear, " +
-      "useful summary (key points, decisions, action items if any), then I might ask follow-ups.\n\n" +
-      "--- transcript ---\n" + transcript;
+      "useful summary (key points, decisions, action items if any), then I might ask follow-ups.\\n\\n" +
+      "--- transcript ---\\n" + transcript;
     send(framed);
   } catch (err) {
     if (pending) pending.remove();


### PR DESCRIPTION
## Root cause
The user reported the Claude-Code monitor showing **0 / idle** despite active sessions. Investigation: the backend was fine (`/api/claude/sessions` returns the active sessions), but **the page's JavaScript never ran**.

The voice feature's transcript-framing string was written with `\n` **inside the page's outer TS template literal**, so it expanded to a **raw newline inside a double-quoted JS string** in the served HTML:
```js
"… follow-ups.
" +            // ← raw newline = Uncaught SyntaxError
"--- transcript ---
" + transcript;
```
The page has a **single** inline `<script>`, so that one SyntaxError made the browser discard *all* page JS — chat send, SSE mood/idle, the Claude monitor, vision, voice — silently, since v0.6.0. (Not a WKWebView/SSE/cache issue, despite first appearances.)

## Fix
- Escape as `\\n` so the emitted JS has a valid `\n`.
- **`html-syntax.test.ts`**: compiles (parses, never runs) both inline scripts via `vm.Script`, catching this class permanently. typecheck can't see inside a template-literal string; this can.

## Verification
- Served page line is now a valid single-line string; headless console shows **no** SyntaxError.
- New test passes; full suite **200** green; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)