### PR TITLE
fix(web): add GET /api/sessions (sidebar count badge was 404'ing)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,9 @@ versioning follows [SemVer](https://semver.org/).
   even with active sessions. Fixed the escaping (`\\n`), and added a
   compile-only test (`html-syntax.test.ts`) that parses both inline scripts so
   this class of break can't ship again.
+- **Sidebar session-count badge always blank.** It fetched `/api/sessions`,
+  which didn't exist (404). Added the route (`{ sessions }` from
+  `listSessionsOnDisk()`), so the footer badge shows the real count.
 - **`heartbeat install --load` / `--every` threw `unknown flag`.** The arg
   parser validated unknown `--flags` globally before subcommand args were split
   out, so the heartbeat installer's own flags never reached its handler. Flags

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -539,6 +539,16 @@ self.addEventListener('fetch', (event) => {
       return;
     }
 
+    if (req.method === "GET" && url === "/api/sessions") {
+      // Lisa's own chat sessions on disk — drives the sidebar footer count
+      // badge. (Was missing → the badge fetch 404'd and stayed a placeholder.)
+      const { listSessionsOnDisk } = await import("../sessions/list.js");
+      const sessions = await listSessionsOnDisk();
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ sessions }));
+      return;
+    }
+
     if (req.method === "GET" && url === "/api/skills") {
       const { listSkills } = await import("../skills/manager.js");
       const skills = await listSkills();


### PR DESCRIPTION
The sidebar footer's *total sessions* badge fetched `/api/sessions`, which had no route (404), so it stayed a placeholder. Adds the route returning `{ sessions }` from `listSessionsOnDisk()` (the same data `lisa sessions` lists). Verified: `HTTP 200`, badge populates. typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)