### PR TITLE
fix(web): GUI white-screen on send; feat(mac): right-click the island to close it

### DIFF
--- a/packaging/mac-client/Sources/Lisa/Island/IslandWindow.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/IslandWindow.swift
@@ -248,6 +248,18 @@ final class IslandWindow: NSPanel {
                 return
             }
         }
+        // Right-click on the pill → a tiny context menu whose only item
+        // closes the island. The pill is the always-visible handle, so it's
+        // where users reach to make the island go away. Without this the only
+        // way to dismiss it is the Settings toggle (⌘,), which isn't
+        // discoverable from the pill itself.
+        if event.type == .rightMouseDown {
+            let mouse = NSEvent.mouseLocation
+            if NSPointInRect(mouse, pillScreenRect) {
+                showCloseMenu(for: event)
+                return
+            }
+        }
         super.sendEvent(event)
     }
 
@@ -311,6 +323,39 @@ final class IslandWindow: NSPanel {
                     Data("[island] evalJS error: \(err)\n".utf8)
                 )
             }
+        }
+    }
+
+    // MARK: - Right-click menu
+
+    private func showCloseMenu(for event: NSEvent) {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        let close = NSMenuItem(
+            title: "Close Lisa Island",
+            action: #selector(closeIslandFromMenu),
+            keyEquivalent: ""
+        )
+        close.target = self
+        menu.addItem(close)
+
+        // Pop the menu at the cursor. locationInWindow is in window coords;
+        // contentView is full-size, so converting from nil (the window) lands
+        // the menu under the pointer.
+        let view = contentView
+        let location = view?.convert(event.locationInWindow, from: nil)
+            ?? event.locationInWindow
+        menu.popUp(positioning: nil, at: location, in: view)
+    }
+
+    @objc private func closeIslandFromMenu() {
+        // Defer the teardown: setEnabled(false) → IslandController.hide() sets
+        // `window = nil`, dropping the last strong ref to self. Doing that
+        // synchronously inside our own menu-action call stack would dealloc
+        // self mid-method. Hop to the next runloop tick so this event finishes
+        // unwinding first; the closure captures only the singleton, not self.
+        DispatchQueue.main.async {
+            IslandController.shared.setEnabled(false)
         }
     }
 

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -1400,8 +1400,8 @@ async function finishRecording() {
     // chat turn, persistence, and her response in her own voice.
     const framed =
       "I just recorded some audio. Here's the transcript — please give me a clear, " +
-      "useful summary (key points, decisions, action items if any), then I might ask follow-ups.\n\n" +
-      "--- transcript ---\n" + transcript;
+      "useful summary (key points, decisions, action items if any), then I might ask follow-ups.\\n\\n" +
+      "--- transcript ---\\n" + transcript;
     send(framed);
   } catch (err) {
     if (pending) pending.remove();


### PR DESCRIPTION
Two independent fixes, both reported live by the user (Mac client).

## 1. `fix(web)` — white screen after clicking Send

**Symptom:** clicking **Send** in the chat blanked the window to solid white.

**Root cause:** the voice transcript-framing string in `lisa-html.ts` used `\n` **inside the page's outer TS template literal**, so it expanded to a **raw newline inside a double-quoted JS string** in the served page:

```js
"…follow-ups.\n\n" +          // ← raw newline → Uncaught SyntaxError
"--- transcript ---\n" + transcript;
```

The page has a **single** inline `<script>`, so that one `SyntaxError: Invalid or unexpected token` made the browser discard **all** page JS. With nothing bound, the composer's `submit` handler never attached, so clicking Send fell back to a **native form submission** → the WKWebView navigated to a blank document (the white screen). `npm run typecheck` can't catch this — the template is valid TypeScript; only the browser fails when it parses the emitted string.

**Fix:** escape as `\\n` so the emitted JS contains a valid `\n` (matches how the rest of the file already escapes newlines, e.g. the SSE split).

**Verified:** `node --check` on the emitted script — old fails at that exact line, fixed parses clean; headless browser repro — pre-fix console shows the `SyntaxError` and Send blanks the page, post-fix `typeof send === 'function'`, Send renders the message bubble and does **not** navigate.

> ⚠️ Overlap: this same one-line fix is also in a parallel branch `fix/gui-js-syntax-error` (which additionally adds an `html-syntax.test.ts` regression test). Merge the white-screen fix from **one** source only — that branch's test is the more complete version.

## 2. `feat(mac)` — right-click the island pill to close it

Dismissing the in-app Lisa Island required the Settings toggle (⌘,), which isn't discoverable from the pill itself — users couldn't tell how to make it go away. Adds a right-click context menu on the pill whose single item (**"Close Lisa Island"**) calls `IslandController.setEnabled(false)`. Mirrors the existing left-click drag/click interception in `sendEvent`. Teardown is deferred to the next runloop tick because `setEnabled(false)` drops the window's last strong ref (would otherwise dealloc `self` mid-menu-action).

**Verified:** `swift build` compiles clean (only pre-existing `WKProcessPool` deprecation warnings). Native floating-panel right-click can't be driven by the available browser tools, so the runtime click wasn't auto-exercised — but the right-click path is identical to the already-working left-click interception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)