### PR TITLE
feat(orchestrator): list_agents — enumerate observed agent sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — list_agents tool
+
+- **`list_agents`** lets LISA enumerate the agent sessions she observes (Claude
+  Code, Codex, …) with their structural activity — state, project, git branch,
+  last tool/command name, files touched, pending permission, errors. Fills the
+  gap where she could only give the relevance-gated `advise_now` summary or list
+  her *own* dispatched agents (`signal_agent`), so "what are my agents doing?"
+  is answerable in chat. Structural metadata only — never conversation content.
+
+
 ### Added — Lisa Island built into Lisa.app
 
 - The notch pill is now a **feature of Lisa.app**, not a separate

--- a/src/tools/list_agents.test.ts
+++ b/src/tools/list_agents.test.ts
@@ -1,0 +1,60 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { formatSessionLine } from "./list_agents.js";
+import type { AgentSession } from "../integrations/types.js";
+
+const NOW = 1_000_000_000_000;
+
+function session(overrides: Partial<AgentSession> = {}): AgentSession {
+  return {
+    agent: "claude-code",
+    sessionId: "abc",
+    project: "LISA",
+    state: "working",
+    stateReason: "user",
+    lastMtime: NOW - 90_000, // 1m ago
+    ...overrides,
+  };
+}
+
+describe("list_agents formatSessionLine", () => {
+  test("renders state, project, agent and relative time", () => {
+    const line = formatSessionLine(session(), NOW);
+    assert.match(line, /\[working\] LISA \(claude-code, 1m ago\)/);
+  });
+
+  test("surfaces a pending permission over other activity", () => {
+    const line = formatSessionLine(
+      session({ activity: { turnCount: 3, lastTools: ["Edit"], filesTouched: [], pendingPermission: "Bash" } }),
+      NOW,
+    );
+    assert.match(line, /needs permission: Bash/);
+  });
+
+  test("shows branch, last command name, and basenames of files", () => {
+    const line = formatSessionLine(
+      session({
+        activity: {
+          turnCount: 5,
+          lastTools: ["Read", "Bash"],
+          filesTouched: ["/Users/x/repo/src/web/server.ts"],
+          lastCommandName: "git",
+          gitBranch: "main",
+        },
+      }),
+      NOW,
+    );
+    assert.match(line, /@main/);
+    assert.match(line, /\$ git/);
+    assert.match(line, /files: server\.ts/);
+  });
+
+  test("never leaks full paths beyond the basename (structural only)", () => {
+    const line = formatSessionLine(
+      session({ activity: { turnCount: 1, lastTools: [], filesTouched: ["/Users/secret/private/notes.md"] } }),
+      NOW,
+    );
+    assert.doesNotMatch(line, /\/Users\/secret/);
+    assert.match(line, /notes\.md/);
+  });
+});

--- a/src/tools/list_agents.ts
+++ b/src/tools/list_agents.ts
@@ -1,0 +1,86 @@
+/**
+ * list_agents (orchestrator OBSERVE — read side) — enumerate the CLI agent
+ * sessions LISA is watching (Claude Code, Codex, …) with their structural
+ * activity, so she can answer "what are my agents doing right now?" in chat.
+ *
+ * Fills the gap between:
+ *   - advise_now  — only the relevance-gated *summary* ("10 active, nothing notable")
+ *   - signal_agent — only LISA's OWN dispatched agents (the user's manual sessions
+ *                    are observed but unreachable there)
+ * The sidebar/island already show this data; this exposes it to the chat agent.
+ *
+ * PRIVACY: structural metadata only — state, project, git branch, tool/command
+ * NAMES, file PATHS, counts, error strings. Never a prompt, a reply, or full
+ * command arguments. Same boundary the parser privacy tests assert.
+ */
+
+import type { ToolDefinition } from "../types.js";
+import { getCurrentHub } from "../integrations/current-hub.js";
+import type { AgentSession } from "../integrations/types.js";
+
+const STATE_RANK: Record<string, number> = {
+  error: 0,
+  waiting: 1,
+  working: 2,
+  done: 3,
+  idle: 4,
+  unknown: 5,
+};
+
+function ago(ms: number, now: number): string {
+  const d = Math.max(0, now - ms);
+  const s = Math.floor(d / 1000);
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m`;
+  return `${Math.floor(m / 60)}h`;
+}
+
+/** One session → a readable, structural-only line. Pure, for display + tests. */
+export function formatSessionLine(s: AgentSession, now: number): string {
+  const a = s.activity;
+  const bits: string[] = [];
+  if (a?.gitBranch) bits.push(`@${a.gitBranch}`);
+  if (a?.pendingPermission) bits.push(`⏳ needs permission: ${a.pendingPermission}`);
+  else if (a?.lastCommandName) bits.push(`$ ${a.lastCommandName}`);
+  else if (a?.lastTools && a.lastTools.length) bits.push(a.lastTools.slice(-3).join("→"));
+  if (a?.lastError) bits.push(`error: ${a.lastError}`);
+  if (a?.filesTouched && a.filesTouched.length) {
+    const f = a.filesTouched
+      .slice(-2)
+      .map((p) => p.split("/").pop() ?? p)
+      .join(", ");
+    bits.push(`files: ${f}`);
+  }
+  const detail = bits.length ? " · " + bits.join(" · ") : "";
+  return `• [${s.state}] ${s.project} (${s.agent}, ${ago(s.lastMtime, now)} ago)${detail}`;
+}
+
+export const listAgentsTool: ToolDefinition<Record<string, never>, string> = {
+  name: "list_agents",
+  description:
+    "List the CLI agent sessions LISA is observing right now (Claude Code, Codex, …) with their " +
+    "structural activity: state (working/waiting/error/idle), project, git branch, last tool/command " +
+    "NAME, files touched, pending permission, errors. Use when the user asks what their agents are " +
+    "doing, what's running, or 'what is <agent> up to'. Structural metadata only — never conversation " +
+    "content; to see what a repo actually changed, read its `git log`. For LISA's OWN dispatched " +
+    "agents (start/stop) use signal_agent; for a relevance-gated summary use advise_now.",
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  async execute() {
+    const hub = getCurrentHub();
+    if (!hub) {
+      return "(agent monitoring isn't active — start the web server with `lisa serve --web`)";
+    }
+    const now = Date.now();
+    const sessions = hub.list();
+    if (sessions.length === 0) return "(no agents are active right now)";
+    const sorted = sessions.slice().sort((a, b) => {
+      const ra = STATE_RANK[a.state] ?? 9;
+      const rb = STATE_RANK[b.state] ?? 9;
+      if (ra !== rb) return ra - rb;
+      return b.lastMtime - a.lastMtime;
+    });
+    const head = `${sessions.length} agent session(s) observed (structural activity only):`;
+    return [head, ...sorted.map((s) => formatSessionLine(s, now))].join("\n");
+  },
+};

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -8,7 +8,7 @@ describe("buildToolRegistry", () => {
     // registry but never pushed into the array, so the model couldn't call
     // them. tsconfig has no noUnusedLocals to catch that, so guard it here.
     const names = new Set(buildToolRegistry().map((t) => t.name));
-    for (const required of ["advise_now", "dispatch_agent", "signal_agent"]) {
+    for (const required of ["list_agents", "advise_now", "dispatch_agent", "signal_agent"]) {
       assert.ok(names.has(required), `${required} must be registered`);
     }
   });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -2,6 +2,7 @@ import type { ToolDefinition } from "../types.js";
 import { memoryTool } from "../memory/tool.js";
 import { memorySearchTool } from "../memory/search_tool.js";
 import { adviseNowTool } from "./advise_now.js";
+import { listAgentsTool } from "./list_agents.js";
 import { dispatchAgentTool } from "./dispatch_agent.js";
 import { signalAgentTool } from "./signal_agent.js";
 import { skillManageTool } from "../skills/tool.js";
@@ -66,6 +67,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     webSearchTool as ToolDefinition,
     redeployTool as ToolDefinition,
     // Orchestration (docs/ORCHESTRATOR_PLAN.md): observe → advise → dispatch → control.
+    listAgentsTool as ToolDefinition,
     adviseNowTool as ToolDefinition,
     dispatchAgentTool as ToolDefinition,
     signalAgentTool as ToolDefinition,


### PR DESCRIPTION
Adds a `list_agents` tool so LISA can answer *what are my agents doing right now* in chat. She previously had only `advise_now` (relevance-gated summary) and `signal_agent` (her own dispatched agents), so she'd claim she couldn't see the user's local Claude Code sessions — even though the hub observes them and the sidebar shows them. This exposes that observed data (state, project, git branch, last tool/command NAME, files touched, pending permission, errors) to the chat agent. **Structural metadata only — never conversation content** (a unit test asserts paths are reduced to basenames). Registry regression test now requires it too. Suite 200 → 204.

🤖 Generated with [Claude Code](https://claude.com/claude-code)