### PR TITLE
fix(web): escape \n in framed voice-summary string + add inline-script syntax guard

### DIFF
--- a/src/web/lisa-html.test.ts
+++ b/src/web/lisa-html.test.ts
@@ -1,0 +1,31 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import vm from "node:vm";
+import { MAIN_HTML } from "./lisa-html.js";
+
+// Pull every inline <script>…</script> body, skipping <script src=…> (external
+// scripts have no inline code to check). This is the exact source the browser
+// hands to V8.
+const INLINE_SCRIPT_RE = /<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g;
+const inlineScripts = [...MAIN_HTML.matchAll(INLINE_SCRIPT_RE)].map((m) => m[1]);
+
+test("MAIN_HTML has inline <script> blocks to validate", () => {
+  assert.ok(
+    inlineScripts.length > 0,
+    "no inline <script> found — did the regex or the template change?",
+  );
+});
+
+// Why this guard exists: MAIN_HTML is one big template literal, so a `\n`
+// (single backslash) written inside a client-side JS string literal becomes a
+// REAL newline in the served script. That breaks the quoted string and throws
+// `SyntaxError: Invalid or unexpected token` at page load — a white screen.
+// `npm run typecheck` can't catch it (the template is valid TypeScript); only
+// V8 fails when it parses the emitted script. vm.Script compiles the code the
+// same way the browser parses a classic <script> — without executing it — so
+// the broken syntax surfaces here instead of in production.
+inlineScripts.forEach((code, i) => {
+  test(`inline <script> #${i} parses as valid JS`, () => {
+    assert.doesNotThrow(() => new vm.Script(code));
+  });
+});

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -1400,8 +1400,8 @@ async function finishRecording() {
     // chat turn, persistence, and her response in her own voice.
     const framed =
       "I just recorded some audio. Here's the transcript — please give me a clear, " +
-      "useful summary (key points, decisions, action items if any), then I might ask follow-ups.\n\n" +
-      "--- transcript ---\n" + transcript;
+      "useful summary (key points, decisions, action items if any), then I might ask follow-ups.\\n\\n" +
+      "--- transcript ---\\n" + transcript;
     send(framed);
   } catch (err) {
     if (pending) pending.remove();


### PR DESCRIPTION
## What & why

`src/web/lisa-html.ts` exports `MAIN_HTML`, a single large **template literal** holding the whole client page (including an inline `<script>`). The `framed` string in `finishRecording()` was written with `\n` / `\n\n`:

```js
const framed =
  "...please give me a clear, useful summary ..., then I might ask follow-ups.\n\n" +
  "--- transcript ---\n" + transcript;
```

Because the surrounding string is a template literal, those `\n` sequences were interpreted at build time into **real newlines** in the served `<script>`. That breaks the double-quoted JS string and throws `SyntaxError: Invalid or unexpected token` at page load — **a white screen for the whole page**.

`npm run typecheck` does **not** catch this (the template is valid TypeScript); only V8 fails when parsing the emitted script.

## Changes

- **Fix:** escape the backslashes (`\n` → `\\n`) so the template emits a proper `\n` escape sequence into the served JS string (runtime behaviour — the rendered newlines in the chat message — is unchanged).
- **Regression guard:** new `src/web/lisa-html.test.ts` that:
  1. imports `MAIN_HTML`,
  2. extracts every inline `<script>` with no `src=` (`/<script(?![^>]*\bsrc=)[^>]*>([\s\S]*?)<\/script>/g`),
  3. asserts each block parses as valid JS via `new vm.Script(code)` (`node:vm`) wrapped in `assert.doesNotThrow`.

`vm.Script` compiles the source exactly like the browser parses a classic `<script>` — without executing it — so this whole class of bug surfaces in CI instead of in production.

## Verification

- `npm test` → **200/200 pass**; `npm run typecheck` clean.
- Reintroducing a raw `\n` into a quoted string makes the new test **fail** (`SyntaxError: Invalid or unexpected token`), confirming it guards the bug. Reverted to the fixed form (passes again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)