### PR TITLE
feat(tools): repo_digest — git truth for what my agents did

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — vibe-coding tools
+
+- **`repo_digest`** — what actually changed in a repo (or every repo your agents
+  touch): recent commits in a window, branch, uncommitted count + diff stat,
+  ahead/behind. Answers "what did <agent> do today" with git truth (the
+  orchestrator only sees structural activity). Read-only.
+
+
 ### Added — list_agents tool
 
 - **`list_agents`** lets LISA enumerate the agent sessions she observes (Claude

--- a/src/tools/exec-util.ts
+++ b/src/tools/exec-util.ts
@@ -1,0 +1,80 @@
+/**
+ * Small process-exec helper shared by the repo/PR/check tools. Runs a command
+ * in a given directory, captures (capped) output, honours an AbortSignal and a
+ * timeout. Never throws — returns a result with the exit code so callers branch
+ * on it. Dependency-free (node:child_process only).
+ */
+import { spawn } from "node:child_process";
+import { stat } from "node:fs/promises";
+
+export interface ExecResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  /** True when the binary itself couldn't be spawned (e.g. not installed). */
+  spawnError?: string;
+}
+
+export function runIn(
+  cwd: string,
+  cmd: string,
+  args: string[],
+  opts: { timeoutMs?: number; signal?: AbortSignal; maxBytes?: number } = {},
+): Promise<ExecResult> {
+  const cap = opts.maxBytes ?? 64 * 1024;
+  return new Promise((resolve) => {
+    let child: ReturnType<typeof spawn>;
+    try {
+      child = spawn(cmd, args, { cwd, signal: opts.signal });
+    } catch (e) {
+      resolve({ code: null, stdout: "", stderr: "", timedOut: false, spawnError: String((e as Error).message) });
+      return;
+    }
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = opts.timeoutMs
+      ? setTimeout(() => {
+          timedOut = true;
+          try {
+            child.kill("SIGKILL");
+          } catch {}
+        }, opts.timeoutMs)
+      : null;
+    child.stdout?.on("data", (b: Buffer) => {
+      if (stdout.length < cap) stdout += b.toString("utf8");
+    });
+    child.stderr?.on("data", (b: Buffer) => {
+      if (stderr.length < cap) stderr += b.toString("utf8");
+    });
+    child.on("error", (e) => {
+      if (timer) clearTimeout(timer);
+      resolve({ code: null, stdout, stderr, timedOut, spawnError: String((e as Error).message) });
+    });
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut });
+    });
+  });
+}
+
+/** Validate that `p` is an absolute path to an existing directory. */
+export async function isDir(p: string): Promise<boolean> {
+  if (!p || !p.startsWith("/")) return false;
+  try {
+    return (await stat(p)).isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+/** `git -C <cwd> rev-parse --show-toplevel` → repo root, or null if not a repo. */
+export async function gitRoot(cwd: string, signal?: AbortSignal): Promise<string | null> {
+  const r = await runIn(cwd, "git", ["-C", cwd, "rev-parse", "--show-toplevel"], { timeoutMs: 5000, signal });
+  if (r.code === 0) {
+    const root = r.stdout.trim();
+    return root || null;
+  }
+  return null;
+}

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,6 +3,7 @@ import { memoryTool } from "../memory/tool.js";
 import { memorySearchTool } from "../memory/search_tool.js";
 import { adviseNowTool } from "./advise_now.js";
 import { listAgentsTool } from "./list_agents.js";
+import { repoDigestTool } from "./repo_digest.js";
 import { dispatchAgentTool } from "./dispatch_agent.js";
 import { signalAgentTool } from "./signal_agent.js";
 import { skillManageTool } from "../skills/tool.js";
@@ -68,6 +69,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     redeployTool as ToolDefinition,
     // Orchestration (docs/ORCHESTRATOR_PLAN.md): observe → advise → dispatch → control.
     listAgentsTool as ToolDefinition,
+    repoDigestTool as ToolDefinition,
     adviseNowTool as ToolDefinition,
     dispatchAgentTool as ToolDefinition,
     signalAgentTool as ToolDefinition,

--- a/src/tools/repo_digest.test.ts
+++ b/src/tools/repo_digest.test.ts
@@ -1,0 +1,45 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { formatDigest, type RepoDigest } from "./repo_digest.js";
+
+function d(over: Partial<RepoDigest> = {}): RepoDigest {
+  return {
+    root: "/Users/x/repo",
+    branch: "main",
+    commits: [],
+    dirtyFiles: 0,
+    diffStat: "",
+    ahead: 0,
+    behind: 0,
+    since: "1 day ago",
+    ...over,
+  };
+}
+
+describe("repo_digest formatDigest", () => {
+  test("clean repo with no recent commits", () => {
+    const out = formatDigest(d());
+    assert.match(out, /▸ repo @ main/);
+    assert.match(out, /no commits since 1 day ago/);
+    assert.match(out, /working tree clean/);
+  });
+
+  test("lists commits and uncommitted changes", () => {
+    const out = formatDigest(
+      d({ commits: ["abc123 feat: x", "def456 fix: y"], dirtyFiles: 2, diffStat: "3 files changed, 10 insertions(+)" }),
+    );
+    assert.match(out, /commits since 1 day ago:/);
+    assert.match(out, /abc123 feat: x/);
+    assert.match(out, /uncommitted: 2 file\(s\) · 3 files changed/);
+  });
+
+  test("shows ahead/behind vs upstream", () => {
+    const out = formatDigest(d({ ahead: 3, behind: 1 }));
+    assert.match(out, /↑3↓1 vs upstream/);
+  });
+
+  test("error repos render a single line", () => {
+    const out = formatDigest(d({ error: "not a git repo" }));
+    assert.equal(out, "▸ repo — not a git repo");
+  });
+});

--- a/src/tools/repo_digest.ts
+++ b/src/tools/repo_digest.ts
@@ -1,0 +1,142 @@
+/**
+ * repo_digest (vibe-coding) — "what actually changed?" across the repos your
+ * agents are working in. The orchestrator only sees structural activity (tool
+ * names, file paths); git is the source of truth for *what was produced*. This
+ * wraps git so LISA can answer "what did Claude Code do today" with real
+ * commits + working-tree state, per repo.
+ *
+ * Reads the user's own git repos (content they've asked LISA to look at) — this
+ * is separate from the orchestrator's no-conversation-content privacy rule.
+ */
+import type { ToolDefinition } from "../types.js";
+import { getCurrentHub } from "../integrations/current-hub.js";
+import { runIn, isDir, gitRoot } from "./exec-util.js";
+
+interface RepoDigestInput {
+  /** Repo path. Omit to digest every repo with an observed agent session. */
+  cwd?: string;
+  /** git --since value. Default "1 day ago". */
+  since?: string;
+}
+
+export interface RepoDigest {
+  root: string;
+  branch: string;
+  commits: string[];
+  dirtyFiles: number;
+  diffStat: string;
+  ahead: number;
+  behind: number;
+  since: string;
+  error?: string;
+}
+
+/** Pure: render one repo's digest. Exported for tests. */
+export function formatDigest(d: RepoDigest): string {
+  const name = d.root.split("/").pop() || d.root;
+  if (d.error) return `▸ ${name} — ${d.error}`;
+  const lines: string[] = [];
+  const sync =
+    d.ahead || d.behind
+      ? `  (${d.ahead ? "↑" + d.ahead : ""}${d.behind ? "↓" + d.behind : ""} vs upstream)`
+      : "";
+  lines.push(`▸ ${name} @ ${d.branch}${sync}`);
+  if (d.commits.length) {
+    lines.push(`  commits since ${d.since}:`);
+    for (const c of d.commits) lines.push(`    ${c}`);
+  } else {
+    lines.push(`  no commits since ${d.since}`);
+  }
+  if (d.dirtyFiles > 0) {
+    lines.push(`  uncommitted: ${d.dirtyFiles} file(s)${d.diffStat ? " · " + d.diffStat : ""}`);
+  } else {
+    lines.push(`  working tree clean`);
+  }
+  return lines.join("\n");
+}
+
+async function digestRepo(cwd: string, since: string, signal?: AbortSignal): Promise<RepoDigest> {
+  const root = await gitRoot(cwd, signal);
+  const base: RepoDigest = { root: root ?? cwd, branch: "?", commits: [], dirtyFiles: 0, diffStat: "", ahead: 0, behind: 0, since };
+  if (!root) return { ...base, error: "not a git repo" };
+
+  const git = (args: string[]) => runIn(root, "git", ["-C", root, ...args], { timeoutMs: 8000, signal });
+
+  const branch = await git(["rev-parse", "--abbrev-ref", "HEAD"]);
+  base.branch = branch.code === 0 ? branch.stdout.trim() || "?" : "?";
+
+  // Commits across all refs in the window (covers agent worktrees/branches).
+  const log = await git(["log", "--all", "--oneline", "--no-decorate", `--since=${since}`, "-n", "25"]);
+  if (log.code === 0) {
+    base.commits = log.stdout.split("\n").map((l) => l.trim()).filter(Boolean);
+  }
+
+  const status = await git(["status", "--porcelain"]);
+  if (status.code === 0) {
+    base.dirtyFiles = status.stdout.split("\n").filter((l) => l.trim()).length;
+  }
+  if (base.dirtyFiles > 0) {
+    const ds = await git(["diff", "--shortstat"]);
+    if (ds.code === 0) base.diffStat = ds.stdout.trim();
+  }
+
+  const ab = await git(["rev-list", "--left-right", "--count", "@{upstream}...HEAD"]);
+  if (ab.code === 0) {
+    const m = ab.stdout.trim().split(/\s+/);
+    base.behind = parseInt(m[0] ?? "0", 10) || 0;
+    base.ahead = parseInt(m[1] ?? "0", 10) || 0;
+  }
+  return base;
+}
+
+/** Collect distinct git roots from the observed agent sessions' cwds. */
+async function observedRepoRoots(signal?: AbortSignal): Promise<string[]> {
+  const hub = getCurrentHub();
+  if (!hub) return [];
+  const cwds = Array.from(
+    new Set(hub.list().map((s) => s.cwd).filter((c): c is string => !!c && c.startsWith("/"))),
+  );
+  const roots = new Set<string>();
+  for (const c of cwds) {
+    const r = await gitRoot(c, signal);
+    if (r) roots.add(r);
+    if (roots.size >= 8) break;
+  }
+  return Array.from(roots);
+}
+
+export const repoDigestTool: ToolDefinition<RepoDigestInput, string> = {
+  name: "repo_digest",
+  description:
+    "Summarise what actually changed in a git repo (or, with no cwd, every repo your agents are " +
+    "working in): recent commits in a time window, current branch, uncommitted file count + diff " +
+    "stat, and ahead/behind vs upstream. Use to answer 'what did <agent> / I do today', 'what's the " +
+    "state of <repo>', or before reviewing/merging. Reads git only (no writes). Pair with review_diff " +
+    "to see the actual changes and run_checks to verify them.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      cwd: { type: "string", description: "Absolute path inside the repo. Omit to digest all repos with an active agent session." },
+      since: { type: "string", description: 'git --since window, e.g. "1 day ago", "today", "3 hours ago". Default "1 day ago".' },
+    },
+    additionalProperties: false,
+  },
+  async execute(input, ctx) {
+    const since = input.since?.trim() || "1 day ago";
+    let roots: string[];
+    if (input.cwd) {
+      if (!(await isDir(input.cwd))) return `(not a directory: ${input.cwd})`;
+      roots = [input.cwd];
+    } else {
+      roots = await observedRepoRoots(ctx.signal);
+      if (roots.length === 0) {
+        // Fall back to the current working directory's repo.
+        const r = await gitRoot(ctx.cwd, ctx.signal);
+        if (r) roots = [r];
+      }
+    }
+    if (roots.length === 0) return "(no git repos to digest — no active agent sessions and cwd isn't a repo)";
+    const digests = await Promise.all(roots.map((r) => digestRepo(r, since, ctx.signal)));
+    return digests.map(formatDigest).join("\n\n");
+  },
+};


### PR DESCRIPTION
First of the vibe-coding tool set. `repo_digest` wraps git (read-only) to answer *what actually changed* across the repos your agents work in — recent commits in a window, branch, uncommitted count + diff stat, ahead/behind. With no `cwd` it digests every repo with an observed agent session. Adds shared `exec-util` (runIn/isDir/gitRoot). Unit-tested + live-smoked against this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)