### PR TITLE
feat(tools): review_diff — show an agent's diff for review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Added — vibe-coding tools
 
+- **`review_diff`** — show the actual code diff in a repo (uncommitted vs HEAD,
+  working/staged, any ref/range, or a GitHub PR via `gh`) so LISA can review an
+  agent's work before merge. Read-only, output capped.
+
 - **`repo_digest`** — what actually changed in a repo (or every repo your agents
   touch): recent commits in a window, branch, uncommitted count + diff stat,
   ahead/behind. Answers "what did <agent> do today" with git truth (the

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -4,6 +4,7 @@ import { memorySearchTool } from "../memory/search_tool.js";
 import { adviseNowTool } from "./advise_now.js";
 import { listAgentsTool } from "./list_agents.js";
 import { repoDigestTool } from "./repo_digest.js";
+import { reviewDiffTool } from "./review_diff.js";
 import { dispatchAgentTool } from "./dispatch_agent.js";
 import { signalAgentTool } from "./signal_agent.js";
 import { skillManageTool } from "../skills/tool.js";
@@ -70,6 +71,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     // Orchestration (docs/ORCHESTRATOR_PLAN.md): observe → advise → dispatch → control.
     listAgentsTool as ToolDefinition,
     repoDigestTool as ToolDefinition,
+    reviewDiffTool as ToolDefinition,
     adviseNowTool as ToolDefinition,
     dispatchAgentTool as ToolDefinition,
     signalAgentTool as ToolDefinition,

--- a/src/tools/review_diff.test.ts
+++ b/src/tools/review_diff.test.ts
@@ -1,0 +1,22 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { assembleReview } from "./review_diff.js";
+
+describe("review_diff assembleReview", () => {
+  test("no changes → just the header", () => {
+    assert.equal(assembleReview("", "", 600), "(no changes)");
+  });
+
+  test("includes stat header and diff body", () => {
+    const out = assembleReview(" foo.ts | 2 +-", "diff --git a/foo.ts\n+added\n-removed", 600);
+    assert.match(out, /foo\.ts \| 2/);
+    assert.match(out, /\+added/);
+  });
+
+  test("truncates long diffs and notes it", () => {
+    const big = Array.from({ length: 1000 }, (_, i) => `+line ${i}`).join("\n");
+    const out = assembleReview("stat", big, 600);
+    assert.match(out, /diff truncated — 600 of 1000 lines/);
+    assert.ok(out.split("\n").length < 1000, "should be capped");
+  });
+});

--- a/src/tools/review_diff.ts
+++ b/src/tools/review_diff.ts
@@ -1,0 +1,90 @@
+/**
+ * review_diff (vibe-coding) — show the actual code changes in a repo (or a PR)
+ * so LISA can review an agent's work: spot bugs, risky edits, leftover debug
+ * code, missing tests. The natural follow-up to repo_digest ("something
+ * changed") and the natural lead-in to run_checks ("does it pass?").
+ *
+ * Read-only. Diff output is capped so a huge change doesn't blow the context.
+ */
+import type { ToolDefinition } from "../types.js";
+import { runIn, isDir, gitRoot } from "./exec-util.js";
+
+interface ReviewDiffInput {
+  /** Repo path. Defaults to the current working directory. */
+  cwd?: string;
+  /**
+   * What to diff: "head" (all uncommitted vs HEAD, default), "working"
+   * (unstaged only), "staged" (staged only), or any git ref/range
+   * (e.g. "main...HEAD", "HEAD~3").
+   */
+  target?: string;
+  /** Review a GitHub PR's diff instead (needs the `gh` CLI). */
+  pr?: number;
+  /** Max diff lines to return. Default 600. */
+  max_lines?: number;
+}
+
+function gitDiffArgs(target: string): string[] {
+  switch (target) {
+    case "working":
+      return ["diff"];
+    case "staged":
+      return ["diff", "--cached"];
+    case "head":
+    case "":
+      return ["diff", "HEAD"];
+    default:
+      return ["diff", target];
+  }
+}
+
+/** Pure: assemble the stat header + (capped) diff body. Exported for tests. */
+export function assembleReview(stat: string, diff: string, maxLines: number): string {
+  const header = stat.trim() ? stat.trim() : "(no changes)";
+  if (!diff.trim()) return header;
+  const lines = diff.split("\n");
+  if (lines.length <= maxLines) return `${header}\n\n${diff.trimEnd()}`;
+  const shown = lines.slice(0, maxLines).join("\n");
+  return `${header}\n\n${shown}\n… [diff truncated — ${maxLines} of ${lines.length} lines shown; narrow with target or review per-file]`;
+}
+
+export const reviewDiffTool: ToolDefinition<ReviewDiffInput, string> = {
+  name: "review_diff",
+  description:
+    "Show the actual code diff in a repo so you can review it — uncommitted changes vs HEAD by " +
+    "default, or working/staged only, or any git ref/range, or a GitHub PR (pr:<n>, needs `gh`). " +
+    "Use to review what an agent wrote before committing/merging: bugs, risky edits, debug leftovers, " +
+    "missing tests. Read-only; output is capped. Pair with repo_digest (what changed) and run_checks " +
+    "(does it pass).",
+  inputSchema: {
+    type: "object",
+    properties: {
+      cwd: { type: "string", description: "Absolute path inside the repo. Defaults to the current directory." },
+      target: { type: "string", description: '"head" (default, all uncommitted), "working", "staged", or a git ref/range like "main...HEAD".' },
+      pr: { type: "integer", description: "Review this GitHub PR's diff instead (needs `gh`)." },
+      max_lines: { type: "integer", minimum: 50, maximum: 4000, description: "Max diff lines (default 600)." },
+    },
+    additionalProperties: false,
+  },
+  async execute(input, ctx) {
+    const cwd = input.cwd && input.cwd.startsWith("/") ? input.cwd : ctx.cwd;
+    if (!(await isDir(cwd))) return `(not a directory: ${cwd})`;
+    const root = await gitRoot(cwd, ctx.signal);
+    if (!root) return `(not a git repo: ${cwd})`;
+    const maxLines = input.max_lines ?? 600;
+
+    if (typeof input.pr === "number") {
+      const r = await runIn(root, "gh", ["pr", "diff", String(input.pr)], { timeoutMs: 20000, signal: ctx.signal, maxBytes: 200_000 });
+      if (r.spawnError) return "(the `gh` CLI isn't installed — needed to fetch PR diffs)";
+      if (r.code !== 0) return `(gh pr diff ${input.pr} failed: ${r.stderr.trim().slice(0, 200) || "unknown error"})`;
+      return assembleReview(`PR #${input.pr} diff`, r.stdout, maxLines);
+    }
+
+    const target = (input.target ?? "head").trim();
+    const args = gitDiffArgs(target);
+    const stat = await runIn(root, "git", ["-C", root, ...args, "--stat"], { timeoutMs: 10000, signal: ctx.signal });
+    const diff = await runIn(root, "git", ["-C", root, ...args], { timeoutMs: 15000, signal: ctx.signal, maxBytes: 200_000 });
+    if (diff.code !== 0) return `(git diff failed: ${diff.stderr.trim().slice(0, 200) || "bad target?"})`;
+    return assembleReview(stat.stdout, diff.stdout, maxLines);
+  },
+};


### PR DESCRIPTION
Vibe-coding tool #2. Read-only `review_diff` shows the actual code changes — uncommitted vs HEAD (default), working/staged, any ref/range, or a GitHub PR (`pr:<n>` via gh) — so LISA can review an agent's work before merge. Stat header + capped body. Unit-tested + smoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)