### PR TITLE
feat(tools): inspect_agent — deep-dive one observed session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Added — vibe-coding tools
 
+- **`inspect_agent`** — deep-dive one observed session (by id/prefix or project):
+  full structural activity — state+reason, branch, turns, every tool run, all
+  files touched, last command, pending permission, errors, tokens. The detail
+  view to list_agents' roster.
+
 - **`pr_status`** — open PRs with each one's CI rollup (✓/✗/⏳) and review
   decision, sorted failing-first. For when several agents have PRs open. Needs
   `gh`; read-only.

--- a/src/tools/inspect_agent.test.ts
+++ b/src/tools/inspect_agent.test.ts
@@ -1,0 +1,60 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { formatDetail } from "./inspect_agent.js";
+import type { AgentSession } from "../integrations/types.js";
+
+const NOW = 1_000_000_000_000;
+
+function session(over: Partial<AgentSession> = {}): AgentSession {
+  return {
+    agent: "claude-code",
+    sessionId: "abcd1234-ef",
+    project: "LISA",
+    cwd: "/Users/x/LISA",
+    state: "working",
+    stateReason: "user",
+    lastMtime: NOW - 30_000,
+    ...over,
+  };
+}
+
+describe("inspect_agent formatDetail", () => {
+  test("renders header, state, cwd", () => {
+    const out = formatDetail(session(), NOW);
+    assert.match(out, /LISA · claude-code · abcd1234-ef/);
+    assert.match(out, /state: working \(user\) · last active 30s ago/);
+    assert.match(out, /cwd: \/Users\/x\/LISA/);
+  });
+
+  test("lists activity detail and caps files at 15", () => {
+    const files = Array.from({ length: 20 }, (_, i) => `/Users/x/LISA/f${i}.ts`);
+    const out = formatDetail(
+      session({
+        activity: {
+          turnCount: 12,
+          lastTools: ["Read", "Edit", "Bash"],
+          filesTouched: files,
+          lastCommandName: "npm",
+          gitBranch: "main",
+          tokens: { input: 1000, output: 200 },
+        },
+      }),
+      NOW,
+    );
+    assert.match(out, /branch: main/);
+    assert.match(out, /turns: 12/);
+    assert.match(out, /tools: Read → Edit → Bash/);
+    assert.match(out, /files touched \(20\):/);
+    assert.match(out, /… \+5 more/);
+    assert.match(out, /tokens: 1000 in \/ 200 out/);
+  });
+
+  test("surfaces pending permission and errors", () => {
+    const out = formatDetail(
+      session({ state: "error", activity: { turnCount: 1, lastTools: [], filesTouched: [], pendingPermission: "Bash", lastError: "ENOENT" } }),
+      NOW,
+    );
+    assert.match(out, /waiting on permission: Bash/);
+    assert.match(out, /error: ENOENT/);
+  });
+});

--- a/src/tools/inspect_agent.ts
+++ b/src/tools/inspect_agent.ts
@@ -1,0 +1,96 @@
+/**
+ * inspect_agent (vibe-coding) — the deep view of ONE observed session, where
+ * list_agents is the one-line-each roster. Full structural activity for the
+ * matched session: state + reason, branch, turn count, every tool it has run,
+ * every file it has touched, last command, pending permission, error, tokens.
+ *
+ * PRIVACY: structural metadata only — never conversation content (file PATHS
+ * and tool NAMES, not contents). For what a repo actually changed, use
+ * repo_digest / review_diff against its cwd.
+ */
+import type { ToolDefinition } from "../types.js";
+import { getCurrentHub } from "../integrations/current-hub.js";
+import type { AgentSession } from "../integrations/types.js";
+
+interface InspectInput {
+  /** Session id (or a prefix), or a project name, to inspect. */
+  target: string;
+}
+
+function ago(ms: number, now: number): string {
+  const s = Math.max(0, Math.floor((now - ms) / 1000));
+  if (s < 60) return `${s}s ago`;
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.floor(m / 60)}h ago`;
+}
+
+/** Pure: full structural detail for one session. Exported for tests. */
+export function formatDetail(s: AgentSession, now: number): string {
+  const a = s.activity;
+  const lines: string[] = [];
+  lines.push(`${s.project} · ${s.agent} · ${s.sessionId}`);
+  lines.push(`  state: ${s.state}${s.stateReason ? ` (${s.stateReason})` : ""} · last active ${ago(s.lastMtime, now)}`);
+  if (s.cwd) lines.push(`  cwd: ${s.cwd}`);
+  if (a?.gitBranch) lines.push(`  branch: ${a.gitBranch}`);
+  if (typeof a?.turnCount === "number") lines.push(`  turns: ${a.turnCount}`);
+  if (a?.pendingPermission) lines.push(`  ⏳ waiting on permission: ${a.pendingPermission}`);
+  if (a?.lastCommandName) lines.push(`  last command: ${a.lastCommandName}`);
+  if (a?.lastTools && a.lastTools.length) lines.push(`  tools: ${a.lastTools.join(" → ")}`);
+  if (a?.filesTouched && a.filesTouched.length) {
+    lines.push(`  files touched (${a.filesTouched.length}):`);
+    for (const f of a.filesTouched.slice(0, 15)) lines.push(`    ${f}`);
+    if (a.filesTouched.length > 15) lines.push(`    … +${a.filesTouched.length - 15} more`);
+  }
+  if (a?.tokens) lines.push(`  tokens: ${a.tokens.input} in / ${a.tokens.output} out`);
+  if (a?.lastError) lines.push(`  error: ${a.lastError}`);
+  return lines.join("\n");
+}
+
+function matches(s: AgentSession, target: string): boolean {
+  const t = target.toLowerCase();
+  return (
+    s.sessionId.toLowerCase().startsWith(t) ||
+    s.sessionId.toLowerCase() === t ||
+    s.project.toLowerCase() === t ||
+    s.project.toLowerCase().includes(t)
+  );
+}
+
+export const inspectAgentTool: ToolDefinition<InspectInput, string> = {
+  name: "inspect_agent",
+  description:
+    "Deep-dive one observed agent session (by session id / prefix, or project name): its full " +
+    "structural activity — state + reason, git branch, turn count, every tool it ran, all files it " +
+    "touched, last command, pending permission, errors, token usage. Use when the user asks 'what is " +
+    "<session/project> doing in detail'. list_agents is the roster; this is one session. Structural " +
+    "metadata only — never conversation content.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      target: { type: "string", description: "Session id (or prefix) or project name to inspect." },
+    },
+    required: ["target"],
+    additionalProperties: false,
+  },
+  async execute(input) {
+    const hub = getCurrentHub();
+    if (!hub) return "(agent monitoring isn't active — start the web server with `lisa serve --web`)";
+    const target = (input.target ?? "").trim();
+    if (!target) return "(give a session id or project name to inspect)";
+    const now = Date.now();
+    const all = hub.list();
+    const hits = all.filter((s) => matches(s, target));
+    if (hits.length === 0) {
+      const names = all.map((s) => `${s.project} (${s.sessionId.slice(0, 8)})`).slice(0, 10).join(", ");
+      return `(no observed session matches "${target}". Active: ${names || "none"})`;
+    }
+    if (hits.length > 1) {
+      // Disambiguate, but still detail the most recently active one.
+      hits.sort((a, b) => b.lastMtime - a.lastMtime);
+      const head = `(${hits.length} match "${target}"; showing the most recent — narrow by session id)\n`;
+      return head + formatDetail(hits[0]!, now);
+    }
+    return formatDetail(hits[0]!, now);
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -3,6 +3,7 @@ import { memoryTool } from "../memory/tool.js";
 import { memorySearchTool } from "../memory/search_tool.js";
 import { adviseNowTool } from "./advise_now.js";
 import { listAgentsTool } from "./list_agents.js";
+import { inspectAgentTool } from "./inspect_agent.js";
 import { repoDigestTool } from "./repo_digest.js";
 import { reviewDiffTool } from "./review_diff.js";
 import { runChecksTool } from "./run_checks.js";
@@ -72,6 +73,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     redeployTool as ToolDefinition,
     // Orchestration (docs/ORCHESTRATOR_PLAN.md): observe → advise → dispatch → control.
     listAgentsTool as ToolDefinition,
+    inspectAgentTool as ToolDefinition,
     repoDigestTool as ToolDefinition,
     reviewDiffTool as ToolDefinition,
     runChecksTool as ToolDefinition,


### PR DESCRIPTION
Vibe-coding tool #5. Where `list_agents` is the roster, `inspect_agent` gives one session's full structural activity (by id/prefix or project): state+reason, branch, turns, every tool run, all files touched, last command, pending permission, errors, tokens. Structural metadata only. Unit-tested; full suite 228 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)