### PR TITLE
Screen Advisor: opt-in periodic screen → next-step suggestion on the island

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — Screen Advisor (opt-in proactive next-step coaching)
+
+- When enabled, every N minutes (default 10) LISA captures a full-screen
+  screenshot, asks the model for the single best next **coding** step grounded
+  in what's on screen, and shows it as a **💡 suggested next step** card on the
+  Lisa Island. Clicking **Optimize ▸** prefills that task into the chat composer
+  (it does **not** auto-run) — you confirm by sending, then Lisa can dispatch a
+  coding agent.
+- **Privacy — this is a sensitive capability, built accordingly:** OFF by
+  default; the screenshot leaves the machine only for the one analysis call and
+  is never persisted (the capture layer deletes its temp file); only the short
+  text suggestion is cached in memory. macOS-only (uses `screencapture -x`).
+- **Settings** (toggle + interval, clamped 2–240 min) live in **both** the
+  Lisa.app ⌘, window and the server config (`~/.lisa/screen-advisor.json`).
+  New endpoints: `GET`/`POST /api/screen-advisor/config` (POST is loopback-only),
+  `GET /api/screen-advisor/latest`; SSE event `screen_suggestion`.
+
 ### Added — GitHub PR observer (orchestrator O4: cloud agents)
 
 - **`github-pr` integration** treats your open pull requests as agent sessions:

--- a/packaging/mac-client/Sources/Lisa/AppDelegate.swift
+++ b/packaging/mac-client/Sources/Lisa/AppDelegate.swift
@@ -43,14 +43,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // chat window forward in-process.
         NotificationCenter.default.addObserver(
             self,
-            selector: #selector(handleShowMainWindow),
+            selector: #selector(handleShowMainWindow(_:)),
             name: IslandContent.showMainWindowNotification,
             object: nil
         )
     }
 
-    @objc private func handleShowMainWindow() {
+    @objc private func handleShowMainWindow(_ note: Notification) {
+        let hadWindow = mainWindow != nil
         showMainWindow()
+        // Screen-advisor "Optimize ▸" carries a prefill — drop it into the
+        // chat composer (never auto-send). A freshly-created window needs a
+        // beat for its WebView to finish loading before the JS bridge is live.
+        if let prefill = note.userInfo?["prefill"] as? String, !prefill.isEmpty {
+            let delay: TimeInterval = hadWindow ? 0.15 : 0.6
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.mainWindow?.prefillComposer(prefill)
+            }
+        }
     }
 
     @objc func captureForLisa(_ sender: Any?) {

--- a/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
@@ -142,8 +142,10 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
     /// AppDelegate to bring it forward (rather than launching a separate app).
     static let showMainWindowNotification = Notification.Name("ai.meetlisa.showMainWindow")
 
-    private func openLisaAppOrBrowser() {
-        NotificationCenter.default.post(name: Self.showMainWindowNotification, object: nil)
+    private func openLisaAppOrBrowser(prefill: String = "") {
+        let info: [AnyHashable: Any] = prefill.isEmpty ? [:] : ["prefill": prefill]
+        NotificationCenter.default.post(
+            name: Self.showMainWindowNotification, object: nil, userInfo: info)
     }
 
     // MARK: - WKScriptMessageHandler
@@ -153,12 +155,11 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
         guard let type = body["type"] as? String else { return }
         switch type {
         case "open_full_gui":
-            // Prefer launching the native Lisa.app (bundle id
-            // ai.meetlisa.app) if it's installed. Falls back to the
-            // browser at http://localhost:5757/ when the app isn't
-            // present — keeps the island useful for users who only
-            // run the web widget.
-            openLisaAppOrBrowser()
+            // Bring the in-process chat window forward. An optional `prefill`
+            // (from the screen-advisor "Optimize ▸" card) is carried along so
+            // the chat composer can be pre-filled — never auto-sent.
+            let prefill = (body["prefill"] as? String) ?? ""
+            openLisaAppOrBrowser(prefill: prefill)
         case "expand":
             // Page-side expand state — Swift uses this to size the
             // click-through "hot rect" (whole window when expanded,

--- a/packaging/mac-client/Sources/Lisa/MainWindow.swift
+++ b/packaging/mac-client/Sources/Lisa/MainWindow.swift
@@ -65,4 +65,10 @@ final class MainWindow: NSWindow {
     func triggerCapture(onAttached: @escaping (Bool) -> Void) {
         content.triggerCapture(onAttached: onAttached)
     }
+
+    /// Pre-fill the chat composer (never auto-sends) — used by the
+    /// screen-advisor suggestion card via the island bridge.
+    func prefillComposer(_ text: String) {
+        content.prefillComposer(text)
+    }
 }

--- a/packaging/mac-client/Sources/Lisa/PreferencesController.swift
+++ b/packaging/mac-client/Sources/Lisa/PreferencesController.swift
@@ -3,10 +3,13 @@
 //  Lisa
 //
 //  The Settings window (⌘,). A small native panel for app-level toggles —
-//  currently the Lisa Island switch. Lazily created, reused across opens.
+//  the Lisa Island switch, and the (opt-in) Screen Advisor. The Screen Advisor
+//  state lives server-side (~/.lisa/screen-advisor.json via the backend), so
+//  this panel GETs it to populate the controls and POSTs on change.
 //
 
 import AppKit
+import Foundation
 
 final class PreferencesController: NSObject, NSWindowDelegate {
     static let shared = PreferencesController()
@@ -15,10 +18,18 @@ final class PreferencesController: NSObject, NSWindowDelegate {
     private var window: NSWindow?
     private var islandCheckbox: NSButton?
     private var resetButton: NSButton?
+    private var screenCheckbox: NSButton?
+    private var intervalField: NSTextField?
+    private var intervalStepper: NSStepper?
+    private var screenCaption: NSTextField?
+
+    /// The local backend the Mac app talks to (same port used elsewhere).
+    private let baseURL = "http://localhost:5757"
 
     func show() {
         if window == nil { build() }
         syncControls()
+        fetchScreenAdvisorConfig()   // pull server truth into the controls
         window?.center()
         window?.makeKeyAndOrderFront(nil)
         NSApp.activate(ignoringOtherApps: true)
@@ -28,7 +39,7 @@ final class PreferencesController: NSObject, NSWindowDelegate {
 
     private func build() {
         let win = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 180),
+            contentRect: NSRect(x: 0, y: 0, width: 440, height: 340),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -40,34 +51,82 @@ final class PreferencesController: NSObject, NSWindowDelegate {
         let content = NSView(frame: win.contentLayoutRect)
         content.autoresizingMask = [.width, .height]
 
-        // Section header
+        // ── Lisa Island ────────────────────────────────────────────────
         let header = label("Lisa Island", size: 13, bold: true)
-        header.frame = NSRect(x: 24, y: 130, width: 372, height: 20)
+        header.frame = NSRect(x: 24, y: 300, width: 392, height: 20)
         content.addSubview(header)
 
-        // The toggle
         let checkbox = NSButton(checkboxWithTitle: "Show Lisa Island (notch pill)",
                                 target: self, action: #selector(toggleIsland(_:)))
-        checkbox.frame = NSRect(x: 22, y: 100, width: 372, height: 22)
+        checkbox.frame = NSRect(x: 22, y: 272, width: 392, height: 22)
         content.addSubview(checkbox)
         islandCheckbox = checkbox
 
-        // Sub-caption
         let caption = label("A small floating pill by the menu bar / notch that shows Lisa's mood and your agents' activity.",
                             size: 11, bold: false)
         caption.textColor = .secondaryLabelColor
-        caption.frame = NSRect(x: 42, y: 60, width: 354, height: 34)
-        (caption.cell as? NSTextFieldCell)?.wraps = true
-        caption.lineBreakMode = .byWordWrapping
+        caption.frame = NSRect(x: 42, y: 236, width: 374, height: 32)
+        wrap(caption)
         content.addSubview(caption)
 
-        // Reset position
         let reset = NSButton(title: "Reset Island Position",
                              target: self, action: #selector(resetPosition(_:)))
         reset.bezelStyle = .rounded
-        reset.frame = NSRect(x: 22, y: 18, width: 200, height: 28)
+        reset.frame = NSRect(x: 22, y: 204, width: 200, height: 28)
         content.addSubview(reset)
         resetButton = reset
+
+        // divider
+        let line = NSBox(frame: NSRect(x: 22, y: 188, width: 396, height: 1))
+        line.boxType = .separator
+        content.addSubview(line)
+
+        // ── Screen Advisor ─────────────────────────────────────────────
+        let saHeader = label("Screen Advisor", size: 13, bold: true)
+        saHeader.frame = NSRect(x: 24, y: 158, width: 392, height: 20)
+        content.addSubview(saHeader)
+
+        let saCheck = NSButton(checkboxWithTitle: "Suggest next steps from my screen",
+                               target: self, action: #selector(screenAdvisorChanged(_:)))
+        saCheck.frame = NSRect(x: 22, y: 130, width: 392, height: 22)
+        content.addSubview(saCheck)
+        screenCheckbox = saCheck
+
+        // interval row: "Every [ 10 ]⇅ minutes"
+        let everyLbl = label("Every", size: 12, bold: false)
+        everyLbl.frame = NSRect(x: 42, y: 102, width: 44, height: 20)
+        content.addSubview(everyLbl)
+
+        let field = NSTextField(frame: NSRect(x: 88, y: 100, width: 48, height: 22))
+        field.alignment = .right
+        field.integerValue = 10
+        field.target = self
+        field.action = #selector(screenAdvisorChanged(_:))
+        content.addSubview(field)
+        intervalField = field
+
+        let stepper = NSStepper(frame: NSRect(x: 138, y: 99, width: 19, height: 25))
+        stepper.minValue = 2
+        stepper.maxValue = 240
+        stepper.increment = 1
+        stepper.integerValue = 10
+        stepper.valueWraps = false
+        stepper.target = self
+        stepper.action = #selector(stepperChanged(_:))
+        content.addSubview(stepper)
+        intervalStepper = stepper
+
+        let minsLbl = label("minutes", size: 12, bold: false)
+        minsLbl.frame = NSRect(x: 162, y: 102, width: 80, height: 20)
+        content.addSubview(minsLbl)
+
+        let saCaption = label("Lisa periodically screenshots your screen and suggests one next coding step in the island. Privacy: off by default; the image is used only for that suggestion and never stored. Requires the Lisa backend running (macOS only).",
+                              size: 11, bold: false)
+        saCaption.textColor = .secondaryLabelColor
+        saCaption.frame = NSRect(x: 42, y: 18, width: 380, height: 72)
+        wrap(saCaption)
+        content.addSubview(saCaption)
+        screenCaption = saCaption
 
         win.contentView = content
         window = win
@@ -79,12 +138,31 @@ final class PreferencesController: NSObject, NSWindowDelegate {
         return l
     }
 
+    private func wrap(_ field: NSTextField) {
+        (field.cell as? NSTextFieldCell)?.wraps = true
+        field.lineBreakMode = .byWordWrapping
+    }
+
     // MARK: - State
 
     private func syncControls() {
         let on = IslandController.shared.isEnabled
         islandCheckbox?.state = on ? .on : .off
         resetButton?.isEnabled = on
+    }
+
+    /// Reflect server config into the Screen Advisor controls.
+    private func applyScreenConfig(enabled: Bool, interval: Int, supported: Bool) {
+        screenCheckbox?.state = enabled ? .on : .off
+        screenCheckbox?.isEnabled = supported
+        intervalField?.integerValue = interval
+        intervalStepper?.integerValue = interval
+        let editable = supported && enabled
+        intervalField?.isEnabled = editable
+        intervalStepper?.isEnabled = editable
+        if !supported {
+            screenCaption?.stringValue = "Screen Advisor is macOS-only and needs the Lisa backend running."
+        }
     }
 
     // MARK: - Actions
@@ -96,5 +174,63 @@ final class PreferencesController: NSObject, NSWindowDelegate {
 
     @objc private func resetPosition(_ sender: Any?) {
         IslandController.shared.resetPosition()
+    }
+
+    @objc private func stepperChanged(_ sender: NSStepper) {
+        intervalField?.integerValue = sender.integerValue
+        postScreenAdvisorConfig()
+    }
+
+    @objc private func screenAdvisorChanged(_ sender: Any?) {
+        // keep stepper + field in sync, clamp, then persist to the server
+        var minutes = intervalField?.integerValue ?? 10
+        if minutes < 2 { minutes = 2 }
+        if minutes > 240 { minutes = 240 }
+        intervalField?.integerValue = minutes
+        intervalStepper?.integerValue = minutes
+        let enabled = screenCheckbox?.state == .on
+        intervalField?.isEnabled = enabled
+        intervalStepper?.isEnabled = enabled
+        postScreenAdvisorConfig()
+    }
+
+    // MARK: - Server sync
+
+    private func fetchScreenAdvisorConfig() {
+        guard let url = URL(string: "\(baseURL)/api/screen-advisor/config") else { return }
+        URLSession.shared.dataTask(with: url) { [weak self] data, _, _ in
+            guard let self = self, let data = data,
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return }
+            let enabled = obj["enabled"] as? Bool ?? false
+            let interval = obj["intervalMinutes"] as? Int ?? 10
+            let supported = obj["supported"] as? Bool ?? true
+            DispatchQueue.main.async {
+                self.applyScreenConfig(enabled: enabled, interval: interval, supported: supported)
+            }
+        }.resume()
+    }
+
+    private func postScreenAdvisorConfig() {
+        guard let url = URL(string: "\(baseURL)/api/screen-advisor/config") else { return }
+        let enabled = screenCheckbox?.state == .on
+        let interval = intervalField?.integerValue ?? 10
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        let body: [String: Any] = ["enabled": enabled, "intervalMinutes": interval]
+        req.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        URLSession.shared.dataTask(with: req) { [weak self] data, _, _ in
+            // Echo back the normalized config so a clamped interval shows up.
+            guard let self = self, let data = data,
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+            else { return }
+            let en = obj["enabled"] as? Bool ?? enabled
+            let iv = obj["intervalMinutes"] as? Int ?? interval
+            let supported = obj["supported"] as? Bool ?? true
+            DispatchQueue.main.async {
+                self.applyScreenConfig(enabled: en, interval: iv, supported: supported)
+            }
+        }.resume()
     }
 }

--- a/packaging/mac-client/Sources/Lisa/WebContent.swift
+++ b/packaging/mac-client/Sources/Lisa/WebContent.swift
@@ -151,6 +151,20 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
         }
     }
 
+    /// Drop text into the page's chat composer via window.lisaPrefillComposer
+    /// (defined in lisa-html.ts). Never sends. The text is JSON-encoded (as a
+    /// 1-element array, taking [0] in JS) so quotes/newlines can't break out.
+    func prefillComposer(_ text: String) {
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: [text]),
+            let json = String(data: data, encoding: .utf8)
+        else { return }
+        webView.evaluateJavaScript(
+            "window.lisaPrefillComposer && window.lisaPrefillComposer(\(json)[0]);",
+            completionHandler: nil
+        )
+    }
+
     private func scheduleReload() {
         reloadTimer?.invalidate()
         reloadTimer = Timer.scheduledTimer(

--- a/src/screen_advisor/engine.test.ts
+++ b/src/screen_advisor/engine.test.ts
@@ -1,0 +1,122 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  normalizeConfig,
+  loadScreenAdvisorConfig,
+  saveScreenAdvisorConfig,
+  parseSuggestion,
+  analyzeScreenshot,
+  DEFAULT_SCREEN_ADVISOR_CONFIG,
+  MIN_INTERVAL_MINUTES,
+  MAX_INTERVAL_MINUTES,
+  type SuggestionProvider,
+} from "./engine.js";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-screenadv-"));
+const CFG = path.join(TMP, "screen-advisor.json");
+
+beforeEach(() => {
+  fs.rmSync(CFG, { force: true });
+});
+
+describe("normalizeConfig", () => {
+  test("defaults: disabled, 10 min", () => {
+    assert.deepEqual(normalizeConfig(undefined), DEFAULT_SCREEN_ADVISOR_CONFIG);
+    assert.equal(DEFAULT_SCREEN_ADVISOR_CONFIG.enabled, false); // privacy: off by default
+  });
+  test("enabled only when strictly true", () => {
+    assert.equal(normalizeConfig({ enabled: true }).enabled, true);
+    assert.equal(normalizeConfig({ enabled: 1 as unknown as boolean }).enabled, false);
+    assert.equal(normalizeConfig({ enabled: undefined }).enabled, false);
+  });
+  test("interval clamps + rounds", () => {
+    assert.equal(normalizeConfig({ intervalMinutes: 0 }).intervalMinutes, MIN_INTERVAL_MINUTES);
+    assert.equal(normalizeConfig({ intervalMinutes: 9999 }).intervalMinutes, MAX_INTERVAL_MINUTES);
+    assert.equal(normalizeConfig({ intervalMinutes: 10.7 }).intervalMinutes, 11);
+    assert.equal(normalizeConfig({ intervalMinutes: NaN }).intervalMinutes, 10);
+  });
+});
+
+describe("load/save config", () => {
+  test("missing file → defaults", async () => {
+    assert.deepEqual(await loadScreenAdvisorConfig(CFG), DEFAULT_SCREEN_ADVISOR_CONFIG);
+  });
+  test("round-trips through disk, normalized", async () => {
+    const saved = await saveScreenAdvisorConfig({ enabled: true, intervalMinutes: 1 }, CFG);
+    assert.equal(saved.intervalMinutes, MIN_INTERVAL_MINUTES); // clamped on save
+    const loaded = await loadScreenAdvisorConfig(CFG);
+    assert.deepEqual(loaded, { enabled: true, intervalMinutes: MIN_INTERVAL_MINUTES });
+  });
+  test("corrupt file → defaults (no throw)", async () => {
+    fs.writeFileSync(CFG, "{not json");
+    assert.deepEqual(await loadScreenAdvisorConfig(CFG), DEFAULT_SCREEN_ADVISOR_CONFIG);
+  });
+});
+
+describe("parseSuggestion", () => {
+  test("plain JSON object", () => {
+    const s = parseSuggestion('{"title":"Fix the failing test","rationale":"auth.test.ts is red","task":"Open src/auth.test.ts and fix the failing assertion"}');
+    assert.equal(s?.title, "Fix the failing test");
+    assert.equal(s?.rationale, "auth.test.ts is red");
+    assert.match(s!.task, /auth\.test\.ts/);
+  });
+  test("strips ```json fences", () => {
+    const s = parseSuggestion('```json\n{"title":"Do X","task":"do x in foo.ts"}\n```');
+    assert.equal(s?.title, "Do X");
+  });
+  test("extracts object embedded in prose", () => {
+    const s = parseSuggestion('Sure! {"title":"Do X","task":"do x"} hope that helps');
+    assert.equal(s?.title, "Do X");
+  });
+  test('{"skip":true} → null', () => {
+    assert.equal(parseSuggestion('{"skip":true}'), null);
+  });
+  test("missing title or task → null", () => {
+    assert.equal(parseSuggestion('{"rationale":"only this"}'), null);
+    assert.equal(parseSuggestion('{"title":"no task"}'), null);
+  });
+  test("garbage / empty → null", () => {
+    assert.equal(parseSuggestion(""), null);
+    assert.equal(parseSuggestion(null), null);
+    assert.equal(parseSuggestion("not json at all"), null);
+  });
+  test("over-long fields are truncated", () => {
+    const s = parseSuggestion(JSON.stringify({ title: "t".repeat(500), task: "x".repeat(5000) }));
+    assert.ok((s?.title.length ?? 0) <= 120);
+    assert.ok((s?.task.length ?? 0) <= 2000);
+  });
+});
+
+describe("analyzeScreenshot", () => {
+  function fakeProvider(reply: string): SuggestionProvider {
+    return {
+      async runTurn(opts) {
+        // assert the image rides along as a base64 image block
+        const content = opts.messages[0]!.content as Array<{ type: string }>;
+        assert.ok(content.some((b) => b.type === "image"), "image block present");
+        return { content: [{ type: "text", text: reply }] };
+      },
+    };
+  }
+
+  test("returns the parsed suggestion", async () => {
+    const s = await analyzeScreenshot({
+      provider: fakeProvider('{"title":"Add a test","task":"write a test for foo"}'),
+      model: "m",
+      imageBase64: "AAAA",
+    });
+    assert.equal(s?.title, "Add a test");
+  });
+
+  test("skip reply → null", async () => {
+    const s = await analyzeScreenshot({
+      provider: fakeProvider('{"skip":true}'),
+      model: "m",
+      imageBase64: "AAAA",
+    });
+    assert.equal(s, null);
+  });
+});

--- a/src/screen_advisor/engine.ts
+++ b/src/screen_advisor/engine.ts
@@ -1,0 +1,170 @@
+/**
+ * Screen advisor — periodic, opt-in screen-aware coaching.
+ *
+ * When enabled, the server captures a full-screen screenshot every N minutes,
+ * asks the model for the single best next coding step grounded in what's on
+ * screen, and pushes it to the Lisa Island as a suggestion card. Clicking it
+ * prefills the suggestion into the chat composer so the user can confirm before
+ * any coding agent is dispatched.
+ *
+ * PRIVACY (this is a sensitive capability — treat it as such):
+ *   - DISABLED by default. Nothing is captured until the user turns it on in
+ *     Settings.
+ *   - The screenshot only leaves the machine for the single analysis call to
+ *     the model the user already uses; the image is never persisted by LISA
+ *     (capture writes a temp PNG that the capture layer deletes), and only the
+ *     short text suggestion is kept in memory.
+ *   - The suggestion never auto-runs anything: clicking it only prefills chat.
+ *
+ * This module is provider-agnostic and side-effect-light so the parsing and
+ * config logic can be unit-tested without a real LLM or a real screen.
+ */
+
+import fsp from "node:fs/promises";
+import path from "node:path";
+import { LISA_HOME } from "../paths.js";
+
+export interface ScreenAdvisorConfig {
+  /** Master switch. Off by default — capture only happens when true. */
+  enabled: boolean;
+  /** Minutes between captures. Clamped to [MIN, MAX]. */
+  intervalMinutes: number;
+}
+
+export const DEFAULT_SCREEN_ADVISOR_CONFIG: ScreenAdvisorConfig = {
+  enabled: false,
+  intervalMinutes: 10,
+};
+
+export const MIN_INTERVAL_MINUTES = 2;
+export const MAX_INTERVAL_MINUTES = 240;
+
+export const SCREEN_ADVISOR_CONFIG_PATH = path.join(LISA_HOME, "screen-advisor.json");
+
+/** Coerce arbitrary input into a valid config (clamped interval, boolean enabled). */
+export function normalizeConfig(
+  raw: Partial<ScreenAdvisorConfig> | null | undefined,
+): ScreenAdvisorConfig {
+  const enabled = raw?.enabled === true;
+  let n = Number(raw?.intervalMinutes);
+  if (!Number.isFinite(n)) n = DEFAULT_SCREEN_ADVISOR_CONFIG.intervalMinutes;
+  n = Math.round(n);
+  if (n < MIN_INTERVAL_MINUTES) n = MIN_INTERVAL_MINUTES;
+  if (n > MAX_INTERVAL_MINUTES) n = MAX_INTERVAL_MINUTES;
+  return { enabled, intervalMinutes: n };
+}
+
+export async function loadScreenAdvisorConfig(
+  p: string = SCREEN_ADVISOR_CONFIG_PATH,
+): Promise<ScreenAdvisorConfig> {
+  try {
+    const raw = JSON.parse(await fsp.readFile(p, "utf8")) as Partial<ScreenAdvisorConfig>;
+    return normalizeConfig(raw);
+  } catch {
+    return { ...DEFAULT_SCREEN_ADVISOR_CONFIG };
+  }
+}
+
+export async function saveScreenAdvisorConfig(
+  cfg: ScreenAdvisorConfig,
+  p: string = SCREEN_ADVISOR_CONFIG_PATH,
+): Promise<ScreenAdvisorConfig> {
+  const norm = normalizeConfig(cfg);
+  await fsp.mkdir(path.dirname(p), { recursive: true });
+  await fsp.writeFile(p, JSON.stringify(norm, null, 2));
+  return norm;
+}
+
+/** A single screen-grounded next-step suggestion. */
+export interface ScreenSuggestion {
+  /** ≤8-word imperative headline. */
+  title: string;
+  /** 1–2 sentences citing what was on screen. */
+  rationale: string;
+  /** Self-contained prompt a coding agent could act on. */
+  task: string;
+  /** ISO timestamp, stamped by the caller. */
+  at: string;
+}
+
+export const SCREEN_ADVISOR_SYSTEM = `You are Lisa's screen advisor. You are shown ONE screenshot of the user's screen. Suggest the single highest-value next CODING step, grounded in what is actually visible — an error, a failing test, a TODO/FIXME, an open file, a diff, a PR, a design. Be specific and actionable: prefer something a coding agent could pick up and finish.
+
+Respond with ONLY a compact JSON object — no prose, no markdown, no code fences:
+{"title":"<=8-word imperative headline","rationale":"1-2 sentences citing what you saw","task":"a self-contained prompt for a coding agent: exactly what to do, and in which file/dir if visible"}
+
+If the screen shows nothing actionable for coding (a video, a chat, the desktop, unrelated browsing), respond with exactly: {"skip":true}`;
+
+/**
+ * Tolerantly parse the model's reply into a suggestion. Strips code fences,
+ * extracts the first JSON object, and returns null for {"skip":true} or any
+ * malformed / incomplete reply (so the loop simply surfaces nothing).
+ */
+export function parseSuggestion(text: string | null | undefined): Omit<ScreenSuggestion, "at"> | null {
+  if (!text) return null;
+  let s = text.trim();
+  // Drop a leading ```json / ``` fence and a trailing fence if present.
+  s = s.replace(/^```[a-zA-Z]*\s*/, "").replace(/\s*```$/, "").trim();
+  const a = s.indexOf("{");
+  const b = s.lastIndexOf("}");
+  if (a < 0 || b <= a) return null;
+  let obj: Record<string, unknown>;
+  try {
+    obj = JSON.parse(s.slice(a, b + 1)) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+  if (obj.skip === true) return null;
+  const title = typeof obj.title === "string" ? obj.title.trim() : "";
+  const task = typeof obj.task === "string" ? obj.task.trim() : "";
+  if (!title || !task) return null;
+  const rationale = typeof obj.rationale === "string" ? obj.rationale.trim() : "";
+  return {
+    title: title.slice(0, 120),
+    rationale: rationale.slice(0, 400),
+    task: task.slice(0, 2000),
+  };
+}
+
+/** Minimal provider surface the analyzer needs (keeps the engine testable). */
+export interface SuggestionProvider {
+  runTurn(opts: {
+    systemPrompt: string;
+    messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+    tools: unknown[];
+    model: string;
+    maxTokens?: number;
+  }): Promise<{ content: Array<{ type: string; text?: string }> }>;
+}
+
+/** Run one screenshot through the model and parse the suggestion (or null). */
+export async function analyzeScreenshot(opts: {
+  provider: SuggestionProvider;
+  model: string;
+  imageBase64: string;
+  mediaType?: string;
+}): Promise<Omit<ScreenSuggestion, "at"> | null> {
+  const result = await opts.provider.runTurn({
+    systemPrompt: SCREEN_ADVISOR_SYSTEM,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "Here is my screen right now. What is the single best next coding step?" },
+          {
+            type: "image",
+            source: {
+              type: "base64",
+              media_type: opts.mediaType ?? "image/png",
+              data: opts.imageBase64,
+            },
+          },
+        ],
+      },
+    ],
+    tools: [],
+    model: opts.model,
+    maxTokens: 600,
+  });
+  const textBlock = result.content.find((b) => b.type === "text");
+  return parseSuggestion(textBlock?.text ?? "");
+}

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -395,6 +395,20 @@ export const ISLAND_HTML = `<!doctype html>
   /* Offline state — desaturate + dim */
   body.offline #avatar { filter: grayscale(1); opacity: 0.5; }
   body.offline #label  { color: var(--fg-faint); }
+
+  /* Screen-advisor suggestion card */
+  #suggestion-section { display: none; }
+  body.has-suggestion #suggestion-section { display: block; }
+  #suggestion-title { font-weight: 600; margin: 2px 0 3px; }
+  #suggestion-rationale { font-size: 11px; color: var(--fg-faint); margin-bottom: 6px; }
+  #suggestion-act {
+    width: 100%; padding: 6px 8px; border: 0; border-radius: 7px; cursor: pointer;
+    font: inherit; font-size: 12px; font-weight: 600;
+    background: var(--accent, #5b8cff); color: #fff;
+  }
+  #suggestion-act:hover { filter: brightness(1.08); }
+  /* a soft glow on the pill dot when a fresh suggestion is waiting */
+  body.has-suggestion #dot { background: var(--accent, #5b8cff); opacity: 1; }
 </style>
 </head>
 <body>
@@ -411,6 +425,12 @@ export const ISLAND_HTML = `<!doctype html>
     <div id="idle-section">
       <div class="section-label">★ while you were away</div>
       <div id="idle-body"></div>
+    </div>
+    <div id="suggestion-section">
+      <div class="section-label">💡 suggested next step</div>
+      <div id="suggestion-title"></div>
+      <div id="suggestion-rationale"></div>
+      <button id="suggestion-act" type="button">Optimize ▸</button>
     </div>
     <div id="claude-section">
       <div class="section-label">claude code · <span id="claude-count">0</span> active</div>
@@ -436,6 +456,9 @@ export const ISLAND_HTML = `<!doctype html>
   const notifyCta    = document.getElementById('notify-cta');
   const btnOpen      = document.getElementById('btn-open');
   const btnDismiss   = document.getElementById('btn-dismiss');
+  const suggTitle    = document.getElementById('suggestion-title');
+  const suggRationale= document.getElementById('suggestion-rationale');
+  const suggAct      = document.getElementById('suggestion-act');
   const body         = document.body;
 
   const state = {
@@ -447,6 +470,7 @@ export const ISLAND_HTML = `<!doctype html>
     thinking: false,
     dreaming: false,
     claudeSessions: [],  // [{project, sessionId, lastMtime}, …]
+    suggestion: null,    // {title, rationale, task, at} from the screen advisor
   };
 
   // 30-min activity window matches the watcher's ACTIVE_WINDOW_MS.
@@ -599,6 +623,11 @@ export const ISLAND_HTML = `<!doctype html>
     idleBody.textContent   = state.idleText || '';
     btnDismiss.classList.toggle('muted', !state.unread);
     btnDismiss.disabled = !state.unread;
+    body.classList.toggle('has-suggestion', !!state.suggestion);
+    if (state.suggestion) {
+      suggTitle.textContent = state.suggestion.title || '';
+      suggRationale.textContent = state.suggestion.rationale || '';
+    }
     renderClaudeList();
   }
 
@@ -839,15 +868,31 @@ export const ISLAND_HTML = `<!doctype html>
     openFull();
   });
 
-  function openFull() {
-    // If a Swift container is present (Phase 2), prefer to delegate.
+  function openFull(prefill) {
+    // If a Swift container is present (Phase 2), prefer to delegate. Pass the
+    // optional prefill text so the app can drop it into the chat composer.
     if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.island) {
-      window.webkit.messageHandlers.island.postMessage({ type: 'open_full_gui' });
+      window.webkit.messageHandlers.island.postMessage({ type: 'open_full_gui', prefill: prefill || '' });
     } else {
-      window.open('/', '_blank');
+      window.open(prefill ? '/?prefill=' + encodeURIComponent(prefill) : '/', '_blank');
     }
   }
   btnOpen.addEventListener('click', (e) => { e.stopPropagation(); openFull(); });
+
+  // Optimize ▸ — prefill the suggested task into the chat for the user to
+  // confirm (and then Lisa can dispatch a coding agent). Never auto-runs.
+  if (suggAct) {
+    suggAct.addEventListener('click', (e) => {
+      e.stopPropagation();
+      const s = state.suggestion;
+      if (!s) return;
+      const prompt =
+        s.task +
+        '\\n\\n(Suggested from my screen: "' + s.title + '". ' +
+        'If this is worth doing, dispatch a coding agent for it — confirm the repo/dir with me first.)';
+      openFull(prompt);
+    });
+  }
   btnDismiss.addEventListener('click', async (e) => {
     e.stopPropagation();
     if (!state.unread) return;
@@ -923,6 +968,18 @@ export const ISLAND_HTML = `<!doctype html>
             [{ opacity: 0.7 }, { opacity: 1 }, { opacity: 0.85 }],
             { duration: 600, iterations: 2 },
           );
+          break;
+        case 'screen_suggestion':
+          if (m.title && m.task) {
+            state.suggestion = { title: m.title, rationale: m.rationale || '', task: m.task, at: m.at };
+            refreshPanel();
+            // gentle pulse + auto-expand so a watching user notices
+            expandPanel(true);
+            document.body.animate(
+              [{ opacity: 0.75 }, { opacity: 1 }],
+              { duration: 500, iterations: 2 },
+            );
+          }
           break;
         case 'claude_session_update':
           upsertClaudeSession({
@@ -1022,6 +1079,12 @@ export const ISLAND_HTML = `<!doctype html>
   fetchClaudeSessions().then(() => { refreshDot(); refreshPanel(); });
   subscribe();
   refreshNotifyCta();
+  // A fresh island picks up the most recent screen-advisor suggestion (if the
+  // feature is on and one was made before this widget loaded).
+  fetch('/api/screen-advisor/latest', { cache: 'no-store' })
+    .then((r) => r.ok ? r.json() : null)
+    .then((j) => { if (j && j.suggestion) { state.suggestion = j.suggestion; refreshPanel(); } })
+    .catch(() => {});
   // Lightweight resync — covers cases where SSE silently disconnected
   // (laptop sleep, network blip) and we need to refresh state.
   setInterval(pollPing, 30_000);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -1259,6 +1259,27 @@ window.lisaAttachImage = function (file) {
   try { input.focus(); } catch (_) {}
 };
 
+// lisaPrefillComposer drops text into the composer WITHOUT sending — the user
+// reads it and hits Enter to send (that send is the confirmation). Used by the
+// island's screen-advisor "Optimize ▸" card (via the Swift bridge) and by the
+// ?prefill= URL param (plain browser tabs).
+window.lisaPrefillComposer = function (text) {
+  if (!text || !input) return;
+  input.value = String(text);
+  try { input.dispatchEvent(new Event('input', { bubbles: true })); } catch (_) {}
+  try { input.focus(); input.setSelectionRange(input.value.length, input.value.length); } catch (_) {}
+};
+
+// On load, honour ?prefill=… (the island opens /?prefill=<task> in a browser
+// tab). Strip it from the URL afterwards so a refresh doesn't re-fill.
+try {
+  var _pf = new URLSearchParams(location.search).get('prefill');
+  if (_pf) {
+    window.lisaPrefillComposer(_pf);
+    history.replaceState(null, '', location.pathname);
+  }
+} catch (_) {}
+
 // lisaCaptureAndAttach asks the server to run a screen capture, then
 // attaches the result. mode: 'interactive' (crosshair, default) | 'full'.
 // Returns true if an image was attached, false if cancelled/failed.

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -25,6 +25,15 @@ import { advise, formatDigest } from "../advisor/engine.js";
 import type { AgentSession } from "../integrations/types.js";
 import { captureScreenshot, captureSupported, type CaptureMode } from "../vision/capture.js";
 import { transcribeAudio } from "../voice/transcribe.js";
+import {
+  loadScreenAdvisorConfig,
+  saveScreenAdvisorConfig,
+  normalizeConfig,
+  analyzeScreenshot,
+  type ScreenAdvisorConfig,
+  type ScreenSuggestion,
+  type SuggestionProvider,
+} from "../screen_advisor/engine.js";
 import os from "node:os";
 import { LISA_HOME } from "../paths.js";
 import type { ToolDefinition, StoredMessage } from "../types.js";
@@ -193,6 +202,60 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   }, ADVISE_INTERVAL_MS);
   if (adviseTimer.unref) adviseTimer.unref();
 
+  // ── Screen advisor (opt-in): periodic screen-grounded next-step ─────
+  // When enabled, every N minutes capture a full-screen shot, ask the model
+  // for the single best next coding step, and push it to the island as a
+  // suggestion card. PRIVACY: disabled by default; the screenshot leaves the
+  // machine only for the one analysis call and is never persisted (capture
+  // deletes its temp file); only the short text suggestion is cached. Nothing
+  // auto-runs — clicking the card just prefills chat.
+  let screenCfg: ScreenAdvisorConfig = await loadScreenAdvisorConfig();
+  let lastScreenSuggestion: ScreenSuggestion | null = null;
+  let screenTimer: NodeJS.Timeout | null = null;
+  let screenTickRunning = false;
+
+  const screenTick = async (): Promise<void> => {
+    if (screenTickRunning || !screenCfg.enabled || !captureSupported()) return;
+    screenTickRunning = true;
+    try {
+      const shot = await captureScreenshot("full");
+      if (!shot) return;
+      const suggestion = await analyzeScreenshot({
+        provider: getProvider() as unknown as SuggestionProvider,
+        model: opts.model,
+        imageBase64: shot.data,
+        mediaType: shot.mediaType,
+      });
+      if (!suggestion) {
+        console.error("[screen-advisor] nothing actionable on screen");
+        return;
+      }
+      lastScreenSuggestion = { ...suggestion, at: new Date().toISOString() };
+      broadcast({ type: "screen_suggestion", ...lastScreenSuggestion });
+      console.error(`[screen-advisor] suggested: ${suggestion.title}`);
+    } catch (err) {
+      console.error(`[screen-advisor] tick failed: ${(err as Error).message}`);
+    } finally {
+      screenTickRunning = false;
+    }
+  };
+
+  const restartScreenTimer = (): void => {
+    if (screenTimer) {
+      clearInterval(screenTimer);
+      screenTimer = null;
+    }
+    if (!screenCfg.enabled) return;
+    // First capture fires after one interval — never immediately on (re)start,
+    // so flipping the toggle doesn't grab the screen the same instant.
+    screenTimer = setInterval(() => void screenTick(), screenCfg.intervalMinutes * 60_000);
+    if (screenTimer.unref) screenTimer.unref();
+  };
+  restartScreenTimer();
+  if (screenCfg.enabled) {
+    console.error(`[screen-advisor] enabled — every ${screenCfg.intervalMinutes}m`);
+  }
+
   // ── Island unread tracking (Phase 1 of MAC_ISLAND_PLAN) ─────────────
   // The island widget caches "last idle_message" so a fresh tab opening
   // mid-conversation knows there's something to read. Cleared via
@@ -289,6 +352,58 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         current_desire: currentDesire,
         uptime_sec: Math.round((Date.now() - serverStartedAt) / 1000),
       }));
+      return;
+    }
+
+    // Screen advisor config — GET current, POST to update (loopback only,
+    // since it controls periodic screen capture). GET also reports `supported`
+    // (macOS only) and the latest suggestion so a fresh island can render it.
+    if (req.method === "GET" && url === "/api/screen-advisor/config") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ...screenCfg, supported: captureSupported() }));
+      return;
+    }
+    if (req.method === "GET" && url === "/api/screen-advisor/latest") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ suggestion: lastScreenSuggestion }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/screen-advisor/config") {
+      const remote = req.socket.remoteAddress ?? "";
+      const isLoopback =
+        remote === "127.0.0.1" ||
+        remote === "::1" ||
+        remote === "::ffff:127.0.0.1" ||
+        remote.startsWith("127.");
+      if (!isLoopback) {
+        res.writeHead(403, { "content-type": "text/plain" });
+        res.end("screen-advisor config only accepted from localhost");
+        return;
+      }
+      let saBody = "";
+      for await (const chunk of req) saBody += chunk.toString("utf8");
+      let payload: Partial<ScreenAdvisorConfig>;
+      try {
+        payload = JSON.parse(saBody || "{}") as Partial<ScreenAdvisorConfig>;
+      } catch {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("bad json");
+        return;
+      }
+      screenCfg = normalizeConfig({ ...screenCfg, ...payload });
+      try {
+        await saveScreenAdvisorConfig(screenCfg);
+      } catch (err) {
+        res.writeHead(500, { "content-type": "text/plain" });
+        res.end((err as Error).message);
+        return;
+      }
+      restartScreenTimer();
+      console.error(
+        `[screen-advisor] config: enabled=${screenCfg.enabled} every=${screenCfg.intervalMinutes}m`,
+      );
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, ...screenCfg, supported: captureSupported() }));
       return;
     }
 


### PR DESCRIPTION
**A new opt-in ability: Lisa watches your screen on a timer and proactively suggests your next coding step on the island; one click prefills it into chat to confirm, then she can dispatch a coding agent.**

### Flow
1. Every N minutes (default **10**) the server silently grabs a full-screen shot (`screencapture -x`).
2. The model returns the single highest-value next **coding** step grounded in what's visible (an error, a failing test, a TODO, a diff, a PR…).
3. It appears as a **💡 suggested next step** card on the Lisa Island (title + rationale + **Optimize ▸**).
4. Clicking **Optimize ▸** **prefills** the task into the chat composer — it does **not** auto-run. You read it, hit send (that's the confirmation), and Lisa can then `dispatch_agent`.

### Privacy — treated as the sensitive capability it is
- **OFF by default.** Nothing is captured until you enable it in Settings.
- The screenshot leaves the machine only for the one analysis call and is **never persisted** (the capture layer deletes its temp PNG); only the short text suggestion is cached in memory.
- Nothing auto-runs from a screenshot — the click only prefills chat.
- macOS-only.

### Settings — in both places, server config is source of truth
- **Lisa.app ⌘, window** (`PreferencesController`): "Suggest next steps from my screen" toggle + an interval field/stepper (clamped 2–240 min), which `GET`/`POST` the server config.
- **Server config** `~/.lisa/screen-advisor.json`. Endpoints: `GET`/`POST /api/screen-advisor/config` (POST **loopback-only**), `GET /api/screen-advisor/latest`. SSE event `screen_suggestion`.

### Pieces
- `src/screen_advisor/engine.ts` — config (default off / 10m, clamped) + tolerant suggestion parse (`{"skip":true}`→none) + `analyzeScreenshot`. **15 unit tests.**
- `server.ts` — restartable interval loop (capture → analyze → broadcast + cache latest; **never captures at t=0**, so flipping the toggle doesn't grab the screen that instant) + the 3 endpoints.
- `island.ts` — suggestion card, `screen_suggestion` SSE case, fetch `/latest` on load, `openFull(prefill)`.
- `lisa-html.ts` — `window.lisaPrefillComposer` + `?prefill=` URL handling (no auto-send).
- Swift — `PreferencesController` UI; the island "Optimize" prefill threads island → AppDelegate → MainWindow → WebContent via `NotificationCenter` + `evaluateJavaScript` (text JSON-encoded so it can't break out).

### Verification
- `npm run typecheck` clean · `npm test` **270 → 285** · `npm run build` clean.
- The inline-script guard `html-syntax.test.ts` passes (island + composer scripts parse — no repeat of the v0.6.0 `\n` break).
- **Server live-verified** on an isolated `LISA_HOME`: `GET` config → `{enabled:false,intervalMinutes:10,supported:true}`, `POST {intervalMinutes:15}` persists + clamps, `/latest` → `null`, config file written.
- **Swift app builds clean** (`swift build`). The capture→LLM loop and the in-app island card/prefill need a Lisa.app rebuild to exercise live — flagged below.

### Needs your hands-on check (can't run Lisa.app from here)
Rebuild Lisa.app, open ⌘, → enable Screen Advisor, set a short interval, and confirm: the card appears, **Optimize ▸** prefills chat (doesn't send), and macOS prompts for Screen Recording permission on first capture. (Requires `ANTHROPIC_API_KEY` for the analysis call.)

Zero new runtime dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)