### PR TITLE
Orchestrator L6: cross-agent recap ("while you were away")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — Cross-agent recap (orchestrator L6: "while you were away")
+
+- **`agent_recap` tool** + **`GET /api/agents/recap?sinceMinutes=N`** synthesize
+  what happened across *all* observed agents (Claude Code, Codex, OpenCode,
+  Aider, GitHub PRs) over a time window — grouped by project, tallying what
+  finished, errored, or is still running, with the notable moments. The
+  temporal counterpart to `advise_now` (alerts *now*) and `list_agents` (the
+  current roster): it answers "what did my agents do since I left?", including
+  sessions that have since ended and dropped out of the live list.
+- **Orchestrator journal** (`src/orchestrator/journal.ts`) — every hub state
+  transition is appended to a capped in-memory ring buffer (consecutive
+  same-state events collapsed), which `recap.ts` reduces into the digest
+  deterministically (no LLM). Structural metadata only — agent, project, state,
+  tool/file names, errors; never prompts or content.
+
 ### Added — GitHub PR observer (orchestrator O4: cloud agents)
 
 - **`github-pr` integration** treats your open pull requests as agent sessions:

--- a/src/orchestrator/journal.test.ts
+++ b/src/orchestrator/journal.test.ts
@@ -1,0 +1,79 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import {
+  recordEvent,
+  eventsSince,
+  allEvents,
+  summarizeActivity,
+  _resetJournalForTest,
+} from "./journal.js";
+import type { AgentSession } from "../integrations/types.js";
+
+function sess(over: Partial<AgentSession> = {}): AgentSession {
+  return {
+    agent: "claude-code",
+    sessionId: "s1",
+    project: "proj",
+    state: "working",
+    stateReason: "tool",
+    lastMtime: 1000,
+    ...over,
+  };
+}
+
+beforeEach(() => _resetJournalForTest());
+
+describe("summarizeActivity", () => {
+  test("tool · $cmd · file", () => {
+    const s = sess({
+      activity: { turnCount: 1, lastTools: ["Read", "Edit"], filesTouched: ["/a/b/foo.ts"], lastCommandName: "npm" },
+    });
+    assert.equal(summarizeActivity(s), "Edit · $npm · foo.ts");
+  });
+  test("no activity → undefined", () => {
+    assert.equal(summarizeActivity(sess()), undefined);
+  });
+});
+
+describe("recordEvent", () => {
+  test("records a transition", () => {
+    const ev = recordEvent(sess({ state: "working" }), 5000);
+    assert.ok(ev);
+    assert.equal(allEvents().length, 1);
+    assert.equal(ev!.at, 1000); // uses lastMtime
+  });
+
+  test("collapses consecutive same state+reason for a session", () => {
+    recordEvent(sess({ state: "working", stateReason: "tool", lastMtime: 1 }));
+    const dup = recordEvent(sess({ state: "working", stateReason: "tool", lastMtime: 2 }));
+    assert.equal(dup, null);
+    assert.equal(allEvents().length, 1);
+  });
+
+  test("records when state changes", () => {
+    recordEvent(sess({ state: "working", lastMtime: 1 }));
+    const e2 = recordEvent(sess({ state: "waiting", stateReason: "end_turn", lastMtime: 2 }));
+    assert.ok(e2);
+    assert.equal(allEvents().length, 2);
+  });
+
+  test("falls back to `now` when lastMtime is missing/zero", () => {
+    const ev = recordEvent(sess({ lastMtime: 0 }), 9999);
+    assert.equal(ev!.at, 9999);
+  });
+
+  test("captures error from activity.lastError", () => {
+    const ev = recordEvent(sess({ state: "error", stateReason: "is_error", activity: { turnCount: 0, lastTools: [], filesTouched: [], lastError: "boom" } }));
+    assert.equal(ev!.error, "boom");
+  });
+});
+
+describe("eventsSince", () => {
+  test("filters by timestamp", () => {
+    recordEvent(sess({ sessionId: "a", state: "working", lastMtime: 100 }));
+    recordEvent(sess({ sessionId: "b", state: "working", lastMtime: 5000 }));
+    const recent = eventsSince(1000);
+    assert.equal(recent.length, 1);
+    assert.equal(recent[0]!.sessionId, "b");
+  });
+});

--- a/src/orchestrator/journal.ts
+++ b/src/orchestrator/journal.ts
@@ -1,0 +1,99 @@
+/**
+ * Orchestrator journal (L6) — a small temporal record of agent activity.
+ *
+ * The hub (L1) only holds a *live snapshot*; once a session goes idle/done it
+ * falls out of `hub.list()`. The advisor (L5) surfaces relevance-gated alerts.
+ * Neither answers "what actually happened across all my agents while I was
+ * away?" — which needs a record over *time*, including sessions that have since
+ * ended. This journal is that record: every meaningful state transition the hub
+ * emits is appended to a capped ring buffer, from which recap.ts synthesizes a
+ * cross-agent "while you were away" digest.
+ *
+ * In-memory + capped (no growth): a recap covers the current server's uptime,
+ * which is exactly the window the user was away *for*. PRIVACY: stores only the
+ * same structural metadata the hub emits (agent, project, state, tool/file
+ * names, error strings) — never prompts, replies, or file contents.
+ */
+
+import type { AgentSession, AgentSessionState } from "../integrations/types.js";
+
+export interface AgentEvent {
+  agent: string;
+  sessionId: string;
+  project: string;
+  cwd?: string;
+  state: AgentSessionState;
+  stateReason: string;
+  /** Epoch ms of the transition. */
+  at: number;
+  /** Compact structural activity summary (tool · file · $cmd), if any. */
+  activity?: string;
+  /** Short error string when the session errored. */
+  error?: string;
+}
+
+const MAX_EVENTS = 400;
+const events: AgentEvent[] = [];
+
+/** Compact, structural one-liner from a session's Tier-2 activity. */
+export function summarizeActivity(s: AgentSession): string | undefined {
+  const a = s.activity;
+  if (!a) return undefined;
+  const bits: string[] = [];
+  const tool = a.lastTools?.length ? a.lastTools[a.lastTools.length - 1] : "";
+  if (tool) bits.push(tool);
+  if (a.lastCommandName) bits.push("$" + a.lastCommandName);
+  const file = a.filesTouched?.length
+    ? a.filesTouched[a.filesTouched.length - 1]!.split("/").pop()
+    : "";
+  if (file) bits.push(file);
+  return bits.length ? bits.join(" · ") : undefined;
+}
+
+/**
+ * Append a transition. Consecutive events for the same session with the same
+ * state + reason are collapsed (we only record *changes*), so a session that
+ * sits in "working" for an hour produces one entry, not hundreds.
+ */
+export function recordEvent(s: AgentSession, now: number = Date.now()): AgentEvent | null {
+  // Find the most recent event for this session.
+  let prev: AgentEvent | undefined;
+  for (let i = events.length - 1; i >= 0; i--) {
+    if (events[i]!.sessionId === s.sessionId) {
+      prev = events[i];
+      break;
+    }
+  }
+  if (prev && prev.state === s.state && prev.stateReason === s.stateReason) {
+    return null; // no real transition
+  }
+  const ev: AgentEvent = {
+    agent: s.agent,
+    sessionId: s.sessionId,
+    project: s.project,
+    cwd: s.cwd,
+    state: s.state,
+    stateReason: s.stateReason,
+    at: Number.isFinite(s.lastMtime) && s.lastMtime > 0 ? s.lastMtime : now,
+    activity: summarizeActivity(s),
+    error: s.activity?.lastError,
+  };
+  events.push(ev);
+  if (events.length > MAX_EVENTS) events.splice(0, events.length - MAX_EVENTS);
+  return ev;
+}
+
+/** All recorded events (oldest → newest). */
+export function allEvents(): AgentEvent[] {
+  return events.slice();
+}
+
+/** Events at or after `sinceMs` (epoch ms), oldest → newest. */
+export function eventsSince(sinceMs: number): AgentEvent[] {
+  return events.filter((e) => e.at >= sinceMs);
+}
+
+/** Test hook — wipe the buffer. */
+export function _resetJournalForTest(): void {
+  events.length = 0;
+}

--- a/src/orchestrator/recap.test.ts
+++ b/src/orchestrator/recap.test.ts
@@ -1,0 +1,77 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { buildRecap, formatRecap } from "./recap.js";
+import type { AgentEvent } from "./journal.js";
+
+function ev(over: Partial<AgentEvent>): AgentEvent {
+  return {
+    agent: "claude-code",
+    sessionId: "s1",
+    project: "proj",
+    state: "working",
+    stateReason: "tool",
+    at: 1000,
+    ...over,
+  };
+}
+
+describe("buildRecap", () => {
+  test("empty window → zero + clear headline", () => {
+    const r = buildRecap([], 0, 10_000);
+    assert.equal(r.totalSessions, 0);
+    assert.match(r.headline, /No agent activity/);
+    assert.equal(formatRecap(r), r.headline);
+  });
+
+  test("filters out events before sinceMs", () => {
+    const r = buildRecap([ev({ at: 100 }), ev({ sessionId: "s2", at: 9000 })], 1000, 10_000);
+    assert.equal(r.totalSessions, 1);
+  });
+
+  test("latest state per session wins; tallies finished/errored/active", () => {
+    const events: AgentEvent[] = [
+      ev({ sessionId: "a", project: "foo", state: "working", at: 1000 }),
+      ev({ sessionId: "a", project: "foo", state: "done", stateReason: "exit", at: 2000 }),
+      ev({ sessionId: "b", project: "foo", agent: "codex", state: "error", stateReason: "is_error", error: "boom", at: 1500 }),
+      ev({ sessionId: "c", project: "bar", state: "working", at: 1800 }),
+    ];
+    const r = buildRecap(events, 0, 3000);
+    assert.equal(r.totalSessions, 3);
+    const foo = r.projects.find((p) => p.project === "foo")!;
+    assert.equal(foo.finished, 1);
+    assert.equal(foo.errored, 1);
+    assert.deepEqual(foo.agents, ["claude-code", "codex"]);
+    const bar = r.projects.find((p) => p.project === "bar")!;
+    assert.equal(bar.active, 1);
+    // errored project sorts first
+    assert.equal(r.projects[0]!.project, "foo");
+    assert.match(r.headline, /3 agent sessions across 2 projects/);
+  });
+
+  test("notable lines include error detail + finishes", () => {
+    const events = [
+      ev({ sessionId: "x", agent: "codex", state: "error", stateReason: "is_error", error: "model not found", at: 1000 }),
+    ];
+    const r = buildRecap(events, 0, 2000);
+    const proj = r.projects[0]!;
+    assert.ok(proj.notable.some((n) => /codex errored: model not found/.test(n)));
+  });
+
+  test("collects touched file basenames from activity summaries", () => {
+    const events = [
+      ev({ sessionId: "x", activity: "Edit · src/foo.ts", at: 1000 }),
+      ev({ sessionId: "x", state: "waiting", stateReason: "end_turn", activity: "Bash · $npm", at: 1100 }),
+    ];
+    const r = buildRecap(events, 0, 2000);
+    assert.ok(r.projects[0]!.files.includes("foo.ts"));
+  });
+
+  test("formatRecap renders headline + per-project lines", () => {
+    const events = [
+      ev({ sessionId: "a", project: "foo", state: "done", stateReason: "exit", at: 1000 }),
+    ];
+    const out = formatRecap(buildRecap(events, 0, 2000));
+    assert.match(out, /foo · claude-code/);
+    assert.match(out, /✓ claude-code finished/);
+  });
+});

--- a/src/orchestrator/recap.ts
+++ b/src/orchestrator/recap.ts
@@ -1,0 +1,179 @@
+/**
+ * Recap (L6) — synthesize the orchestrator journal into a cross-agent
+ * "while you were away" digest. Deterministic (no LLM): given the journal
+ * events in a time window, group by project, tally how each session ended,
+ * and surface the notable moments (errors, finishes, merged PRs, blocks).
+ *
+ * This is the narrative counterpart to the advisor's alerts and list_agents'
+ * roster: it answers "what happened, across everything, since I left?"
+ */
+
+import type { AgentEvent } from "./journal.js";
+import type { AgentSessionState } from "../integrations/types.js";
+
+export interface ProjectRecap {
+  project: string;
+  agents: string[];
+  /** Distinct sessions seen in the window. */
+  sessions: number;
+  finished: number; // ended in "done"
+  errored: number; // currently/last in "error"
+  active: number; // still working/waiting
+  /** Up to a few file basenames touched. */
+  files: string[];
+  /** Human-readable notable lines for this project. */
+  notable: string[];
+}
+
+export interface Recap {
+  sinceMs: number;
+  now: number;
+  /** Distinct sessions that had any event in the window. */
+  totalSessions: number;
+  totalEvents: number;
+  projects: ProjectRecap[];
+  /** One-line headline. */
+  headline: string;
+}
+
+interface SessionRoll {
+  agent: string;
+  project: string;
+  lastState: AgentSessionState;
+  lastReason: string;
+  lastAt: number;
+  files: Set<string>;
+  errored: boolean;
+  lastError?: string;
+  lastActivity?: string;
+}
+
+const FILES_PER_PROJECT = 6;
+
+function basename(p: string): string {
+  return p.split("/").pop() || p;
+}
+
+/** Build the structured recap from journal events in [sinceMs, now]. Pure. */
+export function buildRecap(events: AgentEvent[], sinceMs: number, now: number): Recap {
+  const inWindow = events.filter((e) => e.at >= sinceMs);
+
+  // Roll up per session (the latest meaningful state wins).
+  const sessions = new Map<string, SessionRoll>();
+  for (const e of inWindow) {
+    let r = sessions.get(e.sessionId);
+    if (!r) {
+      r = {
+        agent: e.agent,
+        project: e.project || "(unknown)",
+        lastState: e.state,
+        lastReason: e.stateReason,
+        lastAt: e.at,
+        files: new Set(),
+        errored: false,
+      };
+      sessions.set(e.sessionId, r);
+    }
+    if (e.at >= r.lastAt) {
+      r.lastState = e.state;
+      r.lastReason = e.stateReason;
+      r.lastAt = e.at;
+      if (e.activity) r.lastActivity = e.activity;
+    }
+    if (e.state === "error") {
+      r.errored = true;
+      if (e.error || e.stateReason) r.lastError = e.error || e.stateReason;
+    }
+    if (e.activity) {
+      // The activity summary's last token is often a file basename; cheap to keep.
+      const f = e.activity.split(" · ").find((t) => /\.[a-z0-9]+$/i.test(t));
+      if (f) r.files.add(f);
+    }
+  }
+
+  // Group sessions by project.
+  const byProject = new Map<string, SessionRoll[]>();
+  for (const r of sessions.values()) {
+    const list = byProject.get(r.project) ?? [];
+    list.push(r);
+    byProject.set(r.project, list);
+  }
+
+  const projects: ProjectRecap[] = [];
+  let totalFinished = 0,
+    totalErrored = 0,
+    totalActive = 0;
+  for (const [project, rolls] of byProject) {
+    const agents = [...new Set(rolls.map((r) => r.agent))].sort();
+    let finished = 0,
+      errored = 0,
+      active = 0;
+    const files = new Set<string>();
+    const notable: string[] = [];
+    for (const r of rolls) {
+      if (r.errored) {
+        errored++;
+        notable.push(`✗ ${r.agent} errored${r.lastError ? `: ${r.lastError}` : ""}`);
+      } else if (r.lastState === "done") {
+        finished++;
+        notable.push(`✓ ${r.agent} finished${r.lastReason ? ` (${r.lastReason})` : ""}`);
+      } else if (r.lastState === "working" || r.lastState === "waiting") {
+        active++;
+        if (r.lastState === "waiting" && r.lastReason)
+          notable.push(`• ${r.agent} waiting — ${r.lastReason}`);
+      }
+      for (const f of r.files) files.add(basename(f));
+    }
+    totalFinished += finished;
+    totalErrored += errored;
+    totalActive += active;
+    projects.push({
+      project,
+      agents,
+      sessions: rolls.length,
+      finished,
+      errored,
+      active,
+      files: [...files].slice(0, FILES_PER_PROJECT),
+      notable: notable.slice(0, 6),
+    });
+  }
+
+  // Errors first, then most sessions, then name.
+  projects.sort(
+    (a, b) =>
+      b.errored - a.errored || b.sessions - a.sessions || a.project.localeCompare(b.project),
+  );
+
+  const parts: string[] = [];
+  if (totalFinished) parts.push(`${totalFinished} finished`);
+  if (totalErrored) parts.push(`${totalErrored} errored`);
+  if (totalActive) parts.push(`${totalActive} still going`);
+  const headline =
+    sessions.size === 0
+      ? "No agent activity in this window."
+      : `${sessions.size} agent session${sessions.size === 1 ? "" : "s"} across ` +
+        `${projects.length} project${projects.length === 1 ? "" : "s"}` +
+        (parts.length ? ` — ${parts.join(", ")}.` : ".");
+
+  return {
+    sinceMs,
+    now,
+    totalSessions: sessions.size,
+    totalEvents: inWindow.length,
+    projects,
+    headline,
+  };
+}
+
+/** Render the recap as a readable multi-line digest. Pure. */
+export function formatRecap(recap: Recap): string {
+  if (recap.totalSessions === 0) return recap.headline;
+  const lines: string[] = [recap.headline, ""];
+  for (const p of recap.projects) {
+    lines.push(`${p.project} · ${p.agents.join(", ")}`);
+    for (const n of p.notable) lines.push(`  ${n}`);
+    if (p.files.length) lines.push(`  touched: ${p.files.join(", ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/tools/agent_recap.ts
+++ b/src/tools/agent_recap.ts
@@ -1,0 +1,51 @@
+/**
+ * agent_recap (L6) — the cross-agent "while you were away" digest.
+ *
+ * Answers "what happened across all my agents since I left?" by synthesizing
+ * the orchestrator journal (every observed session's state transitions over
+ * time) into a readable, project-grouped recap: who ran where, what finished,
+ * what errored, what's still going. Complements advise_now (relevance-gated
+ * alerts, now) and list_agents (the current roster) with the temporal story —
+ * including sessions that have since ended and dropped out of the live list.
+ *
+ * Structural metadata only (agent, project, state, tool/file names, errors) —
+ * never prompts, replies, or file contents. Read-only.
+ */
+
+import type { ToolDefinition } from "../types.js";
+import { eventsSince } from "../orchestrator/journal.js";
+import { buildRecap, formatRecap } from "../orchestrator/recap.js";
+
+interface RecapInput {
+  /** Look back this many minutes (default 120, clamped 1–1440). */
+  sinceMinutes?: number;
+}
+
+export const agentRecapTool: ToolDefinition<RecapInput, string> = {
+  name: "agent_recap",
+  description:
+    "Summarize what happened across ALL the coding agents LISA observes (Claude Code, " +
+    "Codex, OpenCode, Aider, GitHub PRs) over a recent time window — the cross-agent " +
+    '"while you were away" recap. Use when the user asks what their agents did, what ' +
+    "happened since they were gone, or for an end-of-session wrap-up. Groups by project " +
+    "and reports what finished, errored, or is still running. Structural metadata only — " +
+    "never conversation content. Read-only.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      sinceMinutes: {
+        type: "number",
+        description: "Window to look back over, in minutes (default 120; max 1440).",
+      },
+    },
+    additionalProperties: false,
+  },
+  async execute(input) {
+    const mins = Math.max(1, Math.min(1440, Math.round(input.sinceMinutes ?? 120)));
+    const now = Date.now();
+    const sinceMs = now - mins * 60_000;
+    const recap = buildRecap(eventsSince(sinceMs), sinceMs, now);
+    const window = mins >= 60 ? `${Math.round(mins / 60)}h` : `${mins}m`;
+    return `Cross-agent recap (last ${window}):\n${formatRecap(recap)}`;
+  },
+};

--- a/src/tools/registry.test.ts
+++ b/src/tools/registry.test.ts
@@ -8,7 +8,7 @@ describe("buildToolRegistry", () => {
     // registry but never pushed into the array, so the model couldn't call
     // them. tsconfig has no noUnusedLocals to catch that, so guard it here.
     const names = new Set(buildToolRegistry().map((t) => t.name));
-    for (const required of ["list_agents", "advise_now", "dispatch_agent", "signal_agent"]) {
+    for (const required of ["list_agents", "advise_now", "dispatch_agent", "signal_agent", "agent_recap"]) {
       assert.ok(names.has(required), `${required} must be registered`);
     }
   });

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -12,6 +12,7 @@ import { dispatchAgentTool } from "./dispatch_agent.js";
 import { scheduledDispatchTool } from "./scheduled_dispatch.js";
 import { compareAgentsTool } from "./compare_agents.js";
 import { signalAgentTool } from "./signal_agent.js";
+import { agentRecapTool } from "./agent_recap.js";
 import { skillManageTool } from "../skills/tool.js";
 import {
   desireCloseTool,
@@ -85,6 +86,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     scheduledDispatchTool as ToolDefinition,
     compareAgentsTool as ToolDefinition,
     signalAgentTool as ToolDefinition,
+    agentRecapTool as ToolDefinition,
   ];
   if (opts.includeVoice) {
     tools.push(speakTool as ToolDefinition, transcribeTool as ToolDefinition);
@@ -110,6 +112,7 @@ export const READ_ONLY_TOOL_NAMES = new Set([
   "soul_diff",
   "web_fetch",
   "web_search",
+  "agent_recap",
 ]);
 
 export function readOnlySubset(tools: ToolDefinition[]): ToolDefinition[] {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -22,6 +22,8 @@ import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
 import { setCurrentHub } from "../integrations/current-hub.js";
 import { advise, formatDigest } from "../advisor/engine.js";
+import { recordEvent } from "../orchestrator/journal.js";
+import { buildRecap, formatRecap } from "../orchestrator/recap.js";
 import type { AgentSession } from "../integrations/types.js";
 import { captureScreenshot, captureSupported, type CaptureMode } from "../vision/capture.js";
 import { transcribeAudio } from "../voice/transcribe.js";
@@ -146,6 +148,10 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     log: (msg) => console.error(msg),
   });
   hub.on("update", (session: AgentSession) => {
+    // L6 — record the transition in the orchestrator journal so the
+    // cross-agent recap can answer "what happened while I was away?" even for
+    // sessions that have since ended. (Dedups consecutive same-state events.)
+    recordEvent(session);
     // New generalized event for the multi-agent UI.
     broadcast({ type: "agent_session_update", ...session });
     // Back-compat: the island still listens for claude_session_update as a
@@ -389,6 +395,19 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       }));
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ sessions }));
+      return;
+    }
+
+    // L6 — cross-agent "while you were away" recap, synthesized from the
+    // journal. ?sinceMinutes=N (default 120) bounds the window.
+    if (req.method === "GET" && url.startsWith("/api/agents/recap")) {
+      const q = new URL(url, "http://localhost").searchParams;
+      const mins = Math.max(1, Math.min(1440, Number(q.get("sinceMinutes")) || 120));
+      const { eventsSince } = await import("../orchestrator/journal.js");
+      const now = Date.now();
+      const recap = buildRecap(eventsSince(now - mins * 60_000), now - mins * 60_000, now);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ recap, text: formatRecap(recap), sinceMinutes: mins }));
       return;
     }
 


### PR DESCRIPTION
**The mission-control finale.** Completes the orchestrator's layers: observe → understand → advise → dispatch → control → **recap**. `agent_recap` answers *"what did all my agents do while I was away?"*

### What it adds
- **`agent_recap` tool** (read-only) and **`GET /api/agents/recap?sinceMinutes=N`** (default 120, clamped 1–1440) synthesize a cross-agent **"while you were away"** digest across Claude Code, Codex, OpenCode, Aider, and GitHub PRs — grouped by project, tallying what **finished**, **errored**, or is **still running**, with the notable moments (errors w/ detail, finishes, blocked-on-review).
- **Orchestrator journal** (`src/orchestrator/journal.ts`): the hub only holds a *live snapshot* (sessions drop out once idle/done). The journal appends every hub state transition to a capped in-memory ring buffer (consecutive same-state collapsed), so the recap can include sessions that have **since ended** — the temporal record the rest of the stack lacked.

### Where it fits (complements, doesn't duplicate)
| layer | answers |
|---|---|
| `advise_now` (L5) | relevance-gated **alerts, now** |
| `list_agents` | the **current roster** |
| **`agent_recap` (L6)** | **the story since you left** — incl. ended sessions |

### Design
- `recap.ts` reduces journal events → digest **deterministically (no LLM)**: filter to window, roll up latest state per session, group by project, sort errors-first.
- **Privacy:** structural metadata only — agent, project, state, tool/file names, error strings. Never prompts, replies, or file contents.

### Verification
- `npm run typecheck` clean · `npm test` **285 → 297** · `npm run build` clean.
- `journal.test.ts` (record/dedup/since/error-capture/activity-summary) + `recap.test.ts` (window filter, latest-state-wins, tallies, notable lines, file collection, formatting).
- `registry.test.ts` guard extended to require `agent_recap` (so it can't become an unwired import like `dispatch_agent` once did).
- `/api/agents/recap` **live-verified** on an isolated server (empty-journal case returns the clean recap shape).

Zero new runtime dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)