### PR TITLE
feat(tools): github — gh-backed issues/PRs/CI/releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — integrations
+
+- **`github`** — gh-backed GitHub operations a coding agent needs beyond pr_status
+  / github_link: issues (list/view/create/comment), PRs (view/create/comment/
+  merge), CI runs (list/view), releases. Read actions are safe; create/comment/
+  merge are writes. Args passed as discrete argv (no shell interpolation).
+
 ## [0.8.0] — 2026-06-02
 
 **Mission control + new senses.** The orchestrator is complete end-to-end —

--- a/src/tools/github.test.ts
+++ b/src/tools/github.test.ts
@@ -1,0 +1,48 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { buildGhArgs } from "./github.js";
+
+describe("github buildGhArgs", () => {
+  test("issue_list uses --json and state", () => {
+    const r = buildGhArgs({ action: "issue_list", state: "all" }) as { args: string[] };
+    assert.deepEqual(r.args.slice(0, 4), ["issue", "list", "--state", "all"]);
+    assert.ok(r.args.includes("--json"));
+  });
+
+  test("issue_create needs a title", () => {
+    assert.ok("error" in buildGhArgs({ action: "issue_create" }));
+    const r = buildGhArgs({ action: "issue_create", title: "bug", body: "details" }) as { args: string[] };
+    assert.deepEqual(r.args, ["issue", "create", "--title", "bug", "--body", "details"]);
+  });
+
+  test("issue_comment needs number + body", () => {
+    assert.ok("error" in buildGhArgs({ action: "issue_comment", number: 1 }));
+    const r = buildGhArgs({ action: "issue_comment", number: 7, body: "ack" }) as { args: string[] };
+    assert.deepEqual(r.args, ["issue", "comment", "7", "--body", "ack"]);
+  });
+
+  test("pr_create passes base when given", () => {
+    const r = buildGhArgs({ action: "pr_create", title: "feat", body: "b", base: "main" }) as { args: string[] };
+    assert.deepEqual(r.args, ["pr", "create", "--title", "feat", "--body", "b", "--base", "main"]);
+  });
+
+  test("pr_merge defaults to squash + delete-branch", () => {
+    const r = buildGhArgs({ action: "pr_merge", number: 12 }) as { args: string[] };
+    assert.deepEqual(r.args, ["pr", "merge", "12", "--squash", "--delete-branch"]);
+    const rebase = buildGhArgs({ action: "pr_merge", number: 12, merge_method: "rebase" }) as { args: string[] };
+    assert.ok(rebase.args.includes("--rebase"));
+  });
+
+  test("run_view needs an id", () => {
+    assert.ok("error" in buildGhArgs({ action: "run_view" }));
+    const r = buildGhArgs({ action: "run_view", number: 123 }) as { args: string[] };
+    assert.deepEqual(r.args, ["run", "view", "123"]);
+  });
+
+  test("task strings are passed as separate argv (no shell interpolation)", () => {
+    const r = buildGhArgs({ action: "issue_create", title: "a; rm -rf /", body: "$(whoami)" }) as { args: string[] };
+    // The dangerous strings are discrete args, never concatenated into a command.
+    assert.ok(r.args.includes("a; rm -rf /"));
+    assert.ok(r.args.includes("$(whoami)"));
+  });
+});

--- a/src/tools/github.ts
+++ b/src/tools/github.ts
@@ -1,0 +1,148 @@
+/**
+ * github (integration) — a gh-CLI-backed tool covering the GitHub operations a
+ * coding agent / orchestrator actually needs beyond pr_status (list+CI) and
+ * github_link (URLs): issues (list/view/create/comment), PRs (view/create/
+ * comment/merge), CI runs (list/view), releases. One tool, action-dispatched.
+ *
+ * Read actions are safe; create/comment/merge are write actions (gated by the
+ * host approval layer like any mutating tool). Needs `gh` authenticated.
+ */
+import type { ToolDefinition } from "../types.js";
+import { runIn, isDir, gitRoot } from "./exec-util.js";
+
+type GithubAction =
+  | "issue_list" | "issue_view" | "issue_create" | "issue_comment"
+  | "pr_view" | "pr_create" | "pr_comment" | "pr_merge"
+  | "run_list" | "run_view" | "release_list";
+
+interface GithubInput {
+  action: GithubAction;
+  cwd?: string;
+  /** Issue / PR / run number (issue_view, pr_view, *_comment, pr_merge, run_view). */
+  number?: number;
+  title?: string;
+  body?: string;
+  /** pr_create base branch. */
+  base?: string;
+  /** issue_list / pr filter state. */
+  state?: "open" | "closed" | "all";
+  /** pr_merge method. Default squash. */
+  merge_method?: "squash" | "merge" | "rebase";
+}
+
+/** Build the gh argv for an action (without the leading "gh"). Pure + tested. */
+export function buildGhArgs(input: GithubInput): { args: string[] } | { error: string } {
+  const need = (v: unknown, name: string) => v == null || v === "" ? `${input.action} needs ${name}` : null;
+  switch (input.action) {
+    case "issue_list":
+      return { args: ["issue", "list", "--state", input.state ?? "open", "--limit", "30", "--json", "number,title,state,author,labels"] };
+    case "issue_view": {
+      const e = need(input.number, "a number"); if (e) return { error: e };
+      return { args: ["issue", "view", String(input.number), "--comments"] };
+    }
+    case "issue_create": {
+      const e = need(input.title, "a title"); if (e) return { error: e };
+      return { args: ["issue", "create", "--title", input.title!, "--body", input.body ?? ""] };
+    }
+    case "issue_comment": {
+      const e = need(input.number, "a number") || need(input.body, "a body"); if (e) return { error: e };
+      return { args: ["issue", "comment", String(input.number), "--body", input.body!] };
+    }
+    case "pr_view": {
+      const e = need(input.number, "a number"); if (e) return { error: e };
+      return { args: ["pr", "view", String(input.number), "--comments"] };
+    }
+    case "pr_create": {
+      const e = need(input.title, "a title"); if (e) return { error: e };
+      const args = ["pr", "create", "--title", input.title!, "--body", input.body ?? ""];
+      if (input.base) args.push("--base", input.base);
+      return { args };
+    }
+    case "pr_comment": {
+      const e = need(input.number, "a number") || need(input.body, "a body"); if (e) return { error: e };
+      return { args: ["pr", "comment", String(input.number), "--body", input.body!] };
+    }
+    case "pr_merge": {
+      const e = need(input.number, "a number"); if (e) return { error: e };
+      return { args: ["pr", "merge", String(input.number), `--${input.merge_method ?? "squash"}`, "--delete-branch"] };
+    }
+    case "run_list":
+      return { args: ["run", "list", "--limit", "15", "--json", "databaseId,name,status,conclusion,headBranch,event"] };
+    case "run_view": {
+      const e = need(input.number, "a run id (number)"); if (e) return { error: e };
+      return { args: ["run", "view", String(input.number)] };
+    }
+    case "release_list":
+      return { args: ["release", "list", "--limit", "10"] };
+    default:
+      return { error: `unknown action: ${input.action}` };
+  }
+}
+
+/** Compact a gh --json issue/PR/run array into readable lines. */
+function formatJsonList(action: GithubAction, raw: string): string {
+  let arr: any[];
+  try { arr = JSON.parse(raw); } catch { return raw.trim(); }
+  if (!Array.isArray(arr) || arr.length === 0) return "(none)";
+  if (action === "issue_list") {
+    return arr.map((i) => {
+      const labels = (i.labels ?? []).map((l: any) => l.name).join(", ");
+      return `#${i.number} [${i.state}] ${i.title}${labels ? ` (${labels})` : ""} — @${i.author?.login ?? "?"}`;
+    }).join("\n");
+  }
+  if (action === "run_list") {
+    return arr.map((r) => {
+      const s = r.conclusion || r.status || "?";
+      return `${r.databaseId} ${s} · ${r.name} · ${r.headBranch} (${r.event})`;
+    }).join("\n");
+  }
+  return raw.trim();
+}
+
+export const githubTool: ToolDefinition<GithubInput, string> = {
+  name: "github",
+  description:
+    "GitHub operations via gh: issues (issue_list / issue_view / issue_create / issue_comment), " +
+    "PRs (pr_view / pr_create / pr_comment / pr_merge), CI (run_list / run_view), releases " +
+    "(release_list). For listing open PRs with CI use pr_status; for URLs use github_link. " +
+    "create/comment/merge are write actions. Needs `gh` authenticated.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: {
+        type: "string",
+        enum: ["issue_list", "issue_view", "issue_create", "issue_comment", "pr_view", "pr_create", "pr_comment", "pr_merge", "run_list", "run_view", "release_list"],
+      },
+      cwd: { type: "string", description: "Absolute path inside the repo. Defaults to the current directory." },
+      number: { type: "integer", description: "Issue / PR number, or run id (per action)." },
+      title: { type: "string", description: "For issue_create / pr_create." },
+      body: { type: "string", description: "Body for create/comment actions." },
+      base: { type: "string", description: "Base branch for pr_create." },
+      state: { type: "string", enum: ["open", "closed", "all"], description: "Filter for issue_list (default open)." },
+      merge_method: { type: "string", enum: ["squash", "merge", "rebase"], description: "For pr_merge (default squash)." },
+    },
+    required: ["action"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx) {
+    const cwd = input.cwd && input.cwd.startsWith("/") ? input.cwd : ctx.cwd;
+    if (!(await isDir(cwd))) return `(not a directory: ${cwd})`;
+    const root = (await gitRoot(cwd, ctx.signal)) ?? cwd;
+
+    const built = buildGhArgs(input);
+    if ("error" in built) return `(${built.error})`;
+
+    const r = await runIn(root, "gh", built.args, { timeoutMs: 30000, signal: ctx.signal, maxBytes: 200_000 });
+    if (r.spawnError) return "(the `gh` CLI isn't installed — needed for GitHub operations. https://cli.github.com)";
+    if (r.code !== 0) {
+      const e = r.stderr.trim();
+      if (/auth|login/i.test(e)) return "(`gh` isn't authenticated — run `gh auth login`)";
+      return `(gh ${input.action} failed: ${e.slice(0, 250) || "unknown error"})`;
+    }
+    const out = r.stdout.trim();
+    if (input.action === "issue_list" || input.action === "run_list") {
+      return formatJsonList(input.action, r.stdout) || "(none)";
+    }
+    return out || "(done)";
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -12,6 +12,7 @@ import { dispatchAgentTool } from "./dispatch_agent.js";
 import { scheduledDispatchTool } from "./scheduled_dispatch.js";
 import { compareAgentsTool } from "./compare_agents.js";
 import { githubLinkTool } from "./github_link.js";
+import { githubTool } from "./github.js";
 import { signalAgentTool } from "./signal_agent.js";
 import { agentRecapTool } from "./agent_recap.js";
 import { skillManageTool } from "../skills/tool.js";
@@ -87,6 +88,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     scheduledDispatchTool as ToolDefinition,
     compareAgentsTool as ToolDefinition,
     githubLinkTool as ToolDefinition,
+    githubTool as ToolDefinition,
     signalAgentTool as ToolDefinition,
     agentRecapTool as ToolDefinition,
   ];


### PR DESCRIPTION
Integration axis #1 (GitHub complete). One action-dispatched `github` tool covering what `pr_status` (list+CI) and `github_link` (URLs) don't: **issues** (list/view/create/comment), **PRs** (view/create/comment/merge), **CI runs** (list/view), **releases**. Read actions safe; create/comment/merge are writes (approval-gated). Args passed as discrete argv (no shell interpolation — unit-tested). gh-authed; smoked live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)