### PR TITLE
feat(tools): npm_info — package view / outdated / audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Added — integrations
 
+- **`npm_info`** — npm registry: view a package (latest/desc/license/deprecation),
+  list a repo's outdated deps, or audit it for known vulnerabilities. No auth.
+
 - **`github`** — gh-backed GitHub operations a coding agent needs beyond pr_status
   / github_link: issues (list/view/create/comment), PRs (view/create/comment/
   merge), CI runs (list/view), releases. Read actions are safe; create/comment/

--- a/src/tools/npm_info.test.ts
+++ b/src/tools/npm_info.test.ts
@@ -1,0 +1,36 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { formatView, formatOutdated, formatAudit } from "./npm_info.js";
+
+describe("npm_info formatView", () => {
+  test("renders name@version + metadata", () => {
+    const out = formatView(JSON.stringify({ name: "sharp", version: "0.34.5", description: "image lib", license: "Apache-2.0", homepage: "https://sharp.pixelplumbing.com" }));
+    assert.match(out, /sharp@0\.34\.5/);
+    assert.match(out, /license: Apache-2\.0/);
+    assert.match(out, /homepage:/);
+  });
+  test("flags deprecation and picks newest from an array", () => {
+    const out = formatView(JSON.stringify([{ name: "x", version: "1.0.0" }, { name: "x", version: "1.2.0", deprecated: "use y" }]));
+    assert.match(out, /x@1\.2\.0/);
+    assert.match(out, /DEPRECATED: use y/);
+  });
+});
+
+describe("npm_info formatOutdated", () => {
+  test("up to date", () => assert.match(formatOutdated("{}"), /up to date/));
+  test("lists current → latest", () => {
+    const out = formatOutdated(JSON.stringify({ react: { current: "18.0.0", latest: "19.0.0" } }));
+    assert.match(out, /1 outdated/);
+    assert.match(out, /react: 18\.0\.0 → 19\.0\.0/);
+  });
+});
+
+describe("npm_info formatAudit", () => {
+  test("clean", () => {
+    assert.match(formatAudit(JSON.stringify({ metadata: { vulnerabilities: { critical: 0, high: 0, moderate: 0, low: 0, info: 0 } } })), /no known vulnerabilities/);
+  });
+  test("summarises severities", () => {
+    const out = formatAudit(JSON.stringify({ metadata: { vulnerabilities: { critical: 1, high: 2, moderate: 0, low: 3, info: 0 } } }));
+    assert.match(out, /6 vulnerabilities: 1 critical, 2 high, 3 low/);
+  });
+});

--- a/src/tools/npm_info.ts
+++ b/src/tools/npm_info.ts
@@ -1,0 +1,96 @@
+/**
+ * npm_info (integration) — the npm registry, the external service every JS
+ * agent touches. view a package's metadata, find outdated deps in a repo, or
+ * audit it for known vulnerabilities. No auth; uses the local npm CLI.
+ */
+import type { ToolDefinition } from "../types.js";
+import { runIn, isDir, gitRoot } from "./exec-util.js";
+
+interface NpmInput {
+  action: "view" | "outdated" | "audit";
+  /** Package name for view (optionally name@range). */
+  package?: string;
+  cwd?: string;
+}
+
+/** Pure: format `npm view --json` metadata. Exported for tests. */
+export function formatView(json: string): string {
+  let d: any;
+  try { d = JSON.parse(json); } catch { return json.trim(); }
+  if (Array.isArray(d)) d = d[d.length - 1]; // version range → newest match
+  const lines = [
+    `${d.name}@${d.version}`,
+    d.description ? `  ${d.description}` : "",
+    d.license ? `  license: ${d.license}` : "",
+    d.homepage ? `  homepage: ${d.homepage}` : "",
+    d.deprecated ? `  ⚠ DEPRECATED: ${d.deprecated}` : "",
+    d.dist?.unpackedSize ? `  size: ${Math.round(d.dist.unpackedSize / 1024)} KB` : "",
+  ].filter(Boolean);
+  return lines.join("\n");
+}
+
+/** Pure: format `npm outdated --json`. Exported for tests. */
+export function formatOutdated(json: string): string {
+  let d: Record<string, any>;
+  try { d = JSON.parse(json || "{}"); } catch { return json.trim(); }
+  const names = Object.keys(d);
+  if (names.length === 0) return "(all dependencies up to date)";
+  return `${names.length} outdated:\n` + names.map((n) => `  ${n}: ${d[n].current ?? "?"} → ${d[n].latest ?? "?"}`).join("\n");
+}
+
+/** Pure: summarise `npm audit --json` (npm v7+ shape). Exported for tests. */
+export function formatAudit(json: string): string {
+  let d: any;
+  try { d = JSON.parse(json); } catch { return json.trim(); }
+  const v = d?.metadata?.vulnerabilities;
+  if (!v) return "(no audit data)";
+  const total = (v.critical ?? 0) + (v.high ?? 0) + (v.moderate ?? 0) + (v.low ?? 0) + (v.info ?? 0);
+  if (total === 0) return "(no known vulnerabilities)";
+  const parts = ["critical", "high", "moderate", "low", "info"].filter((k) => v[k]).map((k) => `${v[k]} ${k}`);
+  return `${total} vulnerabilit${total === 1 ? "y" : "ies"}: ${parts.join(", ")}  (run \`npm audit\` for detail)`;
+}
+
+export const npmInfoTool: ToolDefinition<NpmInput, string> = {
+  name: "npm_info",
+  description:
+    "npm registry info: action:'view' (package — latest version, description, license, deprecation), " +
+    "'outdated' (which of a repo's dependencies have newer versions), 'audit' (known vulnerabilities in " +
+    "a repo). Use when the user asks about a package, whether deps are current, or for a security pass. " +
+    "Read-only; no auth; uses the local npm CLI.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: { type: "string", enum: ["view", "outdated", "audit"] },
+      package: { type: "string", description: "Package name (optionally name@range) for action:'view'." },
+      cwd: { type: "string", description: "Repo path for outdated/audit. Defaults to current directory." },
+    },
+    required: ["action"],
+    additionalProperties: false,
+  },
+  async execute(input, ctx) {
+    if (input.action === "view") {
+      if (!input.package) return "(view needs a package name)";
+      const r = await runIn(ctx.cwd, "npm", ["view", input.package, "--json"], { timeoutMs: 20000, signal: ctx.signal, maxBytes: 200_000 });
+      if (r.spawnError) return "(npm isn't installed)";
+      if (r.code !== 0) return `(npm view failed: ${r.stderr.trim().slice(0, 160) || "no such package?"})`;
+      return formatView(r.stdout);
+    }
+
+    const cwd = input.cwd && input.cwd.startsWith("/") ? input.cwd : ctx.cwd;
+    if (!(await isDir(cwd))) return `(not a directory: ${cwd})`;
+    const root = (await gitRoot(cwd, ctx.signal)) ?? cwd;
+
+    if (input.action === "outdated") {
+      // npm outdated exits non-zero when there ARE outdated deps — that's not an error.
+      const r = await runIn(root, "npm", ["outdated", "--json"], { timeoutMs: 60000, signal: ctx.signal, maxBytes: 200_000 });
+      if (r.spawnError) return "(npm isn't installed)";
+      return formatOutdated(r.stdout || "{}");
+    }
+
+    // audit
+    const r = await runIn(root, "npm", ["audit", "--json"], { timeoutMs: 60000, signal: ctx.signal, maxBytes: 400_000 });
+    if (r.spawnError) return "(npm isn't installed)";
+    if (!r.stdout.trim()) return `(npm audit produced no output${r.stderr ? ": " + r.stderr.trim().slice(0, 120) : ""})`;
+    return formatAudit(r.stdout);
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -13,6 +13,7 @@ import { scheduledDispatchTool } from "./scheduled_dispatch.js";
 import { compareAgentsTool } from "./compare_agents.js";
 import { githubLinkTool } from "./github_link.js";
 import { githubTool } from "./github.js";
+import { npmInfoTool } from "./npm_info.js";
 import { signalAgentTool } from "./signal_agent.js";
 import { agentRecapTool } from "./agent_recap.js";
 import { skillManageTool } from "../skills/tool.js";
@@ -89,6 +90,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     compareAgentsTool as ToolDefinition,
     githubLinkTool as ToolDefinition,
     githubTool as ToolDefinition,
+    npmInfoTool as ToolDefinition,
     signalAgentTool as ToolDefinition,
     agentRecapTool as ToolDefinition,
   ];


### PR DESCRIPTION
Integration axis #3 (external services), starting with the universal no-auth one: **npm**. `npm_info` views a package (latest/license/deprecation), lists a repo's outdated deps, or audits for vulnerabilities. Pure formatters unit-tested; smoked live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)