### PR TITLE
feat(tools): mcp — connect any MCP-server integration on request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ versioning follows [SemVer](https://semver.org/).
 
 ### Added — integrations
 
+- **`mcp`** — manage MCP server connections (list/add/remove ~/.lisa/mcp.json),
+  so LISA can connect any integration that ships an MCP server (GitHub, Linear,
+  Sentry, Postgres, filesystem, …); their tools then auto-appear in her toolset.
+  The standard route for "all integrations an agent might use."
+
 - **`npm_info`** — npm registry: view a package (latest/desc/license/deprecation),
   list a repo's outdated deps, or audit it for known vulnerabilities. No auth.
 

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -39,3 +39,37 @@ export async function loadMcpConfig(): Promise<McpServerSpec[]> {
 }
 
 export const MCP_CONFIG_PATH = CONFIG_PATH;
+
+/** Add or replace a server in mcp.json (upsert by name). Returns the spec. */
+export async function saveMcpServer(
+  name: string,
+  spec: Omit<McpServerSpec, "name">,
+): Promise<void> {
+  let config: McpConfig = { mcpServers: {} };
+  if (await pathExists(CONFIG_PATH)) {
+    try {
+      config = JSON.parse(await fs.readFile(CONFIG_PATH, "utf8")) as McpConfig;
+    } catch {
+      // start fresh on a corrupt file rather than lose the add
+    }
+  }
+  if (!config.mcpServers) config.mcpServers = {};
+  config.mcpServers[name] = spec;
+  await fs.mkdir(path.dirname(CONFIG_PATH), { recursive: true });
+  await fs.writeFile(CONFIG_PATH, JSON.stringify(config, null, 2));
+}
+
+/** Remove a server from mcp.json. Returns false if it wasn't there. */
+export async function deleteMcpServer(name: string): Promise<boolean> {
+  if (!(await pathExists(CONFIG_PATH))) return false;
+  let config: McpConfig;
+  try {
+    config = JSON.parse(await fs.readFile(CONFIG_PATH, "utf8")) as McpConfig;
+  } catch {
+    return false;
+  }
+  if (!config.mcpServers || !(name in config.mcpServers)) return false;
+  delete config.mcpServers[name];
+  await fs.writeFile(CONFIG_PATH, JSON.stringify(config, null, 2));
+  return true;
+}

--- a/src/tools/mcp.test.ts
+++ b/src/tools/mcp.test.ts
@@ -1,0 +1,38 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+// Point LISA_HOME at a temp dir BEFORE importing modules that resolve paths.
+process.env.LISA_HOME = mkdtempSync(path.join(tmpdir(), "lisa-mcp-"));
+const { mcpTool } = await import("./mcp.js");
+
+const ctx = { cwd: "/tmp", signal: new AbortController().signal, log() {} } as any;
+
+describe("mcp tool", () => {
+  test("list is empty initially", async () => {
+    assert.match(await mcpTool.execute({ action: "list" }, ctx), /no MCP servers configured/);
+  });
+
+  test("add → list → remove round-trips", async () => {
+    const add = await mcpTool.execute(
+      { action: "add", name: "filesystem", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"] },
+      ctx,
+    );
+    assert.match(add, /Added MCP server "filesystem"/);
+
+    const list = await mcpTool.execute({ action: "list" }, ctx);
+    assert.match(list, /filesystem: npx -y @modelcontextprotocol\/server-filesystem \/data/);
+
+    const rm = await mcpTool.execute({ action: "remove", name: "filesystem" }, ctx);
+    assert.match(rm, /Removed MCP server "filesystem"/);
+    assert.match(await mcpTool.execute({ action: "list" }, ctx), /no MCP servers configured/);
+  });
+
+  test("add validates required fields; remove validates name", async () => {
+    assert.match(await mcpTool.execute({ action: "add", name: "x" }, ctx), /needs a name and a command/);
+    assert.match(await mcpTool.execute({ action: "remove" }, ctx), /needs a name/);
+    assert.match(await mcpTool.execute({ action: "remove", name: "nope" }, ctx), /no MCP server named/);
+  });
+});

--- a/src/tools/mcp.ts
+++ b/src/tools/mcp.ts
@@ -1,0 +1,87 @@
+/**
+ * mcp (integration) — manage LISA's MCP server connections, so she can connect
+ * any integration that ships an MCP server (GitHub, Linear, Sentry, Postgres,
+ * filesystem, …) on request, rather than each needing a bespoke tool. MCP is
+ * the standard way to "add all the integrations an agent might use".
+ *
+ *   list   — configured MCP servers (from ~/.lisa/mcp.json)
+ *   add    — add a server (name + command [+ args/env]); connects on next start
+ *   remove — remove a server
+ *
+ * Servers connect at startup, so add/remove take effect after a restart
+ * (`lisa serve --web`). Their tools then appear in LISA's toolset automatically.
+ */
+import type { ToolDefinition } from "../types.js";
+import { loadMcpConfig, saveMcpServer, deleteMcpServer, MCP_CONFIG_PATH } from "../mcp/config.js";
+
+interface McpInput {
+  action: "list" | "add" | "remove";
+  name?: string;
+  /** For add: the server command, e.g. "npx". */
+  command?: string;
+  /** For add: command args, e.g. ["-y","@modelcontextprotocol/server-filesystem","/path"]. */
+  args?: string[];
+  /** For add: env vars the server needs (e.g. API tokens). */
+  env?: Record<string, string>;
+  enabled?: boolean;
+}
+
+export const mcpTool: ToolDefinition<McpInput, string> = {
+  name: "mcp",
+  description:
+    "Manage MCP server connections — the standard way to add external integrations (GitHub, Linear, " +
+    "Sentry, Postgres, filesystem, …) whose tools then appear in LISA's toolset. action:'list' shows " +
+    "configured servers; 'add' (name + command [+ args/env]) adds one; 'remove' (name) deletes one. " +
+    "Servers connect at startup, so add/remove take effect after restarting `lisa serve --web`. Use " +
+    "when the user wants to connect a new integration via its MCP server.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: { type: "string", enum: ["list", "add", "remove"] },
+      name: { type: "string", description: "Server name (for add/remove)." },
+      command: { type: "string", description: "Executable for add, e.g. 'npx'." },
+      args: { type: "array", items: { type: "string" }, description: "Args for add, e.g. ['-y','@scope/server-x']." },
+      env: { type: "object", additionalProperties: { type: "string" }, description: "Env vars the server needs (e.g. API tokens)." },
+      enabled: { type: "boolean", description: "Whether the server is enabled (default true)." },
+    },
+    required: ["action"],
+    additionalProperties: false,
+  },
+  async execute(input) {
+    if (input.action === "list") {
+      const servers = await loadMcpConfig();
+      if (servers.length === 0) {
+        return `(no MCP servers configured — add one with mcp action:'add', or edit ${MCP_CONFIG_PATH})`;
+      }
+      return (
+        `${servers.length} MCP server(s) in ${MCP_CONFIG_PATH}:\n` +
+        servers
+          .map((s) => `  ${s.name}${s.enabled === false ? " (disabled)" : ""}: ${s.command} ${(s.args ?? []).join(" ")}`.trimEnd())
+          .join("\n")
+      );
+    }
+
+    if (input.action === "remove") {
+      if (!input.name) return "(remove needs a name — from mcp action:'list')";
+      const ok = await deleteMcpServer(input.name);
+      return ok
+        ? `Removed MCP server "${input.name}". Restart \`lisa serve --web\` for it to disconnect.`
+        : `(no MCP server named "${input.name}")`;
+    }
+
+    // add
+    if (!input.name || !input.command) {
+      return "(add needs a name and a command, e.g. name:'filesystem' command:'npx' args:['-y','@modelcontextprotocol/server-filesystem','/path'])";
+    }
+    await saveMcpServer(input.name, {
+      command: input.command,
+      args: input.args ?? [],
+      env: input.env,
+      enabled: input.enabled ?? true,
+    });
+    return (
+      `Added MCP server "${input.name}": ${input.command} ${(input.args ?? []).join(" ")}`.trimEnd() +
+      `\nRestart \`lisa serve --web\` to connect it — its tools then appear in my toolset automatically.`
+    );
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -14,6 +14,7 @@ import { compareAgentsTool } from "./compare_agents.js";
 import { githubLinkTool } from "./github_link.js";
 import { githubTool } from "./github.js";
 import { npmInfoTool } from "./npm_info.js";
+import { mcpTool } from "./mcp.js";
 import { signalAgentTool } from "./signal_agent.js";
 import { agentRecapTool } from "./agent_recap.js";
 import { skillManageTool } from "../skills/tool.js";
@@ -91,6 +92,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     githubLinkTool as ToolDefinition,
     githubTool as ToolDefinition,
     npmInfoTool as ToolDefinition,
+    mcpTool as ToolDefinition,
     signalAgentTool as ToolDefinition,
     agentRecapTool as ToolDefinition,
   ];


### PR DESCRIPTION
Integration axis #4 (MCP). MCP is the standard route for the long tail of integrations. LISA already loads configured servers; `mcp` lets her **manage** them — list/add/remove in `~/.lisa/mcp.json`. Added servers connect on next `serve --web` start and their tools auto-appear in her toolset. add→list→remove round-trip unit-tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)