### PR TITLE
fix(island): calmer status pips — breathe for working, halo for needs-you

### DIFF
--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -126,14 +126,27 @@ export const ISLAND_HTML = `<!doctype html>
   #dot.unread         { background: var(--accent-warm); }
   /* Phase 2: pill dot reflects the strongest signal across all
      Claude sessions. */
-  #dot.claude-working { background: var(--accent-claude);  animation: pulse 1.8s ease-in-out infinite; }
-  #dot.claude-waiting { background: var(--accent-claude); }  /* solid — "needs you" */
+  /* working = a calm slow breathe (it's running, not actionable);
+     waiting = solid + a soft halo that draws the eye ("needs you"). */
+  #dot.claude-working { background: var(--accent-claude);  opacity: 1; animation: breathe 2.6s ease-in-out infinite; }
+  #dot.claude-waiting { background: var(--accent-claude);  opacity: 1; animation: needsYou 2s ease-in-out infinite; }
   #dot.claude-error   { background: #ff5577;               animation: pulse 0.8s ease-in-out infinite; }
   #dot.offline        { background: var(--fg-faint); }
 
   @keyframes pulse {
     0%, 100% { opacity: 0.35; }
     50%      { opacity: 1; }
+  }
+  /* Gentle breathing for "working" — present but not jumpy. */
+  @keyframes breathe {
+    0%, 100% { opacity: 0.55; }
+    50%      { opacity: 1; }
+  }
+  /* "needs you" — solid dot with a pulsing warm halo, more prominent than
+     working without the harsh on/off flash. */
+  @keyframes needsYou {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(255, 140, 66, 0); }
+    50%      { box-shadow: 0 0 7px 2px rgba(255, 140, 66, 0.65); }
   }
 
   /* Expanded panel — appears below the pill on hover/click.
@@ -287,8 +300,8 @@ export const ISLAND_HTML = `<!doctype html>
     background: var(--fg-faint);
     margin-right: 4px;
   }
-  #claude-list .pip.working { background: var(--accent-claude); animation: pulse 1.8s ease-in-out infinite; }
-  #claude-list .pip.waiting { background: var(--accent-claude); }
+  #claude-list .pip.working { background: var(--accent-claude); opacity: 1; animation: breathe 2.6s ease-in-out infinite; }
+  #claude-list .pip.waiting { background: var(--accent-claude); opacity: 1; animation: needsYou 2s ease-in-out infinite; }
   #claude-list .pip.error   { background: #ff5577; }
   #claude-list .pip.unknown { background: var(--fg-faint); }
 

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -318,8 +318,10 @@ export const MAIN_HTML = `<!doctype html>
     border-radius: 50%;
     background: var(--fg-faint);
   }
-  .session-row .pip.working { background: var(--claude); animation: pulse 1.8s ease-in-out infinite; }
-  .session-row .pip.waiting { background: var(--claude); }
+  /* working = calm slow breathe (running, not actionable);
+     waiting = solid + a soft halo that draws the eye ("needs you"). */
+  .session-row .pip.working { background: var(--claude); opacity: 1; animation: breathe 2.6s ease-in-out infinite; }
+  .session-row .pip.waiting { background: var(--claude); opacity: 1; animation: needsYou 2s ease-in-out infinite; }
   .session-row .pip.error   { background: var(--err-color); }
   .session-row .name {
     color: var(--fg);
@@ -342,6 +344,17 @@ export const MAIN_HTML = `<!doctype html>
   @keyframes pulse {
     0%, 100% { opacity: 0.35; }
     50%      { opacity: 1; }
+  }
+  /* Gentle breathing for "working" — present but not jumpy. */
+  @keyframes breathe {
+    0%, 100% { opacity: 0.55; }
+    50%      { opacity: 1; }
+  }
+  /* "needs you" — solid dot with a pulsing warm halo, prominent without the
+     harsh on/off flash. */
+  @keyframes needsYou {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(255, 140, 66, 0); }
+    50%      { box-shadow: 0 0 7px 2px rgba(255, 140, 66, 0.65); }
   }
 
   /* Compact SOUL / SKILLS / MEMORY / TOOLS row */


### PR DESCRIPTION
The orange `working` pips flashed hard (opacity 0.35↔1, 1.8s) — distracting with 10 active sessions. Per request (a+b):
- **working** → gentle breathe (0.55↔1, 2.6s): present but calm.
- **waiting** → solid dot + soft pulsing warm halo, so the actionable 'needs you' state stands out without the harsh flash.

Applied to both the island and the main GUI sidebar. typecheck + inline-script parse test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)