### PR TITLE
fix(mac): stamp real version into Lisa.app (was stuck at 0.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Lisa.app showed version `0.1.0`** in its About box regardless of the
+  release. `build.sh` now stamps `CFBundleShortVersionString` /
+  `CFBundleVersion` from `LISA_APP_VERSION` (set by `build-mac-apps.sh`) or the
+  repo's `package.json`, so the app version tracks the release automatically
+  (static Info.plist value is now just a fallback).
+
 ### Added — integrations
 
 - **`mcp`** — manage MCP server connections (list/add/remove ~/.lisa/mcp.json),

--- a/packaging/mac-client/Resources/Info.plist
+++ b/packaging/mac-client/Resources/Info.plist
@@ -17,9 +17,9 @@
     <key>CFBundlePackageType</key>
     <string>APPL</string>
     <key>CFBundleShortVersionString</key>
-    <string>0.1.0</string>
+    <string>0.8.0</string>
     <key>CFBundleVersion</key>
-    <string>1</string>
+    <string>0.8.0</string>
     <key>CFBundleIconFile</key>
     <string>AppIcon</string>
     <key>LSMinimumSystemVersion</key>

--- a/packaging/mac-client/build.sh
+++ b/packaging/mac-client/build.sh
@@ -98,6 +98,16 @@ mkdir -p "$APP/Contents/Resources"
 cp "$BIN" "$APP/Contents/MacOS/Lisa"
 chmod +x "$APP/Contents/MacOS/Lisa"
 cp Resources/Info.plist "$APP/Contents/Info.plist"
+# Stamp the real version into the bundle (the static plist value is only a
+# fallback). Single source of truth: LISA_APP_VERSION (set by build-mac-apps.sh)
+# else the repo's package.json — so the About box tracks the release instead of
+# being stuck at a hardcoded number.
+APP_VERSION="${LISA_APP_VERSION:-$(node -p "require('../../package.json').version" 2>/dev/null || echo "")}"
+if [ -n "$APP_VERSION" ]; then
+    /usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $APP_VERSION" "$APP/Contents/Info.plist" 2>/dev/null || true
+    /usr/libexec/PlistBuddy -c "Set :CFBundleVersion $APP_VERSION" "$APP/Contents/Info.plist" 2>/dev/null || true
+    echo "    version:  $APP_VERSION"
+fi
 cp "$ICNS" "$APP/Contents/Resources/AppIcon.icns"
 # Menu bar icon — small face crop loaded by MenuBarController. Bundled
 # at 36×36 (we set image.size to 18pt at runtime so AppKit treats it

--- a/scripts/build-mac-apps.sh
+++ b/scripts/build-mac-apps.sh
@@ -42,6 +42,9 @@ cd "$REPO_ROOT"
 
 PHASE="${1:-full}"
 VERSION="${VERSION:-$(node -p "require('./package.json').version")}"
+# Hand the resolved version to the per-app build so the .app's Info.plist
+# version matches the DMG/release version exactly.
+export LISA_APP_VERSION="$VERSION"
 OUT="${OUT:-dist-release}"
 DMG_NAME="Lisa-Suite-v${VERSION}"
 APPLE_SIGNING_IDENTITY="${APPLE_SIGNING_IDENTITY:-}"


### PR DESCRIPTION
The shipped Lisa.app reports version **0.1.0** in its About box no matter the release — `packaging/mac-client/Resources/Info.plist` hardcoded it and `build.sh` just `cp`'d it verbatim. (Confirmed on the v0.8.0 DMG.)

### Fix
`build.sh` now stamps the bundle version after copying the plist:
- Source of truth: **`LISA_APP_VERSION`** (now exported by `build-mac-apps.sh` from the resolved release version) → falls back to the repo's **`package.json`** version.
- Sets both `CFBundleShortVersionString` and `CFBundleVersion` via `PlistBuddy`.
- Static `Info.plist` value bumped `0.1.0` → `0.8.0` as a fallback for a bare `build.sh` run where neither source is available.

So the app version tracks each release automatically — no more manual plist bumps, no more drift.

### Verified locally
- `bash build.sh` → `CFBundleShortVersionString = 0.8.0` (from package.json).
- `LISA_APP_VERSION=9.9.9 bash build.sh` → `9.9.9` (override honored).

Build/packaging-only change — no TS, no runtime, no tests affected. The next signed DMG (v0.9.0) will carry the correct version; the published v0.8.0 DMG is unaffected (already out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)