### PR TITLE
feat(mac): auto-start backend + Start-backend in every offline surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ versioning follows [SemVer](https://semver.org/).
 
 ## [Unreleased]
 
+### Added — Mac app backend lifecycle
+
+- **Auto-start the backend on launch.** Lisa.app now probes `localhost:5757` at
+  startup and, if nothing answers, launches `lisa serve --web` (login shell,
+  detached) so opening the app just works without a separate terminal.
+- **"Start backend" fallback in every offline surface** — the menu-bar popover,
+  the main-window offline splash (prominent button), and the island offline pill
+  (restyled "sleeping" pill, click to start). All recover automatically once the
+  backend is up. Start command resolves `~/.lisa/serve-command.txt` (override for
+  running from source) then `lisa serve --web`.
+
 ### Added — integrations
 
 - **`mcp`** — manage MCP server connections (list/add/remove ~/.lisa/mcp.json),

--- a/packaging/mac-client/Sources/Lisa/AppDelegate.swift
+++ b/packaging/mac-client/Sources/Lisa/AppDelegate.swift
@@ -19,6 +19,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var mainWindow: MainWindow?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        // Auto-start the local backend if it isn't already up, so opening the
+        // app "just works" without a separate `lisa serve --web` in a terminal.
+        BackendController.shared.ensureRunning()
+
         installMenu()
         showMainWindow()
 

--- a/packaging/mac-client/Sources/Lisa/BackendController.swift
+++ b/packaging/mac-client/Sources/Lisa/BackendController.swift
@@ -1,0 +1,122 @@
+//
+//  BackendController.swift
+//  Lisa
+//
+//  Owns the lifecycle of the local LISA backend (`lisa serve --web`) from the
+//  Mac app's side:
+//    • on launch, if the backend isn't already up, start it (auto-start);
+//    • a manual start() the offline UIs (menu-bar popover, main window splash,
+//      island pill) call as a fallback.
+//
+//  Start command resolution:
+//    1. ~/.lisa/serve-command.txt — a full command line, if present (escape
+//       hatch for running from source, e.g. "node /path/dist/cli.js serve --web").
+//    2. otherwise `lisa serve --web` — resolved on the login shell's PATH
+//       (covers `npm i -g @oratis/lisa` / Homebrew installs).
+//
+//  It's launched via a login shell with nohup + disown so it fully detaches and
+//  outlives both this launcher process and the app itself (the backend is a
+//  service the island / heartbeat / other clients also use).
+//
+
+import AppKit
+import Foundation
+
+@MainActor
+final class BackendController {
+    static let shared = BackendController()
+    private init() {}
+
+    /// Posted (userInfo: ["up": Bool, "note": String?]) when a start attempt
+    /// resolves, so the offline UIs can update.
+    static let statusChanged = Notification.Name("ai.meetlisa.backendStatusChanged")
+
+    private let probeURL = URL(string: "http://localhost:5757/")!
+    private(set) var isStarting = false
+
+    // MARK: - Launch auto-start
+
+    /// If the backend isn't already responding, start it.
+    func ensureRunning() {
+        probe { [weak self] up in
+            guard let self else { return }
+            if up { self.post(up: true) } else { self.start() }
+        }
+    }
+
+    // MARK: - Probe
+
+    func probe(_ completion: @escaping (Bool) -> Void) {
+        var req = URLRequest(url: probeURL, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 2)
+        req.httpMethod = "HEAD"
+        URLSession.shared.dataTask(with: req) { _, resp, _ in
+            let up = (resp as? HTTPURLResponse) != nil
+            DispatchQueue.main.async { completion(up) }
+        }.resume()
+    }
+
+    // MARK: - Start
+
+    /// Spawn the backend (detached) and poll until it answers. No-op while a
+    /// start is already in flight.
+    func start() {
+        guard !isStarting else { return }
+        isStarting = true
+
+        let command = resolveCommand()
+        let logPath = lisaPath("backend.log")
+        try? FileManager.default.createDirectory(
+            atPath: (logPath as NSString).deletingLastPathComponent,
+            withIntermediateDirectories: true)
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        // -l: login shell (PATH has npm-global / Homebrew). nohup + & + disown:
+        // fully detach so the backend survives this shell, the launcher, and the app.
+        proc.arguments = ["-lc", "nohup \(command) >> '\(logPath)' 2>&1 & disown"]
+        do {
+            try proc.run()
+        } catch {
+            isStarting = false
+            post(up: false, note: "spawn failed: \(error.localizedDescription)")
+            return
+        }
+        pollUntilUp(attempts: 25)
+    }
+
+    private func pollUntilUp(attempts: Int) {
+        guard attempts > 0 else {
+            isStarting = false
+            post(up: false, note: "timeout")
+            return
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+            self?.probe { up in
+                guard let self else { return }
+                if up { self.isStarting = false; self.post(up: true) }
+                else { self.pollUntilUp(attempts: attempts - 1) }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func resolveCommand() -> String {
+        let override = lisaPath("serve-command.txt")
+        if let txt = try? String(contentsOfFile: override, encoding: .utf8) {
+            let t = txt.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !t.isEmpty { return t }
+        }
+        return "lisa serve --web"
+    }
+
+    private func lisaPath(_ name: String) -> String {
+        (NSHomeDirectory() as NSString).appendingPathComponent(".lisa/\(name)")
+    }
+
+    private func post(up: Bool, note: String? = nil) {
+        var info: [String: Any] = ["up": up]
+        if let note { info["note"] = note }
+        NotificationCenter.default.post(name: BackendController.statusChanged, object: nil, userInfo: info)
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
@@ -100,37 +100,51 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
     /// understand at a glance that the app's alive but the backend isn't.
     /// Replaced atomically the next time the real page loads.
     private func loadOfflineSplash() {
+        // baseURL is nil here, so no relative image loads — we draw a tidy
+        // "sleeping" pill (moon glyph) instead of a broken avatar. The whole
+        // pill is clickable: tap → ask Swift to start the backend.
         let html = """
-        <!doctype html><html><head><meta charset=\"utf-8\"><style>
+        <!doctype html><html><head><meta charset="utf-8"><style>
           html, body { margin: 0; padding: 0; background: transparent;
-            font-family: -apple-system, BlinkMacSystemFont, \"SF Pro Text\", system-ui, sans-serif;
-            color: #e4e4e6; -webkit-font-smoothing: antialiased; user-select: none; }
-          body { display: flex; flex-direction: column; align-items: center;
-                 padding: 4px 8px; }
-          .pill { display: inline-flex; align-items: center; gap: 8px;
-            background: rgba(8, 12, 24, 0.92);
-            border: 1px solid rgba(255, 255, 255, 0.06);
-            border-radius: 22px; padding: 5px 14px 5px 5px;
-            backdrop-filter: blur(20px);
-            box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4); }
-          /* No avatar image — baseURL is nil on the offline splash, so
-             relative URLs don't resolve. A muted circle with a "Z" mark
-             ("she's sleeping") communicates offline without a broken icon. */
+            font-family: -apple-system, BlinkMacSystemFont, "SF Pro Text", system-ui, sans-serif;
+            color: #e6e8ee; -webkit-font-smoothing: antialiased; user-select: none; cursor: default; }
+          body { display: flex; flex-direction: column; align-items: center; padding: 4px 8px; }
+          .pill { display: inline-flex; align-items: center; gap: 9px;
+            background: linear-gradient(180deg, rgba(28,35,56,0.94) 0%, rgba(10,14,28,0.94) 100%);
+            border: 1px solid rgba(255,255,255,0.08); border-radius: 22px;
+            padding: 5px 14px 5px 5px;
+            backdrop-filter: blur(20px) saturate(1.4);
+            box-shadow: 0 8px 24px rgba(0,0,0,0.45), 0 1px 0 rgba(255,255,255,0.12) inset;
+            cursor: pointer;
+            transition: transform 250ms cubic-bezier(.22,1,.36,1), box-shadow 250ms ease; }
+          .pill:hover { transform: translateY(-1px) scale(1.015);
+            box-shadow: 0 14px 32px rgba(0,0,0,0.5), 0 1px 0 rgba(255,255,255,0.16) inset; }
+          .pill:active { transform: scale(0.99); }
           .av { width: 36px; height: 36px; border-radius: 50%;
-                background: #15192a; opacity: 0.55;
-                border: 1px solid rgba(255, 255, 255, 0.10);
-                display: grid; place-items: center;
-                color: #6b7280; font-size: 16px; font-weight: 700; }
-          .label { font-size: 13px; font-weight: 600; color: #9ba3b8;
-                   letter-spacing: 0.02em; }
-          .dot { width: 7px; height: 7px; border-radius: 50%;
-                 background: #6b7280; flex-shrink: 0; }
+            background: radial-gradient(circle at 50% 38%, #22304a 0%, #141a2c 100%);
+            border: 1px solid rgba(255,255,255,0.10);
+            display: grid; place-items: center; color: #7f8bb0; font-size: 18px; }
+          .txt { display: flex; flex-direction: column; line-height: 1.15; }
+          .label { font-size: 13px; font-weight: 600; color: #c3c9e0; letter-spacing: 0.02em; }
+          .hint { font-size: 10px; color: #7f8bb0; }
+          .dot { width: 7px; height: 7px; border-radius: 50%; background: #6b7280; flex-shrink: 0; margin-left: 2px; }
+          body.starting .dot { background: #6ad4ff; animation: pulse 1.2s ease-in-out infinite; }
+          body.starting .av  { color: #6ad4ff; }
+          @keyframes pulse { 0%,100% { opacity: 0.35; } 50% { opacity: 1; } }
         </style></head><body>
-          <div class=\"pill\" title=\"LISA backend offline — start: lisa serve --web\">
-            <div class=\"av\">z</div>
-            <div class=\"label\">offline</div>
-            <div class=\"dot\"></div>
+          <div class="pill" onclick="wake()" title="Lisa backend offline — click to start">
+            <div class="av">☾</div>
+            <div class="txt"><div class="label" id="lbl">offline</div><div class="hint" id="hint">click to start</div></div>
+            <div class="dot"></div>
           </div>
+          <script>
+            function wake() {
+              document.body.classList.add('starting');
+              document.getElementById('lbl').textContent = 'starting…';
+              document.getElementById('hint').textContent = 'waking Lisa up';
+              try { window.webkit.messageHandlers.island.postMessage({ type: 'start_backend' }); } catch (e) {}
+            }
+          </script>
         </body></html>
         """
         webView.loadHTMLString(html, baseURL: nil)
@@ -154,6 +168,10 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
         guard let body = message.body as? [String: Any] else { return }
         guard let type = body["type"] as? String else { return }
         switch type {
+        case "start_backend":
+            // Offline pill tapped — start the local backend. The island's own
+            // 4s retry loop reloads /island once it's up.
+            Task { @MainActor in BackendController.shared.start() }
         case "open_full_gui":
             // Bring the in-process chat window forward. An optional `prefill`
             // (from the screen-advisor "Optimize ▸" card) is carried along so

--- a/packaging/mac-client/Sources/Lisa/MenuBarController.swift
+++ b/packaging/mac-client/Sources/Lisa/MenuBarController.swift
@@ -65,6 +65,9 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
             applyIcon(button: button, offline: false)
         }
         statusItem = item
+        NotificationCenter.default.addObserver(
+            self, selector: #selector(backendStatusChanged),
+            name: BackendController.statusChanged, object: nil)
         start()
     }
 
@@ -271,8 +274,23 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         stack.addArrangedSubview(headerView(inner: inner))
 
         if offline {
-            stack.addArrangedSubview(wrappedLabel("Backend not running — start it:  lisa serve --web",
-                                                  size: 12, color: .secondaryLabelColor, width: inner))
+            let v = NSStackView()
+            v.orientation = .vertical
+            v.alignment = .leading
+            v.spacing = 9
+            v.translatesAutoresizingMaskIntoConstraints = false
+            let starting = BackendController.shared.isStarting
+            v.addArrangedSubview(wrappedLabel(
+                starting ? "Starting the Lisa backend…" : "The Lisa backend isn't running.",
+                size: 12, color: .secondaryLabelColor, width: inner))
+            let start = NSButton(title: starting ? "Starting…" : "Start Lisa backend",
+                                 target: self, action: #selector(startBackend))
+            start.bezelStyle = .rounded
+            start.keyEquivalent = "\r"
+            start.isEnabled = !starting
+            v.addArrangedSubview(start)
+            v.widthAnchor.constraint(equalToConstant: inner).isActive = true
+            stack.addArrangedSubview(v)
         } else {
             if let d = ping?.current_desire, !d.isEmpty {
                 stack.addArrangedSubview(sectionView(title: "CURRENTLY WANTING", body: oneLine(d, 160), inner: inner))
@@ -440,6 +458,26 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     @objc private func openWindow() {
         bringToFront?()
         popover?.close()
+    }
+
+    @objc private func startBackend() {
+        BackendController.shared.start()
+        // Rebuild so the button flips to "Starting…" immediately.
+        if let p = popover, p.isShown {
+            let vc = makePopoverContent()
+            p.contentViewController = vc
+            p.contentSize = vc.view.fittingSize
+        }
+    }
+
+    @objc private func backendStatusChanged() {
+        // Re-poll + rebuild the popover when a start attempt resolves.
+        Task { @MainActor in await refreshOnce() }
+        if let p = popover, p.isShown {
+            let vc = makePopoverContent()
+            p.contentViewController = vc
+            p.contentSize = vc.view.fittingSize
+        }
     }
 
     @objc private func refreshFromPopover() {

--- a/packaging/mac-client/Sources/Lisa/WebContent.swift
+++ b/packaging/mac-client/Sources/Lisa/WebContent.swift
@@ -42,7 +42,7 @@ final class DragHandleView: NSView {
     }
 }
 
-final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
+final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WKScriptMessageHandler {
     static let lisaURL = URL(string: "http://localhost:5757/")!
     static let titlebarHeight: CGFloat = 36
 
@@ -56,6 +56,9 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
         let preferences = WKWebpagePreferences()
         preferences.allowsContentJavaScript = true
         config.defaultWebpagePreferences = preferences
+
+        // Bridge so the offline splash's "Start backend" button can reach Swift.
+        config.userContentController.add(self, name: "lisa")
 
         let wv = WKWebView(frame: .zero, configuration: config)
         wv.navigationDelegate = self
@@ -102,6 +105,7 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
         webView = wv
         view = container
 
+        observeBackend()
         load()
     }
 
@@ -175,6 +179,26 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
         }
     }
 
+    // MARK: - WKScriptMessageHandler (offline splash → Swift)
+
+    func userContentController(_ uc: WKUserContentController, didReceive message: WKScriptMessage) {
+        guard let body = message.body as? [String: Any],
+              let type = body["type"] as? String else { return }
+        if type == "start_backend" {
+            BackendController.shared.start()
+        }
+    }
+
+    /// Reload the chat as soon as the backend reports up (snappier than waiting
+    /// for the 4s retry). Call once from loadView.
+    private func observeBackend() {
+        NotificationCenter.default.addObserver(
+            forName: BackendController.statusChanged, object: nil, queue: .main
+        ) { [weak self] note in
+            if (note.userInfo?["up"] as? Bool) == true { self?.load() }
+        }
+    }
+
     /// Show a styled "backend not running" placeholder inside the WebView
     /// when localhost:5757 isn't reachable. Visually consistent with the
     /// real chat UI's dark theme; replaced atomically when the next
@@ -233,6 +257,9 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
                    transition: transform 120ms ease, box-shadow 120ms ease; }
           button:hover { transform: translateY(-1px);
                          box-shadow: 0 6px 18px rgba(106, 212, 255, 0.35); }
+          button.ghost { background: rgba(255,255,255,0.06); color: #cdd3f0;
+                         box-shadow: none; border: 1px solid rgba(255,255,255,0.16); }
+          button:disabled { opacity: 0.6; cursor: default; transform: none; }
           .err { margin-top: 18px; padding: 10px 12px; border-radius: 8px;
                  background: rgba(255, 85, 119, 0.08); color: #ff95a8;
                  border: 1px solid rgba(255, 85, 119, 0.30);
@@ -243,22 +270,24 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate {
           <h1>LISA backend offline</h1>
           <p class=\"sub\">
             Lisa.app loads its chat from <code>http://localhost:5757</code> — but
-            that server isn't responding right now. Start it in a terminal:
+            that server isn't responding right now.
           </p>
 
-          <h2>1. Install (one-time)</h2>
-          <pre>npm install -g @oratis/lisa</pre>
-
-          <h2>2. Configure a provider key (one-time)</h2>
-          <pre>mkdir -p ~/.lisa
-        echo 'ANTHROPIC_API_KEY=sk-ant-...' &gt; ~/.lisa/config.env</pre>
-
-          <h2>3. Start the backend</h2>
-          <pre>lisa serve --web</pre>
-
           <div class=\"row\">
-            <button onclick=\"location.assign('http://localhost:5757/')\">Retry now</button>
+            <button id=\"startBtn\" onclick=\"startBackend()\">▶&nbsp;&nbsp;Start Lisa backend</button>
+            <button class=\"ghost\" onclick=\"location.assign('http://localhost:5757/')\">Retry</button>
           </div>
+          <script>
+            function startBackend() {
+              var b = document.getElementById('startBtn');
+              if (b) { b.textContent = 'Starting…'; b.disabled = true; }
+              try { window.webkit.messageHandlers.lisa.postMessage({ type: 'start_backend' }); } catch (e) {}
+            }
+          </script>
+
+          <h2>Or start it manually</h2>
+          <pre>npm install -g @oratis/lisa     # one-time
+        lisa serve --web                # start the backend</pre>
 
           <div class=\"err\">Last error: \(escaped)</div>
           <p class=\"hint\">


### PR DESCRIPTION
Opening Lisa.app no longer needs a separate `lisa serve --web`.

- **Auto-start**: `BackendController` probes `localhost:5757` at launch; if down, starts the backend (login shell + nohup/disown so it detaches and outlives the app). Command resolves `~/.lisa/serve-command.txt` (run-from-source override) then `lisa serve --web`.
- **Start-backend fallback in all three offline surfaces**, auto-recovering when up:
  - menu-bar popover — a Start button (observes status changes);
  - main-window offline splash — a prominent Start button (new JS→Swift bridge + reload-on-up);
  - island offline pill — restyled "sleeping" pill (moon glyph, hover lift), click to start.

Compiles; needs a visual/functional check in the running app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)