### PR TITLE
chore(website): reproducible Cloud Run deploy script + Dockerfile

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -29,12 +29,28 @@ npm run dev
 
 ## Deployment
 
-**Local-only for now** (per `docs/PRODUCTIZATION_PLAN.md`). When ready to go public:
+**Live at [meetlisa.ai](https://meetlisa.ai).** Hosting + routing:
 
-1. Buy a domain (`meetlisa.ai` decided in PRODUCTIZATION_PLAN.md).
-2. Point Cloudflare Pages at this `website/` directory with build command `npm run build` and output `dist/`.
-3. Set DNS: `CNAME @ <project>.pages.dev`.
-4. Update `astro.config.mjs` `site` if changed.
+- **Origin**: GCP **Cloud Run** service `lisa-web` (`oratis-491316` / `us-central1`),
+  built from this `website/` via [`deploy/Dockerfile`](deploy/Dockerfile)
+  (static build → `serve` on `$PORT`).
+- **Edge**: `meetlisa.ai` is on **Cloudflare (Free)**. The Free plan can't
+  rewrite origin Host/SNI (Origin Rules' Host Header + SNI overrides are
+  Enterprise-only), which Cloud Run requires — so a tiny **Cloudflare Worker**
+  (`meetlisa-proxy`, routes `meetlisa.ai/*` + `www/*`) reverse-proxies to the
+  `run.app` origin, where `fetch()` makes Host + SNI correct automatically.
+
+### Deploy
+
+```sh
+website/deploy/deploy.sh --canary   # build a no-traffic 'canary' revision to verify
+website/deploy/deploy.sh            # build + promote to 100% traffic
+```
+
+The script stages a self-contained build context (this `website/` + the
+repo-root `scripts/lisa-moods.ts` and `src/web/assets/` that `prebuild` needs)
+so the asset symlink resolves inside the image. Env overrides: `PROJECT`,
+`REGION`, `SERVICE`.
 
 ## Editing
 

--- a/website/deploy/Dockerfile
+++ b/website/deploy/Dockerfile
@@ -1,0 +1,23 @@
+# Deterministic deploy image for the Lisa website on Cloud Run.
+#
+# The build CONTEXT must contain website/ plus the two repo-root paths that
+# website/scripts/prebuild.mjs needs (it reads ../scripts/lisa-moods.ts and
+# symlinks ../src/web/assets → public/assets). deploy.sh assembles exactly that
+# minimal context, so `COPY . .` here stays small.
+#
+# Astro 6 requires Node >= 22.
+FROM node:22-slim AS build
+WORKDIR /app
+COPY . .
+WORKDIR /app/website
+RUN npm ci || npm install
+RUN npm run build           # prebuild (moods.json + assets symlink) then astro build
+# dist/ is now fully self-contained (assets materialized from the symlink).
+
+FROM node:22-slim
+WORKDIR /app
+RUN npm install -g serve@14
+COPY --from=build /app/website/dist ./dist
+ENV PORT=8080
+# serve resolves clean URLs (/install → /install/index.html) and binds 0.0.0.0.
+CMD ["sh","-c","serve -l ${PORT} dist"]

--- a/website/deploy/deploy.sh
+++ b/website/deploy/deploy.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Deterministic deploy of the Lisa website (meetlisa.ai) to Cloud Run.
+#
+# Why a staging dir: prebuild reads repo-root paths (../scripts, ../src/web/assets),
+# so a plain `gcloud run deploy --source website` would dangle the asset symlink.
+# We assemble a minimal self-contained context (website + those two paths + the
+# Dockerfile) and deploy that.
+#
+# Usage:
+#   website/deploy/deploy.sh             # build + promote to 100% traffic
+#   website/deploy/deploy.sh --canary    # build a --no-traffic 'canary' revision to verify first
+# Env overrides: PROJECT, REGION, SERVICE.
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+PROJECT="${PROJECT:-oratis-491316}"; REGION="${REGION:-us-central1}"; SERVICE="${SERVICE:-lisa-web}"
+
+STAGE="$(mktemp -d)/lisa-web"
+mkdir -p "$STAGE/website" "$STAGE/scripts" "$STAGE/src/web"
+rsync -a --exclude node_modules --exclude dist --exclude .astro --exclude 'public/assets' "$REPO/website/" "$STAGE/website/"
+cp "$REPO/scripts/lisa-moods.ts" "$STAGE/scripts/"
+rsync -aL "$REPO/src/web/assets/" "$STAGE/src/web/assets/"   # -L dereferences → real files
+cp "$HERE/Dockerfile" "$STAGE/Dockerfile"
+
+ARGS=(run deploy "$SERVICE" --source "$STAGE" --project "$PROJECT" --region "$REGION" --quiet)
+if [ "${1:-}" = "--canary" ]; then ARGS+=(--no-traffic --tag canary); fi
+echo "→ deploying $SERVICE to $PROJECT/$REGION ${1:-(promote 100%)}"
+gcloud "${ARGS[@]}"
+rm -rf "$(dirname "$STAGE")"


### PR DESCRIPTION
Captures the exact path that's serving **meetlisa.ai** today as a one-command, repeatable deploy — so future deploys aren't a throwaway `/tmp` artifact.

- **`website/deploy/deploy.sh`** — stages a self-contained build context (this `website/` + the repo-root `scripts/lisa-moods.ts` and `src/web/assets/` that `prebuild` needs, with the asset symlink dereferenced via `rsync -L`) and runs `gcloud run deploy --source`. `--canary` builds a `--no-traffic` revision to verify before promoting; env overrides `PROJECT`/`REGION`/`SERVICE`.
- **`website/deploy/Dockerfile`** — node:22 (Astro 6 needs ≥22) → `npm run build` → `serve` the static `dist/` on `$PORT`.
- **README** Deployment section rewritten to the real architecture: Cloud Run origin + a **Cloudflare Worker** reverse-proxy (Free plan can't override origin Host/SNI, so the orange-proxy + Origin Rule approach isn't possible — the Worker fetches `run.app` so Host/SNI are correct).

Ops-only; no app/runtime/test changes. `bash -n` clean. This is exactly the flow already verified live (canary → promote, twice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)