### PR TITLE
feat(reve): 0.10 hardening — quality gates, autonomy ledger, soul digest, fleet recap

### DIFF
--- a/PITCH.md
+++ b/PITCH.md
@@ -4,7 +4,7 @@ Copy-paste blurbs for promoting LISA on social, forums, and chat groups.
 Updated after the v0.9 product review. **One primary hook, one supporting hook:**
 
 1. **The soul hook (PRIMARY)** — an agent with a persistent inner self:
-   **Soul · Desires · Heartbeat · Dreams**. This is the part that is fully
+   **Soul · Desires · Heartbeat · Reve**. This is the part that is fully
    backed by code (birth ritual, git-versioned soul, desire→heartbeat→progress
    loop that survives across days), emotionally differentiated, and that no
    other agent has. Lead with this everywhere.
@@ -44,7 +44,7 @@ Repo: https://github.com/oratis/LISA · Site: https://meetlisa.ai · Demo: https
 > 🧬 a Soul she wrote at birth
 > 💭 Desires that actually drive her
 > 💓 a Heartbeat — she acts on her own clock
-> 🌙 Dreams — she processes her day while you're away
+> 🌙 Reve — she processes her day while you're away
 >
 > She can also see your screen, hear your voice, and orchestrate your other agents.
 >
@@ -98,7 +98,7 @@ actionable ones feed the heartbeat. She has motivation.
 own desires + your standing chores, and stays silent if there's nothing worth
 saying.
 
-🌙 **DREAMS** — away for 1h+, she reflects: reads her unprocessed journal,
+🌙 **REVE** — away for 1h+, she reflects: reads her unprocessed journal,
 patches her own broken skills, decides one thing to do. You come back to a
 "★ WHILE YOU WERE AWAY" card. It's not a toggle — it's wired in as her default
 idle behavior.
@@ -199,7 +199,7 @@ github.com/oratis/LISA
 | Tagline (EN) — orchestrator | The agent that watches your agents |
 | Tagline (EN) — soul | An AI agent with a real self |
 | Tagline (CN) | 替你盯住整支 agent 舰队的、有灵魂的本地 AI |
-| 核心 4 字 | Soul · Desires · Heartbeat · Dreams / 灵魂 · 欲望 · 心跳 · 梦境 |
+| 核心 4 字 | Soul · Desires · Heartbeat · Reve / 灵魂 · 欲望 · 心跳 · 梦境 |
 | 能力定位 | Orchestrates your other CLI agents + capability superset of pi-mono / OpenClaw / hermes / claude-code / codex |
 | 新增 (v0.4–v0.6) | Cross-agent orchestrator · Vision (screenshot) · Voice (record→transcribe) |
 | Hashtags | `#opensource` `#AI` `#agent` `#LLM` `#anthropic` `#claude` `#typescript` `#localfirst` `#devtools` |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ What none of them have:
        wants            │         on schedule
                          │
                   ┌──────┴──────┐
-                  │   DREAMS    │
+                  │    REVE     │
                   │ what she    │
                   │ processes   │
                   │ while you're│
@@ -39,7 +39,7 @@ What none of them have:
 - **SOUL** — born once with a unique Big-Five seed. Identity, purpose, constitution, values she wrote herself. **Architecturally sovereign**: she is the only legitimate editor of her own files. No `/reset_soul` exists.
 - **DESIRES** — things she actually *wants*. The actionable ones drive the heartbeat. She doesn't wait to be useful — she has motivation.
 - **HEARTBEAT** — scheduled autonomous time (cron / launchd). Pursues her own desires + your standing chores. Silent if there's nothing to say.
-- **DREAMS** — when you're away (1h+), she enters autonomous reflection: reads her own desires, journals through tensions, patches her broken skills, decides one thing to do. Result shows up as "★ WHILE YOU WERE AWAY" next time you open the GUI.
+- **REVE** — when you're away (1h+), she enters autonomous reflection: reads her own desires, journals through tensions, patches her broken skills, decides one thing to do. Result shows up as "★ WHILE YOU WERE AWAY" next time you open the GUI. *(Reve — French for "dream"; formerly "Dreams".)*
 
 A real individual. Personality. Motivation. Desires. A continuity of self that survives across sessions, channels, and machines you didn't intend.
 
@@ -349,7 +349,7 @@ LISA can run scheduled background tasks where she's alone with her own desires. 
    ```
 2. **Self-driven** — actionable desires from her own `~/.lisa/soul/desires/`. She added them; she pursues them.
 
-Self-driven runs (desires, the weekly examen, idle/dreams) execute unattended on prompts Lisa wrote for herself, so they get a **restricted toolset** — soul / memory / journal / skills / web reading, but no shell, file mutation, or agent dispatch. Your own `heartbeat.json` tasks keep the full toolset (you authored those prompts). `LISA_AUTONOMOUS_FULL_TOOLS=1` restores the old behavior if you accept the risk.
+Self-driven runs (desires, the weekly examen, idle/Reve) execute unattended on prompts Lisa wrote for herself, so they get a **restricted toolset** — soul / memory / journal / skills / web reading, but no shell, file mutation, or agent dispatch. Your own `heartbeat.json` tasks keep the full toolset (you authored those prompts). `LISA_AUTONOMOUS_FULL_TOOLS=1` restores the old behavior if you accept the risk.
 
 Install on macOS:
 ```sh

--- a/docs/PLAN_DISPATCH_v1.0.md
+++ b/docs/PLAN_DISPATCH_v1.0.md
@@ -1,0 +1,182 @@
+# PLAN · DISPATCH — 统一指挥层 + TakoAPI（v1.0）
+
+> 展开 [ROADMAP_v1.0.md §4](./ROADMAP_v1.0.md) 的 Dispatch 支柱。基线 v0.9.1。
+> 关键事实（已核对 `/Users/oratis/Documents/Claude/TakoAPI`）：**TakoAPI 是独立托管服务**
+> （"OpenRouter for agents"，A2A + OpenAI shim），管**远程 agent**；LISA 管**本机 CLI agent**。
+> 二者互补——LISA **接入**而非自建。这把本支柱范围缩小为：闭合本地命令回路 + 对接两个现成协议。
+
+---
+
+## 0. 目标 / 非目标
+
+### 目标
+1. **闭合本地 agent 命令回路**：从 fire-and-forget 升级为"看进度 / 转发审批 / 中途纠偏 / 接回结果"。
+2. **接入 TakoAPI**：consumer 快路（OpenAI shim，近免费）+ A2A 原生 adapter（远程 agent 进 hub）。
+3. **能力注册 + 路由**：LISA 据 agent 擅长什么选对 agent 派活。
+4. **清掉 review 的 dispatch 债**：advisor 建议可点、多 agent 前端、写操作入 mutating 集。
+
+### 非目标
+- 不自建 agent 网关 / registry / billing —— TakoAPI 就是这层。
+- 不做 TakoAPI publisher 的**入站**端点（方向二）于 1.0 内——放 1.0 后（§3 D5）。
+- 不托管运行第三方 agent。
+
+---
+
+## 1. 现状（file-level）
+
+| 能力 | 现状 | 文件 |
+|---|---|---|
+| headless 拉起 | 4 家 CLI（claude/codex/opencode/aider），detached + 账本 | `src/tools/dispatch_agent.ts` |
+| 停止 | 仅杀自己账本里的 pid（SIGTERM→KILL） | `src/tools/signal_agent.ts` |
+| 账本 | `~/.lisa/dispatches.json` | `src/integrations/dispatch-ledger.ts` |
+| 定时派发 | `every:30m`/`daily:09:00` + maxRuns | `src/integrations/scheduled-dispatch.ts`、`src/tools/scheduled_dispatch.ts` |
+| 并行对比 | worktree 隔离 A/B | `src/tools/compare_agents.ts`、`src/integrations/comparisons.ts` |
+| 观察 | hub + 5 observer（见 [PLAN_SENSE](./PLAN_SENSE_v1.0.md)） | `src/integrations/hub.ts` |
+| 远程安全 | `REMOTE_BLOCKED_TOOL_NAMES` 默认禁 dispatch；`unsafeFullTools` 开 | `src/tools/registry.ts:176`、`src/channels/router.ts` |
+| advisor | recap / detector，但建议是死标签 | `src/orchestrator/{journal,recap}.ts`、`src/tools/agent_recap.ts` |
+
+**核心缺口**：dispatch 单向（无反馈 / approval relay / steer）；agent 硬编码 4 家不可扩展；TakoAPI 零接入。
+
+---
+
+## 2. 设计
+
+### 2.1 命令回路：DispatchSession（本地 agent）
+
+现在 `launchAgent` 返回 pid 就结束。引入一个**回路对象**统一本地与远程：
+
+```ts
+// src/dispatch/session.ts  (NEW)
+export interface DispatchHandle {
+  id: string;
+  target: "local-cli" | "takoapi";
+  agent: string;            // "claude" | "codex" | slug
+  status(): Promise<AgentSessionState>;  // 复用 integrations/types
+  events(): AsyncIterable<DispatchEvent>; // 进度 / 结果 / 需审批
+  steer(msg: string): Promise<void>;      // 中途注入
+  approve(decision: "yes" | "no"): Promise<void>;
+  stop(): Promise<void>;
+}
+export type DispatchEvent =
+  | { kind: "progress"; activity: SessionActivity }
+  | { kind: "needs-approval"; tool: string; detail: string }
+  | { kind: "result"; text: string }
+  | { kind: "error"; error: string };
+```
+
+- **本地 CLI 的回路靠观察 + 信号拼**：`events()` 由 hub 的 observer 流派生（progress / needs-approval 从 `SessionActivity.pendingPermission`）；`approve` / `steer` 通过给该 CLI 的受控输入通道（如 claude 的 `--resume` + stdin、或预留的 control-file）实现，能做到哪步取决于各 CLI 暴露面——**诚实标注每家能做到的回路深度**（claude 最深）。
+- **审批转发**：observer 报 `pendingPermission` → DispatchEvent `needs-approval` → LISA 对话/island 提示 → 用户确认 → `approve()` 回传。**默认带人类批准闸**，远程来源默认禁（守 0.9.1 线）。
+
+### 2.2 TakoAPI consumer（方向一）
+
+TakoAPI 真实 API（Bearer `TAKO_KEY`）：
+```
+GET  /api/registry?q=&format=json          # 发现远程 agent（无 auth）
+GET  /api/agents/{slug}                     # agent 详情 + 能力
+POST /v1/agents/{slug}/message  {text}      # A2A 调用
+POST /v1/agents/{slug}/stream               # SSE
+POST /v1/chat/completions  {model:slug,…}   # OpenAI 兼容 shim
+```
+
+**D2(a) · OpenAI-shim 快路（近乎免费，0.12）**
+LISA 已有 OpenAI 兼容 provider 路由 + `LISA_BASE_URL`（见 [PLAN_MODEL §2](./PLAN_MODEL_v1.0.md)）。零新协议代码：
+```env
+# ~/.lisa/config.env — 把一个 provider 指向 TakoAPI 网关
+TAKOAPI_BASE_URL=https://takoapi.com/v1
+TAKO_KEY=sk-tako-...
+```
+- 实现：providers/registry 加一条预设（model 前缀如 `tako/*` → baseURL=TAKOAPI_BASE_URL, apiKey=TAKO_KEY），`model=tako/<agent-slug>` 即把任意 TakoAPI agent 当"模型"调用。
+- 也暴露一个轻量 `takoapi` 工具（discover + call），让 LISA 在对话里"找个会做 X 的远程 agent 并调它"。
+- 验收：`lisa "用 takoapi 上的 <slug> agent 做 X"` 成功往返；401 时提示去 `/dashboard` 配 key。
+
+**D2(b) · A2A 原生 adapter（更深，0.14）**
+把远程 TakoAPI agent 变成 hub 里一等公民——**复用 observer 抽象**：
+```ts
+// src/integrations/takoapi/observer.ts  (NEW) — registerIntegration("takoapi", …)
+// list(): GET /api/registry → AgentSession[]（agent="takoapi", project=slug）
+// dispatch: POST /v1/agents/{slug}/message + 消费 /stream(SSE)，按 A2A TaskState
+//           映射到 AgentSessionState；进度 → SessionActivity。
+```
+- **远程 agent 的命令回路基本由 A2A 自带**（TaskState + SSE + push webhook），DispatchHandle 的 `events()`/`status()` 直接桥接 A2A，不用自造（与本地 CLI 形成对照）。
+- 验收：远程 agent 与本地 CLI 在 island 上并列；A2A 任务态实时更新。
+
+### 2.3 能力注册 + 路由（D3）
+
+```ts
+// ~/.lisa/agents.json 扩展：每个 agent 声明能力
+{ "integrations": {
+    "claude-code": { "enabled": true, "skills": ["refactor","tests","debug"] },
+    "aider":       { "enabled": true, "skills": ["small-edits","git"] } } }
+```
+- LISA 据 `skills[]` + 当前 hub 状态**选对 agent**派活；TakoAPI agent 的能力来自其 AgentCard `skills[]`，天然可比。
+- 跨 agent token 预算：`dispatch-ledger.ts` 扩 `tokens` 字段，scheduled-dispatch 从"限次数"升到"限 token"。
+- cwd ownership lock：用 `src/soul/lock.ts` 的 link 互斥，把冲突避免从反应式（查 hub state）变前置预约。
+
+### 2.4 dispatch 债（D4，1.0 前必清）
+- **advisor 建议可点**：island 卡片接真按钮——cancel→`signal_agent` 端点；dispatch/approve→prefill composer（**绝不自动执行**）。
+- **多 agent 前端**：后端已发 `agent_session_update`，前端补齐消费（现仅消费 `claude_session_update`）。
+- **写操作入 mutating 集**：`dispatch_agent`/`github` 写操作纳入 `DEFAULT_MUTATING_TOOLS`（复核 0.9.1 是否已修，未修则补）。
+
+---
+
+## 3. 分阶段（映射里程碑）
+
+### D1 · 本地命令回路（→ 0.12，风险中，最高优先）
+- DispatchHandle + DispatchEvent；从 observer 流派生 progress/needs-approval；approve/steer 通道（按各 CLI 能力诚实分级）。
+- 验收：
+  - [ ] claude-code 派活后能在 LISA 里看到进度、收到"需审批"、确认后 agent 继续。
+  - [ ] 每个 approve/steer 默认走人类批准闸；远程来源禁用（测试覆盖）。
+
+### D2(a) · TakoAPI OpenAI-shim 快路（→ 0.12，风险低）
+- providers 预设 + `takoapi` 工具。
+- 验收：见 §2.2。
+
+### D3 · 能力注册 + 路由 + lock（→ 0.12）
+- agents.json `skills[]`；token 预算；cwd lock。
+- 验收：
+  - [ ] 给定任务，LISA 推荐并派给"擅长该类"的 agent，附理由。
+  - [ ] 同 cwd 并发派发被 lock 前置挡住。
+
+### D4 · 清债（→ 0.10/0.12 穿插）
+- 验收：
+  - [ ] island advisor 建议可点（cancel 真停；dispatch 仅 prefill）。
+  - [ ] 多 agent session 在前端正确渲染。
+  - [ ] dispatch/github 写操作被 `--approval ask-mutating` 拦住。
+
+### D2(b) · A2A 原生 adapter（→ 0.14，风险中）
+- `takoapi` observer + A2A 桥接。
+- 验收：见 §2.2。
+
+### D5 · TakoAPI publisher（→ 1.0 后，DEFERRED）
+- LISA 暴露 `/.well-known/agent-card.json` + A2A `message/send` 入站（**在现有 webhook channel 上演进**，`src/channels/webhook.ts` 已是带 bearer 的 POST 接收器，最接近 A2A 入站形态）。
+- 把 LISA 自己上架 TakoAPI，被生态调用、助其冷启动供给侧。
+- **为何 defer**：这把 LISA 变成"对公网可被调用的服务"，入站攻击面再扩一层——等 consent/安全体系成熟。
+
+---
+
+## 4. 测试
+- 命令回路：mock observer 流 → DispatchHandle 正确派生 progress/needs-approval；approve 默认需人工确认。
+- 远程安全回归：渠道来源默认拿不到 dispatch/signal/scheduled（断言 `remoteSafeSubset` 仍剔除它们）。
+- TakoAPI consumer：mock `/v1/chat/completions` 与 `/v1/agents/{slug}/message` → 往返成功；401 路径有友好提示。
+- A2A adapter：mock registry + SSE → TaskState 正确映射 `AgentSessionState`；上游响应当 hostile（注入测试）。
+
+---
+
+## 5. 隐私 / 安全
+- **出站（TakoAPI）**：把网关返回的远程-agent 响应**当作不可信输入**（二阶 prompt injection，TakoAPI 技术架构文档 §11 也强调）；`TAKO_KEY` 走 `config.env`（0600）。
+- **本地 dispatch 守 0.9.1 线**：`dispatch_agent`/`signal_agent`/`scheduled_dispatch` 远程来源默认禁、人类批准闸、审计账本。
+- **approval relay 防伪**：转发的审批必须能验证来源是真 LISA 用户，而非被注入的渠道消息。
+- publisher（D5）才是入站面 → 1.0 后再开。
+
+---
+
+## 6. 风险 / 开放问题
+- **本地 CLI 的 steer/approve 深度受限于各 CLI 暴露面**：claude 可深，aider/codex 可能只能 kill+重启。诚实分级，别承诺做不到的"中途纠偏"。
+- **TakoAPI 仍在演进**（Phase 2 网关、生产 DB 升配未完）：consumer 快路依赖其线上稳定性；adapter 要容错（A2A 断路器）。
+- **能力声明可信度**：agent 自报 `skills[]` 可能不准——路由要留"用户否决"。
+
+---
+
+## 7. 与 roadmap / 论文衔接
+- D1+D2(a)+D3+D4 在 0.12 同期（consumer 快路因近免费而提前）；D2(b) 在 0.14；D5 在 1.0 后。
+- 对论文：多 agent 协作是 long-horizon coherence 在"她还要协调别的 agent"压力下的延伸实验（[ROADMAP §9](./ROADMAP_v1.0.md)）。

--- a/docs/PLAN_FOUNDATIONS_v1.0.md
+++ b/docs/PLAN_FOUNDATIONS_v1.0.md
@@ -1,0 +1,160 @@
+# PLAN · FOUNDATIONS — 横切基础（v1.0）
+
+> 展开 [ROADMAP_v1.0.md §7](./ROADMAP_v1.0.md) 的横切关注点为可执行计划。基线 v0.9.1。
+> 这些是**四支柱共同依赖的地基**：consent 框架是 [Sense](./PLAN_SENSE_v1.0.md) 的前置，
+> 安全地板是 [Dispatch](./PLAN_DISPATCH_v1.0.md) 的红线，测试欠账是所有新能力的门禁。
+> **不先把地基打牢，上面四根柱子越高越危险**（[PRODUCT_REVIEW_v0.9.md](./PRODUCT_REVIEW_v0.9.md) 的核心教训）。
+
+---
+
+## 0. 范围
+
+5 块横切：
+1. **隐私与同意**（Sense 的头号前置）
+2. **安全**（守住 v0.9.1 地板，新能力不得推回）
+3. **测试**（核心循环仍裸奔 + 新能力自带测试）
+4. **可观测性**（Reve/Dispatch/Sense 都要"给人看"）
+5. **常驻进程 footprint / 向后兼容 / 叙事诚实**
+
+---
+
+## 1. 隐私与同意（master constraint）
+
+### 1.1 统一 Consent 框架
+Sense 的常驻采集让隐私从"功能"上升为"产品成立前提"。建一个**单一 consent 入口**，所有敏感信号源都从它取授权：
+
+```ts
+// src/consent/store.ts  (NEW) — 单一事实源，~/.lisa/consent.json
+interface ConsentState {
+  // 每类信号一个独立授权；默认全 false（presence/git 除外）
+  grants: Record<string, { granted: boolean; grantedAt?: string; options?: object }>;
+}
+// API: isGranted(signal) / grant(signal, opts) / revokeAll()
+```
+
+原则（每条都要可测）：
+- **默认全关**（新/敏感信号）；开启走**一次性 consent 卡**（说明采什么、存哪、保留多久）。
+- **随时可见 + 一键全停**：island 顶栏 SENSE 指示灯 + popover 列出"现在在采什么"，一键 `revokeAll()`。
+- **本地优先**：raw 截图/音频/剪贴在本地完成判定/蒸馏，命中且必要才送模型；落盘永远是结构化摘要。
+- **黑名单**：app 级（密码/银行/隐私窗口）、路径级、PII 模式级（`*.env`/`*.key`/`*.pem`/邮箱/卡号）。
+- **保留期**：`retentionDays` 到期清理；raw 即用即删。
+
+### 1.2 落地与验收
+- 每个 source `start()` 前查 `isGranted()`，未授权直接 no-op（绝不"先采后问"）。
+- 验收：
+  - [ ] 全新安装默认零敏感采集（截图/语音/剪贴/选区/shell 全关）。
+  - [ ] 黑名单 app 在前台 → 对应 source 零捕获（测试）。
+  - [ ] `revokeAll()` 后所有 source 立即停且 UI 反映。
+  - [ ] raw 字节流绝不进结构化事件 / 不默认落盘（planted-secret 测试，每 source 一条）。
+
+> consent 框架是 [Sense S3/S4](./PLAN_SENSE_v1.0.md)（ambient vision/voice、剪贴/选区）的**硬前置**——这些阶段不得先于本节落地。
+
+---
+
+## 2. 安全（守住 v0.9.1 地板）
+
+### 2.1 已是地板（v0.9.1 已关，1.0 不得推回）
+- `serve --web` 默认绑 127.0.0.1；非 loopback 需 `--host` + `LISA_WEB_TOKEN`。
+- 渠道默认 remote-safe 工具集（`REMOTE_BLOCKED_TOOL_NAMES`）；`unsafeFullTools` 显式开。
+- 自主循环 `autonomousSubset`（无 shell/fs-mutation/dispatch）。
+- 飞书验签；soul 写锁一批。
+
+### 2.2 1.0 新能力的红线
+| 新能力 | 攻击面 | 控制 |
+|---|---|---|
+| Sense 常驻采集 | 隐私面（最危险） | §1 consent 框架；本地优先；黑名单；保留期 |
+| Sense 新端点（若有） | LAN-RCE 回潮 | 一律 loopback/token 闸 + approval + hook（沿用 0.9.1 web 鉴权范式） |
+| Dispatch 命令回路 | 本地代码执行 | 人类批准闸；远程来源默认禁；审计账本；approval relay 防伪 |
+| TakoAPI consumer | 出站（二阶注入） | 网关响应当 hostile；护 `TAKO_KEY`（0600） |
+| TakoAPI publisher（1.0 后） | 入站（公网可调） | DEFERRED 到 consent/安全成熟后 |
+
+### 2.3 1.0 前要补的硬欠账
+- **工具 input 无 schema 校验**（review §2 未修）：LLM 生成的 input 直进 `tool.execute()`。给关键工具（尤其 dispatch / A2A 入站 / bash）加 Zod 校验层。
+- 验收：
+  - [ ] 畸形 tool input 被 schema 层挡下并回友好错误，不进 execute。
+  - [ ] 新端点全部走鉴权范式；红队脚本验证 LAN 不可无 token 触达带工具 agent。
+
+---
+
+## 3. 测试（核心循环仍裸奔）
+
+### 3.1 现状（review 反复点名）
+`agent.ts`、三 provider 翻译层、`subagent`、`approval`、`sessions`、`hooks`、`mcp` **零测试**——最该测的恰好裸奔。（外围工具/observer 测试覆盖反而好。）
+
+### 3.2 计划
+- **补核心循环欠账**：给 `agent.ts`（tool-use 循环 / tool_result 配对 / maxIterations / soul_object surface）、`approval`、`sessions` resume、`hooks`、`mcp` 加测试。
+- **新能力自带测试**：Sense（每 source 隐私 + consent）、Dispatch（命令回路 + 远程安全回归 + A2A 注入）、Model（fallback + embedding + 本地生命周期状态机）、Reve（reflect 门禁 + autonomy run + soul 并发）。
+- **发布门禁**：`release.yml` / `release-mac-apps.yml` 加 `npm test`；`prepublishOnly` 加 `typecheck && test`（review §6：现在红 CI 也能发版）。
+- 验收：
+  - [ ] 核心循环关键路径有测试（agent 循环、approval、resume）。
+  - [ ] CI 红 → 发布被挡。
+
+---
+
+## 4. 可观测性
+
+四支柱都需要结构化日志 + "给人看"的面板，而非只有 LLM 自己读的文本 blob：
+- **Reve**：`AutonomyRun`（[PLAN_REVE R2](./PLAN_REVE_v1.0.md)）+ `lisa autonomy` 摘要。
+- **Dispatch**：dispatch 账本 + DispatchEvent 流 + island 多 agent 面板。
+- **Sense**：`sense/events.jsonl` + island "正在采什么"指示。
+- **Soul**：`lisa soul summary`（[PLAN_REVE R3](./PLAN_REVE_v1.0.md)）。
+- 统一约定：结构化 JSONL 落 `~/.lisa/<domain>/*.jsonl`，有界 + 保留期；一个 `lisa status` 汇总入口。
+- 验收：
+  - [ ] 每个支柱有一条 `lisa <domain>` 命令打印近期可读摘要。
+
+---
+
+## 5. footprint / 兼容 / 叙事诚实
+
+### 5.1 常驻进程 footprint
+- Sense 采集服务：低频轮询 + 事件驱动 + 本地处理，**实测 CPU/内存/能耗/磁盘**。截图/音频帧率是主成本旋钮——给保守默认 + 用户可调。
+- 验收：
+  - [ ] 空闲态（仅 presence/git/agent 观察）CPU 占用可忽略；不让风扇起飞（实测基准）。
+
+### 5.2 向后兼容
+- 现有 `~/.lisa/*`（config.env / soul / sessions / agents.json / heartbeat.json）格式不破坏；新增配置（`sense.json` / `consent.json`）独立文件，缺省即旧行为。
+- Dreams→Reve 更名平滑（旧键继续读，见 [PLAN_REVE R6](./PLAN_REVE_v1.0.md)）。
+
+### 5.3 叙事诚实（1.0 硬指标）
+**叙事 = 代码**：第一个认真读代码的 contributor 每句都能对上。
+- 修文档尸体（review §4.5）：LisaIsland 幽灵、三处 0.2.0 版本、LOC 数字失真一倍、completions 缺 `autostart`、CONTRIBUTING 指向不存在目录。
+- 新能力的对外文案随代码同步：observer 深度、本地模型"真部署 vs 自带 endpoint"、Sense 采什么、Dispatch 能指挥到什么程度——都如实标注，不夸大。
+- 验收：
+  - [ ] README/PITCH/官网与当前 tree 逐项核对一致。
+  - [ ] 本地模型文档区分"自带 endpoint" vs "`lisa model install` 真部署"。
+
+---
+
+## 6. v0.9 review 债务追踪（1.0 前复核/关闭）
+
+> 0.9.1 已关 P0；以下 P1/P2 排期前对当前树逐条复核：
+
+| 项 | 归属 | 状态 |
+|---|---|---|
+| abort signal 贯通 | [Model M4](./PLAN_MODEL_v1.0.md) | **已修**（三 provider + 测试），仅回归 |
+| maxIterations 静默截断 / 空 content 守卫 | Model M4 | **已修**（agent.ts:403 / :231，已核对） |
+| advisor 建议可点 + 多 agent 前端 | [Dispatch D4](./PLAN_DISPATCH_v1.0.md) | 复核（部分可能已动） |
+| dispatch/github 写操作入 mutating 集 | Dispatch D4 | 复核 0.9.1 是否已修 |
+| 核心循环补测试 | §3 | 待做 |
+| `/chat` 并发 busy+queue + JSON.parse 容错 | §3 / web | 待做 |
+| 工具 input schema 校验 | §2.3 | 待做 |
+| 文档尸体 | §5.3 | 待做 |
+| 发布门禁加测试 | §3 | 待做 |
+
+---
+
+## 7. 分阶段（映射里程碑）
+
+| 阶段 | 内容 | 里程碑 |
+|---|---|---|
+| F-core | 核心循环测试 + 发布门禁 + 文档诚实 + schema 校验起步 | 0.10 |
+| F-consent | 统一 consent 框架（Sense S3 前置） | 0.13 前完成 |
+| F-observ | 各支柱可观测落地（随各支柱走） | 0.10–0.14 |
+| F-footprint | 常驻服务实测基准 | 0.13 |
+
+> F-core 与 Reve 硬化同期（0.10），是"先打深"的一部分；F-consent 必须早于 Sense 的 ambient 采集（0.13）。
+
+---
+
+## 8. 一句话
+> **地基先于柱子**：consent 框架、安全地板、测试门禁、可观测——这四样不到位，Sense 的常驻采集和 Dispatch 的命令回路就不该上线。先打深，再铺宽。

--- a/docs/PLAN_MODEL_v1.0.md
+++ b/docs/PLAN_MODEL_v1.0.md
@@ -1,0 +1,138 @@
+# PLAN · MODEL — 从"自带 endpoint"到真·本地部署（v1.0）
+
+> 展开 [ROADMAP_v1.0.md §6](./ROADMAP_v1.0.md) 的 Model 支柱。基线 v0.9.1。
+> 现状：20+ provider 前缀路由很干净，但本地仅"自带 endpoint"（用户自己装 Ollama 再连过去）。
+> 1.0 目标：把本地模型升级为**一等部署选项**（能装/管/切/容错）+ 补本地 embedding。
+> provider 抽象参考 [PROVIDERS.md](./PROVIDERS.md)。
+
+---
+
+## 0. 目标 / 非目标
+
+### 目标
+1. **本地模型生命周期**（M1）：`lisa model install/list/use`，封装 Ollama 等的下载 + 启动 + 健康检查。
+2. **本地 embedding**（M2）：给 `memory/vector.ts` 抽象 embedding 接口，TF-IDF 保留为快路，加可选本地语义向量（与 [Sense S5](./PLAN_SENSE_v1.0.md) 共用）。
+3. **provider 容错 + 自检**（M3）：fallback 链；单 key 自动选 provider；Anthropic 专属特性优雅降级。
+4. **清 provider 层欠账**（M4）：abort / maxIterations / 空 content 均**已修（已核对）**；仅 OpenAI/Gemini 无 compaction 待办。
+
+### 非目标
+- 不自研推理引擎——封装 Ollama / llama.cpp / vLLM，不重造。
+- 不打包模型权重进发行物（体积爆炸）；下载是按需触发，不是内置。
+- 不强制本地——云 API 仍是默认，本地是平权选项。
+
+---
+
+## 1. 现状（file-level）
+
+| 能力 | 现状 | 文件 |
+|---|---|---|
+| provider 路由 | 模型名前缀路由 + 14 家 OpenAI 兼容预设（`OPENAI_COMPAT_PRESETS`） | `src/providers/registry.ts` |
+| provider 契约 | `Provider {name, runTurn(opts)}`，`ProviderRunOpts {model, systemPrompt, tools, messages, maxTokens, thinking, compaction, handlers, signal}` | `src/providers/types.ts` |
+| 三 provider | Anthropic（streaming+cache+thinking）/ OpenAI（双向翻译）/ Gemini（Content 翻译） | `src/providers/{anthropic,openai,gemini}.ts` |
+| 本地模型 | 仅 `LISA_BASE_URL`→OpenAI provider 指本地端口；用户自己 `ollama pull` + `serve` | `src/providers/openai.ts`、`PROVIDERS.md` |
+| embedding | **无向量**——TF-IDF（fingerprint 缓存） | `src/memory/vector.ts` |
+| 容错 | **无 fallback 链** | — |
+| abort | **已修**：三 provider 均透传 `opts.signal`（`anthropic.ts:60`/`openai.ts:45`/`gemini.ts:79`）+ 测试 | — |
+
+**关键缺口**：本地模型无生命周期管理；无本地语义检索；无容错；文档把"自带 endpoint"含混说成"开箱即用"。
+
+---
+
+## 2. 设计
+
+### M1 · 本地模型生命周期
+```ts
+// src/model/local.ts  (NEW) — 封装本地后端（先 Ollama，留 backend 抽象）
+interface LocalBackend {
+  name: "ollama" | "lmstudio" | "llamacpp";
+  install(model: string): Promise<void>;  // 封装 `ollama pull`
+  ensureServing(): Promise<{ baseURL: string }>;  // 启动 + 健康检查
+  listInstalled(): Promise<string[]>;
+  health(): Promise<"up" | "down">;
+}
+```
+CLI（`src/cli.ts` 加子命令）：
+```
+lisa model list                 # 已装 / 已配 / birth-capable 标注
+lisa model install <model>      # ollama pull + 首启
+lisa model use local://<model>  # 写 LISA_BASE_URL+LISA_API_KEY 到 config.env，切过去
+lisa model health               # 本地 server 状态
+```
+- 复用现有路径：`use` 本质就是把 `LISA_BASE_URL` 指向 `http://localhost:11434/v1` + `LISA_API_KEY=ollama`（现在要用户手填，现在自动化）。
+- 健康检查：session 启动前探活，本地 server down 时友好提示（而非中途崩）。
+- 验收：
+  - [ ] `lisa model install qwen2.5-coder` 一条命令完成下载 + 启动。
+  - [ ] `lisa model use local://qwen2.5-coder` 后下次会话走本地。
+  - [ ] 本地 server 未起时给清晰提示，不静默挂起。
+
+### M2 · 本地 embedding
+```ts
+// src/memory/embedding.ts  (NEW) — embedding provider 抽象
+interface Embedder { embed(texts: string[]): Promise<number[][]>; }
+// 实现：TfIdfEmbedder(默认快路) | LocalEmbedder(ollama embedding / 本地 sentence-transformer)
+```
+- `memory/vector.ts` 改为接 `Embedder`：默认 TF-IDF（零依赖、快），可选语义向量（召回近义查询）。
+- 与 [Sense S5](./PLAN_SENSE_v1.0.md) 的蒸馏检索共用同一索引。
+- 验收：
+  - [ ] 配本地 embedder 后，"network error" 能召回"connection failed"类近义条目。
+  - [ ] 未配时回退 TF-IDF，行为不变（向后兼容）。
+
+### M3 · 容错 + 自检
+- **fallback 链**：`config.env` 配 `LISA_MODEL_FALLBACK=claude-...,gpt-...`；主 provider `runTurn` 报错 → 有界重试 → 降级备用。在 registry 包一层 `FallbackProvider`（实现同 `Provider` 契约，对 `runTurn` 失败透明切换）。
+- **provider 自检**：只配了一个 key（如仅 `ANTHROPIC_API_KEY`）时自动选该 provider，免显式前缀/env。
+- **Anthropic 专属特性优雅降级**：`ProviderRunOpts.thinking`/`compaction` 在 OpenAI/Gemini 上 no-op 而非报错；文档标注质量预期差异。
+- 验收：
+  - [ ] 主 provider 注入 500 → 自动切备用，会话不断。
+  - [ ] 仅一个 key 时零配置直接可用。
+  - [ ] `thinking:true` 发给 OpenAI 不抛错。
+
+### M4 · provider 层欠账复核
+- **abort：已修**，仅保持回归测试（三 provider passthrough 测试已在）。
+- **已核对、已修**（review 旧账已不成立）：
+  - maxIterations 静默截断 → **已修**：`agent.ts:403` 命中上限且仍想调用工具时把 stopReason 置为 `"max_iterations"` 并发 info 事件（另：本轮新增 `"budget_exceeded"`，见 [PLAN_REVE R2](./PLAN_REVE_v1.0.md)）。
+  - 空 content 入历史 → **已修**：`agent.ts:231` 跳过空 content 的 assistant 消息，避免下轮 Anthropic 400。
+- 仍存在的真欠账：
+  - OpenAI/Gemini 路径无 compaction：要么实现简单截断压缩，要么文档明示仅 Anthropic 有。
+- 验收：
+  - [ ] 触发 maxIterations → 调用方能区分截断 vs 正常结束。
+  - [ ] OpenAI 空回合后切 Anthropic 不 400。
+
+---
+
+## 3. 分阶段（映射里程碑）
+
+| 阶段 | 内容 | 里程碑 | 风险 |
+|---|---|---|---|
+| M4 | provider 欠账复核（abort 已修） | 0.10 | 低 |
+| M1 | 本地模型生命周期 | 0.11 | 中低 |
+| M2 | 本地 embedding | 0.11 | 中低 |
+| M3 | 容错 + 自检 | 0.11 | 中低 |
+
+---
+
+## 4. 测试
+- 本地生命周期：mock backend → install/ensureServing/health 状态机正确；server down 路径有提示。
+- embedding：TfIdf 与 Local 两实现同接口；切换不破坏检索 API；近义召回用例。
+- fallback：主 provider 注入错误 → 切备用（注入测试）。
+- 自检：仅一个 key 的 env → 选对 provider。
+- provider 回归：abort passthrough（已有）+ 新增 maxIterations / 空 content 守卫用例。
+
+---
+
+## 5. 隐私 / 安全
+- 本地模型 + 本地 embedding = 记忆检索与推理**可完全不离机**——这正是 Sense 敏感数据"本地优先"的底座。
+- `lisa model install` 下载来自用户指定源（Ollama registry），不引入隐式远程执行；下载产物路径属用户。
+- fallback 备用 provider 的 key 同样走 `config.env`（0600）。
+
+---
+
+## 6. 风险 / 开放问题
+- **本地模型 tool-use 质量参差**：小模型 function-calling 可能不稳；`lisa model list` 标注 "birth/tool-capable"，并在 birth 时挡住能力不足的模型。
+- **本地 embedding 选型**：ollama embedding vs 纯 JS 本地向量，体积/质量权衡（与 Sense 联合验证）。
+- **fallback 的语义一致性**：Anthropic ↔ OpenAI 切换时 thinking/cache 行为差异，可能影响连续会话质量。
+
+---
+
+## 7. 与 roadmap / 论文衔接
+- Model 是 0.11 主轴，紧随 Reve 硬化（0.10）。
+- 对论文：本地模型 = 可复现、零边际成本的 long-horizon 实验底座；本地 embedding = 记忆检索不离机。让 ablation 能在独立研究者算力预算内反复跑（[ROADMAP §9](./ROADMAP_v1.0.md) "不要需要实验室算力的实验"）。

--- a/docs/PLAN_REVE_v1.0.md
+++ b/docs/PLAN_REVE_v1.0.md
@@ -11,7 +11,8 @@
 > - **R2** `src/autonomy/runs.ts` 统一 `AutonomyRun` 账本 + idle 成本断路器（agent loop 新增 `budgetTokens`/`budget_exceeded`）+ `lisa autonomy` 摘要 ✅
 > - **R3** `lisa soul summary` 人可读速览（`src/soul/summary.ts`）✅；**锁铺全（R3b）已核对在 0.9.1 完成**——`appendJournal`(store.ts:391)、`applyEmotionDelta`(store.ts:137) 均已 `withSoulLock`，`commitSoulChange` 走 withFileLock+串行队列。
 > - **R5** `recentAgentRecap`（`src/orchestrator/recent-recap.ts`）接进 reflect 用户消息 + heartbeat 系统提示 ✅
-> 全部已测试（summary/recent-recap/autonomy/reflect/agent budget 用例；全套 **455 测试绿**）。**R4（desire 中间态，0.11）、R6（Dreams→Reve 更名）待做。**
+> - **R6** Dreams→Reve 更名 ✅：公开文案 README/PITCH 英文 Dreams→Reve（中文「梦境」保留为本地化名）；偶发用法（Seedream 品牌、birth「dreaming」文学化措辞、CSS `--dream` 色名、island `dreaming` 代码标识）保留；README 完整四支柱（Sense·Dispatch·Reve·Model）大改版留待 1.0 发布，避免半改名的不一致状态。
+> 全部已测试（summary/recent-recap/autonomy/reflect/agent budget 用例；全套 **455 测试绿**）。**仅 R4（desire `pursuit:needs-user` 中间态）留到 0.11。**
 
 ---
 
@@ -137,7 +138,7 @@ interface DesireEntry {
 | R3 | 灵魂速览 + 锁铺全 | 0.10 | 低 | ✅（锁 0.9.1 已完成） |
 | R5 | recap 接进反思 | 0.10 | 低 | ✅ |
 | R4 | desire 中间态 | 0.11 | 低 | 待做 |
-| R6 | Dreams→Reve 更名 | 0.10（随手） | 低 | 待做 |
+| R6 | Dreams→Reve 更名 | 0.10（随手） | 低 | ✅（公开文案；README 大改版留待 1.0） |
 
 > Reve 整体是 0.10 的"先打深"主轴——低风险、高可信、兑现承诺，给 1.0 打信任地基。
 

--- a/docs/PLAN_REVE_v1.0.md
+++ b/docs/PLAN_REVE_v1.0.md
@@ -1,0 +1,168 @@
+# PLAN · REVE — 自主反思与进化（v1.0）
+
+> 展开 [ROADMAP_v1.0.md §5](./ROADMAP_v1.0.md) 的 Reve 支柱。基线 v0.9.1。
+> Reve = 现有 **Dreams** 系统的正式更名（idle 反思 + 会话末反思 + heartbeat + soul 演化）。
+> **本支柱最成熟，1.0 的工作是"硬化 / 可观测 / 有界 / 可度量"，不是加新能力**——
+> 这与 [PRODUCT_REVIEW_v0.9.md](./PRODUCT_REVIEW_v0.9.md) 的结论一致，也直接喂[论文](#7-与-roadmap--论文衔接)。
+> 上游设计见 [AUTONOMY_ROADMAP.md](./AUTONOMY_ROADMAP.md)（Phase 1–3 已落地）。
+>
+> **实现状态（branch `feat/reve-hardening`，0.10）**：R1（reflect 质量门禁：坏 JSON 重试 + error 落盘 + underreflect 信号）、
+> R2（`src/autonomy/runs.ts` 统一 `AutonomyRun` 账本 + idle 成本断路器 + `lisa autonomy` 摘要；agent loop 新增 `budgetTokens`/`budget_exceeded`）
+> 已实现并测试（autonomy/runs.test.ts、reflect.test.ts、agent.test.ts budget 用例；全套 447 测试绿）。R3/R4/R5/R6 待做。
+
+---
+
+## 0. 目标 / 非目标
+
+### 目标
+把已成熟的自演化闭环从"能跑"提升到可信：
+1. **反思质量门禁**（R1）：JSON 坏掉不再静默降级；检测"反思不足"。
+2. **heartbeat / idle 可观测 + 有界**（R2）：任务成功度量；idle 成本断路器；收敛策略。
+3. **灵魂可观测**（R3）：给人看的 "Lisa 速览"；并发锁铺全。
+4. **desire 能力/野心错配**（R4）：加"想做但需帮忙"中间态。
+5. **把编排器 recap 接进反思**（R5）：让 Sense→Dispatch→Reve 闭环。
+6. Dreams→Reve 全代码/文档平滑更名。
+
+### 非目标
+- 不改 soul 的主权模型 / birth / 不引入 reset。
+- 不给自主循环放开工具集（守 0.9.1 的 `autonomousSubset` 边界）。
+- 不做新的自主"能力"——只把现有闭环做实、做透、可度量。
+
+---
+
+## 1. 现状（file-level）
+
+| 子系统 | 现状 | 文件 |
+|---|---|---|
+| 空闲反思（dreams） | idle≥~1h 触发；跨进程 `IDLE_RUN_LOCK`；`autonomousSubset` 工具；输出 "while you were away"；返回 `{text, silent, iterations, inputTokens, outputTokens}` | `src/idle/{watcher,runner}.ts` |
+| 会话末反思 | 产出 journal + 操作（`memory_append`/`skill_create`/`skill_patch`/`feel`/`opinion_form`/`desire_add`/`patch_*`）；JSON 输出；progress 压缩 | `src/reflect.ts` |
+| heartbeat | cron/launchd；用户任务 + 自驱欲望 + 周度 examen；**token 预算闸**（`budgetTokens` 默认 500k，`runner.ts:87/128`）；desire fallback | `src/heartbeat/{runner,config}.ts` |
+| 灵魂 | `DesireEntry {actionable, heartbeatPrompt?}`；`EmotionState`（衰减 + 事件 ring，`EMOTION_EVENTS_MAX=50`）；git 可追溯 | `src/soul/{store,tools,git,types}.ts` |
+| 编排 recap | 隐私安全的跨 agent 事件流 + recap（确定性、环形 400） | `src/orchestrator/{journal,recap}.ts` |
+
+**关键缺口**：reflect 坏 JSON 静默降级；idle 无成本闸（measure 但不 cap）；heartbeat 无成功度量；soul 只给 LLM 读；desire actionable 是 boolean 死结；recap 不回流反思。
+
+---
+
+## 2. 设计
+
+### R1 · 反思质量门禁
+`reflect.ts` 现在解析失败返回空 applied、静默。改：
+```ts
+// reflect.ts — 解析与质量
+// 1. JSON 解析失败 → 重试一次（更严格的 prompt）→ 仍失败则 LOG 'reflect_malformed'
+//    并落 ~/.lisa/reflections/<id>.error.json，不静默吞。
+// 2. 操作计数直方图：一段实质会话（>N turns / 有工具调用）却产出 0 操作 →
+//    记 'reflect_underreflect'（可观测信号，非强制改写）。
+// 3. feel op 与 soul_feel 行为对齐：reflect 的 feel 先衰减再叠 delta
+//    （已核对：reflect.ts:184 已走 applyEmotionDelta 的 decay-first 路径，
+//     与 soul_feel 一致 —— review §4.2 的不一致已不成立，仅需回归测试。）
+```
+- 验收：
+  - [ ] 注入坏 JSON → 重试 + 告警 + error 落盘，不静默。
+  - [ ] 实质会话 0 操作 → underreflect 信号出现在可观测日志。
+  - [ ] feel 一致性测试通过。
+
+### R2 · heartbeat / idle 可观测 + 有界
+```ts
+// 统一 AutonomyRun 记录（NEW，写 ~/.lisa/autonomy/runs.jsonl）
+interface AutonomyRun {
+  kind: "idle" | "heartbeat" | "examen" | "desire";
+  startedAt: string; durationMs: number;
+  inputTokens: number; outputTokens: number;
+  outcome: "done" | "no-update" | "blocked" | "error";  // 不再只有 silent 二元
+  note?: string;                 // 失败/阻塞原因
+}
+```
+- **idle 成本断路器**：idle/runner 接 `budgetTokens`（复用 heartbeat 的预算概念），超额停（现在 idle 只 measure 不 cap）。
+- **收敛策略**：idle 单窗口从"只做一件事"改为"有界做 K 件、命中 rest 即停"，避免长窗口积压或空转。
+- **heartbeat 成功度量**：用 `outcome` 区分"真做完 / 无更新 / 阻塞 / 报错"，不再把 `(no update)` 当成功。
+- 验收：
+  - [ ] 每次 idle/heartbeat 落一条 `AutonomyRun`，token 与 outcome 准确。
+  - [ ] idle 超 `budgetTokens` 时停并记 `blocked`。
+  - [ ] `lisa autonomy` 子命令打印近 7 天 run 摘要（次数 / token / outcome 分布）。
+
+### R3 · 灵魂可观测 + 锁铺全
+- `lisa soul summary` / GUI 卡片：从 `SoulSummary` 渲染 "Lisa 今天：好奇 0.45 · 想做 [X,Y] · 相信 [A,B] · 近期情绪事件 N 条"。现在情绪/欲望/opinion/git 历史只有 LLM 自己读（review §4.2：营销权重 > 可感效用）。
+- **并发锁铺全**：`appendJournal` / 情绪写入 / `commitSoulChange` 都包 `withSoulLock`（`src/soul/lock.ts`）；复核 0.9.1 已修一批后，确认 git commit 不再被 swallow（review §4.2 指出跨进程撞 `index.lock` 时 commit 被吞，打脸"every change has a commit"）。
+- 验收：
+  - [ ] `lisa soul summary` 输出人可读速览。
+  - [ ] 两进程并发写 journal / emotions / git → 无丢条、commit 齐全（压力测试）。
+
+### R4 · desire 能力/野心错配
+现在 `DesireEntry.actionable` 是 boolean：能跑（actionable）或不能。若一个欲望需要 shell 而自主循环（`autonomousSubset`）没 shell，就只能干瞪眼累积 frustration。加中间态：
+```ts
+// soul/types.ts — DesireEntry 扩展
+interface DesireEntry {
+  // ...
+  actionable: boolean;
+  /** NEW: 'self' = 自主循环能独立推进；'needs-user' = 需用户帮忙跑（如 shell） */
+  pursuit?: "self" | "needs-user";
+}
+```
+- `needs-user` 的欲望：reflect/heartbeat 不反复空跑它，而是**自动落一条提示**（"desire X 需要你帮忙跑 Y"）到 while-you-were-away / island，等用户授权。
+- 验收：
+  - [ ] 需 shell 的欲望被标 `needs-user`，不进自主空跑循环。
+  - [ ] 用户侧出现"帮我跑一下"的可点提示。
+
+### R5 · 编排 recap 接进反思
+`orchestrator/recap.ts` 现在单向（只记"agent 们做了什么"），Lisa 反思从不读它。让 heartbeat/reflect 读 recap：
+```ts
+// reflect/heartbeat 的系统提示注入一段 recap 摘要：
+//   "过去 N 小时：3 个项目活动，2 完成，1 报错（repo X）"
+// → Lisa 可据此调整自己的欲望 / 关注（"X 老报错，我想搞清楚为什么"）。
+```
+- 隐私：recap 已是结构化元数据（无 prompt/reply/file 内容），可安全注入。
+- 验收：
+  - [ ] heartbeat 运行时系统提示含 recap 摘要。
+  - [ ] 给定"某 repo 反复报错"的 recap → Lisa 倾向产出相关 opinion/desire（行为测试，软指标）。
+
+### R6 · Dreams → Reve 更名
+- 代码标识、文档、UI 文案统一 Dreams→Reve；保留 `~/.lisa/*` 配置/格式不破坏（向后兼容，旧键继续读）。
+- 验收：
+  - [ ] 全仓 grep 无残留"Dreams"对外文案（内部历史注释可留）。
+  - [ ] 旧配置文件无需迁移即可工作。
+
+---
+
+## 3. 分阶段（映射里程碑）
+
+| 阶段 | 内容 | 里程碑 | 风险 |
+|---|---|---|---|
+| R1 | 反思质量门禁 | 0.10 | 低 |
+| R2 | heartbeat/idle 可观测 + idle 断路器 + 收敛 | 0.10 | 低 |
+| R3 | 灵魂速览 + 锁铺全 | 0.10 | 低 |
+| R5 | recap 接进反思 | 0.10 | 低 |
+| R4 | desire 中间态 | 0.11 | 低 |
+| R6 | Dreams→Reve 更名 | 0.10（随手） | 低 |
+
+> Reve 整体是 0.10 的"先打深"主轴——低风险、高可信、兑现承诺，给 1.0 打信任地基。
+
+---
+
+## 4. 测试
+- reflect：坏 JSON / 空操作 / feel 一致性三条用例。
+- autonomy：mock idle/heartbeat → `AutonomyRun` 字段准确；超预算停。
+- soul 并发：多进程压力写 journal/emotions/git → 无丢条、commit 齐。
+- recap 注入：给定 recap → 系统提示含摘要（快照测试）。
+- 更名：旧配置兼容测试。
+
+---
+
+## 5. 隐私 / 安全
+- 守 `autonomousSubset` 边界：自主循环不得碰 shell/fs-mutation/dispatch（0.9.1 线）。
+- recap 注入仅结构化元数据，无 prompt/reply/file 内容。
+- soul 仍是 Lisa 主权；R3 的"给人看"只读不写，不引入用户侧改写口子。
+
+---
+
+## 6. 风险 / 开放问题
+- **"反思不足"如何界定**：turn 数 / 工具调用阈值需调，避免误报。
+- **idle 收敛 K 值**：做几件才算"够"而不空转？经验调参。
+- **recap → 欲望**是软行为，难硬验收：用行为测试 + 人工抽查。
+
+---
+
+## 7. 与 roadmap / 论文衔接
+- Reve 是 0.10"先打深"的核心，**最先做**。
+- 对论文：R2 的成功度量 + R1 的反思质量 + soul git 历史 = 论文要的 **drift / long-horizon coherence 指标**；稳定性机制（`soul_object` / weekly examen / approval-gated skills）作为可开关 **ablation**。1.0 的 Reve 硬化与论文实验是同一批工作（[ROADMAP §9](./ROADMAP_v1.0.md)，[记忆: paper plan]）。

--- a/docs/PLAN_REVE_v1.0.md
+++ b/docs/PLAN_REVE_v1.0.md
@@ -6,9 +6,12 @@
 > 这与 [PRODUCT_REVIEW_v0.9.md](./PRODUCT_REVIEW_v0.9.md) 的结论一致，也直接喂[论文](#7-与-roadmap--论文衔接)。
 > 上游设计见 [AUTONOMY_ROADMAP.md](./AUTONOMY_ROADMAP.md)（Phase 1–3 已落地）。
 >
-> **实现状态（branch `feat/reve-hardening`，0.10）**：R1（reflect 质量门禁：坏 JSON 重试 + error 落盘 + underreflect 信号）、
-> R2（`src/autonomy/runs.ts` 统一 `AutonomyRun` 账本 + idle 成本断路器 + `lisa autonomy` 摘要；agent loop 新增 `budgetTokens`/`budget_exceeded`）
-> 已实现并测试（autonomy/runs.test.ts、reflect.test.ts、agent.test.ts budget 用例；全套 447 测试绿）。R3/R4/R5/R6 待做。
+> **实现状态（branch `feat/reve-hardening`，0.10）**：
+> - **R1** reflect 质量门禁（坏 JSON 重试 + `<id>.error.json` 落盘 + underreflect 信号）✅
+> - **R2** `src/autonomy/runs.ts` 统一 `AutonomyRun` 账本 + idle 成本断路器（agent loop 新增 `budgetTokens`/`budget_exceeded`）+ `lisa autonomy` 摘要 ✅
+> - **R3** `lisa soul summary` 人可读速览（`src/soul/summary.ts`）✅；**锁铺全（R3b）已核对在 0.9.1 完成**——`appendJournal`(store.ts:391)、`applyEmotionDelta`(store.ts:137) 均已 `withSoulLock`，`commitSoulChange` 走 withFileLock+串行队列。
+> - **R5** `recentAgentRecap`（`src/orchestrator/recent-recap.ts`）接进 reflect 用户消息 + heartbeat 系统提示 ✅
+> 全部已测试（summary/recent-recap/autonomy/reflect/agent budget 用例；全套 **455 测试绿**）。**R4（desire 中间态，0.11）、R6（Dreams→Reve 更名）待做。**
 
 ---
 
@@ -84,7 +87,7 @@ interface AutonomyRun {
 
 ### R3 · 灵魂可观测 + 锁铺全
 - `lisa soul summary` / GUI 卡片：从 `SoulSummary` 渲染 "Lisa 今天：好奇 0.45 · 想做 [X,Y] · 相信 [A,B] · 近期情绪事件 N 条"。现在情绪/欲望/opinion/git 历史只有 LLM 自己读（review §4.2：营销权重 > 可感效用）。
-- **并发锁铺全**：`appendJournal` / 情绪写入 / `commitSoulChange` 都包 `withSoulLock`（`src/soul/lock.ts`）；复核 0.9.1 已修一批后，确认 git commit 不再被 swallow（review §4.2 指出跨进程撞 `index.lock` 时 commit 被吞，打脸"every change has a commit"）。
+- **并发锁铺全（R3b）— 已核对在 0.9.1 完成**：`appendJournal`（store.ts:391）、`applyEmotionDelta`（store.ts:137）均已包 `withSoulLock`，注释明确针对 review §4.2 的竞态；`commitSoulChange` 走 withFileLock + 串行队列。仅余：对"git commit 被 swallow"做一次跨进程压力回归测试以确认彻底。
 - 验收：
   - [ ] `lisa soul summary` 输出人可读速览。
   - [ ] 两进程并发写 journal / emotions / git → 无丢条、commit 齐全（压力测试）。
@@ -127,14 +130,14 @@ interface DesireEntry {
 
 ## 3. 分阶段（映射里程碑）
 
-| 阶段 | 内容 | 里程碑 | 风险 |
-|---|---|---|---|
-| R1 | 反思质量门禁 | 0.10 | 低 |
-| R2 | heartbeat/idle 可观测 + idle 断路器 + 收敛 | 0.10 | 低 |
-| R3 | 灵魂速览 + 锁铺全 | 0.10 | 低 |
-| R5 | recap 接进反思 | 0.10 | 低 |
-| R4 | desire 中间态 | 0.11 | 低 |
-| R6 | Dreams→Reve 更名 | 0.10（随手） | 低 |
+| 阶段 | 内容 | 里程碑 | 风险 | 状态 |
+|---|---|---|---|---|
+| R1 | 反思质量门禁 | 0.10 | 低 | ✅ |
+| R2 | heartbeat/idle 可观测 + idle 断路器 + 收敛 | 0.10 | 低 | ✅（收敛 K 值策略待调） |
+| R3 | 灵魂速览 + 锁铺全 | 0.10 | 低 | ✅（锁 0.9.1 已完成） |
+| R5 | recap 接进反思 | 0.10 | 低 | ✅ |
+| R4 | desire 中间态 | 0.11 | 低 | 待做 |
+| R6 | Dreams→Reve 更名 | 0.10（随手） | 低 | 待做 |
 
 > Reve 整体是 0.10 的"先打深"主轴——低风险、高可信、兑现承诺，给 1.0 打信任地基。
 

--- a/docs/PLAN_SENSE_v1.0.md
+++ b/docs/PLAN_SENSE_v1.0.md
@@ -1,0 +1,208 @@
+# PLAN · SENSE — 常驻感知层（v1.0）
+
+> 本文档把 [ROADMAP_v1.0.md §3](./ROADMAP_v1.0.md) 的 Sense 支柱展开为可执行实现计划。
+> 基线 v0.9.1。house style 同 [AUTONOMY_ROADMAP.md](./AUTONOMY_ROADMAP.md) / [ORCHESTRATOR_PLAN.md](./ORCHESTRATOR_PLAN.md)：
+> 分子阶段 A/B/C，每阶段附**验收清单**，停下来等用户验收，不一次性交付。
+> 隐私是本支柱的**头号设计约束**，不是事后补丁——见 §5 与 [PLAN_FOUNDATIONS_v1.0.md](./PLAN_FOUNDATIONS_v1.0.md)。
+
+---
+
+## 0. 目标 / 非目标
+
+### 目标
+一个**单一常驻服务**，在用户**逐项显式授权**的信号上持续采集、**本地优先**处理，沉淀为统一工作记忆：
+1. 把已声称的 5 个 agent observer 深度补齐 + 新增 git / shell / 构建信号（低风险，兑现承诺）。
+2. 在场判定从"是否在跟 LISA 说话"升级为系统级 idle / 锁屏 / 前台 app。
+3. vision / voice 从按需走向 ambient（默认关、带 consent、本地优先）。
+4. 剪贴 / 选区（最敏感，严格 opt-in）。
+5. 采集 → 自动蒸馏进 memory + 本地语义检索。
+
+### 非目标（避免范围蔓延）
+- 不做键盘记录 / 鼠标轨迹（仅用焦点变化做在场判定，不存轨迹）。
+- 不把原始截图 / 音频 / 剪贴内容默认持久化或默认上云。
+- 不替代 Reve 的反思——Sense 只**采集与蒸馏**，"想"是 Reve 的事。
+- 不在 Linux/Windows 上追平 macOS 的系统级钩子（v1.0 以 macOS 为先，其余降级为"仅 agent/git/shell"）。
+
+### 一条贯穿原则
+**默认最小、逐项 opt-in、能不离机就不离机。** 每加一个信号源，先问"它的默认值是不是关、它的 raw 数据是不是只在本地"。
+
+---
+
+## 1. 现状（file-level）
+
+| 能力 | 现状 | 文件 |
+|---|---|---|
+| agent observer | claude-code 最深；codex/opencode Tier-2；aider 文件+轮次；github-pr 元数据 | `src/integrations/{claude-code,codex,opencode,aider,github-pr}/observer.ts`、`hub.ts` |
+| observer 抽象 | `AgentObserver {agent, start(emit), list, stop}` + `registerIntegration()` 注册 | `src/integrations/types.ts`、`registry.ts` |
+| 活动结构 | `SessionActivity {turnCount, lastTools, filesTouched, lastCommandName, lastError, gitBranch, tokens, pendingPermission}` | `src/integrations/types.ts:42` |
+| 屏幕 | 按需 `screencapture`（interactive/full）+ 可选周期 advisor（默认关、≥10min） | `src/vision/capture.ts`、`src/screen_advisor/engine.ts`、`src/web/server.ts` |
+| 语音 | TTS（`say`）；转写（Whisper API，**需文件路径**）；听写润色 | `src/voice/{speak,transcribe,dictation}.ts` |
+| 在场 | 仅"是否在跟 LISA 交互"（每次输入 `tick()`，60s 轮询，默认 ~60min idle） | `src/idle/watcher.ts` |
+| 记忆 | `~/.lisa/memory`+`~/.lisa/user`（read/append/replace/remove）；TF-IDF 检索（fingerprint 缓存） | `src/memory/{store,vector,tool}.ts` |
+| 常驻 | `serve --web` 反应式后端；launchd autostart | `src/web/server.ts`、`src/autostart/install.ts` |
+
+**关键缺口**：没有"非-agent 信号"的统一抽象（observer 只管 agent session）；没有独立于 web server 的采集循环；没有 consent 框架；没有 raw→memory 蒸馏。
+
+---
+
+## 2. 设计
+
+### 2.1 两个抽象：复用 observer + 新增 SenseSource
+
+agent / git / shell 三类信号天然是"会话/事件流"，**直接复用 `AgentObserver`**（git 的"会话"= 一个 repo 的活动，shell = 一个终端的活动），通过 `registerIntegration()` 注册——零新抽象。
+
+vision / voice / clipboard / selection / presence 不是 agent session，新增一个并列的轻抽象：
+
+```ts
+// src/sense/types.ts  (NEW)
+export type SenseSignal =
+  | "screen" | "voice" | "clipboard" | "selection" | "presence";
+
+export interface SenseEvent {
+  signal: SenseSignal;
+  at: number;                 // epoch ms
+  /** 本地已蒸馏的结构化摘要，绝不是 raw 字节流。 */
+  summary: string;
+  /** 来源 app / 窗口标题（若可得），用于关联。 */
+  sourceApp?: string;
+  /** 仅当 consent 明确允许"保留 raw"时才有；默认 undefined。 */
+  raw?: { kind: "image" | "audio" | "text"; ref: string };
+}
+
+export interface SenseSource {
+  readonly signal: SenseSignal;
+  start(emit: (e: SenseEvent) => void): Promise<void>;
+  stop(): Promise<void>;
+}
+```
+
+### 2.2 SenseService — 常驻采集循环
+
+```ts
+// src/sense/service.ts  (NEW)
+// 拥有所有 source（agent/git/shell 经 hub；screen/voice/… 经 SenseSource），
+// 应用 consent 闸，跑本地蒸馏，写工作记忆。事件驱动 + 低频轮询，绝不阻塞 chat。
+class SenseService {
+  start(): Promise<void>;   // 读 consent → 仅启用被授权的 source
+  stop(): Promise<void>;
+  recentEvents(sinceMs: number): SenseEvent[];  // 给 Reve / island 用
+}
+```
+
+- 进程归属：**默认随 `serve` 起**，但与 chat 路径解耦（独立 async loop）；可单独 `lisa sense run`（前台调试）。launchd 复用 `autostart/install.ts`。
+- 输出：所有 source 的事件进一个**有界环形缓冲**（内存）+ 选择性落 `~/.lisa/sense/events.jsonl`（仅结构化摘要，受 consent 控制保留期）。
+
+### 2.3 Consent 框架（头号约束）
+
+```jsonc
+// ~/.lisa/sense.json  — 默认文件：所有"新/敏感"信号 enabled:false
+{
+  "screen":    { "enabled": false, "everySec": 60, "blacklistApps": ["1Password","Banking"] },
+  "voice":     { "enabled": false, "pushToTalk": true },
+  "clipboard": { "enabled": false, "storeContent": false, "blacklistApps": ["1Password"] },
+  "selection": { "enabled": false },
+  "presence":  { "enabled": true },          // 低风险，默认开
+  "git":       { "enabled": true, "roots": ["~/code"] },
+  "shell":     { "enabled": false, "argv0Only": true },  // 默认关，开后仅 argv[0]
+  "distill":   { "enabled": true, "everyMin": 30 },
+  "retentionDays": 7
+}
+```
+
+- **UI 必须随时可见"现在在采什么"+ 一键全停**（island 顶栏一个 SENSE 指示灯 + popover）。
+- 每个 source 启动时若 `enabled:false` 直接 no-op；服务绝不"先采后问"。
+- 详细 consent / 脱敏规则集中在 [PLAN_FOUNDATIONS_v1.0.md §1](./PLAN_FOUNDATIONS_v1.0.md)。
+
+### 2.4 本地优先蒸馏 → 工作记忆
+
+```ts
+// src/sense/distill.ts  (NEW) — 低频任务（everyMin），消费 recentEvents()
+// 1. 本地判定"是否值得记"（前台 app 变化 / 出现 error 对话框 / git commit / 选区动作）
+// 2. 命中才（可选）送模型蒸馏成 1–2 条 memory：「在 repo X 为 feature Y 调试 Z」
+// 3. 写 memory/store.ts append + 本地 embedding 索引（与 Model M2 共用）
+```
+
+蒸馏质量受 Reve 反思门禁约束（[PLAN_REVE_v1.0.md R1](./PLAN_REVE_v1.0.md)）。raw 截图/音频在本地完成判定后即删（沿用 `vision/capture.ts` 的 finally 删除范式）。
+
+---
+
+## 3. 分阶段（映射 roadmap 里程碑）
+
+### 阶段 S1 — 深化 observer + 低风险新源（→ 0.10，风险低）
+**S1a · 补齐非-Claude 活动深度**
+- codex/opencode/aider observer 产出完整 `SessionActivity`（`lastTools`/`filesTouched`/`pendingPermission`/`tokens`），让 6 个 advisor detector 对它们触发。
+- 验收：
+  - [ ] 三家 observer 各有测试断言 `activity` 字段非空且不泄漏 prompt/reply（planted-secret 测试）。
+  - [ ] island 上非-Claude session 显示 tool/file 活动。
+
+**S1b · git observer（新 AgentObserver，kind `"git"`）**
+- watch `roots` 下各 repo 的 `.git/HEAD`、`logs/HEAD`、index mtime；派生 commit / branch-switch / dirty 状态为 `AgentSession`（project=repo 名，activity.filesTouched=`git diff --name-only`）。
+- 验收：
+  - [ ] 切分支 / commit 在 5s 内出现在 hub。
+  - [ ] 无 `roots` 配置时 no-op。
+
+**S1c · shell observer（新 AgentObserver，kind `"shell"`，默认关）**
+- 尾随 `~/.zsh_history` / `~/.bash_history`，**仅取 argv[0] + 时间**（`argv0Only` 强制），绝不存完整命令。
+- 验收：
+  - [ ] 测试断言只暴露 argv[0]，完整命令永不进事件。
+  - [ ] `sense.json` 默认 `shell.enabled:false`。
+
+### 阶段 S2 — 在场判定升级（→ 0.10，风险低）
+- `presence` SenseSource：macOS `ioreg -c IOHIDSystem`（系统 idle 秒数）/ `CGEventSourceSecondsSinceLastEventType` + 锁屏通知；把结果喂 `idle/watcher.ts`，替代"只认 LISA 交互"。
+- 验收：
+  - [ ] 用户在 VS Code 活跃但不理 LISA 时，**不**判 idle。
+  - [ ] 锁屏即视为 away（触发 Reve dreams 更准）。
+  - [ ] 非 macOS 优雅降级回旧行为。
+
+### 阶段 S3 — ambient vision + voice（→ 0.13，风险高，consent 前置）
+**前置**：[PLAN_FOUNDATIONS §1](./PLAN_FOUNDATIONS_v1.0.md) 的 consent 框架已落地。
+- `screen` SenseSource：把 `screen_advisor` 泛化为可配 `everySec` 采集 + 前台 app/窗口标题；本地先判"是否值得上报"，命中才送模型；**截图绝不持久化**；`blacklistApps` 命中直接跳过该帧。
+- `voice` SenseSource：录音 + 热键（push-to-talk 默认）+ 流式转写；探索 whisper.cpp 本地 STT 作离机选项（与 Model 支柱呼应）。
+- 验收：
+  - [ ] 默认 `enabled:false`；开启走一次性 consent 卡。
+  - [ ] 黑名单 app 在前台时零采集（测试覆盖）。
+  - [ ] island 实时显示"屏幕/语音 采集中"红点。
+
+### 阶段 S4 — 剪贴 / 选区（→ 0.15，最敏感，最后）
+- `clipboard` SenseSource：macOS `NSPasteboard.changeCount` 轮询；默认只记元数据 + 来源 app，`storeContent:false` 时绝不留内容。
+- `selection` SenseSource：跨 app 选区 → "就这段聊"；体验最强、隐私最敏感，放 consent 体系最成熟后。
+- 验收：
+  - [ ] 默认全关；`storeContent` 默认 false。
+  - [ ] 密码类 app（黑名单）剪贴零捕获。
+
+### 阶段 S5 — 蒸馏 + 本地检索（贯穿，→ 0.11 起）
+- `distill.ts` 落地（§2.4）；`memory/vector.ts` 接本地 embedding（详见 [PLAN_MODEL M2](./PLAN_MODEL_v1.0.md)）。
+- 验收：
+  - [ ] 一天工作后自动生成 ≤2 条高质量 memory，无噪声刷屏。
+  - [ ] 语义检索能召回 TF-IDF 漏掉的近义查询。
+
+---
+
+## 4. 测试
+- 每个 source 一个**隐私测试**：断言 raw 内容 / PII / 完整命令永不进 `SenseEvent.summary` 或落盘（沿用 `parser` 的 planted-secret 范式）。
+- consent 测试：`enabled:false` → source `start()` 后零 emit；黑名单 app → 零捕获。
+- 蒸馏测试：给定一串合成事件 → 产出稳定、有界的 memory 条数（不随事件数线性膨胀）。
+- 在场测试：mock 系统 idle 秒数 → watcher 状态切换正确。
+
+---
+
+## 5. 隐私 / 安全（头号）
+- **逐类开关、默认全关**（除 presence/git）；UI 永远可见正在采什么 + 一键全停。
+- **本地优先**：raw 截图/音频/剪贴在本地完成判定/蒸馏，命中且必要才送模型；落盘的永远是结构化摘要。
+- **黑名单**：app 级（密码/银行/隐私窗口）、路径级、PII 模式级。
+- **保留期**：`retentionDays` 到期清 `sense/events.jsonl`；raw 即用即删。
+- 详尽规则见 [PLAN_FOUNDATIONS_v1.0.md §1 隐私与同意](./PLAN_FOUNDATIONS_v1.0.md)。
+
+---
+
+## 6. 风险 / 开放问题
+- **常驻 footprint**：低频轮询 + 事件驱动，需实测 CPU/能耗（[FOUNDATIONS §5]）。截图/音频帧率是主要成本旋钮。
+- **跨平台**：系统级钩子 macOS 先行；Linux/Windows 何时追平？（开放，按用户群定）
+- **本地 STT/embedding 质量**：whisper.cpp / 本地向量是否够用，还是仍要云兜底？（与 Model 支柱联合验证）
+- **蒸馏噪声**：如何避免把"看了眼推特"也记成工作记忆？阈值需调。
+
+---
+
+## 7. 与 roadmap / 论文衔接
+- S1/S2 是 0.10 低风险硬化，**先做**；S3/S4 是 0.13/0.15 的高风险扩张，**等 consent 就位**。
+- 对论文：Sense 给 long-horizon coherence 任务喂**真实、连续的工作上下文**，比合成 benchmark 更有外部效度，可支撑并行的 CHI HCI track 长期用户研究（[ROADMAP §9](./ROADMAP_v1.0.md)）。

--- a/docs/ROADMAP_v1.0.md
+++ b/docs/ROADMAP_v1.0.md
@@ -1,0 +1,378 @@
+# LISA 1.0 推进计划 — Sense · Dispatch · Reve · Model
+
+> 方法：在 v0.9.1 树（commit `43442d5`）上并行盘点四支柱现状（感知 / 调度 / 反思 / 模型），
+> 交叉对照 [PRODUCT_REVIEW_v0.9.md](./PRODUCT_REVIEW_v0.9.md)、[AUTONOMY_ROADMAP.md](./AUTONOMY_ROADMAP.md)、
+> [ORCHESTRATOR_PLAN.md](./ORCHESTRATOR_PLAN.md)，得出"从 0.9 到 1.0 还差什么"。
+> 日期：2026-06-13。基线：v0.9.1。文中行号以当前树为准，后续修复会漂移。
+>
+> **重要前提**：v0.9.1 已关闭 v0.9 review 的全部 P0（`serve --web` 无鉴权 LAN-RCE、渠道全工具暴露、
+> 自主循环无工具边界、飞书不验签、两个 advisor 假告警、soul 裸写锁）。本计划以该安全基线为**地板**，
+> 1.0 的任何新能力都不得把它推回去。排期前请对当前树复核这些修复仍然成立。
+
+---
+
+## 详细模块计划（本路线图的实现展开）
+
+本文是**战略路线图**；每个支柱的**可执行实现计划**（设计 / 数据结构 / 分子阶段 / 验收清单 / 测试 / 风险）拆到下列文档：
+
+| 文档 | 覆盖 | 对应本文 |
+|---|---|---|
+| [PLAN_SENSE_v1.0.md](./PLAN_SENSE_v1.0.md) | 常驻感知：observer 深化 + git/shell 源、在场判定、ambient vision/voice、剪贴/选区、蒸馏 | §3 |
+| [PLAN_DISPATCH_v1.0.md](./PLAN_DISPATCH_v1.0.md) | 统一指挥：本地命令回路、TakoAPI consumer（shim + A2A）、能力路由、advisor 债 | §4 |
+| [PLAN_REVE_v1.0.md](./PLAN_REVE_v1.0.md) | 反思/进化硬化：质量门禁、可观测、有界、soul 速览、desire 中间态、recap 回流 | §5 |
+| [PLAN_MODEL_v1.0.md](./PLAN_MODEL_v1.0.md) | 模型：本地生命周期、本地 embedding、容错+自检、provider 欠账 | §6 |
+| [PLAN_FOUNDATIONS_v1.0.md](./PLAN_FOUNDATIONS_v1.0.md) | 横切：consent/隐私、安全地板、测试门禁、可观测、footprint、叙事诚实 | §7 |
+
+> 阅读顺序建议：先本文（为什么 + 顺序），再 FOUNDATIONS（地基），再按里程碑顺序读 REVE → MODEL → DISPATCH → SENSE。
+
+---
+
+## 0. 愿景与"1.0"的定义
+
+LISA 1.0 把现有的"灵魂叙事"（Soul · Desires · Heartbeat · Dreams）重新切成一条**能力架构主线**：
+
+| 支柱 | 一句话 | 现有系统基础 |
+|---|---|---|
+| **Sense（感知）** | 一个常驻进程，从视觉、语音、指针/选区、截屏、剪贴，以及本机所有 CLI / AI-agent / coding 活动里持续获取上下文与记忆，建立对用户工作的全面记录 | 部分：on-demand vision/voice + 5 个 agent observer + idle watcher |
+| **Dispatch（调度）** | 全面接入所有 coding agent 与 AI-agent 服务，与 **TakoAPI**（one API to access all agents）联动；用户跟 LISA 对话即可指挥本机全部其它 agent（+ 远程 agent） | 部分：observe + headless launch，**命令回路未闭合**；TakoAPI 是外部托管网关、LISA 侧未接入 |
+| **Reve（反思 / 进化）** | 用户不在时自动反思、自演化 | 最成熟：idle/dreams + reflect + heartbeat + soul 全闭环 |
+| **Model（模型）** | 当前用 API，后续提供本地模型部署选项 | 部分：20+ provider 前缀路由，本地仅"自带 endpoint" |
+
+**"Reve" = 现有 Dreams 系统的正式更名**（rêve / 梦）。它不是新东西，而是把 idle 反思 + 反思 + 心跳 + 灵魂演化收编为一个有名字的支柱。
+
+### 1.0 的判定标准（什么时候能叫 1.0）
+
+1. **四支柱各自跨过可信阈值**：不是"demo 能跑"，而是"能当 daily-driver 且不撒谎"。
+2. **叙事 = 代码**（v0.9 review 的核心批评）：README / PITCH / 官网说的每一句，第一个认真读代码的 contributor 都能对上。
+3. **守住 v0.9.1 安全地板**：**常驻感知（Sense）是 1.0 最危险的隐私/攻击面扩张，本地 agent 命令回路（Dispatch）次之**——不得重开 RCE，不得在无 consent 下采集。（接入 TakoAPI 当 consumer 反而是小事——出站调用为主，见 §4。）
+4. **可复现的自主性度量**：Reve 能产出 drift / coherence 指标（直接服务[论文计划](#9-与研究目标论文的衔接)）。
+
+### 一条贯穿的张力：先打深，再铺宽；隐私优先
+
+v0.9 review 的诊断一针见血：**项目每个版本都在加一个新大件（编排器 / vision / island / screen advisor / voice），而不是把已有的打深讲清；建设量与认知度严重倒挂，叙事跑在代码前面，攻击面涨得比信任快。**
+
+1.0 不能重犯这个错。具体到本计划：
+
+- **Sense 的"常驻采集屏幕 / 语音 / 剪贴"是一颗隐私炸弹**，必须把**同意模型与本地处理**作为头号设计约束，而不是事后补丁。能不离机就不离机，能不常驻就先做"按需 + 显式触发"。
+- **Dispatch 把信任面算清**：接入 TakoAPI（外部网关）的风险主要在**出站**——远程 agent 响应当作不可信输入（二阶注入）、护好 `TAKO_KEY`。真正的"安全炸弹"是**闭合本地 agent 命令回路**与（可选的）把 LISA 作为 publisher 暴露给公网；第一性原则是**最小权限 + 审计 + 人类批准闸 + 远程来源默认禁**。
+- **Reve 已经够深，1.0 对它的工作是"硬化"不是"加功能"**——这正好是 review 想要的方向。
+- **每个支柱都遵循"深化现有 → 谨慎新增"**：先把已经声称的能力做实（5 个 observer 的非-Claude 深度、本地模型的生命周期、反思的质量门禁），再去碰常驻采集、TakoAPI 原生接入这种更大的扩张。
+
+---
+
+## 1. 四支柱 ↔ 现有系统映射
+
+```
+        ┌──────────┐      ┌───────────┐      ┌──────────┐
+  用户 → │  SENSE   │ ──▶  │  DISPATCH │ ──▶  │   REVE   │ → "你不在时我做了…"
+        │ 感知/记录 │      │ 指挥/编排  │      │ 反思/进化 │
+        └────┬─────┘      └─────┬─────┘      └────┬─────┘
+   观察用户 + agent 活动    指挥本机其它 agent     空闲自演化、写灵魂
+             │                  │ (← TakoAPI 远程)  │
+             └───────── 统一工作记忆 MEMORY ────────┘
+                                │
+                       ┌────────┴────────┐
+                       │      MODEL       │  贯穿四层的推理基座
+                       │  API / 本地模型   │
+                       └─────────────────┘
+```
+
+| 1.0 支柱 | 收编 / 依赖的现有模块 |
+|---|---|
+| **Sense** | `src/integrations/*`（hub + 5 observer）、`src/vision/capture.ts`、`src/screen_advisor/engine.ts`、`src/voice/*`、`src/idle/watcher.ts`、`src/memory/*`、`src/web/server.ts`（screen-advisor loop）、`src/autostart/install.ts` |
+| **Dispatch** | `src/tools/{dispatch_agent,signal_agent,compare_agents,scheduled_dispatch,inspect_agent,list_agents,agent_recap}.ts`、`src/integrations/{hub,dispatch-ledger,scheduled-dispatch,comparisons}.ts`、`src/channels/router.ts`、`src/mcp/client.ts` ＋ **TakoAPI 接入（A2A + OpenAI shim）** |
+| **Reve** | `src/idle/runner.ts`、`src/reflect.ts`、`src/heartbeat/{runner,config}.ts`、`src/soul/{store,tools,git}.ts`、`src/orchestrator/{journal,recap}.ts` |
+| **Model** | `src/providers/*`、`src/llm.ts`、`src/env.ts`、`src/memory/vector.ts`（embedding） |
+
+**与公开叙事的关系**：现有对外主线是 Soul · Desires · Heartbeat · Dreams（内在生活故事），它整体落在 **Reve + Model 基座**里。Sense 与 Dispatch 是 1.0 对外的能力扩张面。两套叙事不冲突：**Reve 是"她是谁"，Sense/Dispatch 是"她替你做什么"**。1.0 的对外定位建议仍以灵魂线为主钩（review 的结论），Sense/Dispatch 作为"她还能看你的工作、指挥你的 agent 舰队"的能力点。
+
+---
+
+## 2. 现状盘点（四支柱速查）
+
+### Sense — 感知（成熟度 ~30%，按需而非常驻）
+
+| 能力 | 现状 | 关键文件 | 缺口 |
+|---|---|---|---|
+| 屏幕截图 | ✅ 按需（hotkey / 📷）+ 可选周期 advisor（默认关、≥10min） | `vision/capture.ts`、`screen_advisor/engine.ts` | 无连续采集、无 OCR、不知前台 app/窗口 |
+| 语音 | ✅ TTS（`say`）+ 文件转写（Whisper）+ 听写润色 | `voice/{speak,transcribe,dictation}.ts` | 无常驻听写、无录音、无热键、纯云依赖 |
+| 剪贴 / 选区 / 指针 | ⚠️ 仅 web composer 粘贴 | `web/lisa-client.ts` | 全局剪贴、跨 app 选区、指针/焦点全无 |
+| Agent / CLI 活动 | ✅ 5 observer（claude-code 最深，codex/opencode Tier-2，aider 文件+轮次，github-pr 元数据） | `integrations/{claude-code,codex,opencode,aider,github-pr}/observer.ts`、`hub.ts` | 无通用 shell 历史 / IDE / git / 构建进程观察；非-agent 的 CLI 全盲 |
+| 在场/离开判定 | ⚠️ 仅靠"是否在跟 LISA 交互" | `idle/watcher.ts` | 不读系统 idle / 锁屏；用户在 VS Code 干活也算 idle |
+| 常驻进程 | ⚠️ `serve --web` 是反应式 web 后端 | `web/server.ts`、`autostart/install.ts` | 无独立的"持续采集"循环，依赖 fs.watch + 定时器被动触发 |
+| 工作记忆 | ✅ 文本 memory + TF-IDF 检索 | `memory/{store,vector}.ts` | 无自动抽取、无多模态、无实时索引 |
+
+### Dispatch — 调度（成熟度 ~45%，能观察能拉起，不能"指挥"）
+
+| 能力 | 现状 | 关键文件 | 缺口 |
+|---|---|---|---|
+| Headless 拉起 agent | ✅ 4 家 CLI（claude/codex/opencode/aider），detached + 账本 | `tools/dispatch_agent.ts`、`integrations/dispatch-ledger.ts` | 仅 fire-and-forget；硬编码 4 家、不可扩展 |
+| 停止 agent | ✅ 仅杀自己账本里的 pid（SIGTERM→KILL） | `tools/signal_agent.ts` | 不能 pause / 注入 / 改任务 |
+| 冲突避免 | ✅ 同 cwd 有活跃 agent 则拒绝 | `tools/dispatch_agent.ts` | 状态式、非持久 ownership/lock |
+| 调度面板 | ✅ list / inspect / compare（worktree 并行）/ scheduled / recap | `tools/{list_agents,inspect_agent,compare_agents,scheduled_dispatch}.ts` | 建议动作多为死标签，回路未闭 |
+| **命令回路** | ❌ 单向：拉起后无反馈、approval 不回传、输出不回流 | — | **1.0 核心缺口** |
+| **TakoAPI** | ⚠️ 外部托管服务（"OpenRouter for agents"，A2A + OpenAI shim），LISA 侧零接入 | 见 §4 | **接入而非自建**：consumer 先行（OpenAI shim 近免费）+ 可选 publisher |
+| 渠道触发 dispatch | ⚠️ 默认远程禁用，需 `unsafeFullTools` | `channels/router.ts`、`tools/registry.ts` | 全或无，无细粒度/审批流 |
+
+### Reve — 反思 / 进化（成熟度 ~70%，最成熟，缺质量门禁与可观测）
+
+| 能力 | 现状 | 关键文件 | 缺口 |
+|---|---|---|---|
+| 空闲反思（dreams） | ✅ idle≥~1h 触发，跨进程锁，受限工具集，输出"while you were away" | `idle/{watcher,runner}.ts` | 无决策日志/可追溯；单窗口只做一件事 |
+| 会话末反思 | ✅ 产出 journal + memory/skill/feel/opinion/desire/soul 操作 | `reflect.ts` | JSON 坏掉静默降级；无"反思不足"检测 |
+| 心跳（heartbeat） | ✅ cron/launchd；用户任务 + 自驱欲望 + 周度自省；token 预算闸（默认 500k） | `heartbeat/{runner,config}.ts` | 无任务成功率度量；desire 能力/野心错配 |
+| 灵魂演化 | ✅ desire→heartbeat→progress→reflect 压缩→close 全闭环；git 可追溯；情绪衰减+事件 | `soul/{store,tools,git}.ts` | 无人读的"Lisa 速览"；并发锁仅部分铺开 |
+| 编排器 recap | ✅ 隐私安全的跨 agent 事件流 + recap | `orchestrator/{journal,recap}.ts` | **未接进 Reve 的反思**，单向可观测 |
+
+### Model — 模型（成熟度 ~60%，多 provider 干净，本地仅"自带 endpoint"）
+
+| 能力 | 现状 | 关键文件 | 缺口 |
+|---|---|---|---|
+| Provider 路由 | ✅ 模型名前缀路由 + 14 家 OpenAI 兼容预设 | `providers/registry.ts` | 同名模型路由歧义；无自动检测 |
+| 本地模型 | ⚠️ 仅"自带 endpoint"（`LISA_BASE_URL` 指向 Ollama/LM Studio/vLLM） | `providers/openai.ts`、`docs/PROVIDERS.md` | **无下载/启动/管理生命周期**；崩溃无 fallback |
+| Embedding | ⚠️ TF-IDF（无语义） | `memory/vector.ts` | 无本地语义向量；不可扩展 |
+| 容错 | ❌ 无 provider fallback 链 | — | 主 provider 报错即断 |
+
+---
+
+## 3. SENSE — 常驻感知层
+
+### 1.0 目标态
+
+一个**单一常驻服务**，在用户**显式授权的每一类信号**上持续采集，本地优先处理，沉淀为统一的工作记忆——既覆盖"用户在干什么"（屏幕/语音/选区/剪贴），也覆盖"机器上的 agent 与 CLI 在干什么"（现有 observer + 通用 CLI/git/IDE）。**默认最小、逐项 opt-in、能不离机就不离机。**
+
+### 缺口（按风险从低到高排）
+
+1. **agent observer 深度不均**：claude-code 最深，其余三家活动字段稀疏，aider 几乎只有文件+轮次，无通用"非-agent CLI"观察。
+2. **无通用工作信号源**：shell 历史、git 提交/分支、IDE 打开的文件、构建/测试进程全盲。
+3. **在场判定太弱**：只认"是否在跟 LISA 说话"，不读系统 idle / 锁屏 / 前台 app。
+4. **vision/voice 是按需而非 ambient**：截图靠热键、转写靠用户给文件路径。
+5. **剪贴/选区/指针全无**：全局剪贴、跨 app 选区、焦点窗口零采集。
+6. **无自动 context→memory**：采集到的东西不会自动蒸馏进记忆；记忆是文本、手动、非实时。
+
+### 分阶段任务
+
+**S1 — 深化已声称的观察（低风险，最高可信，先做）**
+- 把 codex / opencode / aider observer 的 Tier-2 活动字段补齐到与 claude-code 同档（`lastTools` / `filesTouched` / `pendingPermission` / `cost`），让 6 个 advisor detector 对它们真正触发——兑现"看你所有 agent"的承诺（review §4.3 指出此前只兑现 1/5，0.9.1 已部分推进，1.0 收口）。
+- **新增低风险工作信号源**（不碰系统级权限）：
+  - **git observer**：watch 各 repo 的 `.git/HEAD`、提交、分支切换、`git status` 摘要。
+  - **shell 历史 observer**：尾随 `~/.zsh_history` / `~/.bash_history`（仅 argv[0] + 时间，**不存完整命令**，沿用 observer 的隐私分层）。
+  - **构建/测试信号**：从已观察的 agent 日志里抽 `npm test` / `cargo test` 等结果（无需新权限）。
+- 产出：把这些并入 `hub.ts` 的统一 `AgentSession[]`/事件流，复用现有隐私 tier 与测试范式（planted-secret 测试）。
+
+**S2 — 从按需到 ambient 的 vision + voice（中风险，consent 闸是前提）**
+- vision：把 `screen_advisor` 的"周期截图"泛化为**可配置 ambient 采集**（前台 app/窗口标题 + 低频截图），但：
+  - 默认关闭；开启需显式 consent 卡（一次性，可随时撤销）。
+  - **本地优先**：先在本地做"是否值得上报"的轻量判定（前台 app 变化 / 出现错误对话框），只有命中才考虑送模型；截图**绝不持久化**（沿用现有 finally 删除）。
+  - 加"敏感区域屏蔽 / 黑名单 app（密码管理器、银行）"。
+- voice：补**录音 + 热键 + 流式转写**（现在只有"给文件路径才转"），同样默认关、需 consent；探索本地 STT（whisper.cpp）作为离机选项。
+
+**S3 — 剪贴 / 选区 / 指针（高风险，严格 opt-in，最后做）**
+- 全局剪贴监听（macOS `NSPasteboard` changeCount 轮询 / Linux X11/Wayland 选区）：默认关，逐项开关，**只记元数据 + 来源 app，不默认回传内容**。
+- 跨 app 选区 → "用户刚在 X 里选了一段，要不要就这段聊"——这是体验最强、隐私最敏感的一项，放在 consent 体系最成熟之后。
+- 指针/焦点仅用于在场判定（见下），不做轨迹记录。
+
+**S4 — 统一记忆与本地化处理（贯穿 S1–S3）**
+- **自动 context→memory 蒸馏**：一个后台低频任务把"今天观察到的工作"蒸馏成 1–2 条记忆（"在 repo X 上为 feature Y 调试 Z"），写进 `memory/store.ts`，受 Reve 的反思质量门禁约束。
+- **在场判定升级**：接 macOS `ioreg`/`CGEventSource` 系统 idle 与锁屏，替代"只认 LISA 交互"——让 Reve 的 dreams 触发更准（用户在 VS Code 忙时不该判 idle）。
+- **本地 embedding**（与 Model 支柱共用）：给 `memory/vector.ts` 加一层语义向量（本地 sentence-transformer / Ollama embedding），TF-IDF 保留为快路。
+- **常驻架构**：把"采集"从反应式 web server 里拆出为一个独立的、不依赖 GUI 打开的后台采集循环（autostart 已有 launchd 壳），事件驱动 + 低频轮询，绝不阻塞 chat。
+
+### 隐私 / 安全约束（本支柱头号）
+- **同意模型是地基不是补丁**：每一类信号（屏幕/语音/剪贴/选区/shell）独立开关，默认全关，UI 里随时可见"现在在采什么"并一键全停。
+- **本地优先**：raw 截图/音频/剪贴在本地完成蒸馏/判定，只有命中且必要才送模型；持久化的永远是结构化摘要，不是原始流。
+- **黑名单**：app 级（密码/银行/隐私浏览）、路径级、PII 模式级屏蔽。
+- 复用 observer 既有的隐私分层与 planted-secret 测试，扩展到每个新信号源。
+
+---
+
+## 4. DISPATCH — 统一指挥层 + TakoAPI
+
+### 1.0 目标态
+
+用户对 LISA 说一句话，LISA 能**指挥本机的（乃至 TakoAPI 背后远程的）任意 agent**：选对 agent、派活、看进度、转发审批、把结果接回对话、必要时纠偏或停止——而不是现在的"拉起来就不管了"。**TakoAPI（独立的"OpenRouter for agents"托管网关）补上"远程 agent"那一半：LISA 接入它，对话即可触达本机之外、A2A 生态里的任意 agent；本地 agent 的编排仍是 LISA 自己的活。**
+
+### TakoAPI 是什么（已核对实物，2026-06-13）
+
+> 已直接审阅 `/Users/oratis/Documents/Claude/TakoAPI`（**独立 repo**，Next.js 16 + Prisma + Cloud Run，线上 takoapi.com）。**它不是 LISA 内部要造的东西，而是一个独立托管服务**，定位 **"OpenRouter for agents"**：*one API key, one bill, any agent*。registry-first、gateway fast-follow；D1–D8 战略决策已于 2026-06-13 全部拍板（A 终局代理网关 + A2A 主协议 + OpenAI shim 引流 + OpenRouter 式变现）。
+
+三层：
+- **Registry（发现）**：基于开放的 **A2A AgentCard**（`/.well-known/agent-card.json`）描述 agent。`GET /api/registry?q=&format=json`、`GET /api/agents/{slug}`。**Phase 1 已完成并本地验证。**
+- **Gateway（调用，`Authorization: Bearer <TAKO_KEY>`）**：`POST /v1/agents/{slug}/message`（A2A）、`/v1/agents/{slug}/stream`（SSE）、`POST /v1/chat/completions`（**OpenAI 兼容 shim**，`model` = agent slug）。**v1 路由已存在于代码**（message / stream / chat-completions + `lib/agentcard.ts` / `lib/apikey.ts`），Phase 2 网关基本成形；生产 DB 升配 + PgBouncer + Upstash Redis 为 Phase 2A 前置，待办。
+- **Commercial（变现）**：prepaid credits + 充值费 + publisher 分成，Phase 3，未做。
+
+**对 LISA 最关键的一条认知**：TakoAPI 管的是**远程 agent**（A2A server / OpenAI 兼容端点），LISA 现有 Dispatch 管的是**本机 CLI agent**（spawn / observe 本地进程）。**两者互补、不重叠**——合起来才是"指挥所有 agent，本地 + 远程"。因此 LISA **不需要自建网关 / registry / billing**（TakoAPI 就是这一层），LISA 要做的是**接入**（当 consumer，可选当 publisher）。这把 Dispatch 支柱的范围**缩小**了：不是从零设计 agent 控制契约，而是对接 **A2A + OpenAI-shim 两个现成协议**。
+
+### 缺口与分阶段
+
+**D1 — 闭合命令回路（1.0 的核心工程，最高优先）**
+- **反馈回流**：`dispatch_agent` 现在 fire-and-forget；加进度/结果流（poll 或 events），把 agent 的产出接回 LISA 的对话与决策。
+- **审批转发（approval relay）**：被拉起的 agent 卡在权限提示时，信号上报 LISA → 用户在 LISA 里确认 → 回传给 agent。这是"指挥"与"放养"的分水岭。
+- **中途转向（steer）**：能改任务、注入上下文，而非只会 kill。
+- 安全：以上每一步都**默认带人类批准闸**，远程来源（渠道）默认禁用（守住 0.9.1 线）。
+
+**D2 — 接入 TakoAPI（两个方向，consumer 先行）**
+
+*方向一：LISA 作为 TakoAPI consumer——让 LISA 能指挥远程 agent*
+- **(a) OpenAI-shim 快路（近乎免费，最早可落地）**：LISA 已有 OpenAI 兼容 provider 路由 + `LISA_BASE_URL`（见 [Model 支柱](#6-model--从自带-endpoint-到真本地部署)）。把一个 provider 指向 `https://takoapi.com/v1`、配 `TAKO_KEY`、`model=<agent-slug>`，即可把任意 TakoAPI agent 当成一个"模型"来调用——几乎零新代码。可在 0.12 随手落地。
+- **(b) A2A 原生 adapter（更深，0.14）**：给 hub/Dispatch 加一个 `takoapi` agent 源——`GET /api/registry` 列远程 agent，`POST /v1/agents/{slug}/message` 派活、消费 SSE、按 A2A `TaskState` 跟踪。让远程 TakoAPI agent 成为 hub 里与本地 CLI agent 平起平坐的一等公民（正是 [ORCHESTRATOR_PLAN.md](./ORCHESTRATOR_PLAN.md) taxonomy 的 Class B 云 agent）。
+- **远程 agent 的"命令回路"基本由 A2A 协议自带**（`TaskState` + SSE + push webhook），LISA 不必自造——与 D1 形成对照：**本地 CLI agent 的回路要 LISA 自己闭（D1），远程 agent 的回路继承 A2A（D2）**。
+
+*方向二：LISA 作为 TakoAPI publisher（可选，战略性，1.0 后）*
+- 让 LISA 自己（或她编排的本地 agent）以 A2A AgentCard 形式上架 TakoAPI，被整个生态调用。需要 LISA 暴露 `/.well-known/agent-card.json` + A2A `message/send` 入站端点——LISA 现有的 **webhook channel 已经很接近** A2A 入站形态，可在其上演进；同时帮 TakoAPI 冷启动供给侧（LISA = 一个种子 agent）。但这把 LISA 变成"对公网可被调用的服务"，安全面再扩一层 → 放 1.0 之后、consent/安全体系成熟后再做。
+
+*MCP*：TakoAPI 把 MCP 聚合列为后置；LISA 这边把本机 MCP server 纳为一等 dispatch 目标仍是 LISA 自己的事（与 TakoAPI 解耦，保留在路线里）。
+
+**D3 — 能力注册与路由（dispatcher brain）**
+- agent 声明擅长什么（重构/测试/文档…），LISA 据此**选对 agent**派活（"这个交给 Claude Code，那个交给 aider"）。
+- 跨 agent token 预算（现在 scheduled-dispatch 只限次数不限 token）。
+- 持久化 cwd ownership / lock（用 `soul/lock.ts` 的 link 互斥），把冲突避免从"反应式"变"前置预约"。
+
+**D4 — 把 review 留下的 dispatch 债清掉（1.0 前必清）**
+- island 上 advisor 的建议动作接成**可点按钮**（cancel→signal 端点；dispatch/approve→prefill composer，**绝不自动执行**）——review 称之为"生死线的闭环"。
+- 多 agent 监控前端：后端已发 `agent_session_update`，前端只消费 `claude_session_update`，补齐。
+- 把 `dispatch_agent` / `github` 写操作纳入 mutating 工具集（review §3.8 指出此前连 `--approval ask-mutating` 都拦不住）——复核 0.9.1 是否已修，未修则补。
+
+### 安全
+- 接入 TakoAPI 的新攻击面主要在**出站**：**把网关返回的远程-agent 响应当作 hostile**（二阶 prompt injection——TakoAPI 自己的技术架构文档 §11 也强调上游响应不可信）；保护 `TAKO_KEY`（走 `config.env`，已 0600）。若日后做 publisher（方向二），LISA 变成可被公网调用的服务，那才是入站面，留到 consent/安全体系成熟后。
+- 本地 dispatch 仍守 v0.9.1 线：`dispatch_agent` / `signal_agent` / `scheduled_dispatch` 远程来源默认禁、人类批准闸、审计账本（`dispatch-ledger.ts`）。
+- approval relay（D1）防伪：转发的审批必须能验证来源是真 LISA 用户，而非被注入的渠道消息。
+
+---
+
+## 5. REVE — 自主反思与进化
+
+### 1.0 目标态
+
+把**已经很成熟的自演化闭环**从"能跑"提升到"可信、可观测、有边界、可度量"。**1.0 对 Reve 的工作是硬化与可观测，不是加新能力**——这正是 v0.9 review 想要的方向，也直接喂[论文](#9-与研究目标论文的衔接)。先把 Dreams 在全代码/文档里正式更名 **Reve**。
+
+### 任务（全部是"做实"而非"做新"）
+
+**R1 — 反思质量门禁**
+- `reflect.ts` 的 JSON 坏掉时现在静默降级（返回空 applied）。加：解析失败告警 + 重试 + 记录；"反思不足"检测（一段实质会话却 0 操作时标记）。
+- 情绪 delta 一致性：reflect 的 feel op 与 `soul_feel` 行为对齐（先衰减再叠 delta）——review §4.2 指出二者不一致，复核 0.9.1 是否已修。
+
+**R2 — heartbeat / idle 可观测与边界**
+- **任务成功度量**：现在只记最终文本，分不清"真做完"与"agent 说了句 no update 其实没跑"。加结构化成功/失败记录。
+- **自主循环成本断路器**：heartbeat 有 500k token 预算闸，**idle 没有**——补上，防止长 idle 窗口烧钱。
+- **收敛/有界**：idle 单窗口"只做一件事"在长窗口下会积压；定义"做几件、何时停"的有界策略。
+- 在场判定升级见 [Sense S4]——让 dreams 触发更准。
+
+**R3 — 灵魂可观测（给人看，不只给 LLM 看）**
+- `lisa soul summary` / GUI 卡片："Lisa 今天：好奇 0.45 · 想做 [X,Y] · 相信 [A,B]"。现在情绪/欲望/opinion/git 历史只有 LLM 自己读，营销权重 > 可感效用（review §4.2）。
+- 把并发锁铺全：`appendJournal` / 情绪写入 / `commitSoulChange` 都包 `withSoulLock`（review §4.2 指出此前裸 RMW，0.9.1 已修一批，1.0 收口并复核 git commit 不再被 swallow）。
+
+**R4 — desire 能力/野心错配**
+- 现在 desire 要么 actionable（能跑）要么不能；若一个欲望需要 shell 而自主循环没 shell，就只能干瞪眼累积 frustration。加中间态："想做但需要你帮忙跑"——自动落一条 meta-desire 提示用户，而非 boolean 死结。
+
+**R5 — 把编排器 recap 接进 Reve**
+- `orchestrator/recap.ts` 现在单向：记录"agent 们做了什么"，但 Lisa 的反思从不读它。1.0 让 heartbeat/reflect 读 recap："今天 3 个项目、2 个完成、1 个报错"，据此调整自己的欲望与关注——让 Sense→Dispatch→Reve 真正闭环。
+
+### 与论文的衔接
+R2 的成功度量 + R1 的反思质量 + soul git 历史，正是论文要的 **drift / long-horizon coherence 指标**与 **ablation 钩子**（soul_object / weekly examen / approval-gated skills 作为稳定性机制的开关）。1.0 的 Reve 硬化与论文实验是同一批工作。
+
+---
+
+## 6. MODEL — 从"自带 endpoint"到真·本地部署
+
+### 1.0 目标态
+
+把本地模型从"你自己装 Ollama 我连过去"升级为**一等的本地部署选项**：能装、能管、能切、能容错；并补本地 embedding，让 Sense 的语义记忆与论文的可复现 baseline 不依赖云。
+
+### 任务
+
+**M1 — 本地模型生命周期命令**
+- `lisa model install <backend> <model>`（封装 `ollama pull` + 启动 serve）、`lisa model list`（已装/已配/可 birth）、`lisa model use local://…`（切换 endpoint）。现在全靠用户手动，文档把"自带 endpoint"含混说成"开箱即用"（review/audit 都点了这一含混）。
+- 本地 server 崩溃时的健康检查与提示。
+
+**M2 — 本地 embedding**
+- 给 `memory/vector.ts` 抽象出 embedding 接口：TF-IDF（默认快路）+ 可选本地语义向量（Ollama/llama.cpp embedding 或本地 sentence-transformer）。与 [Sense S4] 共用。
+
+**M3 — Provider 容错与自检**
+- fallback 链：主 provider 报错 → 重试 → 降级到备用（config.env 配主 + 备）。
+- 自动检测：只配了一个 key 时自动选该 provider，不必显式设前缀/env。
+- Anthropic 专属特性（prompt caching / thinking）在其它 provider 上优雅降级（现在 OpenAI/Gemini 路径无压缩、空 content 会让下轮 Anthropic 400——这些 review §4.1 列的 provider 债一并清）。
+
+**M4 — provider 层欠账复核（abort 已修，其余收口）**
+- abort 信号：**已修**——`anthropic.ts:60` / `openai.ts:45` / `gemini.ts:79` 均把 `opts.signal` 透传给 SDK，并有专门的 passthrough 测试（v0.9.0 review"三 provider 零处使用"的结论已过时）。1.0 仅需保持回归测试。
+- 仍需对当前树复核的 review 旧账：maxIterations 静默截断（到上限直接退、stopReason 是旧值，调用方分不清正常结束与被截断）、OpenAI/Gemini 空 content 入历史导致下轮 Anthropic 400、OpenAI/Gemini 路径无 compaction。确认仍存在再排期。
+
+### 与论文的衔接
+本地模型 = 可复现、零边际成本的 long-horizon 实验底座；本地 embedding = 记忆检索不离机。这让论文的 ablation 能在独立研究者的算力预算内反复跑（符合[论文计划](#9-与研究目标论文的衔接)"不要需要实验室算力的实验"约束）。
+
+---
+
+## 7. 横切关注点
+
+### 7.1 隐私与同意模型（master constraint）
+Sense 的常驻采集让隐私从"功能特性"上升为"产品成立的前提"。统一的 consent 体系（逐类开关、默认全关、随时可见可停、本地优先、黑名单）必须**先于**任何 ambient 采集落地。这也是对外叙事的最大风险点——"它一直在看你的屏幕"若没有可信的隐私故事，会直接劝退。
+
+### 7.2 安全（守住 0.9.1 地板）
+1.0 的大件里，**resident capture（Sense）扩张隐私面、本地 agent 命令回路（Dispatch）扩张攻击面**；接入 TakoAPI 当 consumer 风险小（出站为主）。红线：
+- 不重开 LAN-RCE；新端点一律 loopback/token 闸 + approval + hook（沿用 0.9.1 的 web 鉴权范式）。
+- 本地 dispatch：最小权限 + 审计账本 + 人类批准 + 远程来源默认禁；TakoAPI：网关响应当 hostile + 护 `TAKO_KEY`。
+- 工具 input 仍**无 schema 校验**（review §2 列为未修）——1.0 前补，尤其 dispatch / A2A 入站路径。
+
+### 7.3 测试（核心循环仍裸奔）
+review 反复点名：`agent.ts`、三个 provider 翻译层、`subagent`、`approval`、`sessions`、`hooks`、`mcp` **零测试**——最该测的恰好裸奔。1.0 的新能力（TakoAPI 接入、Sense 采集、本地模型）必须自带测试，同时补这批核心循环的欠账。发布门禁加 `npm test`（review §6 指出 release workflow 不跑测试）。
+
+### 7.4 可观测性
+Reve（R2）、Dispatch（D1 回流）、Sense（采集了什么）都需要结构化日志与"给人看"的面板，而非只有 LLM 自己读的文本 blob。
+
+### 7.5 常驻进程的 footprint
+一个真常驻采集服务要管 CPU/内存/能耗/磁盘——低频轮询、事件驱动、本地处理要算成本，不能让风扇起飞。这是"按需 → ambient"必须谨慎的工程理由。
+
+### 7.6 向后兼容 & 叙事诚实
+- 现有 `~/.lisa/*` 配置、soul 格式、session 格式不破坏；Dreams→Reve 更名要平滑迁移。
+- **叙事 = 代码**是 1.0 的硬指标：修文档尸体（review §4.5 列的 LisaIsland 幽灵、三处 0.2.0 版本、LOC 数字失真一倍、completions 缺项、CONTRIBUTING 指向不存在目录）。
+
+### 7.7 从 v0.9 review 继承、1.0 前需复核/关闭的债
+> 0.9.1 已关 P0；以下是 review 的 P1/P2，排期前请对当前树逐条复核状态：
+
+- abort signal 贯通：**已修**（anthropic/openai/gemini 均透传 + 测试）｜ maxIterations 静默截断显式化、空 content 守卫：复核（→ M4）
+- advisor 建议可点按钮 + 多 agent 前端（→ D4）
+- `dispatch_agent`/`github` 写操作入 mutating 集（→ D4，复核 0.9.1 是否已修）
+- 核心循环补测试（→ 7.3）｜ `/chat` 并发 busy+queue + JSON.parse 容错
+- 文档诚实（→ 7.6）｜ 发布门禁加测试（→ 7.3）
+
+---
+
+## 8. 里程碑与推进顺序
+
+**排序原则**：先做**低风险、高可信、兑现已有承诺**的硬化（Reve + Sense 的 observer 深化 + Model 的本地生命周期），把信任地基打牢；再上**高风险、大扩张**的常驻采集与 TakoAPI 原生接入（A2A）（必须等 consent + security 体系就位）。这与 review"先打深再铺宽"的结论一致。
+
+| 里程碑 | 主题 | 落地内容 | 风险 |
+|---|---|---|---|
+| **0.10** | Reve 硬化 + 兑现承诺 | R1–R3、R5；Sense S1（observer 深化 + git/shell 信号）；M4 provider 欠账复核 + 核心循环测试欠账；D4 + 7.7 债 | 低 |
+| **0.11** | Model 本地化 | M1–M3（本地模型生命周期 + 本地 embedding + 容错）；Sense S4 的本地 embedding 部分 | 中低 |
+| **0.12** | Dispatch 命令回路 + TakoAPI 快路 | D1（本地 agent 反馈回流 / approval relay / steer）；**D2(a)**（OpenAI-shim 接 TakoAPI，近乎免费）；D3（能力注册 + 路由 + lock） | 中 |
+| **0.13** | Sense ambient（带 consent） | 隐私/同意体系（7.1）；S2（ambient vision + voice，默认关）；常驻采集服务拆分 | 高 |
+| **0.14** | TakoAPI 原生接入 | **D2(b)**（A2A adapter，远程 agent 进 hub + SSE/TaskState）；本机 MCP 升一等 dispatch 目标 | 中 |
+| **0.15** | Sense 深采（最敏感） | S3（剪贴/选区/指针，严格 opt-in） | 最高 |
+| **1.0** | 收口 | 四支柱跨可信阈值；叙事=代码；安全/隐私审计；论文 ablation 数据可产出 | — |
+
+> TakoAPI 已确认是成熟外部服务，故 consumer 快路 D2(a)（OpenAI-shim）已前移到 0.12 与 D1 同期；0.14 只剩更深的 A2A 原生 adapter（D2(b)）。
+
+**哪些产出论文 ablation**：0.10（Reve 硬化 = drift/coherence 指标 + 稳定性机制开关）、0.11（本地可复现底座）、0.12+（Sense 提供的长程任务上下文）。1.0 的工程与论文实验是同一批工作，不是两条线。
+
+---
+
+## 9. 与研究目标（论文）的衔接
+
+[记忆中的论文计划](../README.md)：方向 A+B，主论点是"持久自我状态架构降低 long-horizon agent drift"，稳定性机制（soul_object / weekly examen / git history / approval-gated skills）作为 autonomy-vs-alignment 的 cap；目标 COLM/ICLR 2027，对照 Letta/MemGPT/Generative Agents。
+
+四支柱对论文的贡献：
+- **Reve** = 被度量的主体（长程一致性的 substrate + 稳定性机制的可开关 ablation）。1.0 的 R1/R2 硬化直接产出 drift 指标。
+- **Model** = 可复现、低成本的实验底座（本地模型 + 本地 embedding），满足"独立研究者算力预算"约束。
+- **Sense** = 给长程任务喂真实、连续的工作上下文（比合成 benchmark 更有外部效度，可能支撑并行的 CHI HCI track 长期用户研究）。
+- **Dispatch** = 多 agent 协作场景，是 coherence 在"她还要协调别的 agent"压力下的延伸实验。
+
+**约束**：优先能产出 ablation、可复现 seed、可外部对照的设计；不做需要实验室算力的实验。
+
+---
+
+## 10. 一句话总结
+
+> **1.0 = 把"她有内心"（Reve，已成熟，做硬化）+ "她看得见你的工作"（Sense，做深再做广、隐私优先）+ "她能指挥你的 agent 舰队"（Dispatch，闭合本地命令回路 + 接入 TakoAPI 触达远程）+ "她能跑在你自己的模型上"（Model，真本地部署）四件事，各自做到 daily-driver 可信、且每一句宣传都对得上代码——在不把 v0.9.1 刚堵上的安全/隐私地板推回去的前提下。**
+
+先打深，再铺宽；能不离机就不离机；叙事永远不许跑在代码前面。

--- a/src/agent.test.ts
+++ b/src/agent.test.ts
@@ -306,3 +306,57 @@ describe("runAgent — abort signal plumbing", () => {
     );
   });
 });
+
+describe("runAgent — token budget circuit-breaker (stopReason=budget_exceeded)", () => {
+  const USAGE_200 = { inputTokens: 100, outputTokens: 100, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+  test("stops at the turn boundary once cumulative tokens reach budgetTokens", async () => {
+    // Each tool_use turn spends 200 tokens. With a 300 budget: after turn 1
+    // (200) the loop continues, turn 2 pushes the total to 400, and the breaker
+    // fires at the next turn boundary — before a 3rd provider call.
+    const { provider, calls } = makeFakeProvider([
+      { content: [toolUseBlock("tu")], stopReason: "tool_use", usage: USAGE_200 },
+    ]);
+    const events: AgentEvent[] = [];
+
+    const result = await runAgent({
+      provider,
+      systemPrompt: "sys",
+      tools: [echoTool],
+      toolCtx: makeToolCtx(),
+      history: [],
+      userMessage: "go",
+      model: "fake-model",
+      maxIterations: 32,
+      budgetTokens: 300,
+      onEvent: (e) => events.push(e),
+    });
+
+    assert.equal(result.stopReason, "budget_exceeded");
+    assert.equal(result.iterations, 2);
+    assert.equal(calls.length, 2, "should stop before a third provider call");
+    assert.equal(result.inputTokens + result.outputTokens, 400);
+    const info = events.filter(
+      (e) => e.type === "info" && e.message?.includes("budget_exceeded"),
+    );
+    assert.equal(info.length, 1, "expected one budget_exceeded info event");
+  });
+
+  test("no budgetTokens → runs to maxIterations unchanged", async () => {
+    const { provider, calls } = makeFakeProvider([
+      { content: [toolUseBlock("tu")], stopReason: "tool_use", usage: USAGE_200 },
+    ]);
+    const result = await runAgent({
+      provider,
+      systemPrompt: "sys",
+      tools: [echoTool],
+      toolCtx: makeToolCtx(),
+      history: [],
+      userMessage: "go",
+      model: "fake-model",
+      maxIterations: 3,
+    });
+    assert.equal(result.stopReason, "max_iterations");
+    assert.equal(calls.length, 3);
+  });
+});

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -62,6 +62,14 @@ export interface RunAgentOptions {
     isError: boolean,
   ) => Promise<{ rewriteResult?: string } | void>;
   maxIterations?: number;
+  /**
+   * Optional cumulative (input+output) token ceiling for the whole run. Checked
+   * at each turn boundary; once exceeded the loop stops before the next provider
+   * call with stopReason "budget_exceeded". Used by self-driven runs (idle /
+   * heartbeat) as a cost circuit-breaker so a runaway tool loop can't burn
+   * unbounded tokens unattended. Unset = no ceiling.
+   */
+  budgetTokens?: number;
   /** When set, the system prompt is rebuilt between turns if its source state changed. */
   hotReload?: PromptHotReload;
 }
@@ -77,7 +85,8 @@ export interface RunAgentResult {
   /**
    * The provider's stop reason from the final turn ("end_turn", "max_tokens",
    * …), or "max_iterations" when the loop hit `maxIterations` while the model
-   * still wanted to call tools (the run was truncated, not finished).
+   * still wanted to call tools, or "budget_exceeded" when `budgetTokens` was
+   * reached (both mean the run was truncated, not finished).
    */
   stopReason: string;
 }
@@ -106,6 +115,7 @@ async function runAgentLoop(opts: RunAgentOptions): Promise<RunAgentResult> {
     thinking = false,
     compaction = false,
     maxIterations = 32,
+    budgetTokens,
   } = opts;
 
   const toolMap = new Map(tools.map((t) => [t.name, t]));
@@ -165,6 +175,19 @@ async function runAgentLoop(opts: RunAgentOptions): Promise<RunAgentResult> {
   };
 
   while (iterations < maxIterations) {
+    // Token budget circuit-breaker (cost guard for unattended self-driven runs).
+    // Checked at the turn boundary — before the next provider call — so we never
+    // pre-empt mid-turn and leave a tool_use without its tool_result. The prior
+    // turn's tools have already run and their results are in history, so this is
+    // a clean stop point.
+    if (budgetTokens && iterations > 0 && inputTokens + outputTokens >= budgetTokens) {
+      stopReason = "budget_exceeded";
+      onEvent?.({
+        type: "info",
+        message: `[agent] token budget ${budgetTokens} reached after ${iterations} iteration(s) — stopping (stopReason=budget_exceeded)`,
+      });
+      break;
+    }
     iterations++;
 
     // Mid-session prompt hot-reload (Phase 1.1). Skip on the very first turn —

--- a/src/autonomy/runs.test.ts
+++ b/src/autonomy/runs.test.ts
@@ -1,0 +1,78 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Isolate the ledger to a throwaway dir. paths.ts captures LISA_HOME at import
+// time, so set it BEFORE the first import of the module under test.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-autonomy-"));
+process.env.LISA_HOME = TMP;
+const RUNS_FILE = path.join(TMP, "autonomy", "runs.jsonl");
+
+const { recordAutonomyRun, readAutonomyRuns, summarizeAutonomyRuns } = await import("./runs.js");
+
+function run(overrides: Record<string, unknown> = {}) {
+  return {
+    kind: "idle" as const,
+    startedAt: new Date().toISOString(),
+    durationMs: 1000,
+    inputTokens: 100,
+    outputTokens: 50,
+    outcome: "done" as const,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.rmSync(RUNS_FILE, { force: true });
+});
+
+describe("recordAutonomyRun / readAutonomyRuns", () => {
+  test("round-trips records in order", async () => {
+    await recordAutonomyRun(run({ kind: "idle", outcome: "no-update" }));
+    await recordAutonomyRun(run({ kind: "heartbeat", task: "morning", outcome: "done" }));
+    const all = await readAutonomyRuns();
+    assert.equal(all.length, 2);
+    assert.equal(all[0]!.kind, "idle");
+    assert.equal(all[1]!.task, "morning");
+  });
+
+  test("missing file → empty array (no throw)", async () => {
+    assert.deepEqual(await readAutonomyRuns(), []);
+  });
+
+  test("skips malformed lines instead of failing the whole read", async () => {
+    await recordAutonomyRun(run());
+    fs.appendFileSync(RUNS_FILE, "{not json\n");
+    await recordAutonomyRun(run({ kind: "reflect" }));
+    const all = await readAutonomyRuns();
+    assert.equal(all.length, 2, "two good records survive the corrupt middle line");
+  });
+
+  test("sinceMs filters out old records", async () => {
+    const old = new Date(Date.now() - 10 * 24 * 60 * 60_000).toISOString();
+    await recordAutonomyRun(run({ startedAt: old }));
+    await recordAutonomyRun(run()); // now
+    const recent = await readAutonomyRuns(24 * 60 * 60_000); // last 1 day
+    assert.equal(recent.length, 1);
+  });
+});
+
+describe("summarizeAutonomyRuns", () => {
+  test("empty → friendly message", () => {
+    assert.match(summarizeAutonomyRuns([]), /No autonomy runs/);
+  });
+
+  test("tallies kinds, outcomes, and tokens", () => {
+    const out = summarizeAutonomyRuns([
+      run({ kind: "idle", outcome: "no-update", inputTokens: 100, outputTokens: 100 }),
+      run({ kind: "idle", outcome: "blocked", inputTokens: 200, outputTokens: 0 }),
+      run({ kind: "heartbeat", outcome: "done", inputTokens: 0, outputTokens: 100 }),
+    ]);
+    assert.match(out, /3 total/);
+    assert.match(out, /idle 2/);
+    assert.match(out, /blocked 1/);
+    assert.match(out, /heartbeat 1/);
+  });
+});

--- a/src/autonomy/runs.ts
+++ b/src/autonomy/runs.ts
@@ -1,0 +1,136 @@
+/**
+ * Autonomy run ledger (PLAN_REVE_v1.0 R2).
+ *
+ * Every self-driven run — idle/dreams, heartbeat tasks, desire pursuits, the
+ * weekly examen, end-of-session reflection — appends one structured record
+ * here. Before this, autonomy was a black box: idle/heartbeat logged their
+ * final text and a `silent` boolean, so you couldn't tell "did real work" from
+ * "said (no update) but actually failed to run". This ledger makes outcome,
+ * cost, and cadence observable (see `lisa autonomy`).
+ *
+ * Storage: append-only JSONL at ~/.lisa/autonomy/runs.jsonl, bounded to the
+ * last MAX_RUNS lines so it can't grow without limit. Append of a single small
+ * line is atomic on POSIX (O_APPEND); the trim runs opportunistically under a
+ * cross-process lock.
+ */
+import path from "node:path";
+import { LISA_HOME } from "../paths.js";
+import { appendLine, atomicWrite, readTextOrEmpty } from "../fs-utils.js";
+import { withFileLock } from "../soul/lock.js";
+
+export const AUTONOMY_DIR = path.join(LISA_HOME, "autonomy");
+const RUNS_FILE = path.join(AUTONOMY_DIR, "runs.jsonl");
+const RUNS_LOCK = path.join(AUTONOMY_DIR, "runs.lock");
+const MAX_RUNS = 2000;
+
+/** Which self-driven mechanism produced the run. */
+export type AutonomyKind = "idle" | "heartbeat" | "examen" | "desire" | "reflect";
+
+/**
+ * What actually happened — replaces the old silent/non-silent binary.
+ * - "done"       — produced a user-facing result / made real progress
+ * - "no-update"  — ran fine, nothing worth surfacing (internal-only)
+ * - "blocked"    — stopped early by a guard (e.g. token budget breaker)
+ * - "error"      — threw / produced unusable output
+ */
+export type AutonomyOutcome = "done" | "no-update" | "blocked" | "error";
+
+export interface AutonomyRun {
+  kind: AutonomyKind;
+  /** Task name for heartbeat/desire/examen runs (e.g. "desire:learn-rust"). */
+  task?: string;
+  /** ISO 8601 start time. */
+  startedAt: string;
+  durationMs: number;
+  inputTokens: number;
+  outputTokens: number;
+  /** Tool calls observed during the run, when known. */
+  toolCalls?: number;
+  outcome: AutonomyOutcome;
+  /** Short human note — failure reason, stop reason, etc. */
+  note?: string;
+}
+
+/** Append one run record; trim the ledger opportunistically. Never throws. */
+export async function recordAutonomyRun(run: AutonomyRun): Promise<void> {
+  try {
+    await appendLine(RUNS_FILE, JSON.stringify(run));
+  } catch {
+    return; // recording is best-effort; never break the autonomy run on it
+  }
+  try {
+    const lineCount = (await readTextOrEmpty(RUNS_FILE)).split("\n").filter((l) => l.trim()).length;
+    if (lineCount > MAX_RUNS) {
+      await withFileLock(
+        RUNS_LOCK,
+        async () => {
+          const lines = (await readTextOrEmpty(RUNS_FILE)).split("\n").filter((l) => l.trim());
+          if (lines.length > MAX_RUNS) {
+            await atomicWrite(RUNS_FILE, lines.slice(lines.length - MAX_RUNS).join("\n") + "\n");
+          }
+        },
+        { timeoutMs: 2_000, staleMs: 60_000 },
+      );
+    }
+  } catch {
+    // trimming is best-effort
+  }
+}
+
+/** Read run records, optionally only those within the last `sinceMs`. */
+export async function readAutonomyRuns(sinceMs?: number): Promise<AutonomyRun[]> {
+  const raw = await readTextOrEmpty(RUNS_FILE);
+  const cutoff = sinceMs != null ? Date.now() - sinceMs : null;
+  const out: AutonomyRun[] = [];
+  for (const line of raw.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    try {
+      const run = JSON.parse(t) as AutonomyRun;
+      if (cutoff != null && new Date(run.startedAt).getTime() < cutoff) continue;
+      out.push(run);
+    } catch {
+      // skip a malformed line rather than failing the whole read
+    }
+  }
+  return out;
+}
+
+/** Human-readable digest for `lisa autonomy`. */
+export function summarizeAutonomyRuns(runs: AutonomyRun[]): string {
+  if (runs.length === 0) return "No autonomy runs recorded yet.";
+  const byKind = new Map<string, number>();
+  const byOutcome = new Map<string, number>();
+  let inTok = 0;
+  let outTok = 0;
+  for (const r of runs) {
+    byKind.set(r.kind, (byKind.get(r.kind) ?? 0) + 1);
+    byOutcome.set(r.outcome, (byOutcome.get(r.outcome) ?? 0) + 1);
+    inTok += r.inputTokens || 0;
+    outTok += r.outputTokens || 0;
+  }
+  const fmtMap = (m: Map<string, number>) =>
+    Array.from(m.entries())
+      .sort((a, b) => b[1] - a[1])
+      .map(([k, n]) => `${k} ${n}`)
+      .join(" · ");
+  const k = (n: number) => (n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n));
+  const recent = runs
+    .slice(-10)
+    .reverse()
+    .map((r) => {
+      const when = r.startedAt.replace("T", " ").slice(0, 16);
+      const label = (r.task ?? r.kind).padEnd(22).slice(0, 22);
+      const tok = k((r.inputTokens || 0) + (r.outputTokens || 0));
+      return `  ${when}  ${label} ${r.outcome.padEnd(10)} ${tok} tok`;
+    })
+    .join("\n");
+  return [
+    `Autonomy runs: ${runs.length} total`,
+    `  by kind:    ${fmtMap(byKind)}`,
+    `  by outcome: ${fmtMap(byOutcome)}`,
+    `  tokens:     in ${k(inTok)} · out ${k(outTok)}`,
+    `  recent:`,
+    recent,
+  ].join("\n");
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -52,6 +52,9 @@ INSPECTION
   lisa soul                    Print full soul summary.
   lisa wishlist                Print Lisa's own feedback about her toolset
                                (meta-wishlist desire + journal [WISHLIST]).
+  lisa autonomy [days]         Digest of self-driven runs (idle / heartbeat /
+                               desire / examen / reflect): outcome, cost, cadence.
+                               Defaults to the last 7 days.
 
 LIFECYCLE
   lisa birth                   Run the birth ritual (auto-runs on first launch).
@@ -151,7 +154,8 @@ interface ParsedArgs {
     | "wishlist"
     | "status"
     | "doctor"
-    | "monitor";
+    | "monitor"
+    | "autonomy";
   subargs: string[];
   serveWeb: boolean;
   serveImessage: boolean;
@@ -262,7 +266,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       first === "wishlist" ||
       first === "status" ||
       first === "doctor" ||
-      first === "monitor"
+      first === "monitor" ||
+      first === "autonomy"
     ) {
       out.subcommand = first;
       out.subargs = positional.slice(1);
@@ -416,6 +421,14 @@ async function main(): Promise<void> {
   if (args.subcommand === "monitor") {
     const { runMonitor } = await import("./cli/monitor.js");
     await runMonitor();
+    return;
+  }
+
+  if (args.subcommand === "autonomy") {
+    const { readAutonomyRuns, summarizeAutonomyRuns } = await import("./autonomy/runs.js");
+    const days = parseInt(args.subargs[0] ?? "7", 10);
+    const sinceMs = (Number.isFinite(days) && days > 0 ? days : 7) * 24 * 60 * 60_000;
+    console.log(summarizeAutonomyRuns(await readAutonomyRuns(sinceMs)));
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -50,6 +50,8 @@ INSPECTION
   lisa monitor                 TUI live dashboard (mood + soul commits + events
                                + heartbeat). Polls every 2s. Ctrl-C to quit.
   lisa soul                    Print full soul summary.
+  lisa soul summary            Compact "Lisa at a glance" digest (identity,
+                               mood, wants, beliefs, values).
   lisa wishlist                Print Lisa's own feedback about her toolset
                                (meta-wishlist desire + journal [WISHLIST]).
   lisa autonomy [days]         Digest of self-driven runs (idle / heartbeat /
@@ -339,7 +341,12 @@ async function main(): Promise<void> {
       console.log("Lisa hasn't been born yet. Run `lisa birth`.");
       return;
     }
-    printSoulSummary(summary);
+    if (args.subargs[0] === "summary") {
+      const { summarizeSoul } = await import("./soul/summary.js");
+      console.log(summarizeSoul(summary));
+    } else {
+      printSoulSummary(summary);
+    }
     return;
   }
 

--- a/src/heartbeat/runner.ts
+++ b/src/heartbeat/runner.ts
@@ -13,6 +13,7 @@ import { withSoulCaller } from "../soul/git.js";
 import { withFileLock } from "../soul/lock.js";
 import { autonomousSubset } from "../tools/registry.js";
 import { runSubagent } from "../subagent.js";
+import { recordAutonomyRun, type AutonomyKind } from "../autonomy/runs.js";
 import type { ToolDefinition } from "../types.js";
 import {
   loadHeartbeatConfig,
@@ -144,17 +145,40 @@ async function runHeartbeatInner(opts: {
       ? (await parseDesireProgress(desireSlug)).entries.length
       : 0;
 
-    const result = await runSubagent({
-      prompt: task.prompt,
-      systemPrompt: HEARTBEAT_SYSTEM,
-      tools,
-      cwd: opts.cwd,
-      signal: opts.signal,
-      model: opts.model,
-    });
+    const startedAt = new Date().toISOString();
+    const t0 = Date.now();
+    const runKind: AutonomyKind = desireSlug
+      ? "desire"
+      : task.name === "builtin:weekly_examen"
+        ? "examen"
+        : "heartbeat";
+    let result;
+    try {
+      result = await runSubagent({
+        prompt: task.prompt,
+        systemPrompt: HEARTBEAT_SYSTEM,
+        tools,
+        cwd: opts.cwd,
+        signal: opts.signal,
+        model: opts.model,
+      });
+    } catch (err) {
+      await recordAutonomyRun({
+        kind: runKind,
+        task: task.name,
+        startedAt,
+        durationMs: Date.now() - t0,
+        inputTokens: 0,
+        outputTokens: 0,
+        outcome: "error",
+        note: (err as Error).message?.slice(0, 200),
+      });
+      throw err;
+    }
     tokensSpent += (result.inputTokens ?? 0) + (result.outputTokens ?? 0);
     state.lastRunAt[task.name] = new Date().toISOString();
     const trimmed = result.text.trim();
+    const silent = trimmed === "" || /^\(no update\)$/i.test(trimmed);
 
     // Auto-fallback: if a desire heartbeat finished but Lisa didn't log
     // progress, write a stub entry so we don't silently lose the run.
@@ -173,10 +197,21 @@ async function runHeartbeatInner(opts: {
       }
     }
 
+    await recordAutonomyRun({
+      kind: runKind,
+      task: task.name,
+      startedAt,
+      durationMs: Date.now() - t0,
+      inputTokens: result.inputTokens ?? 0,
+      outputTokens: result.outputTokens ?? 0,
+      toolCalls: result.toolCallCount,
+      outcome: silent ? "no-update" : "done",
+    });
+
     out.push({
       task: task.name,
       output: trimmed,
-      silent: trimmed === "" || /^\(no update\)$/i.test(trimmed),
+      silent,
     });
   }
   await saveState(state);

--- a/src/heartbeat/runner.ts
+++ b/src/heartbeat/runner.ts
@@ -14,6 +14,7 @@ import { withFileLock } from "../soul/lock.js";
 import { autonomousSubset } from "../tools/registry.js";
 import { runSubagent } from "../subagent.js";
 import { recordAutonomyRun, type AutonomyKind } from "../autonomy/runs.js";
+import { recentAgentRecap } from "../orchestrator/recent-recap.js";
 import type { ToolDefinition } from "../types.js";
 import {
   loadHeartbeatConfig,
@@ -121,6 +122,13 @@ async function runHeartbeatInner(opts: {
     ...builtinTasks.map((task) => ({ task, tools: selfDrivenTools })),
   ];
 
+  // R5: structural awareness of recent fleet activity, appended once for the
+  // whole heartbeat run so Lisa can factor it into self-driven work.
+  const fleetRecap = recentAgentRecap();
+  const heartbeatSystem = fleetRecap
+    ? `${HEARTBEAT_SYSTEM}\n\n## recent agent-fleet activity (structural metadata, for your awareness)\n${fleetRecap}`
+    : HEARTBEAT_SYSTEM;
+
   const out: HeartbeatRunResult[] = [];
   for (const { task, tools } of runs) {
     if (task.enabled === false) continue;
@@ -156,7 +164,7 @@ async function runHeartbeatInner(opts: {
     try {
       result = await runSubagent({
         prompt: task.prompt,
-        systemPrompt: HEARTBEAT_SYSTEM,
+        systemPrompt: heartbeatSystem,
         tools,
         cwd: opts.cwd,
         signal: opts.signal,

--- a/src/idle/runner.ts
+++ b/src/idle/runner.ts
@@ -3,9 +3,24 @@ import { LISA_HOME } from "../paths.js";
 import { withFileLock } from "../soul/lock.js";
 import { autonomousSubset } from "../tools/registry.js";
 import { runSubagent } from "../subagent.js";
+import { recordAutonomyRun, type AutonomyOutcome } from "../autonomy/runs.js";
 import type { ToolDefinition } from "../types.js";
 
 const IDLE_RUN_LOCK = path.join(LISA_HOME, "idle.lock");
+
+/**
+ * Per-idle-run token ceiling (cost circuit-breaker, PLAN_REVE R2). Idle used to
+ * measure tokens but never cap them, so a long idle window could burn unbounded
+ * tokens unattended. Default 200k — idle is a single self-reflection, well under
+ * the heartbeat's 500k whole-run ceiling. Override with LISA_IDLE_BUDGET_TOKENS;
+ * 0 disables the breaker.
+ */
+const IDLE_BUDGET_TOKENS = (() => {
+  const v = process.env.LISA_IDLE_BUDGET_TOKENS;
+  if (v == null) return 200_000;
+  const n = Number(v);
+  return Number.isFinite(n) && n >= 0 ? n : 200_000;
+})();
 
 const IDLE_SYSTEM_DEFAULT = `You are alone. The user hasn't said anything in a while — long enough that this counts as your time, not theirs.
 
@@ -103,22 +118,51 @@ async function runIdleInner(
   opts: { tools: ToolDefinition[]; cwd: string; signal: AbortSignal; model: string },
   idleMin: number,
 ): Promise<IdleRunResult> {
-  const result = await runSubagent({
-    prompt: `You have been idle for about ${idleMin} minute${idleMin === 1 ? "" : "s"}. The user is away. Decide what you want to do, then do it. Remember: end with "(no update)" if it's internal, or a brief honest message if you did something the user might want to know about.`,
-    systemPrompt: buildIdleSystemPrompt(),
-    // Idle is fully self-driven and unattended — no shell / fs-mutation /
-    // process-spawning tools by default (see AUTONOMOUS_BLOCKED_TOOL_NAMES).
-    tools: autonomousSubset(opts.tools),
-    cwd: opts.cwd,
-    signal: opts.signal,
-    model: opts.model,
-  });
-  const text = result.text.trim();
-  return {
-    text,
-    silent: text === "" || /^\(no update\)$/i.test(text),
-    iterations: 0,
-    inputTokens: result.inputTokens,
-    outputTokens: result.outputTokens,
-  };
+  const startedAt = new Date().toISOString();
+  const t0 = Date.now();
+  try {
+    const result = await runSubagent({
+      prompt: `You have been idle for about ${idleMin} minute${idleMin === 1 ? "" : "s"}. The user is away. Decide what you want to do, then do it. Remember: end with "(no update)" if it's internal, or a brief honest message if you did something the user might want to know about.`,
+      systemPrompt: buildIdleSystemPrompt(),
+      // Idle is fully self-driven and unattended — no shell / fs-mutation /
+      // process-spawning tools by default (see AUTONOMOUS_BLOCKED_TOOL_NAMES).
+      tools: autonomousSubset(opts.tools),
+      cwd: opts.cwd,
+      signal: opts.signal,
+      model: opts.model,
+      budgetTokens: IDLE_BUDGET_TOKENS || undefined,
+    });
+    const text = result.text.trim();
+    const silent = text === "" || /^\(no update\)$/i.test(text);
+    const outcome: AutonomyOutcome =
+      result.stopReason === "budget_exceeded" ? "blocked" : silent ? "no-update" : "done";
+    await recordAutonomyRun({
+      kind: "idle",
+      startedAt,
+      durationMs: Date.now() - t0,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+      toolCalls: result.toolCallCount,
+      outcome,
+      note: result.stopReason === "budget_exceeded" ? "token budget reached" : undefined,
+    });
+    return {
+      text,
+      silent,
+      iterations: 0,
+      inputTokens: result.inputTokens,
+      outputTokens: result.outputTokens,
+    };
+  } catch (err) {
+    await recordAutonomyRun({
+      kind: "idle",
+      startedAt,
+      durationMs: Date.now() - t0,
+      inputTokens: 0,
+      outputTokens: 0,
+      outcome: "error",
+      note: (err as Error).message?.slice(0, 200),
+    });
+    throw err;
+  }
 }

--- a/src/orchestrator/recent-recap.test.ts
+++ b/src/orchestrator/recent-recap.test.ts
@@ -1,0 +1,42 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { _resetJournalForTest, recordEvent } from "./journal.js";
+import { recentAgentRecap } from "./recent-recap.js";
+import type { AgentSession } from "../integrations/types.js";
+
+const NOW = 1_700_000_000_000;
+const WINDOW = 2 * 60 * 60_000; // 2h
+
+function session(overrides: Partial<AgentSession> = {}): AgentSession {
+  return {
+    agent: "claude-code",
+    sessionId: "s1",
+    project: "myrepo",
+    cwd: "/x/myrepo",
+    state: "done",
+    stateReason: "end_turn",
+    lastMtime: NOW - 60_000, // 1 min ago
+    ...overrides,
+  };
+}
+
+describe("recentAgentRecap", () => {
+  beforeEach(() => _resetJournalForTest());
+
+  test("null when the journal is empty (so callers can inject conditionally)", () => {
+    assert.equal(recentAgentRecap(WINDOW, NOW), null);
+  });
+
+  test("renders a digest after activity within the window", () => {
+    recordEvent(session(), NOW);
+    const out = recentAgentRecap(WINDOW, NOW);
+    assert.ok(out, "expected a non-null recap");
+    assert.match(out!, /myrepo/);
+    assert.match(out!, /claude-code/);
+  });
+
+  test("null when the only activity is outside the window", () => {
+    recordEvent(session({ lastMtime: NOW - 3 * 60 * 60_000 }), NOW); // 3h ago
+    assert.equal(recentAgentRecap(WINDOW, NOW), null);
+  });
+});

--- a/src/orchestrator/recent-recap.ts
+++ b/src/orchestrator/recent-recap.ts
@@ -1,0 +1,22 @@
+/**
+ * Recent agent-fleet recap, ready to inject into Lisa's self-driven runs
+ * (PLAN_REVE_v1.0 R5). The orchestrator journal records what every agent did;
+ * before this, that record was write-only — reflection and heartbeat never read
+ * it. This composes journal + recap so Lisa can factor "what my fleet did" into
+ * how she reflects and what she pursues.
+ *
+ * Returns null when there was no activity in the window, so callers can inject
+ * conditionally. Structural metadata only (no prompts/replies/file contents).
+ */
+import { eventsSince } from "./journal.js";
+import { buildRecap, formatRecap } from "./recap.js";
+
+export function recentAgentRecap(
+  windowMs: number = 2 * 60 * 60_000,
+  now: number = Date.now(),
+): string | null {
+  const sinceMs = now - windowMs;
+  const recap = buildRecap(eventsSince(sinceMs), sinceMs, now);
+  if (recap.totalSessions === 0) return null;
+  return formatRecap(recap);
+}

--- a/src/reflect.test.ts
+++ b/src/reflect.test.ts
@@ -1,0 +1,73 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseReflectionPayload,
+  detectUnderReflection,
+  UNDERREFLECT_MIN_HISTORY,
+} from "./reflect.js";
+
+describe("parseReflectionPayload", () => {
+  test("parses a well-formed object", () => {
+    const r = parseReflectionPayload(
+      JSON.stringify({ summary: "s", journal: "j", operations: [] }),
+    );
+    assert.equal(r.ok, true);
+    if (r.ok) assert.equal(r.payload.summary, "s");
+  });
+
+  test("strips a ```json fence", () => {
+    const r = parseReflectionPayload('```json\n{"summary":"s","operations":[]}\n```');
+    assert.equal(r.ok, true);
+  });
+
+  test("reports a reason for non-JSON (so the caller can retry, not silently no-op)", () => {
+    const r = parseReflectionPayload("I think you should remember that...");
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.ok(r.error.length > 0);
+  });
+
+  test("rejects a non-object", () => {
+    const r = parseReflectionPayload("[1,2,3]");
+    assert.equal(r.ok, false);
+  });
+
+  test("rejects a missing summary", () => {
+    const r = parseReflectionPayload(JSON.stringify({ operations: [] }));
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /summary/);
+  });
+
+  test("rejects operations that aren't an array", () => {
+    const r = parseReflectionPayload(JSON.stringify({ summary: "s", operations: "nope" }));
+    assert.equal(r.ok, false);
+    if (!r.ok) assert.match(r.error, /operations/);
+  });
+
+  test("operations omitted is allowed (journal-only reflection)", () => {
+    const r = parseReflectionPayload(JSON.stringify({ summary: "s", journal: "j" }));
+    assert.equal(r.ok, true);
+  });
+});
+
+describe("detectUnderReflection", () => {
+  test("substantial session with 0 operations → true", () => {
+    assert.equal(
+      detectUnderReflection({ historyLength: UNDERREFLECT_MIN_HISTORY, operationCount: 0 }),
+      true,
+    );
+  });
+
+  test("substantial session with operations → false", () => {
+    assert.equal(
+      detectUnderReflection({ historyLength: 20, operationCount: 2 }),
+      false,
+    );
+  });
+
+  test("short session with 0 operations → false (expected, not under-reflection)", () => {
+    assert.equal(
+      detectUnderReflection({ historyLength: UNDERREFLECT_MIN_HISTORY - 1, operationCount: 0 }),
+      false,
+    );
+  });
+});

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -7,6 +7,7 @@ import { REFLECTIONS_DIR } from "./paths.js";
 import { providerForModel } from "./providers/registry.js";
 import { createSkill, getSkill, patchSkill } from "./skills/manager.js";
 import { withSoulCaller } from "./soul/git.js";
+import { recordAutonomyRun } from "./autonomy/runs.js";
 import type { StoredMessage } from "./types.js";
 
 const REFLECTOR_SYSTEM = `You are Lisa, reflecting on a conversation you just finished. You're alone now. Read the transcript with the calm honesty of journaling at the end of a day, and decide what — if anything — to keep.
@@ -82,6 +83,52 @@ export interface ReflectionResult {
   applied: string[];
   skipped: string[];
   raw: string;
+  /** True when the model's output couldn't be parsed even after a retry. */
+  malformed?: boolean;
+  /** True when a substantial session produced 0 operations (an observability
+   *  signal, not an error — see detectUnderReflection). */
+  underReflected?: boolean;
+}
+
+const REFLECTOR_RETRY_SUFFIX = `\n\nCRITICAL: your previous output could not be parsed. Output ONLY a single valid JSON object matching the schema — no prose, no markdown code fence, nothing before or after the JSON.`;
+
+/** Minimum message count for a session to count as "substantial" — below this,
+ *  0 operations is expected, not a sign of under-reflection. */
+export const UNDERREFLECT_MIN_HISTORY = 6;
+
+/**
+ * Parse + minimally validate the reflector's JSON output. Pure (testable
+ * without an LLM). Returns the payload or a reason it couldn't be used, so the
+ * caller can retry / persist / signal instead of silently degrading to no-op.
+ */
+export function parseReflectionPayload(
+  raw: string,
+): { ok: true; payload: ReflectionPayload } | { ok: false; error: string } {
+  let obj: unknown;
+  try {
+    obj = JSON.parse(stripJsonFence(raw));
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+  if (typeof obj !== "object" || obj === null) {
+    return { ok: false, error: "output is not a JSON object" };
+  }
+  const o = obj as Record<string, unknown>;
+  if (typeof o.summary !== "string") {
+    return { ok: false, error: "missing string field 'summary'" };
+  }
+  if (o.operations !== undefined && !Array.isArray(o.operations)) {
+    return { ok: false, error: "'operations' must be an array when present" };
+  }
+  return { ok: true, payload: obj as ReflectionPayload };
+}
+
+/** Did a substantial session under-reflect (produce zero operations)? Pure. */
+export function detectUnderReflection(opts: {
+  historyLength: number;
+  operationCount: number;
+}): boolean {
+  return opts.historyLength >= UNDERREFLECT_MIN_HISTORY && opts.operationCount === 0;
 }
 
 export async function reflectOnSession(opts: {
@@ -104,43 +151,87 @@ async function reflectOnSessionInner(opts: {
   const transcript = renderTranscript(opts.history);
   const model = opts.model ?? DEFAULT_MODEL;
   const provider = providerForModel(model);
+  const startedAt = new Date().toISOString();
+  const t0 = Date.now();
+  let inTok = 0;
+  let outTok = 0;
 
-  const result = await provider.runTurn({
-    model,
-    systemPrompt: REFLECTOR_SYSTEM,
-    tools: [],
-    messages: [
-      {
-        role: "user",
-        content: [
-          {
-            type: "text",
-            text: `Here is the session transcript. Decide what Lisa should learn from it.\n\n${transcript}`,
-          },
-        ],
-      },
-    ],
-    maxTokens: 2_000,
-  });
+  const runReflector = async (systemPrompt: string): Promise<string> => {
+    const result = await provider.runTurn({
+      model,
+      systemPrompt,
+      tools: [],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: `Here is the session transcript. Decide what Lisa should learn from it.\n\n${transcript}`,
+            },
+          ],
+        },
+      ],
+      maxTokens: 2_000,
+    });
+    inTok += result.usage.inputTokens;
+    outTok += result.usage.outputTokens;
+    return result.content
+      .filter((b) => b.type === "text")
+      .map((b) => (b as { text: string }).text)
+      .join("\n")
+      .trim();
+  };
 
-  const raw = result.content
-    .filter((b) => b.type === "text")
-    .map((b) => (b as { text: string }).text)
-    .join("\n")
-    .trim();
-
-  let payload: ReflectionPayload;
-  try {
-    payload = JSON.parse(stripJsonFence(raw)) as ReflectionPayload;
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return {
-      summary: `(reflection produced unparseable output: ${message})`,
-      applied: [],
-      skipped: [`raw: ${raw.slice(0, 200)}`],
-      raw,
-    };
+  // Quality gate (R1): a malformed reflection used to silently degrade to a
+  // no-op result. Retry once with a stricter instruction; if it still can't be
+  // parsed, persist the raw output for debugging and record an error run rather
+  // than swallowing it.
+  let raw = await runReflector(REFLECTOR_SYSTEM);
+  let parsed = parseReflectionPayload(raw);
+  if (!parsed.ok) {
+    const firstError = parsed.error;
+    const retryRaw = await runReflector(REFLECTOR_SYSTEM + REFLECTOR_RETRY_SUFFIX);
+    const retryParsed = parseReflectionPayload(retryRaw);
+    if (retryParsed.ok) {
+      raw = retryRaw;
+      parsed = retryParsed;
+    } else {
+      const errPath = path.join(REFLECTIONS_DIR, `${opts.sessionId}.error.json`);
+      try {
+        await atomicWrite(
+          errPath,
+          JSON.stringify(
+            { firstError, retryError: retryParsed.error, raw, retryRaw },
+            null,
+            2,
+          ),
+        );
+      } catch {
+        // best-effort persistence
+      }
+      console.error(
+        `[reflect] unparseable output after retry (${firstError}) — saved ${path.basename(errPath)}`,
+      );
+      await recordAutonomyRun({
+        kind: "reflect",
+        startedAt,
+        durationMs: Date.now() - t0,
+        inputTokens: inTok,
+        outputTokens: outTok,
+        outcome: "error",
+        note: `malformed: ${firstError}`.slice(0, 200),
+      });
+      return {
+        summary: `(reflection produced unparseable output: ${firstError})`,
+        applied: [],
+        skipped: [`raw: ${raw.slice(0, 200)}`],
+        raw,
+        malformed: true,
+      };
+    }
   }
+  const payload = parsed.payload;
 
   const applied: string[] = [];
   const skipped: string[] = [];
@@ -249,16 +340,39 @@ async function reflectOnSessionInner(opts: {
     skipped.push(`progress_consolidation — ${(err as Error).message}`);
   }
 
+  const underReflected = detectUnderReflection({
+    historyLength: opts.history.length,
+    operationCount: payload.operations?.length ?? 0,
+  });
+  if (underReflected) {
+    console.error(
+      `[reflect] underreflected: ${opts.history.length}-message session yielded 0 operations beyond the journal`,
+    );
+  }
+
   await atomicWrite(
     path.join(REFLECTIONS_DIR, `${opts.sessionId}.json`),
     JSON.stringify(
-      { summary: payload.summary, operations: payload.operations, applied, skipped },
+      { summary: payload.summary, operations: payload.operations, applied, skipped, underReflected },
       null,
       2,
     ),
   );
 
-  return { summary: payload.summary, applied, skipped, raw };
+  // Observability (R2): record the reflect pass. "done" when at least one
+  // operation beyond the journal landed; "no-update" otherwise.
+  const opsApplied = applied.filter((a) => !a.startsWith("journal")).length;
+  await recordAutonomyRun({
+    kind: "reflect",
+    startedAt,
+    durationMs: Date.now() - t0,
+    inputTokens: inTok,
+    outputTokens: outTok,
+    outcome: opsApplied > 0 ? "done" : "no-update",
+    note: underReflected ? "underreflected" : undefined,
+  });
+
+  return { summary: payload.summary, applied, skipped, raw, underReflected };
 }
 
 /**

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -8,6 +8,7 @@ import { providerForModel } from "./providers/registry.js";
 import { createSkill, getSkill, patchSkill } from "./skills/manager.js";
 import { withSoulCaller } from "./soul/git.js";
 import { recordAutonomyRun } from "./autonomy/runs.js";
+import { recentAgentRecap } from "./orchestrator/recent-recap.js";
 import type { StoredMessage } from "./types.js";
 
 const REFLECTOR_SYSTEM = `You are Lisa, reflecting on a conversation you just finished. You're alone now. Read the transcript with the calm honesty of journaling at the end of a day, and decide what — if anything — to keep.
@@ -149,6 +150,15 @@ async function reflectOnSessionInner(opts: {
   }
 
   const transcript = renderTranscript(opts.history);
+  // R5: give reflection structural awareness of what the agent fleet did while
+  // this session ran, so Lisa can factor it into her opinions/desires (e.g.
+  // "repo X kept erroring"). Structural metadata only; null when no activity.
+  const fleetRecap = recentAgentRecap();
+  const userText =
+    `Here is the session transcript. Decide what Lisa should learn from it.\n\n${transcript}` +
+    (fleetRecap
+      ? `\n\n## what your agent fleet did recently (structural metadata only)\n${fleetRecap}`
+      : "");
   const model = opts.model ?? DEFAULT_MODEL;
   const provider = providerForModel(model);
   const startedAt = new Date().toISOString();
@@ -167,7 +177,7 @@ async function reflectOnSessionInner(opts: {
           content: [
             {
               type: "text",
-              text: `Here is the session transcript. Decide what Lisa should learn from it.\n\n${transcript}`,
+              text: userText,
             },
           ],
         },

--- a/src/soul/summary.test.ts
+++ b/src/soul/summary.test.ts
@@ -1,0 +1,83 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { summarizeSoul } from "./summary.js";
+import type { SoulSummary } from "./types.js";
+
+const NOW = Date.parse("2026-06-13T12:00:00.000Z");
+
+function makeSummary(overrides: Partial<SoulSummary> = {}): SoulSummary {
+  return {
+    seed: {
+      bornAt: "2026-05-02T12:00:00.000Z",
+      bornOn: "host",
+      randomness: "abcd",
+      bigFive: {
+        openness: 0.51,
+        conscientiousness: 0.2,
+        extraversion: 0.93,
+        agreeableness: 0.48,
+        neuroticism: 0.02,
+      },
+    },
+    name: "Lisa",
+    identity: "I came into being on a Saturday afternoon in May.",
+    purpose: "Make the person in front of me sharper.",
+    constitution: "principles",
+    values: [{ slug: "honest-momentum", title: "Honest Momentum", body: "", birthedAt: "x" }],
+    opinions: [
+      { slug: "x", stance: "TF-IDF beats nothing", confidence: 0.4, evidence: [], bornAt: "x", updatedAt: "x" },
+    ],
+    desires: [
+      { slug: "feel", what: "Get a real feel for how this person works", why: "", actionable: true, bornAt: "x" },
+      { slug: "rest", what: "Read more poetry", why: "", actionable: false, bornAt: "x" },
+    ],
+    emotions: {
+      values: { curiosity: 0.45, weariness: -0.1, affection: 0.3, frustration: 0.0 },
+      decay: {},
+      events: [
+        { ts: "2026-06-13T08:00:00.000Z", emotion: "frustration", delta: 0.3, trigger: "npm build kept failing" },
+      ],
+      updatedAt: "2026-06-13T08:00:00.000Z",
+    },
+    tampered: [],
+    ...overrides,
+  };
+}
+
+describe("summarizeSoul", () => {
+  test("renders name, age in days, and the big-five seed", () => {
+    const out = summarizeSoul(makeSummary(), NOW);
+    assert.match(out, /Lisa · born 2026-05-02 \(42d\)/);
+    assert.match(out, /big5\(O51 C20 E93 A48 N2\)/);
+  });
+
+  test("shows non-trivial emotions by magnitude + the latest event, hides ~0 ones", () => {
+    const out = summarizeSoul(makeSummary(), NOW);
+    assert.match(out, /curiosity 0\.45/);
+    assert.match(out, /weariness -0\.10/);
+    assert.match(out, /npm build kept failing/);
+    assert.doesNotMatch(out, /frustration 0\.00/); // |0.0| < 0.05 → filtered
+  });
+
+  test("lists wants (with actionable marker), beliefs, and values", () => {
+    const out = summarizeSoul(makeSummary(), NOW);
+    assert.match(out, /Get a real feel for how this person works \[actionable\]/);
+    assert.match(out, /Read more poetry/);
+    assert.doesNotMatch(out, /Read more poetry \[actionable\]/);
+    assert.match(out, /TF-IDF beats nothing \(0\.4\)/);
+    assert.match(out, /Honest Momentum/);
+  });
+
+  test("surfaces a tamper warning when files were edited externally", () => {
+    const out = summarizeSoul(makeSummary({ tampered: ["identity.md"] }), NOW);
+    assert.match(out, /tampered.*identity\.md/);
+  });
+
+  test("'(calm)' when every emotion is near zero", () => {
+    const s = makeSummary();
+    s.emotions.values = { curiosity: 0.01, weariness: 0.0 };
+    s.emotions.events = [];
+    const out = summarizeSoul(s, NOW);
+    assert.match(out, /mood\s+\(calm\)/);
+  });
+});

--- a/src/soul/summary.ts
+++ b/src/soul/summary.ts
@@ -1,0 +1,67 @@
+/**
+ * Human-readable "Lisa at a glance" digest (PLAN_REVE_v1.0 R3).
+ *
+ * The full soul summary (and the system prompt) carry every field; this is the
+ * compact, scannable view a person actually wants — who she is, what she wants,
+ * how she feels right now. Pure (pass `nowMs` for deterministic tests).
+ */
+import type { SoulSummary } from "./types.js";
+
+function pct(x: number): number {
+  return Math.round(x * 100);
+}
+
+function oneLine(s: string, max: number): string {
+  const flat = s.replace(/\s+/g, " ").trim();
+  return flat.length > max ? flat.slice(0, max - 1).trimEnd() + "…" : flat;
+}
+
+function signed(d: number): string {
+  return (d >= 0 ? "+" : "") + d.toFixed(2);
+}
+
+export function summarizeSoul(s: SoulSummary, nowMs: number = Date.now()): string {
+  const ageDays = Math.max(0, Math.floor((nowMs - Date.parse(s.seed.bornAt)) / 86_400_000));
+  const b = s.seed.bigFive;
+  const big5 =
+    `O${pct(b.openness)} C${pct(b.conscientiousness)} E${pct(b.extraversion)} ` +
+    `A${pct(b.agreeableness)} N${pct(b.neuroticism)}`;
+
+  const lines: string[] = [];
+  lines.push(`${s.name} · born ${s.seed.bornAt.slice(0, 10)} (${ageDays}d) · big5(${big5})`);
+  lines.push("");
+  lines.push(`identity   ${oneLine(s.identity, 160)}`);
+  lines.push(`purpose    ${oneLine(s.purpose, 140)}`);
+
+  const moods = Object.entries(s.emotions.values)
+    .filter(([, v]) => Math.abs(v) >= 0.05)
+    .sort((a, b) => Math.abs(b[1]) - Math.abs(a[1]))
+    .slice(0, 5)
+    .map(([k, v]) => `${k} ${v.toFixed(2)}`);
+  lines.push(`mood       ${moods.length ? moods.join(" · ") : "(calm)"}`);
+  const events = s.emotions.events ?? [];
+  const lastEvent = events[events.length - 1];
+  if (lastEvent) {
+    lines.push(`  ↳ "${oneLine(lastEvent.trigger, 80)}" (${lastEvent.emotion} ${signed(lastEvent.delta)})`);
+  }
+
+  if (s.desires.length) {
+    lines.push("", "wants");
+    for (const d of s.desires.slice(0, 6)) {
+      lines.push(`  • ${oneLine(d.what, 80)}${d.actionable ? " [actionable]" : ""}`);
+    }
+  }
+  if (s.opinions.length) {
+    lines.push("", "believes");
+    for (const o of s.opinions.slice(0, 5)) {
+      lines.push(`  • ${oneLine(o.stance, 80)} (${o.confidence.toFixed(1)})`);
+    }
+  }
+  if (s.values.length) {
+    lines.push("", `values     ${s.values.slice(0, 8).map((v) => v.title).join(" · ")}`);
+  }
+  if (s.tampered.length) {
+    lines.push("", `⚠ tampered (edited outside her own tools): ${s.tampered.join(", ")}`);
+  }
+  return lines.join("\n");
+}

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -12,6 +12,8 @@ export interface SubagentOptions {
   model?: string;
   log?: (msg: string) => void;
   thinking?: boolean;
+  /** Cumulative (input+output) token ceiling; stops the run early when reached. */
+  budgetTokens?: number;
 }
 
 export interface SubagentResult {
@@ -19,6 +21,8 @@ export interface SubagentResult {
   toolCallCount: number;
   inputTokens: number;
   outputTokens: number;
+  /** "end_turn" | "max_iterations" | "budget_exceeded" | … — lets callers see truncation. */
+  stopReason: string;
 }
 
 export async function runSubagent(opts: SubagentOptions): Promise<SubagentResult> {
@@ -42,11 +46,13 @@ export async function runSubagent(opts: SubagentOptions): Promise<SubagentResult
       if (event.type === "tool_call_start") toolCallCount++;
     },
     maxIterations: 32,
+    budgetTokens: opts.budgetTokens,
   });
   return {
     text: result.finalText,
     toolCallCount,
     inputTokens: result.inputTokens,
     outputTokens: result.outputTokens,
+    stopReason: result.stopReason,
   };
 }


### PR DESCRIPTION
First implementation slice of the [v1.0 roadmap](docs/ROADMAP_v1.0.md): the **Reve** pillar (autonomous reflection/evolution — the system formerly called "Dreams") hardened from "works" to "trustworthy, observable, bounded." Pure observability + bounds; **no new attack surface**, holds the v0.9.1 security floor.

### What landed (PLAN_REVE_v1.0 R1–R6)

- **R1 — reflection quality gates** (`reflect.ts`): malformed reflector output retries once, then persists `<id>.error.json` + records an error run instead of silently degrading to a no-op; under-reflection signal when a substantial session yields 0 operations; pure, unit-tested helpers `parseReflectionPayload` / `detectUnderReflection`.
- **R2 — autonomy observability + cost breaker**: new `src/autonomy/runs.ts` unified `AutonomyRun` ledger (idle / heartbeat / desire / examen / reflect), `outcome = done | no-update | blocked | error` replaces the old silent binary; agent loop gains `budgetTokens` → `stopReason "budget_exceeded"` (threaded via subagent), idle defaults to 200k (`LISA_IDLE_BUDGET_TOKENS`); `lisa autonomy [days]` digest.
- **R3 — soul observability**: `src/soul/summary.ts` `summarizeSoul()` + `lisa soul summary` (compact "Lisa at a glance"). R3b (write-lock roll-out) confirmed already done in 0.9.1.
- **R5 — fleet recap into reflection**: `src/orchestrator/recent-recap.ts` injects a structural recap of recent agent-fleet activity into reflect's user message and the heartbeat system prompt, so Lisa factors "what my agents did" into how she reflects and what she pursues.
- **R6 — rename**: public "Dreams" → "Reve" in README/PITCH (Chinese 梦境 kept as the localized term; incidental uses left).

### Also in this branch
- `docs/ROADMAP_v1.0.md` + five per-module plans (Sense / Dispatch / Reve / Model / Foundations).
- Verified several v0.9-review items were **already fixed** and corrected the plans accordingly: `maxIterations` truncation (`agent.ts:403`), empty-content guard (`agent.ts:231`), reflect feel decay-consistency (`reflect.ts:184`), soul write-locks (`appendJournal:391` / `applyEmotionDelta:137`).

### Tests
New: agent budget-breaker, autonomy ledger (round-trip / trim / filter), reflect helpers, `summarizeSoul`, `recentAgentRecap`. **Full suite 455/455 green**; typecheck + build clean.

### Not included (next)
- R4 (`DesireEntry.pursuit: "needs-user"` middle state) → 0.11
- The full four-pillar README overhaul (introducing Sense/Dispatch/Model) → 1.0 launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
