### PR TITLE
feat(model): 0.11 — local-model lifecycle, local embeddings, provider fallback

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,8 @@ INSPECTION
   lisa autonomy [days]         Digest of self-driven runs (idle / heartbeat /
                                desire / examen / reflect): outcome, cost, cadence.
                                Defaults to the last 7 days.
+  lisa model <sub>             Local model lifecycle (Ollama): list, install
+                               <model>, use local://<model> to switch, health.
 
 LIFECYCLE
   lisa birth                   Run the birth ritual (auto-runs on first launch).
@@ -142,6 +144,8 @@ interface ParsedArgs {
   loadPlugins: boolean;
   voice: boolean;
   idleMinutes: number;
+  /** True when --model was passed, so a LISA_MODEL default from config.env won't override it. */
+  modelExplicit: boolean;
   subcommand?:
     | "resume"
     | "sessions"
@@ -157,7 +161,8 @@ interface ParsedArgs {
     | "status"
     | "doctor"
     | "monitor"
-    | "autonomy";
+    | "autonomy"
+    | "model";
   subargs: string[];
   serveWeb: boolean;
   serveImessage: boolean;
@@ -177,6 +182,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     thinking: false,
     compaction: false,
     model: DEFAULT_MODEL,
+    modelExplicit: false,
     approval: "auto",
     loadMcp: true,
     loadPlugins: true,
@@ -221,8 +227,13 @@ function parseArgs(argv: string[]): ParsedArgs {
         .map((s) => s.trim())
         .filter(Boolean);
     }
-    else if (arg === "--model") out.model = mustNext(argv, ++i, "--model");
-    else if (arg.startsWith("--model=")) out.model = arg.slice("--model=".length);
+    else if (arg === "--model") {
+      out.model = mustNext(argv, ++i, "--model");
+      out.modelExplicit = true;
+    } else if (arg.startsWith("--model=")) {
+      out.model = arg.slice("--model=".length);
+      out.modelExplicit = true;
+    }
     else if (arg === "--provider") {
       const v = mustNext(argv, ++i, "--provider");
       process.env.LISA_PROVIDER = v;
@@ -269,7 +280,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       first === "status" ||
       first === "doctor" ||
       first === "monitor" ||
-      first === "autonomy"
+      first === "autonomy" ||
+      first === "model"
     ) {
       out.subcommand = first;
       out.subargs = positional.slice(1);
@@ -321,6 +333,12 @@ async function main(): Promise<void> {
 
   await ensureDir(LISA_HOME);
   loadConfigEnv();
+  // If the user didn't pass --model, honor a LISA_MODEL default from config.env
+  // (set by `lisa model use local://…`). Done after loadConfigEnv so the file's
+  // value is in process.env; --model still wins.
+  if (!args.modelExplicit && process.env.LISA_MODEL?.trim()) {
+    args.model = process.env.LISA_MODEL.trim();
+  }
   // Re-bridge proxy in case HTTPS_PROXY was set in config.env rather than
   // the shell. configureProxyFromEnv is idempotent.
   configureProxyFromEnv({ log: (m) => console.error(m) });
@@ -437,6 +455,11 @@ async function main(): Promise<void> {
     const sinceMs = (Number.isFinite(days) && days > 0 ? days : 7) * 24 * 60 * 60_000;
     console.log(summarizeAutonomyRuns(await readAutonomyRuns(sinceMs)));
     return;
+  }
+
+  if (args.subcommand === "model") {
+    const { runModelCommand } = await import("./cli/model.js");
+    process.exit(await runModelCommand(args.subargs));
   }
 
   if (args.subcommand === "sessions") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { LISA_HOME } from "./paths.js";
 import { loadAllPlugins, PLUGINS_ROOT } from "./plugins/loader.js";
 import type { HookSpec } from "./plugins/types.js";
 import { buildSystemPromptSnapshot, getPromptFingerprint } from "./prompt.js";
-import { providerForModel } from "./providers/registry.js";
+import { providerForModel, resolveDefaultModel } from "./providers/registry.js";
 import { reflectOnSession } from "./reflect.js";
 import { runRepl } from "./cli/repl.js";
 import { listSessionsOnDisk, loadSessionMessages } from "./sessions/list.js";
@@ -333,11 +333,11 @@ async function main(): Promise<void> {
 
   await ensureDir(LISA_HOME);
   loadConfigEnv();
-  // If the user didn't pass --model, honor a LISA_MODEL default from config.env
-  // (set by `lisa model use local://…`). Done after loadConfigEnv so the file's
-  // value is in process.env; --model still wins.
-  if (!args.modelExplicit && process.env.LISA_MODEL?.trim()) {
-    args.model = process.env.LISA_MODEL.trim();
+  // If the user didn't pass --model, resolve the default now that config.env is
+  // loaded: an explicit LISA_MODEL (e.g. `lisa model use`) wins, else auto-detect
+  // from the single configured cloud key. An explicit --model always overrides.
+  if (!args.modelExplicit) {
+    args.model = resolveDefaultModel();
   }
   // Re-bridge proxy in case HTTPS_PROXY was set in config.env rather than
   // the shell. configureProxyFromEnv is idempotent.
@@ -478,9 +478,11 @@ async function main(): Promise<void> {
       console.error("usage: lisa search <query>");
       process.exit(2);
     }
-    const { buildIndex, search } = await import("./memory/vector.js");
+    const { buildIndex, search, semanticSearch } = await import("./memory/vector.js");
+    const { getConfiguredEmbedder } = await import("./memory/embedding.js");
     const index = await buildIndex();
-    const hits = search(index, query, 10);
+    const embedder = getConfiguredEmbedder();
+    const hits = embedder ? await semanticSearch(index, query, embedder, 10) : search(index, query, 10);
     if (hits.length === 0) console.log("(no matches)");
     for (const h of hits) {
       console.log(

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,0 +1,89 @@
+/**
+ * `lisa model <list|install|use|health>` — local-model lifecycle (M1).
+ * Thin CLI over src/model/local.ts; `use` writes config.env via env.ts.
+ */
+import { OllamaBackend, localEndpoint, parseLocalRef } from "../model/local.js";
+import { saveConfigEnv } from "../env.js";
+
+function gb(bytes?: number): string {
+  return bytes ? `  (${(bytes / 1e9).toFixed(1)} GB)` : "";
+}
+
+export async function runModelCommand(subargs: string[]): Promise<number> {
+  const sub = subargs[0];
+
+  if (sub === "health") {
+    const backend = new OllamaBackend();
+    const h = await backend.health();
+    console.log(`${backend.name} @ ${backend.host}: ${h}`);
+    return h === "up" ? 0 : 1;
+  }
+
+  if (sub === "list") {
+    const backend = new OllamaBackend();
+    const health = await backend.health();
+    console.log(`local backend: ${backend.name} @ ${backend.host} (${health})`);
+    if (health === "up") {
+      const installed = await backend.listInstalled();
+      if (installed.length === 0) {
+        console.log("  (none installed — `lisa model install <model>`)");
+      }
+      for (const m of installed) console.log(`  ${m.name}${gb(m.sizeBytes)}`);
+    } else {
+      console.log("  (backend not running — start it, e.g. `ollama serve`)");
+    }
+    const base = process.env.LISA_BASE_URL;
+    const model = process.env.LISA_MODEL;
+    console.log(
+      `\nconfigured: ${base ? `${base}${model ? ` · model=${model}` : ""}` : "(cloud provider — no local endpoint set)"}`,
+    );
+    return 0;
+  }
+
+  if (sub === "install") {
+    const model = subargs[1];
+    if (!model) {
+      console.error("usage: lisa model install <model>   (e.g. qwen2.5-coder:32b)");
+      return 2;
+    }
+    const backend = new OllamaBackend();
+    console.log(`pulling "${model}" via ${backend.name}…`);
+    try {
+      await backend.install(model, (line) => console.error(line));
+      console.log(`✓ ${model} installed. Switch to it with:  lisa model use local://${model}`);
+      return 0;
+    } catch (err) {
+      console.error(`✗ ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  if (sub === "use") {
+    const ref = subargs[1];
+    const parsed = ref ? parseLocalRef(ref) : null;
+    if (!parsed) {
+      console.error("usage: lisa model use local://<model>   (e.g. local://qwen2.5-coder:32b)");
+      return 2;
+    }
+    const ep = localEndpoint(parsed.backend);
+    await saveConfigEnv({
+      LISA_BASE_URL: ep.baseURL,
+      LISA_API_KEY: ep.apiKey,
+      LISA_MODEL: parsed.model,
+    });
+    console.log(`✓ default model → "${parsed.model}" via ${parsed.backend} (${ep.baseURL}).`);
+    // Probe so the user finds out now, not on the next chat, if it isn't running.
+    const { defaultRuntime } = await import("../model/local.js");
+    const probe = await defaultRuntime.httpGet(`${ep.host}/api/tags`);
+    if (!probe.ok) {
+      console.log(
+        `⚠ ${parsed.backend} doesn't appear to be running at ${ep.host} — start it ` +
+          `(e.g. \`ollama serve\`) and \`lisa model install ${parsed.model}\` if you haven't.`,
+      );
+    }
+    return 0;
+  }
+
+  console.error("usage: lisa model <list | install <model> | use local://<model> | health>");
+  return 2;
+}

--- a/src/memory/embedding.test.ts
+++ b/src/memory/embedding.test.ts
@@ -1,0 +1,95 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cosineSimilarity,
+  parseOllamaEmbedding,
+  OllamaEmbedder,
+  type Embedder,
+  type PostJson,
+} from "./embedding.js";
+import { semanticSearch, type Index, type Document } from "./vector.js";
+
+describe("cosineSimilarity", () => {
+  test("identical → 1", () => assert.equal(cosineSimilarity([1, 2, 3], [1, 2, 3]), 1));
+  test("orthogonal → 0", () => assert.equal(cosineSimilarity([1, 0], [0, 1]), 0));
+  test("opposite → -1", () => assert.equal(cosineSimilarity([1, 0], [-1, 0]), -1));
+  test("zero vector → 0, not NaN", () => assert.equal(cosineSimilarity([0, 0], [1, 1]), 0));
+});
+
+describe("parseOllamaEmbedding", () => {
+  test("extracts a numeric embedding array", () => {
+    assert.deepEqual(parseOllamaEmbedding(JSON.stringify({ embedding: [0.1, 0.2] })), [0.1, 0.2]);
+  });
+  test("rejects non-number arrays / missing / malformed", () => {
+    assert.equal(parseOllamaEmbedding(JSON.stringify({ embedding: ["a"] })), null);
+    assert.equal(parseOllamaEmbedding(JSON.stringify({})), null);
+    assert.equal(parseOllamaEmbedding("nope"), null);
+  });
+});
+
+describe("OllamaEmbedder", () => {
+  test("posts to /api/embeddings per text and collects vectors", async () => {
+    const urls: string[] = [];
+    const post: PostJson = async (url) => {
+      urls.push(url);
+      return { ok: true, status: 200, body: JSON.stringify({ embedding: [1, 0] }) };
+    };
+    const e = new OllamaEmbedder("nomic-embed-text", "http://h:1", post);
+    const vecs = await e.embed(["a", "b"]);
+    assert.equal(vecs.length, 2);
+    assert.deepEqual(vecs[0], [1, 0]);
+    assert.match(urls[0]!, /\/api\/embeddings$/);
+    assert.equal(e.id, "ollama:nomic-embed-text");
+  });
+  test("throws when the backend is unreachable", async () => {
+    const post: PostJson = async () => ({ ok: false, status: 0, body: "" });
+    await assert.rejects(new OllamaEmbedder("m", "http://h", post).embed(["x"]), /embedding failed/);
+  });
+});
+
+function doc(id: string, text: string): Document {
+  return { sessionId: id, startedAt: "2026-01-01", text, tokens: [], tokenSet: new Set(), termFreq: new Map() };
+}
+
+// "network"/"connection" → [1,0]; else → [0,1]. Lets us prove semantic search
+// catches a paraphrase ("connection" vs "network error") with no shared tokens.
+const fakeEmbedder: Embedder = {
+  id: "fake",
+  async embed(texts) {
+    return texts.map((t) => (/network|connection/i.test(t) ? [1, 0] : [0, 1]));
+  },
+};
+
+describe("semanticSearch", () => {
+  test("ranks the semantic match first even with zero lexical overlap", async () => {
+    const index: Index = {
+      docs: [doc("cats", "the cats slept"), doc("net", "a network error occurred"), doc("dogs", "the dogs ran")],
+      idf: new Map(),
+    };
+    const hits = await semanticSearch(index, "connection failed", fakeEmbedder, 2);
+    assert.equal(hits[0]!.sessionId, "net");
+  });
+
+  test("caches doc vectors on the index (keyed by embedderId)", async () => {
+    const index: Index = { docs: [doc("a", "network")], idf: new Map() };
+    await semanticSearch(index, "connection", fakeEmbedder, 1);
+    assert.equal(index.embedderId, "fake");
+    assert.ok(index.embeddings?.has("a"));
+  });
+
+  test("empty query / empty index → []", async () => {
+    assert.deepEqual(await semanticSearch({ docs: [], idf: new Map() }, "x", fakeEmbedder), []);
+    assert.deepEqual(await semanticSearch({ docs: [doc("a", "x")], idf: new Map() }, "  ", fakeEmbedder), []);
+  });
+
+  test("falls back to TF-IDF (no throw) when the embedder is down", async () => {
+    const boom: Embedder = {
+      id: "boom",
+      async embed() {
+        throw new Error("down");
+      },
+    };
+    const hits = await semanticSearch({ docs: [doc("a", "alpha")], idf: new Map() }, "alpha", boom, 5);
+    assert.ok(Array.isArray(hits));
+  });
+});

--- a/src/memory/embedding.ts
+++ b/src/memory/embedding.ts
@@ -1,0 +1,94 @@
+/**
+ * Embedding abstraction for semantic memory search (PLAN_MODEL_v1.0 M2).
+ *
+ * TF-IDF (vector.ts) stays the zero-dependency default. When LISA_EMBED_MODEL
+ * is set, an Embedder provides dense vectors so search can match paraphrases
+ * ("connection failed" ↔ "network error") that share no literal tokens.
+ *
+ * The HTTP POST is injectable so the logic is unit-testable without a running
+ * embedding backend.
+ */
+import { localEndpoint } from "../model/local.js";
+
+export interface Embedder {
+  /** Stable id, e.g. "ollama:nomic-embed-text" — used to cache doc vectors. */
+  readonly id: string;
+  /** Embed each text into a dense vector. Throws if the backend is unreachable. */
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+/** Cosine similarity in [-1, 1]; 0 for a zero or empty vector. Pure. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const n = Math.min(a.length, b.length);
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < n; i++) {
+    dot += a[i]! * b[i]!;
+    na += a[i]! * a[i]!;
+    nb += b[i]! * b[i]!;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+export type PostJson = (
+  url: string,
+  body: unknown,
+) => Promise<{ ok: boolean; status: number; body: string }>;
+
+const defaultPostJson: PostJson = async (url, body) => {
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return { ok: res.ok, status: res.status, body: await res.text() };
+  } catch {
+    return { ok: false, status: 0, body: "" };
+  }
+};
+
+/** Parse Ollama's /api/embeddings response. Pure. */
+export function parseOllamaEmbedding(body: string): number[] | null {
+  try {
+    const j = JSON.parse(body) as { embedding?: unknown };
+    return Array.isArray(j.embedding) && j.embedding.every((x) => typeof x === "number")
+      ? (j.embedding as number[])
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export class OllamaEmbedder implements Embedder {
+  readonly id: string;
+  private host: string;
+  constructor(
+    private model: string,
+    host: string = localEndpoint("ollama").host,
+    private post: PostJson = defaultPostJson,
+  ) {
+    this.host = host.replace(/\/$/, "");
+    this.id = `ollama:${model}`;
+  }
+  async embed(texts: string[]): Promise<number[][]> {
+    const out: number[][] = [];
+    for (const t of texts) {
+      const res = await this.post(`${this.host}/api/embeddings`, { model: this.model, prompt: t });
+      const emb = res.ok ? parseOllamaEmbedding(res.body) : null;
+      if (!emb) {
+        throw new Error(`ollama embedding failed for "${this.model}" (status ${res.status || "unreachable"})`);
+      }
+      out.push(emb);
+    }
+    return out;
+  }
+}
+
+/** The embedder configured via LISA_EMBED_MODEL, or null (→ TF-IDF default). */
+export function getConfiguredEmbedder(): Embedder | null {
+  const model = process.env.LISA_EMBED_MODEL?.trim();
+  return model ? new OllamaEmbedder(model) : null;
+}

--- a/src/memory/search_tool.ts
+++ b/src/memory/search_tool.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "../types.js";
-import { buildIndex, search } from "./vector.js";
+import { buildIndex, search, semanticSearch } from "./vector.js";
+import { getConfiguredEmbedder } from "./embedding.js";
 
 interface SearchInput {
   query: string;
@@ -23,7 +24,10 @@ export const memorySearchTool: ToolDefinition<SearchInput, string> = {
   },
   async execute(input) {
     const index = await buildIndex();
-    const hits = search(index, input.query, input.limit ?? 5);
+    const embedder = getConfiguredEmbedder();
+    const hits = embedder
+      ? await semanticSearch(index, input.query, embedder, input.limit ?? 5)
+      : search(index, input.query, input.limit ?? 5);
     if (hits.length === 0) return "(no matches)";
     return hits
       .map(

--- a/src/memory/vector.ts
+++ b/src/memory/vector.ts
@@ -3,8 +3,9 @@ import fs from "node:fs/promises";
 import { listSessionsOnDisk, loadSessionMessages } from "../sessions/list.js";
 import { SESSIONS_DIR } from "../paths.js";
 import { extractTextFromContent } from "../agent.js";
+import { cosineSimilarity, type Embedder } from "./embedding.js";
 
-interface Document {
+export interface Document {
   sessionId: string;
   startedAt: string;
   text: string;
@@ -13,9 +14,12 @@ interface Document {
   termFreq: Map<string, number>;
 }
 
-interface Index {
+export interface Index {
   docs: Document[];
   idf: Map<string, number>;
+  /** Lazily-populated dense doc vectors (M2), keyed by sessionId; cached per embedderId. */
+  embeddings?: Map<string, number[]>;
+  embedderId?: string;
 }
 
 const STOPWORDS = new Set([
@@ -145,6 +149,53 @@ export function search(index: Index, query: string, k = 5): SearchHit[] {
     score: s.score,
     excerpt: excerptAround(s.doc.text, qTokens, 200),
   }));
+}
+
+const SEMANTIC_DOC_CHARS = 2000;
+
+/** Populate (and cache on the index) a dense vector per doc, once per embedder. */
+async function ensureEmbeddings(index: Index, embedder: Embedder): Promise<void> {
+  if (index.embedderId === embedder.id && index.embeddings) return;
+  const vecs = await embedder.embed(index.docs.map((d) => d.text.slice(0, SEMANTIC_DOC_CHARS)));
+  const map = new Map<string, number[]>();
+  index.docs.forEach((d, i) => map.set(d.sessionId, vecs[i] ?? []));
+  index.embeddings = map;
+  index.embedderId = embedder.id;
+}
+
+/**
+ * Semantic search: rank docs by cosine similarity to the query embedding, so
+ * paraphrases TF-IDF misses ("connection failed" ↔ "network error") still
+ * match. Doc vectors are computed once and cached on the (fingerprint-cached)
+ * index, so steady-state cost is one query embedding per search. Falls back to
+ * TF-IDF if the embedding backend is unreachable — memory_search never breaks.
+ */
+export async function semanticSearch(
+  index: Index,
+  query: string,
+  embedder: Embedder,
+  k = 5,
+): Promise<SearchHit[]> {
+  if (index.docs.length === 0 || !query.trim()) return [];
+  try {
+    await ensureEmbeddings(index, embedder);
+    const [qv] = await embedder.embed([query]);
+    if (!qv) return search(index, query, k);
+    const qTokens = tokenize(query);
+    const scored = index.docs.map((d) => ({
+      doc: d,
+      score: cosineSimilarity(qv, index.embeddings!.get(d.sessionId) ?? []),
+    }));
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, k).map((s) => ({
+      sessionId: s.doc.sessionId,
+      startedAt: s.doc.startedAt,
+      score: s.score,
+      excerpt: excerptAround(s.doc.text, qTokens, 200),
+    }));
+  } catch {
+    return search(index, query, k);
+  }
 }
 
 function tokenize(text: string): string[] {

--- a/src/model/local.test.ts
+++ b/src/model/local.test.ts
@@ -1,0 +1,113 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+// localEndpoint("ollama") consults OLLAMA_HOST; clear it so the default is
+// deterministic regardless of the runner's environment.
+delete process.env.OLLAMA_HOST;
+
+import {
+  parseLocalRef,
+  parseOllamaTags,
+  localEndpoint,
+  OllamaBackend,
+  type LocalRuntime,
+} from "./local.js";
+
+describe("parseLocalRef", () => {
+  test("local://model → ollama + model", () => {
+    assert.deepEqual(parseLocalRef("local://qwen2.5-coder:32b"), {
+      backend: "ollama",
+      model: "qwen2.5-coder:32b",
+    });
+  });
+  test("local://backend/model → that backend", () => {
+    assert.deepEqual(parseLocalRef("local://lmstudio/qwen"), { backend: "lmstudio", model: "qwen" });
+  });
+  test("unknown prefix stays part of the model name", () => {
+    assert.deepEqual(parseLocalRef("local://hf.co/user/model"), {
+      backend: "ollama",
+      model: "hf.co/user/model",
+    });
+  });
+  test("non-local refs and empty → null", () => {
+    assert.equal(parseLocalRef("gpt-4o"), null);
+    assert.equal(parseLocalRef("local://"), null);
+  });
+});
+
+describe("localEndpoint", () => {
+  test("ollama → :11434/v1, apiKey is the backend name", () => {
+    const ep = localEndpoint("ollama");
+    assert.equal(ep.baseURL, "http://localhost:11434/v1");
+    assert.equal(ep.apiKey, "ollama");
+  });
+  test("lmstudio → :1234", () => {
+    assert.match(localEndpoint("lmstudio").baseURL, /:1234\/v1$/);
+  });
+  test("unknown backend falls back to the ollama host", () => {
+    assert.match(localEndpoint("weird").baseURL, /:11434\/v1$/);
+  });
+});
+
+describe("parseOllamaTags", () => {
+  test("extracts name + size, tolerates missing size", () => {
+    const out = parseOllamaTags(
+      JSON.stringify({ models: [{ name: "qwen:7b", size: 4_700_000_000 }, { name: "llama3.1:70b" }] }),
+    );
+    assert.equal(out.length, 2);
+    assert.equal(out[0]!.name, "qwen:7b");
+    assert.equal(out[0]!.sizeBytes, 4_700_000_000);
+    assert.equal(out[1]!.sizeBytes, undefined);
+  });
+  test("malformed / empty JSON → []", () => {
+    assert.deepEqual(parseOllamaTags("not json"), []);
+    assert.deepEqual(parseOllamaTags("{}"), []);
+  });
+});
+
+function fakeRuntime(over: Partial<LocalRuntime> = {}): LocalRuntime {
+  return {
+    exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+    httpGet: async () => ({ ok: true, status: 200, body: JSON.stringify({ models: [] }) }),
+    ...over,
+  };
+}
+
+describe("OllamaBackend", () => {
+  test("health is up when /api/tags responds ok", async () => {
+    assert.equal(await new OllamaBackend(fakeRuntime()).health(), "up");
+  });
+  test("health is down when the endpoint is unreachable", async () => {
+    const b = new OllamaBackend(fakeRuntime({ httpGet: async () => ({ ok: false, status: 0, body: "" }) }));
+    assert.equal(await b.health(), "down");
+  });
+  test("listInstalled parses the tags response", async () => {
+    const b = new OllamaBackend(
+      fakeRuntime({
+        httpGet: async () => ({ ok: true, status: 200, body: JSON.stringify({ models: [{ name: "qwen:7b", size: 1 }] }) }),
+      }),
+    );
+    assert.equal((await b.listInstalled())[0]!.name, "qwen:7b");
+  });
+  test("install shells out to `ollama pull <model>` and resolves on exit 0", async () => {
+    const calls: string[][] = [];
+    const b = new OllamaBackend(
+      fakeRuntime({
+        exec: async (cmd, args) => {
+          calls.push([cmd, ...args]);
+          return { code: 0, stdout: "", stderr: "" };
+        },
+      }),
+    );
+    await b.install("qwen:7b");
+    assert.deepEqual(calls[0], ["ollama", "pull", "qwen:7b"]);
+  });
+  test("install gives a friendly error when ollama is missing (exit 127)", async () => {
+    const b = new OllamaBackend(fakeRuntime({ exec: async () => ({ code: 127, stdout: "", stderr: "" }) }));
+    await assert.rejects(b.install("x"), /ollama CLI not found/);
+  });
+  test("install surfaces the stderr tail on a non-zero exit", async () => {
+    const b = new OllamaBackend(fakeRuntime({ exec: async () => ({ code: 1, stdout: "", stderr: "manifest not found" }) }));
+    await assert.rejects(b.install("x"), /manifest not found/);
+  });
+});

--- a/src/model/local.ts
+++ b/src/model/local.ts
@@ -1,0 +1,133 @@
+/**
+ * Local-model lifecycle (PLAN_MODEL_v1.0 M1).
+ *
+ * Before this, "local models" meant: the user installs Ollama themselves, runs
+ * `ollama serve`, and hand-edits LISA_BASE_URL in config.env. This module makes
+ * it a first-class option — install / list / health / switch — while still
+ * routing through the existing OpenAI-compatible provider (Ollama et al. speak
+ * the OpenAI API), so no provider code changes.
+ *
+ * The runtime (process exec + HTTP) is injectable so the logic is unit-testable
+ * without a real Ollama install.
+ */
+import { spawn } from "node:child_process";
+
+export interface LocalModelInfo {
+  name: string;
+  sizeBytes?: number;
+}
+
+export interface LocalRuntime {
+  /** Run a command; stream stdout/stderr lines to onLine. Never rejects. */
+  exec(
+    cmd: string,
+    args: string[],
+    onLine?: (line: string) => void,
+  ): Promise<{ code: number; stdout: string; stderr: string }>;
+  /** GET a URL. Never rejects — a network error resolves to { ok:false }. */
+  httpGet(url: string): Promise<{ ok: boolean; status: number; body: string }>;
+}
+
+export const defaultRuntime: LocalRuntime = {
+  exec(cmd, args, onLine) {
+    return new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      let child;
+      try {
+        child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+      } catch (err) {
+        resolve({ code: 127, stdout: "", stderr: (err as Error).message });
+        return;
+      }
+      const pump = (chunk: Buffer, sink: "out" | "err") => {
+        const s = chunk.toString();
+        if (sink === "out") stdout += s;
+        else stderr += s;
+        if (onLine) for (const line of s.split("\n")) if (line.trim()) onLine(line.trim());
+      };
+      child.stdout?.on("data", (c) => pump(c, "out"));
+      child.stderr?.on("data", (c) => pump(c, "err")); // ollama writes pull progress to stderr
+      child.on("error", (err) => resolve({ code: 127, stdout, stderr: stderr + err.message }));
+      child.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr }));
+    });
+  },
+  async httpGet(url) {
+    try {
+      const res = await fetch(url);
+      return { ok: res.ok, status: res.status, body: await res.text() };
+    } catch {
+      return { ok: false, status: 0, body: "" };
+    }
+  },
+};
+
+/** Default OpenAI-compatible endpoints per local backend. Pure. */
+export function localEndpoint(backend: string): { host: string; baseURL: string; apiKey: string } {
+  const hosts: Record<string, string> = {
+    ollama: "http://localhost:11434",
+    lmstudio: "http://localhost:1234",
+    llamacpp: "http://localhost:8080",
+  };
+  const envHost = backend === "ollama" ? process.env.OLLAMA_HOST : undefined;
+  const host = (envHost || hosts[backend] || hosts.ollama!).replace(/\/$/, "");
+  return { host, baseURL: `${host}/v1`, apiKey: backend };
+}
+
+/** Parse a `local://[backend/]model` reference. Pure. */
+export function parseLocalRef(ref: string): { backend: string; model: string } | null {
+  const m = ref.match(/^local:\/\/(.+)$/);
+  if (!m) return null;
+  const rest = m[1]!.trim();
+  if (!rest) return null;
+  const known = new Set(["ollama", "lmstudio", "llamacpp"]);
+  const slash = rest.indexOf("/");
+  if (slash > 0 && known.has(rest.slice(0, slash))) {
+    return { backend: rest.slice(0, slash), model: rest.slice(slash + 1) };
+  }
+  return { backend: "ollama", model: rest };
+}
+
+/** Parse Ollama's /api/tags JSON into model infos. Pure. */
+export function parseOllamaTags(body: string): LocalModelInfo[] {
+  try {
+    const json = JSON.parse(body) as { models?: Array<{ name?: string; size?: number }> };
+    return (json.models ?? [])
+      .filter((m): m is { name: string; size?: number } => typeof m.name === "string")
+      .map((m) => ({ name: m.name, sizeBytes: typeof m.size === "number" ? m.size : undefined }));
+  } catch {
+    return [];
+  }
+}
+
+/** The Ollama backend: install / list / health via its CLI + HTTP API. */
+export class OllamaBackend {
+  readonly name = "ollama";
+  readonly host: string;
+  constructor(
+    private runtime: LocalRuntime = defaultRuntime,
+    host: string = localEndpoint("ollama").host,
+  ) {
+    this.host = host.replace(/\/$/, "");
+  }
+
+  async health(): Promise<"up" | "down"> {
+    const res = await this.runtime.httpGet(`${this.host}/api/tags`);
+    return res.ok ? "up" : "down";
+  }
+
+  async listInstalled(): Promise<LocalModelInfo[]> {
+    const res = await this.runtime.httpGet(`${this.host}/api/tags`);
+    return res.ok ? parseOllamaTags(res.body) : [];
+  }
+
+  async install(model: string, onLine?: (line: string) => void): Promise<void> {
+    const { code, stderr } = await this.runtime.exec("ollama", ["pull", model], onLine);
+    if (code === 0) return;
+    throw new Error(
+      code === 127
+        ? "ollama CLI not found — install it from https://ollama.com, then retry"
+        : `\`ollama pull ${model}\` failed: ${stderr.trim().slice(-200) || `exit ${code}`}`,
+    );
+  }
+}

--- a/src/providers/fallback.test.ts
+++ b/src/providers/fallback.test.ts
@@ -1,0 +1,95 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import type Anthropic from "@anthropic-ai/sdk";
+import { FallbackProvider } from "./fallback.js";
+import { resolveDefaultModel } from "./registry.js";
+import { DEFAULT_MODEL } from "../llm.js";
+import type { Provider, ProviderResult, ProviderRunOpts } from "./types.js";
+
+const ZERO_USAGE = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+function okResult(text: string): ProviderResult {
+  return {
+    content: [{ type: "text", text, citations: null } as Anthropic.TextBlock],
+    stopReason: "end_turn",
+    usage: ZERO_USAGE,
+  };
+}
+function textOf(r: ProviderResult): string {
+  return (r.content[0] as Anthropic.TextBlock).text;
+}
+function fakeProvider(behavior: (opts: ProviderRunOpts) => Promise<ProviderResult>): Provider {
+  return { name: "fake", runTurn: behavior };
+}
+function baseOpts(): ProviderRunOpts {
+  return { model: "primary", systemPrompt: "s", tools: [], messages: [] };
+}
+
+describe("FallbackProvider", () => {
+  test("uses the primary when it succeeds; the fallback is never called", async () => {
+    const calls: string[] = [];
+    const fp = new FallbackProvider([
+      { model: "m1", provider: fakeProvider(async (o) => (calls.push(o.model), okResult("from m1"))) },
+      { model: "m2", provider: fakeProvider(async (o) => (calls.push(o.model), okResult("from m2"))) },
+    ]);
+    assert.equal(textOf(await fp.runTurn(baseOpts())), "from m1");
+    assert.deepEqual(calls, ["m1"]);
+  });
+
+  test("falls through on error, running each link with its own model id", async () => {
+    const calls: string[] = [];
+    const fp = new FallbackProvider([
+      { model: "m1", provider: fakeProvider(async (o) => { calls.push(o.model); throw new Error("boom"); }) },
+      { model: "m2", provider: fakeProvider(async (o) => (calls.push(o.model), okResult("from m2"))) },
+    ]);
+    assert.equal(textOf(await fp.runTurn(baseOpts())), "from m2");
+    assert.deepEqual(calls, ["m1", "m2"]);
+  });
+
+  test("throws the last error when every link fails", async () => {
+    const fp = new FallbackProvider([
+      { model: "m1", provider: fakeProvider(async () => { throw new Error("first"); }) },
+      { model: "m2", provider: fakeProvider(async () => { throw new Error("last"); }) },
+    ]);
+    await assert.rejects(fp.runTurn(baseOpts()), /last/);
+  });
+
+  test("an empty chain is a programmer error", () => {
+    assert.throws(() => new FallbackProvider([]), /at least one/);
+  });
+});
+
+describe("resolveDefaultModel — single-key auto-detect", () => {
+  const KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "LISA_MODEL"];
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {};
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test("an explicit LISA_MODEL wins, even over an Anthropic key", () => {
+    process.env.LISA_MODEL = "qwen2.5-coder:32b";
+    process.env.ANTHROPIC_API_KEY = "x";
+    assert.equal(resolveDefaultModel(), "qwen2.5-coder:32b");
+  });
+  test("an Anthropic key → the canonical default", () => {
+    process.env.ANTHROPIC_API_KEY = "x";
+    assert.equal(resolveDefaultModel(), DEFAULT_MODEL);
+  });
+  test("only an OpenAI key → gpt-4o", () => {
+    process.env.OPENAI_API_KEY = "x";
+    assert.equal(resolveDefaultModel(), "gpt-4o");
+  });
+  test("nothing configured → the canonical default", () => {
+    assert.equal(resolveDefaultModel(), DEFAULT_MODEL);
+  });
+});

--- a/src/providers/fallback.ts
+++ b/src/providers/fallback.ts
@@ -1,0 +1,45 @@
+/**
+ * Fallback provider (PLAN_MODEL_v1.0 M3).
+ *
+ * Wraps a chain of {model, provider} links. runTurn tries each in order; if one
+ * throws (network error, rate limit, provider outage), it moves to the next.
+ * Configured by LISA_MODEL_FALLBACK (a comma-separated list of model ids) — the
+ * primary model is the chain head, the fallbacks follow.
+ *
+ * It implements the same Provider interface, so the agent loop is unaware it's
+ * talking to a chain rather than a single provider.
+ */
+import type { Provider, ProviderResult, ProviderRunOpts } from "./types.js";
+
+export interface FallbackLink {
+  model: string;
+  provider: Provider;
+}
+
+export class FallbackProvider implements Provider {
+  readonly name = "fallback";
+  constructor(private chain: FallbackLink[]) {
+    if (chain.length === 0) throw new Error("FallbackProvider requires at least one link");
+  }
+
+  async runTurn(opts: ProviderRunOpts): Promise<ProviderResult> {
+    let lastErr: unknown;
+    for (let i = 0; i < this.chain.length; i++) {
+      const link = this.chain[i]!;
+      try {
+        // Each link runs with its own model id; everything else is unchanged.
+        return await link.provider.runTurn({ ...opts, model: link.model });
+      } catch (err) {
+        lastErr = err;
+        const next = this.chain[i + 1];
+        if (next) {
+          console.error(
+            `[provider] "${link.model}" failed (${(err as Error).message?.slice(0, 120)}) — ` +
+              `falling back to "${next.model}"`,
+          );
+        }
+      }
+    }
+    throw lastErr;
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,6 +1,8 @@
 import { AnthropicProvider } from "./anthropic.js";
 import { GeminiProvider } from "./gemini.js";
 import { OpenAIProvider } from "./openai.js";
+import { FallbackProvider } from "./fallback.js";
+import { DEFAULT_MODEL } from "../llm.js";
 import type { Provider } from "./types.js";
 
 export type ProviderName = "anthropic" | "openai" | "gemini";
@@ -177,10 +179,11 @@ export function makeProvider(name: ProviderName): Provider {
 }
 
 /**
- * Resolve a Provider instance for a given model name. Looks up preset →
- * LISA_BASE_URL override → vanilla provider, in that order.
+ * Resolve a SINGLE Provider instance for a model name. Looks up preset →
+ * LISA_BASE_URL override → vanilla provider, in that order. (No fallback chain —
+ * that's providerForModel's job.)
  */
-export function providerForModel(model: string): Provider {
+function resolveProvider(model: string): Provider {
   const provider = detectProvider(model);
   if (provider === "anthropic") {
     return new AnthropicProvider({
@@ -215,6 +218,33 @@ export function providerForModel(model: string): Provider {
     baseURL: process.env.OPENAI_BASE_URL,
     apiKey: process.env.OPENAI_API_KEY,
   });
+}
+
+/**
+ * Resolve the provider for a model, wrapping it in a FallbackProvider when
+ * LISA_MODEL_FALLBACK lists alternate models to try if the primary errors.
+ * Drop-in for the old single-provider behavior (no env → identical).
+ */
+export function providerForModel(model: string): Provider {
+  const fallbacks = (process.env.LISA_MODEL_FALLBACK ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (fallbacks.length === 0) return resolveProvider(model);
+  const chain = [model, ...fallbacks].map((m) => ({ model: m, provider: resolveProvider(m) }));
+  return new FallbackProvider(chain);
+}
+
+/**
+ * Pick the default model when the user didn't pass --model. An explicit local
+ * default (LISA_MODEL, e.g. set by `lisa model use`) wins; otherwise auto-detect
+ * from the single configured cloud key so a one-key setup works with no flags.
+ */
+export function resolveDefaultModel(): string {
+  if (process.env.LISA_MODEL?.trim()) return process.env.LISA_MODEL.trim();
+  if (process.env.ANTHROPIC_API_KEY) return DEFAULT_MODEL;
+  if (process.env.OPENAI_API_KEY) return "gpt-4o";
+  return DEFAULT_MODEL;
 }
 
 /** For docs / CLI listing. */


### PR DESCRIPTION
Second slice of the v1.0 roadmap: the **Model** pillar (PLAN_MODEL_v1.0 M1–M3). Turns local models from "bring your own endpoint" into a first-class option, and makes the provider layer resilient. Everything is opt-in — **the default cloud path is unchanged** (full suite 464/464).

> Independent of PR #75 (Reve). Branched off `main`; the v1.0 plan docs land on `main` when #75 merges.

### M1 — local-model lifecycle
`lisa model <list | install <model> | use local://<model> | health>`
- `src/model/local.ts`: an Ollama backend over an **injectable runtime** (process exec + HTTP) so the logic is unit-testable without a real install. Pure helpers `parseLocalRef` / `localEndpoint` / `parseOllamaTags`.
- `install` = `ollama pull` with streamed progress + a clear "ollama not found" error; `use` writes `LISA_BASE_URL` / `LISA_API_KEY` / `LISA_MODEL` to config.env and probes whether the backend is running.
- **`LISA_MODEL` is now honored as the default model** (resolved after config.env loads; `--model` still wins), so `use` actually switches the default — no provider-code changes.

### M2 — local embeddings (semantic memory search)
- `src/memory/embedding.ts`: `Embedder` abstraction + `cosineSimilarity` + `OllamaEmbedder` (injectable POST). `getConfiguredEmbedder()` returns one only when `LISA_EMBED_MODEL` is set.
- `vector.ts`: `semanticSearch()` ranks by cosine to the query embedding, catching paraphrases TF-IDF misses (*"connection failed" ↔ "network error"*). Doc vectors are computed once and cached on the (fingerprint-cached) index — steady-state cost is one query embedding per search; **falls back to TF-IDF if the backend is down**. TF-IDF stays the zero-dependency default; `memory_search` / `lisa search` use the semantic path only when configured.

### M3 — provider resilience
- `src/providers/fallback.ts`: `FallbackProvider` tries a chain of models in order on error (configured by `LISA_MODEL_FALLBACK`); implements `Provider`, so the agent loop is unaware.
- `resolveDefaultModel()`: single-key auto-detect (explicit `LISA_MODEL` wins, else the one configured cloud key) — a one-key setup needs no `--model`.
- Graceful degradation was **already in place**: OpenAI/Gemini ignore `thinking` / `compaction` (silent no-op, not an error), and `abort` passthrough + `maxIterations`/empty-content guards were already fixed (confirmed during the audit).

### Tests
35 new (model lifecycle 15, embeddings 12, fallback + auto-detect 8). **Full suite 464/464**, typecheck + build clean. Smoke-tested `lisa model use/list/health` against a temp HOME. Real end-to-end needs Ollama (+ an embedding model like `nomic-embed-text`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
