### PR TITLE
feat(sense): git observer — surface the user's own repo work (S1)

### DIFF
--- a/src/integrations/git/observer.test.ts
+++ b/src/integrations/git/observer.test.ts
@@ -1,0 +1,88 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { parseGitStatus, deriveGitState, gitActivity, findGitRepos } from "./observer.js";
+
+describe("parseGitStatus", () => {
+  test("extracts branch, ahead/behind, changed files, staged count", () => {
+    const g = parseGitStatus(
+      [
+        "## main...origin/main [ahead 2, behind 1]",
+        " M src/foo.ts",
+        "?? new.txt",
+        "A  staged.ts",
+        "R  old.ts -> renamed.ts",
+      ].join("\n"),
+    );
+    assert.equal(g.branch, "main");
+    assert.equal(g.ahead, 2);
+    assert.equal(g.behind, 1);
+    assert.deepEqual(g.changedFiles, ["src/foo.ts", "new.txt", "staged.ts", "renamed.ts"]);
+    assert.equal(g.staged, 2); // the A and R entries
+  });
+
+  test("clean repo → no files, ahead 0", () => {
+    const g = parseGitStatus("## main...origin/main");
+    assert.equal(g.branch, "main");
+    assert.equal(g.ahead, 0);
+    assert.deepEqual(g.changedFiles, []);
+  });
+
+  test("branch names with dots are kept whole (split on '...', not '.')", () => {
+    assert.equal(parseGitStatus("## feat/v2.0...origin/feat/v2.0 [ahead 1]").branch, "feat/v2.0");
+  });
+
+  test("detached HEAD → null branch", () => {
+    assert.equal(parseGitStatus("## HEAD (no branch)").branch, null);
+  });
+
+  test("a fresh repo with no commits still reports its branch", () => {
+    assert.equal(parseGitStatus("## No commits yet on main").branch, "main");
+  });
+});
+
+describe("deriveGitState", () => {
+  const base = { branch: "main", ahead: 0, behind: 0, changedFiles: [], staged: 0 };
+  test("uncommitted changes → working", () => {
+    assert.deepEqual(deriveGitState({ ...base, changedFiles: ["a.ts", "b.ts"] }), {
+      state: "working",
+      reason: "2 uncommitted",
+    });
+  });
+  test("clean but ahead → waiting", () => {
+    assert.deepEqual(deriveGitState({ ...base, ahead: 3 }), { state: "waiting", reason: "3 to push" });
+  });
+  test("clean and in sync → idle", () => {
+    assert.deepEqual(deriveGitState(base), { state: "idle", reason: "clean" });
+  });
+  test("detached → unknown", () => {
+    assert.deepEqual(deriveGitState({ ...base, branch: null }), { state: "unknown", reason: "detached" });
+  });
+});
+
+describe("gitActivity (privacy: paths + branch only)", () => {
+  test("surfaces branch + changed paths, never tool calls", () => {
+    const a = gitActivity({ branch: "dev", ahead: 1, behind: 0, changedFiles: ["x.ts"], staged: 0 });
+    assert.equal(a.gitBranch, "dev");
+    assert.deepEqual(a.filesTouched, ["x.ts"]);
+    assert.deepEqual(a.lastTools, []);
+    assert.equal(a.turnCount, 1);
+  });
+});
+
+describe("findGitRepos", () => {
+  test("finds repos, stops at a repo boundary, skips node_modules", async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-git-"));
+    fs.mkdirSync(path.join(tmp, "repoA", ".git"), { recursive: true });
+    fs.mkdirSync(path.join(tmp, "repoA", "nested", ".git"), { recursive: true });
+    fs.mkdirSync(path.join(tmp, "sub", "repoB", ".git"), { recursive: true });
+    fs.mkdirSync(path.join(tmp, "node_modules", "pkg", ".git"), { recursive: true });
+
+    const found = (await findGitRepos(tmp)).map((p) => path.relative(tmp, p)).sort();
+    assert.deepEqual(found, ["repoA", path.join("sub", "repoB")]);
+    // nested repo under repoA isn't found (we don't descend into a repo);
+    // node_modules is skipped.
+  });
+});

--- a/src/integrations/git/observer.ts
+++ b/src/integrations/git/observer.ts
@@ -1,0 +1,283 @@
+/**
+ * Git observer (Sense S1b — the user's actual repo work, not just AI agents).
+ *
+ * The orchestrator hub only saw AI-agent sessions; this widens "what Lisa can
+ * see" to the user's own coding: which repo they're in, the branch, uncommitted
+ * changes, unpushed commits. Like Aider it has no central store — it scans the
+ * configured `watchRoots` for git repos and watches each repo's `.git` refs.
+ * With no watchRoots it observes nothing. Off by default.
+ *
+ * State (a git working tree isn't an "agent", so we map sensibly):
+ *   - uncommitted changes  → working ("N uncommitted")
+ *   - clean but ahead      → waiting ("N to push")
+ *   - clean & in sync      → idle ("clean")
+ *   - detached HEAD        → unknown
+ *
+ * PRIVACY: only branch name, file PATHS (from `git status --porcelain`), and
+ * ahead/behind counts are surfaced — never a diff, a commit message body, or
+ * any file content.
+ */
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { EventEmitter } from "node:events";
+import { registerIntegration } from "../registry.js";
+import type {
+  AgentIntegrationConfig,
+  AgentObserver,
+  AgentSession,
+  AgentSessionState,
+  SessionActivity,
+} from "../types.js";
+
+const pexec = promisify(execFile);
+
+const ACTIVE_WINDOW_MS = 60 * 60_000; // 1h — repos linger longer than chat sessions
+const MAX_LISTED = 10;
+const DEBOUNCE_MS = 400;
+const MAX_DEPTH = 3;
+const ACTIVITY_MAX_FILES = 10;
+const REF_FILES = new Set(["HEAD", "index", "ORIG_HEAD", "MERGE_HEAD"]);
+
+export interface GitState {
+  /** null when detached / no branch. */
+  branch: string | null;
+  ahead: number;
+  behind: number;
+  /** Paths with index or worktree changes (paths only — never content). */
+  changedFiles: string[];
+  /** Number of staged entries. */
+  staged: number;
+}
+
+/** Parse `git status --porcelain=v1 --branch` output. Pure — the unit under test. */
+export function parseGitStatus(porcelain: string): GitState {
+  let branch: string | null = null;
+  let ahead = 0;
+  let behind = 0;
+  let staged = 0;
+  const changedFiles: string[] = [];
+
+  for (const line of porcelain.split("\n")) {
+    if (!line) continue;
+    if (line.startsWith("## ")) {
+      const head = line.slice(3);
+      const bracket = head.indexOf(" [");
+      const refPart = (bracket >= 0 ? head.slice(0, bracket) : head).trim();
+      if (refPart.startsWith("No commits yet on ")) {
+        branch = refPart.slice("No commits yet on ".length).trim() || null;
+      } else if (refPart.startsWith("HEAD") || refPart.includes("(no branch)")) {
+        branch = null; // detached
+      } else {
+        branch = refPart.split("...")[0]!.trim() || null;
+      }
+      const a = head.match(/ahead (\d+)/);
+      const b = head.match(/behind (\d+)/);
+      if (a) ahead = parseInt(a[1]!, 10);
+      if (b) behind = parseInt(b[1]!, 10);
+      continue;
+    }
+    // "XY path" — X index status, Y worktree status; path starts at column 3.
+    const x = line[0]!;
+    const rest = line.slice(3).trim();
+    if (!rest) continue;
+    // Renames/copies: "R  old -> new" — keep the destination path.
+    const p = rest.includes(" -> ") ? rest.split(" -> ")[1]!.trim() : rest;
+    if (p) changedFiles.push(p);
+    if (x !== " " && x !== "?") staged++;
+  }
+  return { branch, ahead, behind, changedFiles, staged };
+}
+
+/** Map git working-tree state onto a normalized session state. Pure. */
+export function deriveGitState(g: GitState): { state: AgentSessionState; reason: string } {
+  if (g.branch === null) return { state: "unknown", reason: "detached" };
+  if (g.changedFiles.length > 0) {
+    return { state: "working", reason: `${g.changedFiles.length} uncommitted` };
+  }
+  if (g.ahead > 0) return { state: "waiting", reason: `${g.ahead} to push` };
+  return { state: "idle", reason: "clean" };
+}
+
+/** Tier-2 structural activity for a repo. Paths + branch only. Pure. */
+export function gitActivity(g: GitState): SessionActivity {
+  return {
+    turnCount: g.ahead, // commits ahead of upstream ≈ progress since last push
+    lastTools: [], // git has no tool calls to read; inventing them would be dishonest
+    filesTouched: g.changedFiles.slice(-ACTIVITY_MAX_FILES),
+    gitBranch: g.branch ?? undefined,
+  };
+}
+
+/** Find git repos under a root (bounded depth; doesn't descend into a repo). */
+export async function findGitRepos(root: string, maxDepth = MAX_DEPTH): Promise<string[]> {
+  const out: string[] = [];
+  async function rec(dir: string, depth: number): Promise<void> {
+    let entries: fs.Dirent[];
+    try {
+      entries = await fsp.readdir(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    if (entries.some((e) => e.name === ".git")) {
+      out.push(dir);
+      return; // a repo — don't recurse into it looking for nested repos
+    }
+    if (depth >= maxDepth) return;
+    for (const e of entries) {
+      if (e.isDirectory() && !e.name.startsWith(".") && e.name !== "node_modules") {
+        await rec(path.join(dir, e.name), depth + 1);
+      }
+    }
+  }
+  await rec(root, 0);
+  return out;
+}
+
+async function readGitStatus(repoDir: string): Promise<string | null> {
+  try {
+    const { stdout } = await pexec("git", ["-C", repoDir, "status", "--porcelain=v1", "--branch"], {
+      timeout: 5_000,
+      maxBuffer: 2 * 1024 * 1024,
+    });
+    return stdout;
+  } catch {
+    return null; // not a repo / git missing / timeout
+  }
+}
+
+interface GitSessionInfo {
+  sessionId: string;
+  project: string;
+  cwd: string;
+  lastMtime: number;
+  state: AgentSessionState;
+  stateReason: string;
+  activity?: SessionActivity;
+}
+
+export class GitObserver extends EventEmitter implements AgentObserver {
+  readonly agent = "git";
+  private roots: string[];
+  private sessions = new Map<string, GitSessionInfo>();
+  private watchers: fs.FSWatcher[] = [];
+  private pending = new Map<string, NodeJS.Timeout>();
+  private emitFn: ((s: AgentSession) => void) | null = null;
+  private readonly computeActivity: boolean;
+
+  constructor(cfg: AgentIntegrationConfig) {
+    super();
+    const raw = Array.isArray(cfg.watchRoots) ? cfg.watchRoots : [];
+    this.roots = raw
+      .filter((r): r is string => typeof r === "string")
+      .map((r) => r.replace(/^~/, os.homedir()));
+    this.computeActivity = cfg.visibility === "activity" || cfg.visibility === "intent";
+  }
+
+  async start(emit: (s: AgentSession) => void): Promise<void> {
+    this.emitFn = emit;
+    for (const root of this.roots) {
+      for (const repo of await findGitRepos(root)) await this.record(repo);
+      this.attach(root);
+    }
+  }
+
+  list(): AgentSession[] {
+    const cutoff = Date.now() - ACTIVE_WINDOW_MS;
+    return [...this.sessions.values()]
+      .filter((s) => s.lastMtime >= cutoff)
+      .sort((a, b) => b.lastMtime - a.lastMtime)
+      .slice(0, MAX_LISTED)
+      .map(toAgentSession);
+  }
+
+  async stop(): Promise<void> {
+    for (const w of this.watchers) w.close();
+    this.watchers = [];
+    for (const t of this.pending.values()) clearTimeout(t);
+    this.pending.clear();
+  }
+
+  private attach(root: string): void {
+    try {
+      const w = fs.watch(root, { recursive: true, persistent: false }, (_e, filename) => {
+        if (!filename) return;
+        const parts = filename.split(path.sep);
+        const gi = parts.indexOf(".git");
+        if (gi < 0) return;
+        const base = parts[parts.length - 1]!;
+        // React to ref/index/log changes — i.e. commit / checkout / stage.
+        if (!REF_FILES.has(base) && !parts.includes("logs")) return;
+        const repoDir = path.join(root, ...parts.slice(0, gi));
+        const prev = this.pending.get(repoDir);
+        if (prev) clearTimeout(prev);
+        this.pending.set(
+          repoDir,
+          setTimeout(() => {
+            this.pending.delete(repoDir);
+            void this.record(repoDir).then(() => {
+              const info = this.sessions.get(repoDir);
+              if (info && this.emitFn) this.emitFn(toAgentSession(info));
+            });
+          }, DEBOUNCE_MS),
+        );
+      });
+      w.on("error", () => w.close());
+      this.watchers.push(w);
+    } catch {
+      // root unwatchable → no-op
+    }
+  }
+
+  private async record(repoDir: string): Promise<void> {
+    const porcelain = await readGitStatus(repoDir);
+    if (porcelain === null) {
+      this.sessions.delete(repoDir);
+      return;
+    }
+    const g = parseGitStatus(porcelain);
+    const { state, reason } = deriveGitState(g);
+    let lastMtime = Date.now();
+    try {
+      // The most recently touched ref/index gives "when did this repo last move".
+      const stats = await Promise.all(
+        ["index", "HEAD", "logs/HEAD"].map((f) =>
+          fsp.stat(path.join(repoDir, ".git", f)).then(
+            (s) => s.mtimeMs,
+            () => 0,
+          ),
+        ),
+      );
+      lastMtime = Math.max(...stats, 0) || Date.now();
+    } catch {
+      // keep Date.now()
+    }
+    this.sessions.set(repoDir, {
+      sessionId: repoDir,
+      project: path.basename(repoDir),
+      cwd: repoDir,
+      lastMtime,
+      state,
+      stateReason: reason,
+      activity: this.computeActivity ? gitActivity(g) : undefined,
+    });
+  }
+}
+
+function toAgentSession(i: GitSessionInfo): AgentSession {
+  return {
+    agent: "git",
+    sessionId: i.sessionId,
+    project: i.project,
+    cwd: i.cwd,
+    state: i.state,
+    stateReason: i.stateReason,
+    lastMtime: i.lastMtime,
+    activity: i.activity,
+  };
+}
+
+registerIntegration("git", (cfg) => new GitObserver(cfg));

--- a/src/integrations/hub.ts
+++ b/src/integrations/hub.ts
@@ -41,6 +41,10 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: OrchestratorConfig = {
     // Aider has no central store — point it at the dirs you run it in:
     // `{ "enabled": true, "watchRoots": ["~/code/foo"] }`. Off by default.
     aider: { enabled: false },
+    // Git: surfaces the user's OWN repo work (branch / uncommitted / unpushed)
+    // under `watchRoots`, not just AI agents. Off by default; opt in with
+    // `{ "enabled": true, "watchRoots": ["~/code"] }`.
+    git: { enabled: false },
   },
   visibility: "activity",
 };

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -57,4 +57,5 @@ export async function registerBuiltinIntegrations(): Promise<void> {
   await import("./github-pr/observer.js");
   await import("./opencode/observer.js");
   await import("./aider/observer.js");
+  await import("./git/observer.js");
 }


### PR DESCRIPTION
First **Sense** increment (PLAN_SENSE_v1.0 **S1**). The orchestrator hub only saw AI-agent sessions; this widens "what Lisa can see" to the user's **own coding** — which repo they're in, the branch, uncommitted changes, unpushed commits. A low-risk new work-source that starts making good on "she sees your whole workflow, not just your agents."

> Independent PR off `main` (does not depend on #75 / #76 / #77).

### What it does
- **`GitObserver`** (`src/integrations/git/observer.ts`, a new `AgentObserver`, kind `"git"`) — mirrors the Aider adapter: no central store, so it scans configured `watchRoots`, finds repos, and watches each repo's `.git` refs (HEAD / index / logs) with a per-repo debounce.
- State maps a working tree onto the normalized session states: uncommitted → **working**, clean-but-ahead → **waiting**, clean → **idle**, detached → **unknown**.
- Registered in `registerBuiltinIntegrations`; **off by default** in `DEFAULT_ORCHESTRATOR_CONFIG` — opt in with `{ "git": { "enabled": true, "watchRoots": ["~/code"] } }` in `~/.lisa/agents.json`.

### Verified end-to-end
Pointed at the LISA repo it produced:
```
agent=git project=LISA state=working (6 uncommitted)
  branch=feat/sense-git-observer files=src/integrations/hub.ts, src/integrations/registry.ts, …
```

### Privacy
Only the branch name, file **paths** (from `git status --porcelain`), and ahead/behind counts are surfaced — **never a diff, a commit-message body, or any file content** (same contract as the other observers; `lastTools` is intentionally `[]` since git has no tool calls to read).

### Tests
11 new, all pure units: `parseGitStatus` (branch/ahead/behind/rename/detached/no-commits), `deriveGitState`, `gitActivity`, and `findGitRepos` (stops at repo boundary, skips node_modules). **Full suite 440/440**; typecheck + build clean.

### Still in Sense S1 (follow-ups)
A shell observer (tail history, argv[0] only) and deepening the non-Claude agent observers' Tier-2 activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
