### PR TITLE
feat(dispatch): close the feedback half of the command loop (D1)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,8 @@ INSPECTION
   lisa autonomy [days]         Digest of self-driven runs (idle / heartbeat /
                                desire / examen / reflect): outcome, cost, cadence.
                                Defaults to the last 7 days.
+  lisa model <sub>             Local model lifecycle (Ollama): list, install
+                               <model>, use local://<model> to switch, health.
 
 LIFECYCLE
   lisa birth                   Run the birth ritual (auto-runs on first launch).
@@ -142,6 +144,8 @@ interface ParsedArgs {
   loadPlugins: boolean;
   voice: boolean;
   idleMinutes: number;
+  /** True when --model was passed, so a LISA_MODEL default from config.env won't override it. */
+  modelExplicit: boolean;
   subcommand?:
     | "resume"
     | "sessions"
@@ -157,7 +161,8 @@ interface ParsedArgs {
     | "status"
     | "doctor"
     | "monitor"
-    | "autonomy";
+    | "autonomy"
+    | "model";
   subargs: string[];
   serveWeb: boolean;
   serveImessage: boolean;
@@ -177,6 +182,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     thinking: false,
     compaction: false,
     model: DEFAULT_MODEL,
+    modelExplicit: false,
     approval: "auto",
     loadMcp: true,
     loadPlugins: true,
@@ -221,8 +227,13 @@ function parseArgs(argv: string[]): ParsedArgs {
         .map((s) => s.trim())
         .filter(Boolean);
     }
-    else if (arg === "--model") out.model = mustNext(argv, ++i, "--model");
-    else if (arg.startsWith("--model=")) out.model = arg.slice("--model=".length);
+    else if (arg === "--model") {
+      out.model = mustNext(argv, ++i, "--model");
+      out.modelExplicit = true;
+    } else if (arg.startsWith("--model=")) {
+      out.model = arg.slice("--model=".length);
+      out.modelExplicit = true;
+    }
     else if (arg === "--provider") {
       const v = mustNext(argv, ++i, "--provider");
       process.env.LISA_PROVIDER = v;
@@ -269,7 +280,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       first === "status" ||
       first === "doctor" ||
       first === "monitor" ||
-      first === "autonomy"
+      first === "autonomy" ||
+      first === "model"
     ) {
       out.subcommand = first;
       out.subargs = positional.slice(1);
@@ -321,6 +333,12 @@ async function main(): Promise<void> {
 
   await ensureDir(LISA_HOME);
   loadConfigEnv();
+  // If the user didn't pass --model, honor a LISA_MODEL default from config.env
+  // (set by `lisa model use local://…`). Done after loadConfigEnv so the file's
+  // value is in process.env; --model still wins.
+  if (!args.modelExplicit && process.env.LISA_MODEL?.trim()) {
+    args.model = process.env.LISA_MODEL.trim();
+  }
   // Re-bridge proxy in case HTTPS_PROXY was set in config.env rather than
   // the shell. configureProxyFromEnv is idempotent.
   configureProxyFromEnv({ log: (m) => console.error(m) });
@@ -437,6 +455,11 @@ async function main(): Promise<void> {
     const sinceMs = (Number.isFinite(days) && days > 0 ? days : 7) * 24 * 60 * 60_000;
     console.log(summarizeAutonomyRuns(await readAutonomyRuns(sinceMs)));
     return;
+  }
+
+  if (args.subcommand === "model") {
+    const { runModelCommand } = await import("./cli/model.js");
+    process.exit(await runModelCommand(args.subargs));
   }
 
   if (args.subcommand === "sessions") {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { LISA_HOME } from "./paths.js";
 import { loadAllPlugins, PLUGINS_ROOT } from "./plugins/loader.js";
 import type { HookSpec } from "./plugins/types.js";
 import { buildSystemPromptSnapshot, getPromptFingerprint } from "./prompt.js";
-import { providerForModel } from "./providers/registry.js";
+import { providerForModel, resolveDefaultModel } from "./providers/registry.js";
 import { reflectOnSession } from "./reflect.js";
 import { runRepl } from "./cli/repl.js";
 import { listSessionsOnDisk, loadSessionMessages } from "./sessions/list.js";
@@ -333,11 +333,11 @@ async function main(): Promise<void> {
 
   await ensureDir(LISA_HOME);
   loadConfigEnv();
-  // If the user didn't pass --model, honor a LISA_MODEL default from config.env
-  // (set by `lisa model use local://…`). Done after loadConfigEnv so the file's
-  // value is in process.env; --model still wins.
-  if (!args.modelExplicit && process.env.LISA_MODEL?.trim()) {
-    args.model = process.env.LISA_MODEL.trim();
+  // If the user didn't pass --model, resolve the default now that config.env is
+  // loaded: an explicit LISA_MODEL (e.g. `lisa model use`) wins, else auto-detect
+  // from the single configured cloud key. An explicit --model always overrides.
+  if (!args.modelExplicit) {
+    args.model = resolveDefaultModel();
   }
   // Re-bridge proxy in case HTTPS_PROXY was set in config.env rather than
   // the shell. configureProxyFromEnv is idempotent.
@@ -478,9 +478,11 @@ async function main(): Promise<void> {
       console.error("usage: lisa search <query>");
       process.exit(2);
     }
-    const { buildIndex, search } = await import("./memory/vector.js");
+    const { buildIndex, search, semanticSearch } = await import("./memory/vector.js");
+    const { getConfiguredEmbedder } = await import("./memory/embedding.js");
     const index = await buildIndex();
-    const hits = search(index, query, 10);
+    const embedder = getConfiguredEmbedder();
+    const hits = embedder ? await semanticSearch(index, query, embedder, 10) : search(index, query, 10);
     if (hits.length === 0) console.log("(no matches)");
     for (const h of hits) {
       console.log(

--- a/src/cli/model.ts
+++ b/src/cli/model.ts
@@ -1,0 +1,89 @@
+/**
+ * `lisa model <list|install|use|health>` — local-model lifecycle (M1).
+ * Thin CLI over src/model/local.ts; `use` writes config.env via env.ts.
+ */
+import { OllamaBackend, localEndpoint, parseLocalRef } from "../model/local.js";
+import { saveConfigEnv } from "../env.js";
+
+function gb(bytes?: number): string {
+  return bytes ? `  (${(bytes / 1e9).toFixed(1)} GB)` : "";
+}
+
+export async function runModelCommand(subargs: string[]): Promise<number> {
+  const sub = subargs[0];
+
+  if (sub === "health") {
+    const backend = new OllamaBackend();
+    const h = await backend.health();
+    console.log(`${backend.name} @ ${backend.host}: ${h}`);
+    return h === "up" ? 0 : 1;
+  }
+
+  if (sub === "list") {
+    const backend = new OllamaBackend();
+    const health = await backend.health();
+    console.log(`local backend: ${backend.name} @ ${backend.host} (${health})`);
+    if (health === "up") {
+      const installed = await backend.listInstalled();
+      if (installed.length === 0) {
+        console.log("  (none installed — `lisa model install <model>`)");
+      }
+      for (const m of installed) console.log(`  ${m.name}${gb(m.sizeBytes)}`);
+    } else {
+      console.log("  (backend not running — start it, e.g. `ollama serve`)");
+    }
+    const base = process.env.LISA_BASE_URL;
+    const model = process.env.LISA_MODEL;
+    console.log(
+      `\nconfigured: ${base ? `${base}${model ? ` · model=${model}` : ""}` : "(cloud provider — no local endpoint set)"}`,
+    );
+    return 0;
+  }
+
+  if (sub === "install") {
+    const model = subargs[1];
+    if (!model) {
+      console.error("usage: lisa model install <model>   (e.g. qwen2.5-coder:32b)");
+      return 2;
+    }
+    const backend = new OllamaBackend();
+    console.log(`pulling "${model}" via ${backend.name}…`);
+    try {
+      await backend.install(model, (line) => console.error(line));
+      console.log(`✓ ${model} installed. Switch to it with:  lisa model use local://${model}`);
+      return 0;
+    } catch (err) {
+      console.error(`✗ ${(err as Error).message}`);
+      return 1;
+    }
+  }
+
+  if (sub === "use") {
+    const ref = subargs[1];
+    const parsed = ref ? parseLocalRef(ref) : null;
+    if (!parsed) {
+      console.error("usage: lisa model use local://<model>   (e.g. local://qwen2.5-coder:32b)");
+      return 2;
+    }
+    const ep = localEndpoint(parsed.backend);
+    await saveConfigEnv({
+      LISA_BASE_URL: ep.baseURL,
+      LISA_API_KEY: ep.apiKey,
+      LISA_MODEL: parsed.model,
+    });
+    console.log(`✓ default model → "${parsed.model}" via ${parsed.backend} (${ep.baseURL}).`);
+    // Probe so the user finds out now, not on the next chat, if it isn't running.
+    const { defaultRuntime } = await import("../model/local.js");
+    const probe = await defaultRuntime.httpGet(`${ep.host}/api/tags`);
+    if (!probe.ok) {
+      console.log(
+        `⚠ ${parsed.backend} doesn't appear to be running at ${ep.host} — start it ` +
+          `(e.g. \`ollama serve\`) and \`lisa model install ${parsed.model}\` if you haven't.`,
+      );
+    }
+    return 0;
+  }
+
+  console.error("usage: lisa model <list | install <model> | use local://<model> | health>");
+  return 2;
+}

--- a/src/integrations/dispatch-ledger.ts
+++ b/src/integrations/dispatch-ledger.ts
@@ -29,12 +29,25 @@ export interface DispatchEntry {
   task: string;
   /** Epoch ms when dispatched. */
   startedAt: number;
+  /** Captured stdout+stderr file for this agent (D1 feedback), if any. */
+  logPath?: string;
+}
+
+/** How long a finished dispatch (and its output log) is retained for readback. */
+const RETAIN_MS = 24 * 60 * 60_000;
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
 }
 
 /** Resolved lazily (reads env at call time) so tests can point LISA_HOME at a tmp dir. */
 function ledgerPath(): string {
-  const home = process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
-  return path.join(home, "dispatches.json");
+  return path.join(lisaHome(), "dispatches.json");
+}
+
+/** Directory for per-dispatch captured-output logs. */
+export function dispatchLogDir(): string {
+  return path.join(lisaHome(), "dispatches");
 }
 
 /** Read the ledger; tolerant of a missing or corrupt file (returns []). */
@@ -86,6 +99,8 @@ export function recordDispatch(d: {
   pid: number;
   cwd: string;
   task: string;
+  /** Captured-output log file for this agent (D1 feedback). */
+  logPath?: string;
   /** Override the clock (tests). */
   now?: number;
 }): DispatchEntry {
@@ -97,20 +112,66 @@ export function recordDispatch(d: {
     cwd: d.cwd,
     task: d.task.slice(0, 200),
     startedAt,
+    ...(d.logPath ? { logPath: d.logPath } : {}),
   };
-  // Drop any stale entry that reused this pid before appending.
-  const entries = loadLedger().filter((e) => e.pid !== d.pid);
+  // Drop any stale same-pid entry, and age out finished dispatches older than
+  // the retention window so the file (and its logs) don't grow unbounded.
+  const cutoff = startedAt - RETAIN_MS;
+  const entries = loadLedger().filter(
+    (e) => e.pid !== d.pid && (isAlive(e.pid) || e.startedAt >= cutoff),
+  );
   entries.push(entry);
   saveLedger(entries);
   return entry;
 }
 
-/** Live dispatched agents, pruning any that have since exited. */
+/**
+ * Live dispatched agents. Rewrites the ledger to retain live agents AND
+ * recently-finished ones (so their captured output stays readable via
+ * dispatch_status); only truly-aged-out entries (and their logs) are dropped.
+ */
 export function listLiveDispatches(): DispatchEntry[] {
   const all = loadLedger();
-  const live = all.filter((e) => isAlive(e.pid));
-  if (live.length !== all.length) saveLedger(live); // prune the dead
-  return live;
+  const now = Date.now();
+  const keep = all.filter((e) => isAlive(e.pid) || now - e.startedAt < RETAIN_MS);
+  if (keep.length !== all.length) {
+    for (const e of all) {
+      if (!keep.includes(e) && e.logPath) {
+        try {
+          fs.unlinkSync(e.logPath);
+        } catch {
+          // log already gone — ignore
+        }
+      }
+    }
+    saveLedger(keep);
+  }
+  return all.filter((e) => isAlive(e.pid));
+}
+
+/** All retained dispatches (live + recently-finished). For status / result readback. */
+export function listRecentDispatches(): DispatchEntry[] {
+  return loadLedger();
+}
+
+/** Tail (up to maxBytes) of a dispatch's captured output. "" if none/unreadable. */
+export function readDispatchOutput(entry: DispatchEntry, maxBytes = 2000): string {
+  if (!entry.logPath) return "";
+  try {
+    const st = fs.statSync(entry.logPath);
+    if (st.size === 0) return "";
+    const fd = fs.openSync(entry.logPath, "r");
+    try {
+      const len = Math.min(maxBytes, st.size);
+      const buf = Buffer.alloc(len);
+      fs.readSync(fd, buf, 0, len, st.size - len);
+      return (st.size > len ? "…" : "") + buf.toString("utf8");
+    } finally {
+      fs.closeSync(fd);
+    }
+  } catch {
+    return "";
+  }
 }
 
 /** Find a *live* dispatch by id or by pid (as a string). Null if absent/dead. */

--- a/src/integrations/dispatch-output.test.ts
+++ b/src/integrations/dispatch-output.test.ts
@@ -1,0 +1,87 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Isolate to a throwaway LISA_HOME before importing the ledger (it reads the
+// env lazily, but set it up front to be safe).
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-dispatch-out-"));
+process.env.LISA_HOME = TMP;
+const LEDGER = path.join(TMP, "dispatches.json");
+
+const {
+  recordDispatch,
+  listLiveDispatches,
+  listRecentDispatches,
+  readDispatchOutput,
+  dispatchLogDir,
+} = await import("./dispatch-ledger.js");
+
+const DEAD_PID = 2_000_000_000;
+
+beforeEach(() => {
+  fs.rmSync(LEDGER, { force: true });
+  fs.rmSync(dispatchLogDir(), { recursive: true, force: true });
+});
+
+describe("recordDispatch — logPath", () => {
+  test("stores logPath when given; omits the key when not", () => {
+    const a = recordDispatch({ agent: "claude", pid: process.pid, cwd: "/a", task: "t", logPath: "/x/y.log", now: 1000 });
+    assert.equal(a.logPath, "/x/y.log");
+    const b = recordDispatch({ agent: "codex", pid: process.pid + 1, cwd: "/b", task: "t", now: 1000 });
+    assert.equal("logPath" in b, false);
+  });
+});
+
+describe("retention (finished dispatches stay readable, old ones age out)", () => {
+  test("a recently-finished (dead) entry is retained on disk, but not 'live'", () => {
+    const now = Date.now();
+    fs.writeFileSync(
+      LEDGER,
+      JSON.stringify([{ id: "deadrecent", agent: "claude", pid: DEAD_PID, cwd: "/a", task: "t", startedAt: now - 1000 }]),
+    );
+    assert.equal(listLiveDispatches().length, 0); // dead → not live
+    assert.equal(listRecentDispatches().length, 1); // but kept for readback
+  });
+
+  test("a dead entry past the retention window is dropped, and its log deleted", () => {
+    fs.mkdirSync(dispatchLogDir(), { recursive: true });
+    const logFile = path.join(dispatchLogDir(), "old.log");
+    fs.writeFileSync(logFile, "old output");
+    fs.writeFileSync(
+      LEDGER,
+      JSON.stringify([{ id: "deadold", agent: "claude", pid: DEAD_PID, cwd: "/a", task: "t", startedAt: 2, logPath: logFile }]),
+    );
+    listLiveDispatches();
+    assert.equal(listRecentDispatches().length, 0);
+    assert.equal(fs.existsSync(logFile), false);
+  });
+});
+
+describe("readDispatchOutput", () => {
+  test("returns the tail of the captured log", () => {
+    fs.mkdirSync(dispatchLogDir(), { recursive: true });
+    const logFile = path.join(dispatchLogDir(), "x.log");
+    fs.writeFileSync(logFile, "line1\nline2\nthe-end");
+    const out = readDispatchOutput(
+      { id: "i", agent: "claude", pid: 1, cwd: "/", task: "t", startedAt: 0, logPath: logFile },
+      1000,
+    );
+    assert.match(out, /the-end/);
+  });
+  test("caps to maxBytes (tail) with an ellipsis", () => {
+    fs.mkdirSync(dispatchLogDir(), { recursive: true });
+    const logFile = path.join(dispatchLogDir(), "big.log");
+    fs.writeFileSync(logFile, "A".repeat(100) + "TAIL");
+    const out = readDispatchOutput(
+      { id: "i", agent: "claude", pid: 1, cwd: "/", task: "t", startedAt: 0, logPath: logFile },
+      10,
+    );
+    assert.match(out, /^…/);
+    assert.match(out, /TAIL$/);
+  });
+  test("no logPath → empty string", () => {
+    assert.equal(readDispatchOutput({ id: "i", agent: "claude", pid: 1, cwd: "/", task: "t", startedAt: 0 }), "");
+  });
+});

--- a/src/memory/embedding.test.ts
+++ b/src/memory/embedding.test.ts
@@ -1,0 +1,95 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  cosineSimilarity,
+  parseOllamaEmbedding,
+  OllamaEmbedder,
+  type Embedder,
+  type PostJson,
+} from "./embedding.js";
+import { semanticSearch, type Index, type Document } from "./vector.js";
+
+describe("cosineSimilarity", () => {
+  test("identical → 1", () => assert.equal(cosineSimilarity([1, 2, 3], [1, 2, 3]), 1));
+  test("orthogonal → 0", () => assert.equal(cosineSimilarity([1, 0], [0, 1]), 0));
+  test("opposite → -1", () => assert.equal(cosineSimilarity([1, 0], [-1, 0]), -1));
+  test("zero vector → 0, not NaN", () => assert.equal(cosineSimilarity([0, 0], [1, 1]), 0));
+});
+
+describe("parseOllamaEmbedding", () => {
+  test("extracts a numeric embedding array", () => {
+    assert.deepEqual(parseOllamaEmbedding(JSON.stringify({ embedding: [0.1, 0.2] })), [0.1, 0.2]);
+  });
+  test("rejects non-number arrays / missing / malformed", () => {
+    assert.equal(parseOllamaEmbedding(JSON.stringify({ embedding: ["a"] })), null);
+    assert.equal(parseOllamaEmbedding(JSON.stringify({})), null);
+    assert.equal(parseOllamaEmbedding("nope"), null);
+  });
+});
+
+describe("OllamaEmbedder", () => {
+  test("posts to /api/embeddings per text and collects vectors", async () => {
+    const urls: string[] = [];
+    const post: PostJson = async (url) => {
+      urls.push(url);
+      return { ok: true, status: 200, body: JSON.stringify({ embedding: [1, 0] }) };
+    };
+    const e = new OllamaEmbedder("nomic-embed-text", "http://h:1", post);
+    const vecs = await e.embed(["a", "b"]);
+    assert.equal(vecs.length, 2);
+    assert.deepEqual(vecs[0], [1, 0]);
+    assert.match(urls[0]!, /\/api\/embeddings$/);
+    assert.equal(e.id, "ollama:nomic-embed-text");
+  });
+  test("throws when the backend is unreachable", async () => {
+    const post: PostJson = async () => ({ ok: false, status: 0, body: "" });
+    await assert.rejects(new OllamaEmbedder("m", "http://h", post).embed(["x"]), /embedding failed/);
+  });
+});
+
+function doc(id: string, text: string): Document {
+  return { sessionId: id, startedAt: "2026-01-01", text, tokens: [], tokenSet: new Set(), termFreq: new Map() };
+}
+
+// "network"/"connection" → [1,0]; else → [0,1]. Lets us prove semantic search
+// catches a paraphrase ("connection" vs "network error") with no shared tokens.
+const fakeEmbedder: Embedder = {
+  id: "fake",
+  async embed(texts) {
+    return texts.map((t) => (/network|connection/i.test(t) ? [1, 0] : [0, 1]));
+  },
+};
+
+describe("semanticSearch", () => {
+  test("ranks the semantic match first even with zero lexical overlap", async () => {
+    const index: Index = {
+      docs: [doc("cats", "the cats slept"), doc("net", "a network error occurred"), doc("dogs", "the dogs ran")],
+      idf: new Map(),
+    };
+    const hits = await semanticSearch(index, "connection failed", fakeEmbedder, 2);
+    assert.equal(hits[0]!.sessionId, "net");
+  });
+
+  test("caches doc vectors on the index (keyed by embedderId)", async () => {
+    const index: Index = { docs: [doc("a", "network")], idf: new Map() };
+    await semanticSearch(index, "connection", fakeEmbedder, 1);
+    assert.equal(index.embedderId, "fake");
+    assert.ok(index.embeddings?.has("a"));
+  });
+
+  test("empty query / empty index → []", async () => {
+    assert.deepEqual(await semanticSearch({ docs: [], idf: new Map() }, "x", fakeEmbedder), []);
+    assert.deepEqual(await semanticSearch({ docs: [doc("a", "x")], idf: new Map() }, "  ", fakeEmbedder), []);
+  });
+
+  test("falls back to TF-IDF (no throw) when the embedder is down", async () => {
+    const boom: Embedder = {
+      id: "boom",
+      async embed() {
+        throw new Error("down");
+      },
+    };
+    const hits = await semanticSearch({ docs: [doc("a", "alpha")], idf: new Map() }, "alpha", boom, 5);
+    assert.ok(Array.isArray(hits));
+  });
+});

--- a/src/memory/embedding.ts
+++ b/src/memory/embedding.ts
@@ -1,0 +1,94 @@
+/**
+ * Embedding abstraction for semantic memory search (PLAN_MODEL_v1.0 M2).
+ *
+ * TF-IDF (vector.ts) stays the zero-dependency default. When LISA_EMBED_MODEL
+ * is set, an Embedder provides dense vectors so search can match paraphrases
+ * ("connection failed" ↔ "network error") that share no literal tokens.
+ *
+ * The HTTP POST is injectable so the logic is unit-testable without a running
+ * embedding backend.
+ */
+import { localEndpoint } from "../model/local.js";
+
+export interface Embedder {
+  /** Stable id, e.g. "ollama:nomic-embed-text" — used to cache doc vectors. */
+  readonly id: string;
+  /** Embed each text into a dense vector. Throws if the backend is unreachable. */
+  embed(texts: string[]): Promise<number[][]>;
+}
+
+/** Cosine similarity in [-1, 1]; 0 for a zero or empty vector. Pure. */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  const n = Math.min(a.length, b.length);
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < n; i++) {
+    dot += a[i]! * b[i]!;
+    na += a[i]! * a[i]!;
+    nb += b[i]! * b[i]!;
+  }
+  if (na === 0 || nb === 0) return 0;
+  return dot / (Math.sqrt(na) * Math.sqrt(nb));
+}
+
+export type PostJson = (
+  url: string,
+  body: unknown,
+) => Promise<{ ok: boolean; status: number; body: string }>;
+
+const defaultPostJson: PostJson = async (url, body) => {
+  try {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    return { ok: res.ok, status: res.status, body: await res.text() };
+  } catch {
+    return { ok: false, status: 0, body: "" };
+  }
+};
+
+/** Parse Ollama's /api/embeddings response. Pure. */
+export function parseOllamaEmbedding(body: string): number[] | null {
+  try {
+    const j = JSON.parse(body) as { embedding?: unknown };
+    return Array.isArray(j.embedding) && j.embedding.every((x) => typeof x === "number")
+      ? (j.embedding as number[])
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+export class OllamaEmbedder implements Embedder {
+  readonly id: string;
+  private host: string;
+  constructor(
+    private model: string,
+    host: string = localEndpoint("ollama").host,
+    private post: PostJson = defaultPostJson,
+  ) {
+    this.host = host.replace(/\/$/, "");
+    this.id = `ollama:${model}`;
+  }
+  async embed(texts: string[]): Promise<number[][]> {
+    const out: number[][] = [];
+    for (const t of texts) {
+      const res = await this.post(`${this.host}/api/embeddings`, { model: this.model, prompt: t });
+      const emb = res.ok ? parseOllamaEmbedding(res.body) : null;
+      if (!emb) {
+        throw new Error(`ollama embedding failed for "${this.model}" (status ${res.status || "unreachable"})`);
+      }
+      out.push(emb);
+    }
+    return out;
+  }
+}
+
+/** The embedder configured via LISA_EMBED_MODEL, or null (→ TF-IDF default). */
+export function getConfiguredEmbedder(): Embedder | null {
+  const model = process.env.LISA_EMBED_MODEL?.trim();
+  return model ? new OllamaEmbedder(model) : null;
+}

--- a/src/memory/search_tool.ts
+++ b/src/memory/search_tool.ts
@@ -1,5 +1,6 @@
 import type { ToolDefinition } from "../types.js";
-import { buildIndex, search } from "./vector.js";
+import { buildIndex, search, semanticSearch } from "./vector.js";
+import { getConfiguredEmbedder } from "./embedding.js";
 
 interface SearchInput {
   query: string;
@@ -23,7 +24,10 @@ export const memorySearchTool: ToolDefinition<SearchInput, string> = {
   },
   async execute(input) {
     const index = await buildIndex();
-    const hits = search(index, input.query, input.limit ?? 5);
+    const embedder = getConfiguredEmbedder();
+    const hits = embedder
+      ? await semanticSearch(index, input.query, embedder, input.limit ?? 5)
+      : search(index, input.query, input.limit ?? 5);
     if (hits.length === 0) return "(no matches)";
     return hits
       .map(

--- a/src/memory/vector.ts
+++ b/src/memory/vector.ts
@@ -3,8 +3,9 @@ import fs from "node:fs/promises";
 import { listSessionsOnDisk, loadSessionMessages } from "../sessions/list.js";
 import { SESSIONS_DIR } from "../paths.js";
 import { extractTextFromContent } from "../agent.js";
+import { cosineSimilarity, type Embedder } from "./embedding.js";
 
-interface Document {
+export interface Document {
   sessionId: string;
   startedAt: string;
   text: string;
@@ -13,9 +14,12 @@ interface Document {
   termFreq: Map<string, number>;
 }
 
-interface Index {
+export interface Index {
   docs: Document[];
   idf: Map<string, number>;
+  /** Lazily-populated dense doc vectors (M2), keyed by sessionId; cached per embedderId. */
+  embeddings?: Map<string, number[]>;
+  embedderId?: string;
 }
 
 const STOPWORDS = new Set([
@@ -145,6 +149,53 @@ export function search(index: Index, query: string, k = 5): SearchHit[] {
     score: s.score,
     excerpt: excerptAround(s.doc.text, qTokens, 200),
   }));
+}
+
+const SEMANTIC_DOC_CHARS = 2000;
+
+/** Populate (and cache on the index) a dense vector per doc, once per embedder. */
+async function ensureEmbeddings(index: Index, embedder: Embedder): Promise<void> {
+  if (index.embedderId === embedder.id && index.embeddings) return;
+  const vecs = await embedder.embed(index.docs.map((d) => d.text.slice(0, SEMANTIC_DOC_CHARS)));
+  const map = new Map<string, number[]>();
+  index.docs.forEach((d, i) => map.set(d.sessionId, vecs[i] ?? []));
+  index.embeddings = map;
+  index.embedderId = embedder.id;
+}
+
+/**
+ * Semantic search: rank docs by cosine similarity to the query embedding, so
+ * paraphrases TF-IDF misses ("connection failed" ↔ "network error") still
+ * match. Doc vectors are computed once and cached on the (fingerprint-cached)
+ * index, so steady-state cost is one query embedding per search. Falls back to
+ * TF-IDF if the embedding backend is unreachable — memory_search never breaks.
+ */
+export async function semanticSearch(
+  index: Index,
+  query: string,
+  embedder: Embedder,
+  k = 5,
+): Promise<SearchHit[]> {
+  if (index.docs.length === 0 || !query.trim()) return [];
+  try {
+    await ensureEmbeddings(index, embedder);
+    const [qv] = await embedder.embed([query]);
+    if (!qv) return search(index, query, k);
+    const qTokens = tokenize(query);
+    const scored = index.docs.map((d) => ({
+      doc: d,
+      score: cosineSimilarity(qv, index.embeddings!.get(d.sessionId) ?? []),
+    }));
+    scored.sort((a, b) => b.score - a.score);
+    return scored.slice(0, k).map((s) => ({
+      sessionId: s.doc.sessionId,
+      startedAt: s.doc.startedAt,
+      score: s.score,
+      excerpt: excerptAround(s.doc.text, qTokens, 200),
+    }));
+  } catch {
+    return search(index, query, k);
+  }
 }
 
 function tokenize(text: string): string[] {

--- a/src/model/local.test.ts
+++ b/src/model/local.test.ts
@@ -1,0 +1,113 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+// localEndpoint("ollama") consults OLLAMA_HOST; clear it so the default is
+// deterministic regardless of the runner's environment.
+delete process.env.OLLAMA_HOST;
+
+import {
+  parseLocalRef,
+  parseOllamaTags,
+  localEndpoint,
+  OllamaBackend,
+  type LocalRuntime,
+} from "./local.js";
+
+describe("parseLocalRef", () => {
+  test("local://model → ollama + model", () => {
+    assert.deepEqual(parseLocalRef("local://qwen2.5-coder:32b"), {
+      backend: "ollama",
+      model: "qwen2.5-coder:32b",
+    });
+  });
+  test("local://backend/model → that backend", () => {
+    assert.deepEqual(parseLocalRef("local://lmstudio/qwen"), { backend: "lmstudio", model: "qwen" });
+  });
+  test("unknown prefix stays part of the model name", () => {
+    assert.deepEqual(parseLocalRef("local://hf.co/user/model"), {
+      backend: "ollama",
+      model: "hf.co/user/model",
+    });
+  });
+  test("non-local refs and empty → null", () => {
+    assert.equal(parseLocalRef("gpt-4o"), null);
+    assert.equal(parseLocalRef("local://"), null);
+  });
+});
+
+describe("localEndpoint", () => {
+  test("ollama → :11434/v1, apiKey is the backend name", () => {
+    const ep = localEndpoint("ollama");
+    assert.equal(ep.baseURL, "http://localhost:11434/v1");
+    assert.equal(ep.apiKey, "ollama");
+  });
+  test("lmstudio → :1234", () => {
+    assert.match(localEndpoint("lmstudio").baseURL, /:1234\/v1$/);
+  });
+  test("unknown backend falls back to the ollama host", () => {
+    assert.match(localEndpoint("weird").baseURL, /:11434\/v1$/);
+  });
+});
+
+describe("parseOllamaTags", () => {
+  test("extracts name + size, tolerates missing size", () => {
+    const out = parseOllamaTags(
+      JSON.stringify({ models: [{ name: "qwen:7b", size: 4_700_000_000 }, { name: "llama3.1:70b" }] }),
+    );
+    assert.equal(out.length, 2);
+    assert.equal(out[0]!.name, "qwen:7b");
+    assert.equal(out[0]!.sizeBytes, 4_700_000_000);
+    assert.equal(out[1]!.sizeBytes, undefined);
+  });
+  test("malformed / empty JSON → []", () => {
+    assert.deepEqual(parseOllamaTags("not json"), []);
+    assert.deepEqual(parseOllamaTags("{}"), []);
+  });
+});
+
+function fakeRuntime(over: Partial<LocalRuntime> = {}): LocalRuntime {
+  return {
+    exec: async () => ({ code: 0, stdout: "", stderr: "" }),
+    httpGet: async () => ({ ok: true, status: 200, body: JSON.stringify({ models: [] }) }),
+    ...over,
+  };
+}
+
+describe("OllamaBackend", () => {
+  test("health is up when /api/tags responds ok", async () => {
+    assert.equal(await new OllamaBackend(fakeRuntime()).health(), "up");
+  });
+  test("health is down when the endpoint is unreachable", async () => {
+    const b = new OllamaBackend(fakeRuntime({ httpGet: async () => ({ ok: false, status: 0, body: "" }) }));
+    assert.equal(await b.health(), "down");
+  });
+  test("listInstalled parses the tags response", async () => {
+    const b = new OllamaBackend(
+      fakeRuntime({
+        httpGet: async () => ({ ok: true, status: 200, body: JSON.stringify({ models: [{ name: "qwen:7b", size: 1 }] }) }),
+      }),
+    );
+    assert.equal((await b.listInstalled())[0]!.name, "qwen:7b");
+  });
+  test("install shells out to `ollama pull <model>` and resolves on exit 0", async () => {
+    const calls: string[][] = [];
+    const b = new OllamaBackend(
+      fakeRuntime({
+        exec: async (cmd, args) => {
+          calls.push([cmd, ...args]);
+          return { code: 0, stdout: "", stderr: "" };
+        },
+      }),
+    );
+    await b.install("qwen:7b");
+    assert.deepEqual(calls[0], ["ollama", "pull", "qwen:7b"]);
+  });
+  test("install gives a friendly error when ollama is missing (exit 127)", async () => {
+    const b = new OllamaBackend(fakeRuntime({ exec: async () => ({ code: 127, stdout: "", stderr: "" }) }));
+    await assert.rejects(b.install("x"), /ollama CLI not found/);
+  });
+  test("install surfaces the stderr tail on a non-zero exit", async () => {
+    const b = new OllamaBackend(fakeRuntime({ exec: async () => ({ code: 1, stdout: "", stderr: "manifest not found" }) }));
+    await assert.rejects(b.install("x"), /manifest not found/);
+  });
+});

--- a/src/model/local.ts
+++ b/src/model/local.ts
@@ -1,0 +1,133 @@
+/**
+ * Local-model lifecycle (PLAN_MODEL_v1.0 M1).
+ *
+ * Before this, "local models" meant: the user installs Ollama themselves, runs
+ * `ollama serve`, and hand-edits LISA_BASE_URL in config.env. This module makes
+ * it a first-class option — install / list / health / switch — while still
+ * routing through the existing OpenAI-compatible provider (Ollama et al. speak
+ * the OpenAI API), so no provider code changes.
+ *
+ * The runtime (process exec + HTTP) is injectable so the logic is unit-testable
+ * without a real Ollama install.
+ */
+import { spawn } from "node:child_process";
+
+export interface LocalModelInfo {
+  name: string;
+  sizeBytes?: number;
+}
+
+export interface LocalRuntime {
+  /** Run a command; stream stdout/stderr lines to onLine. Never rejects. */
+  exec(
+    cmd: string,
+    args: string[],
+    onLine?: (line: string) => void,
+  ): Promise<{ code: number; stdout: string; stderr: string }>;
+  /** GET a URL. Never rejects — a network error resolves to { ok:false }. */
+  httpGet(url: string): Promise<{ ok: boolean; status: number; body: string }>;
+}
+
+export const defaultRuntime: LocalRuntime = {
+  exec(cmd, args, onLine) {
+    return new Promise((resolve) => {
+      let stdout = "";
+      let stderr = "";
+      let child;
+      try {
+        child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+      } catch (err) {
+        resolve({ code: 127, stdout: "", stderr: (err as Error).message });
+        return;
+      }
+      const pump = (chunk: Buffer, sink: "out" | "err") => {
+        const s = chunk.toString();
+        if (sink === "out") stdout += s;
+        else stderr += s;
+        if (onLine) for (const line of s.split("\n")) if (line.trim()) onLine(line.trim());
+      };
+      child.stdout?.on("data", (c) => pump(c, "out"));
+      child.stderr?.on("data", (c) => pump(c, "err")); // ollama writes pull progress to stderr
+      child.on("error", (err) => resolve({ code: 127, stdout, stderr: stderr + err.message }));
+      child.on("close", (code) => resolve({ code: code ?? 0, stdout, stderr }));
+    });
+  },
+  async httpGet(url) {
+    try {
+      const res = await fetch(url);
+      return { ok: res.ok, status: res.status, body: await res.text() };
+    } catch {
+      return { ok: false, status: 0, body: "" };
+    }
+  },
+};
+
+/** Default OpenAI-compatible endpoints per local backend. Pure. */
+export function localEndpoint(backend: string): { host: string; baseURL: string; apiKey: string } {
+  const hosts: Record<string, string> = {
+    ollama: "http://localhost:11434",
+    lmstudio: "http://localhost:1234",
+    llamacpp: "http://localhost:8080",
+  };
+  const envHost = backend === "ollama" ? process.env.OLLAMA_HOST : undefined;
+  const host = (envHost || hosts[backend] || hosts.ollama!).replace(/\/$/, "");
+  return { host, baseURL: `${host}/v1`, apiKey: backend };
+}
+
+/** Parse a `local://[backend/]model` reference. Pure. */
+export function parseLocalRef(ref: string): { backend: string; model: string } | null {
+  const m = ref.match(/^local:\/\/(.+)$/);
+  if (!m) return null;
+  const rest = m[1]!.trim();
+  if (!rest) return null;
+  const known = new Set(["ollama", "lmstudio", "llamacpp"]);
+  const slash = rest.indexOf("/");
+  if (slash > 0 && known.has(rest.slice(0, slash))) {
+    return { backend: rest.slice(0, slash), model: rest.slice(slash + 1) };
+  }
+  return { backend: "ollama", model: rest };
+}
+
+/** Parse Ollama's /api/tags JSON into model infos. Pure. */
+export function parseOllamaTags(body: string): LocalModelInfo[] {
+  try {
+    const json = JSON.parse(body) as { models?: Array<{ name?: string; size?: number }> };
+    return (json.models ?? [])
+      .filter((m): m is { name: string; size?: number } => typeof m.name === "string")
+      .map((m) => ({ name: m.name, sizeBytes: typeof m.size === "number" ? m.size : undefined }));
+  } catch {
+    return [];
+  }
+}
+
+/** The Ollama backend: install / list / health via its CLI + HTTP API. */
+export class OllamaBackend {
+  readonly name = "ollama";
+  readonly host: string;
+  constructor(
+    private runtime: LocalRuntime = defaultRuntime,
+    host: string = localEndpoint("ollama").host,
+  ) {
+    this.host = host.replace(/\/$/, "");
+  }
+
+  async health(): Promise<"up" | "down"> {
+    const res = await this.runtime.httpGet(`${this.host}/api/tags`);
+    return res.ok ? "up" : "down";
+  }
+
+  async listInstalled(): Promise<LocalModelInfo[]> {
+    const res = await this.runtime.httpGet(`${this.host}/api/tags`);
+    return res.ok ? parseOllamaTags(res.body) : [];
+  }
+
+  async install(model: string, onLine?: (line: string) => void): Promise<void> {
+    const { code, stderr } = await this.runtime.exec("ollama", ["pull", model], onLine);
+    if (code === 0) return;
+    throw new Error(
+      code === 127
+        ? "ollama CLI not found — install it from https://ollama.com, then retry"
+        : `\`ollama pull ${model}\` failed: ${stderr.trim().slice(-200) || `exit ${code}`}`,
+    );
+  }
+}

--- a/src/providers/fallback.test.ts
+++ b/src/providers/fallback.test.ts
@@ -1,0 +1,95 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import type Anthropic from "@anthropic-ai/sdk";
+import { FallbackProvider } from "./fallback.js";
+import { resolveDefaultModel } from "./registry.js";
+import { DEFAULT_MODEL } from "../llm.js";
+import type { Provider, ProviderResult, ProviderRunOpts } from "./types.js";
+
+const ZERO_USAGE = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+function okResult(text: string): ProviderResult {
+  return {
+    content: [{ type: "text", text, citations: null } as Anthropic.TextBlock],
+    stopReason: "end_turn",
+    usage: ZERO_USAGE,
+  };
+}
+function textOf(r: ProviderResult): string {
+  return (r.content[0] as Anthropic.TextBlock).text;
+}
+function fakeProvider(behavior: (opts: ProviderRunOpts) => Promise<ProviderResult>): Provider {
+  return { name: "fake", runTurn: behavior };
+}
+function baseOpts(): ProviderRunOpts {
+  return { model: "primary", systemPrompt: "s", tools: [], messages: [] };
+}
+
+describe("FallbackProvider", () => {
+  test("uses the primary when it succeeds; the fallback is never called", async () => {
+    const calls: string[] = [];
+    const fp = new FallbackProvider([
+      { model: "m1", provider: fakeProvider(async (o) => (calls.push(o.model), okResult("from m1"))) },
+      { model: "m2", provider: fakeProvider(async (o) => (calls.push(o.model), okResult("from m2"))) },
+    ]);
+    assert.equal(textOf(await fp.runTurn(baseOpts())), "from m1");
+    assert.deepEqual(calls, ["m1"]);
+  });
+
+  test("falls through on error, running each link with its own model id", async () => {
+    const calls: string[] = [];
+    const fp = new FallbackProvider([
+      { model: "m1", provider: fakeProvider(async (o) => { calls.push(o.model); throw new Error("boom"); }) },
+      { model: "m2", provider: fakeProvider(async (o) => (calls.push(o.model), okResult("from m2"))) },
+    ]);
+    assert.equal(textOf(await fp.runTurn(baseOpts())), "from m2");
+    assert.deepEqual(calls, ["m1", "m2"]);
+  });
+
+  test("throws the last error when every link fails", async () => {
+    const fp = new FallbackProvider([
+      { model: "m1", provider: fakeProvider(async () => { throw new Error("first"); }) },
+      { model: "m2", provider: fakeProvider(async () => { throw new Error("last"); }) },
+    ]);
+    await assert.rejects(fp.runTurn(baseOpts()), /last/);
+  });
+
+  test("an empty chain is a programmer error", () => {
+    assert.throws(() => new FallbackProvider([]), /at least one/);
+  });
+});
+
+describe("resolveDefaultModel — single-key auto-detect", () => {
+  const KEYS = ["ANTHROPIC_API_KEY", "OPENAI_API_KEY", "LISA_MODEL"];
+  let saved: Record<string, string | undefined>;
+  beforeEach(() => {
+    saved = {};
+    for (const k of KEYS) {
+      saved[k] = process.env[k];
+      delete process.env[k];
+    }
+  });
+  afterEach(() => {
+    for (const k of KEYS) {
+      if (saved[k] === undefined) delete process.env[k];
+      else process.env[k] = saved[k];
+    }
+  });
+
+  test("an explicit LISA_MODEL wins, even over an Anthropic key", () => {
+    process.env.LISA_MODEL = "qwen2.5-coder:32b";
+    process.env.ANTHROPIC_API_KEY = "x";
+    assert.equal(resolveDefaultModel(), "qwen2.5-coder:32b");
+  });
+  test("an Anthropic key → the canonical default", () => {
+    process.env.ANTHROPIC_API_KEY = "x";
+    assert.equal(resolveDefaultModel(), DEFAULT_MODEL);
+  });
+  test("only an OpenAI key → gpt-4o", () => {
+    process.env.OPENAI_API_KEY = "x";
+    assert.equal(resolveDefaultModel(), "gpt-4o");
+  });
+  test("nothing configured → the canonical default", () => {
+    assert.equal(resolveDefaultModel(), DEFAULT_MODEL);
+  });
+});

--- a/src/providers/fallback.ts
+++ b/src/providers/fallback.ts
@@ -1,0 +1,45 @@
+/**
+ * Fallback provider (PLAN_MODEL_v1.0 M3).
+ *
+ * Wraps a chain of {model, provider} links. runTurn tries each in order; if one
+ * throws (network error, rate limit, provider outage), it moves to the next.
+ * Configured by LISA_MODEL_FALLBACK (a comma-separated list of model ids) — the
+ * primary model is the chain head, the fallbacks follow.
+ *
+ * It implements the same Provider interface, so the agent loop is unaware it's
+ * talking to a chain rather than a single provider.
+ */
+import type { Provider, ProviderResult, ProviderRunOpts } from "./types.js";
+
+export interface FallbackLink {
+  model: string;
+  provider: Provider;
+}
+
+export class FallbackProvider implements Provider {
+  readonly name = "fallback";
+  constructor(private chain: FallbackLink[]) {
+    if (chain.length === 0) throw new Error("FallbackProvider requires at least one link");
+  }
+
+  async runTurn(opts: ProviderRunOpts): Promise<ProviderResult> {
+    let lastErr: unknown;
+    for (let i = 0; i < this.chain.length; i++) {
+      const link = this.chain[i]!;
+      try {
+        // Each link runs with its own model id; everything else is unchanged.
+        return await link.provider.runTurn({ ...opts, model: link.model });
+      } catch (err) {
+        lastErr = err;
+        const next = this.chain[i + 1];
+        if (next) {
+          console.error(
+            `[provider] "${link.model}" failed (${(err as Error).message?.slice(0, 120)}) — ` +
+              `falling back to "${next.model}"`,
+          );
+        }
+      }
+    }
+    throw lastErr;
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -206,11 +206,12 @@ function resolveProvider(model: string): Provider {
     });
   }
   if (process.env.LISA_BASE_URL) {
-    // Catch-all (Ollama, self-hosted, unknown providers).
+    // Catch-all (Ollama, self-hosted, the TakoAPI gateway, unknown providers).
     return new OpenAIProvider({
       baseURL: process.env.LISA_BASE_URL,
-      // LISA_API_KEY first, fall back to OPENAI_API_KEY for compatibility.
-      apiKey: process.env.LISA_API_KEY ?? process.env.OPENAI_API_KEY,
+      // LISA_API_KEY first, then TAKO_KEY (so pointing LISA_BASE_URL at
+      // https://takoapi.com/v1 just works), then OPENAI_API_KEY for compat.
+      apiKey: process.env.LISA_API_KEY ?? process.env.TAKO_KEY ?? process.env.OPENAI_API_KEY,
     });
   }
   // Vanilla OpenAI.

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -1,6 +1,8 @@
 import { AnthropicProvider } from "./anthropic.js";
 import { GeminiProvider } from "./gemini.js";
 import { OpenAIProvider } from "./openai.js";
+import { FallbackProvider } from "./fallback.js";
+import { DEFAULT_MODEL } from "../llm.js";
 import type { Provider } from "./types.js";
 
 export type ProviderName = "anthropic" | "openai" | "gemini";
@@ -177,10 +179,11 @@ export function makeProvider(name: ProviderName): Provider {
 }
 
 /**
- * Resolve a Provider instance for a given model name. Looks up preset →
- * LISA_BASE_URL override → vanilla provider, in that order.
+ * Resolve a SINGLE Provider instance for a model name. Looks up preset →
+ * LISA_BASE_URL override → vanilla provider, in that order. (No fallback chain —
+ * that's providerForModel's job.)
  */
-export function providerForModel(model: string): Provider {
+function resolveProvider(model: string): Provider {
   const provider = detectProvider(model);
   if (provider === "anthropic") {
     return new AnthropicProvider({
@@ -215,6 +218,33 @@ export function providerForModel(model: string): Provider {
     baseURL: process.env.OPENAI_BASE_URL,
     apiKey: process.env.OPENAI_API_KEY,
   });
+}
+
+/**
+ * Resolve the provider for a model, wrapping it in a FallbackProvider when
+ * LISA_MODEL_FALLBACK lists alternate models to try if the primary errors.
+ * Drop-in for the old single-provider behavior (no env → identical).
+ */
+export function providerForModel(model: string): Provider {
+  const fallbacks = (process.env.LISA_MODEL_FALLBACK ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (fallbacks.length === 0) return resolveProvider(model);
+  const chain = [model, ...fallbacks].map((m) => ({ model: m, provider: resolveProvider(m) }));
+  return new FallbackProvider(chain);
+}
+
+/**
+ * Pick the default model when the user didn't pass --model. An explicit local
+ * default (LISA_MODEL, e.g. set by `lisa model use`) wins; otherwise auto-detect
+ * from the single configured cloud key so a one-key setup works with no flags.
+ */
+export function resolveDefaultModel(): string {
+  if (process.env.LISA_MODEL?.trim()) return process.env.LISA_MODEL.trim();
+  if (process.env.ANTHROPIC_API_KEY) return DEFAULT_MODEL;
+  if (process.env.OPENAI_API_KEY) return "gpt-4o";
+  return DEFAULT_MODEL;
 }
 
 /** For docs / CLI listing. */

--- a/src/tools/dispatch_agent.ts
+++ b/src/tools/dispatch_agent.ts
@@ -22,9 +22,12 @@
  */
 
 import { spawn } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
 import type { ToolDefinition } from "../types.js";
 import { getCurrentHub } from "../integrations/current-hub.js";
-import { recordDispatch } from "../integrations/dispatch-ledger.js";
+import { recordDispatch, dispatchLogDir } from "../integrations/dispatch-ledger.js";
 
 interface DispatchInput {
   agent: "claude" | "codex" | "opencode" | "aider";
@@ -81,6 +84,10 @@ export interface LaunchResult {
   /** Present when the launch failed (binary missing, spawn error). */
   error?: string;
   cmd: string;
+  /** Dispatch ledger id (for dispatch_status / signal_agent), when launched. */
+  id?: string;
+  /** Captured-output log path, when capture succeeded. */
+  logPath?: string;
 }
 
 /**
@@ -95,12 +102,40 @@ export async function launchAgent(
   log?: (m: string) => void,
 ): Promise<LaunchResult> {
   const { cmd, args } = buildDispatchArgv(agent, task);
+
+  // Capture the agent's stdout+stderr so dispatch isn't fire-and-forget: LISA
+  // can read back what the agent SHE launched produced (D1 feedback). Detached
+  // + a real file fd keeps capturing after LISA's own process exits. Reading a
+  // self-dispatched agent's own output is hers to read — distinct from the
+  // observers, which deliberately never read another session's content.
+  const startedAt = Date.now();
+  let logPath: string | undefined;
+  let outFd: number | undefined;
+  try {
+    fs.mkdirSync(dispatchLogDir(), { recursive: true });
+    logPath = path.join(
+      dispatchLogDir(),
+      `${agent}-${startedAt.toString(36)}-${crypto.randomBytes(3).toString("hex")}.log`,
+    );
+    outFd = fs.openSync(logPath, "a");
+  } catch {
+    logPath = undefined;
+    outFd = undefined;
+  }
+
   let child;
   try {
-    child = spawn(cmd, args, { cwd, detached: true, stdio: "ignore" });
+    child = spawn(cmd, args, {
+      cwd,
+      detached: true,
+      stdio: outFd !== undefined ? ["ignore", outFd, outFd] : "ignore",
+    });
   } catch (err) {
+    if (outFd !== undefined) try { fs.closeSync(outFd); } catch { /* ignore */ }
     return { error: `Failed to launch ${agent}: ${(err as Error).message}. Is "${cmd}" installed and on PATH?`, cmd };
   }
+  // The child dup'd the fd for its stdio; close our copy.
+  if (outFd !== undefined) try { fs.closeSync(outFd); } catch { /* ignore */ }
 
   const launchError = await new Promise<string | null>((resolve) => {
     let settled = false;
@@ -115,18 +150,22 @@ export async function launchAgent(
       resolve(null);
     }, 150);
   });
-  if (launchError) return { error: launchError, cmd };
+  if (launchError) {
+    if (logPath) try { fs.unlinkSync(logPath); } catch { /* ignore */ }
+    return { error: launchError, cmd };
+  }
 
   const pid = child.pid;
   child.unref();
+  let id: string | undefined;
   if (typeof pid === "number") {
     try {
-      recordDispatch({ agent, pid, cwd, task });
+      id = recordDispatch({ agent, pid, cwd, task, logPath, now: startedAt }).id;
     } catch (err) {
       log?.(`[dispatch] ledger write failed (non-fatal): ${(err as Error).message}`);
     }
   }
-  return { pid, cmd };
+  return { pid, cmd, id, logPath };
 }
 
 export const dispatchAgentTool: ToolDefinition<DispatchInput, string> = {
@@ -179,15 +218,14 @@ export const dispatchAgentTool: ToolDefinition<DispatchInput, string> = {
       }
     }
 
-    const { pid, error } = await launchAgent(input.agent, input.task, cwd, ctx.log);
+    const { pid, error, id } = await launchAgent(input.agent, input.task, cwd, ctx.log);
     if (error) return error;
 
     ctx.log(`[dispatch] launched ${input.agent} (pid ${pid}) in ${cwd}: ${input.task.slice(0, 80)}`);
     return (
       `Launched ${input.agent} (pid ${pid}) in ${cwd}.\n` +
-      `It's running autonomously and will appear in the agent session monitor. ` +
-      `I won't block on it — ask me "what's running?" (advise_now) to check progress, ` +
-      `or signal_agent to list/cancel it.`
+      `Running autonomously — I won't block on it. Check whether it finished and read ` +
+      `its output with dispatch_status${id ? ` (id ${id})` : ""}; signal_agent lists/cancels it.`
     );
   },
 };

--- a/src/tools/dispatch_status.test.ts
+++ b/src/tools/dispatch_status.test.ts
@@ -1,0 +1,55 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ToolContext } from "../types.js";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-dstatus-"));
+process.env.LISA_HOME = TMP;
+const LEDGER = path.join(TMP, "dispatches.json");
+
+const { recordDispatch, dispatchLogDir } = await import("../integrations/dispatch-ledger.js");
+const { dispatchStatusTool } = await import("./dispatch_status.js");
+
+const CTX = {} as ToolContext; // execute doesn't use ctx
+const DEAD_PID = 2_000_000_000;
+
+beforeEach(() => {
+  fs.rmSync(LEDGER, { force: true });
+  fs.rmSync(dispatchLogDir(), { recursive: true, force: true });
+});
+
+function withLog(pid: number, content: string, now: number) {
+  fs.mkdirSync(dispatchLogDir(), { recursive: true });
+  const logPath = path.join(dispatchLogDir(), `t-${pid}.log`);
+  fs.writeFileSync(logPath, content);
+  return recordDispatch({ agent: "claude", pid, cwd: "/r", task: "do the thing", logPath, now });
+}
+
+describe("dispatch_status", () => {
+  test("empty → friendly message", async () => {
+    assert.match(await dispatchStatusTool.execute({}, CTX), /No dispatched agents/);
+  });
+
+  test("distinguishes running vs finished and shows the output tail", async () => {
+    const now = Date.now();
+    withLog(process.pid, "still going...", now); // our own pid → alive → running
+    withLog(DEAD_PID, "FINAL RESULT: done", now); // dead → finished
+    const out = await dispatchStatusTool.execute({}, CTX);
+    assert.match(out, /▶ running/);
+    assert.match(out, /✓ finished/);
+    assert.match(out, /FINAL RESULT: done/);
+  });
+
+  test("by id returns that one with its output", async () => {
+    const e = withLog(DEAD_PID, "the answer is 42", Date.now());
+    const out = await dispatchStatusTool.execute({ id: e.id }, CTX);
+    assert.match(out, /✓ finished/);
+    assert.match(out, /the answer is 42/);
+  });
+
+  test("unknown id → not found", async () => {
+    assert.match(await dispatchStatusTool.execute({ id: "nope" }, CTX), /No dispatch found/);
+  });
+});

--- a/src/tools/dispatch_status.ts
+++ b/src/tools/dispatch_status.ts
@@ -1,0 +1,82 @@
+/**
+ * dispatch_status (L3 DISPATCH — feedback half of the command loop, D1).
+ *
+ * dispatch_agent launches agents detached and fire-and-forget; this closes the
+ * loop on the READ side: for each agent LISA dispatched, report whether it's
+ * still running or has finished, and show the tail of its captured output — so
+ * Lisa (and the user) can actually see what the delegated agent produced.
+ *
+ * This reads the output of an agent LISA HERSELF launched (captured to a log by
+ * dispatch_agent). That's hers to read — distinct from the observers, which
+ * deliberately never read another session's content. It's read-only: no spawn,
+ * no signal. (Mid-run approval-relay / steering is a separate, harder piece —
+ * it needs a control surface each headless CLI doesn't currently expose.)
+ */
+import type { ToolDefinition } from "../types.js";
+import {
+  isAlive,
+  listRecentDispatches,
+  readDispatchOutput,
+  type DispatchEntry,
+} from "../integrations/dispatch-ledger.js";
+
+interface DispatchStatusInput {
+  /** A dispatch id or pid; omit to list all recent dispatches. */
+  id?: string;
+}
+
+function fmtAge(sec: number): string {
+  if (sec < 60) return `${sec}s`;
+  if (sec < 3600) return `${Math.round(sec / 60)}m`;
+  return `${Math.round(sec / 3600)}h`;
+}
+
+function indent(text: string): string {
+  return text
+    .split("\n")
+    .map((l) => `    | ${l}`)
+    .join("\n");
+}
+
+function render(e: DispatchEntry, now: number, maxBytes: number): string {
+  const live = isAlive(e.pid);
+  const age = Math.max(0, Math.round((now - e.startedAt) / 1000));
+  const head =
+    `${live ? "▶ running" : "✓ finished"} · ${e.agent} (pid ${e.pid}, ${fmtAge(age)} ago) · id ${e.id}\n` +
+    `  task: ${e.task.slice(0, 100)}`;
+  const out = readDispatchOutput(e, maxBytes).trim();
+  if (!out) return `${head}\n  (no output captured${e.logPath ? " yet" : ""})`;
+  return `${head}\n  output (tail):\n${indent(out)}`;
+}
+
+export const dispatchStatusTool: ToolDefinition<DispatchStatusInput, string> = {
+  name: "dispatch_status",
+  description:
+    "Check on the CLI agents you dispatched (dispatch_agent): whether each is still running or has " +
+    "finished, and the tail of its captured output — so dispatching isn't fire-and-forget. Pass `id` " +
+    "(a dispatch id or pid) for one agent's fuller output, or omit to list all recent dispatches. Read-only.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "A dispatch id (from dispatch_agent) or pid; omit to list all recent dispatches.",
+      },
+    },
+    additionalProperties: false,
+  },
+  async execute(input) {
+    const all = listRecentDispatches();
+    const now = Date.now();
+    if (input.id) {
+      const e = all.find((x) => x.id === input.id || String(x.pid) === input.id);
+      if (!e) return `No dispatch found for "${input.id}". (It may have aged out, or was never dispatched by me.)`;
+      return render(e, now, 4000);
+    }
+    if (all.length === 0) return "No dispatched agents on record.";
+    return all
+      .sort((a, b) => b.startedAt - a.startedAt)
+      .map((e) => render(e, now, 600))
+      .join("\n\n");
+  },
+};

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -9,6 +9,7 @@ import { reviewDiffTool } from "./review_diff.js";
 import { runChecksTool } from "./run_checks.js";
 import { prStatusTool } from "./pr_status.js";
 import { dispatchAgentTool } from "./dispatch_agent.js";
+import { dispatchStatusTool } from "./dispatch_status.js";
 import { scheduledDispatchTool } from "./scheduled_dispatch.js";
 import { compareAgentsTool } from "./compare_agents.js";
 import { githubLinkTool } from "./github_link.js";
@@ -89,6 +90,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     prStatusTool as ToolDefinition,
     adviseNowTool as ToolDefinition,
     dispatchAgentTool as ToolDefinition,
+    dispatchStatusTool as ToolDefinition,
     scheduledDispatchTool as ToolDefinition,
     compareAgentsTool as ToolDefinition,
     githubLinkTool as ToolDefinition,
@@ -181,6 +183,11 @@ export function autonomousSubset(tools: ToolDefinition[]): ToolDefinition[] {
 export const REMOTE_BLOCKED_TOOL_NAMES = new Set([
   ...AUTONOMOUS_BLOCKED_TOOL_NAMES,
   "skill_manage",
+  // dispatch_status surfaces the raw output of dispatched agents — read-only,
+  // but richer content than the structural observers and not for remote-origin
+  // (channel) callers. NOT autonomous-blocked: an autonomous run may read the
+  // result of work it dispatched.
+  "dispatch_status",
 ]);
 
 export function remoteSafeSubset(tools: ToolDefinition[]): ToolDefinition[] {

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -40,6 +40,7 @@ import { redeployTool } from "./redeploy.js";
 import { setMoodTool } from "./set_mood.js";
 import { webFetchTool } from "./web_fetch.js";
 import { webSearchTool } from "./web_search.js";
+import { takoapiTool } from "./takoapi.js";
 import { writeTool } from "./write.js";
 
 export interface ToolRegistryOptions {
@@ -77,6 +78,7 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     desireCloseTool as ToolDefinition,
     webFetchTool as ToolDefinition,
     webSearchTool as ToolDefinition,
+    takoapiTool as ToolDefinition,
     redeployTool as ToolDefinition,
     // Orchestration (docs/ORCHESTRATOR_PLAN.md): observe → advise → dispatch → control.
     listAgentsTool as ToolDefinition,
@@ -154,6 +156,9 @@ export const AUTONOMOUS_BLOCKED_TOOL_NAMES = new Set([
   "run_checks",
   "github",
   "mcp",
+  // takoapi calls spend the user's TAKO_KEY and send data to a remote agent —
+  // not something an unattended/remote-origin run should do on its own.
+  "takoapi",
 ]);
 
 export function autonomousSubset(tools: ToolDefinition[]): ToolDefinition[] {

--- a/src/tools/subsets.test.ts
+++ b/src/tools/subsets.test.ts
@@ -28,6 +28,7 @@ const SAMPLE = [
   "run_checks",
   "github",
   "mcp",
+  "takoapi",
   "skill_manage",
   "memory",
   "memory_search",

--- a/src/tools/takoapi.test.ts
+++ b/src/tools/takoapi.test.ts
@@ -1,0 +1,107 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  formatRegistry,
+  extractAgentReply,
+  takoDiscover,
+  takoCall,
+  takoapiTool,
+  type TakoFetcher,
+} from "./takoapi.js";
+import type { ToolContext } from "../types.js";
+
+const CTX = {} as ToolContext; // execute guard paths don't touch ctx
+
+describe("formatRegistry", () => {
+  test("lists agents from an {agents:[…]} shape with skills", () => {
+    const out = formatRegistry(
+      JSON.stringify({
+        agents: [
+          { name: "Refactor Bot", slug: "refactor-bot", description: "refactors code", skills: ["refactor", { name: "rename" }] },
+        ],
+      }),
+    );
+    assert.match(out, /Refactor Bot/);
+    assert.match(out, /slug: refactor-bot/);
+    assert.match(out, /refactors code/);
+    assert.match(out, /refactor, rename/);
+  });
+  test("accepts a bare array and caps the list at `limit`", () => {
+    const arr = Array.from({ length: 20 }, (_, i) => ({ name: `a${i}`, slug: `s${i}` }));
+    assert.equal(formatRegistry(JSON.stringify(arr), 3).split("\n").length, 3);
+  });
+  test("empty / malformed → friendly message", () => {
+    assert.match(formatRegistry(JSON.stringify({ agents: [] })), /no matching agents/);
+    assert.match(formatRegistry("nope"), /could not parse/);
+  });
+});
+
+describe("extractAgentReply", () => {
+  test("OpenAI-shim shape", () => {
+    assert.equal(extractAgentReply(JSON.stringify({ choices: [{ message: { content: "hi there" } }] })), "hi there");
+  });
+  test("A2A message parts", () => {
+    assert.equal(
+      extractAgentReply(JSON.stringify({ message: { parts: [{ text: "part one" }, { text: "two" }] } })),
+      "part one\ntwo",
+    );
+  });
+  test("flat fields (reply/text/result)", () => {
+    assert.equal(extractAgentReply(JSON.stringify({ reply: "r" })), "r");
+  });
+  test("non-JSON → raw passthrough", () => {
+    assert.equal(extractAgentReply("plain text reply"), "plain text reply");
+  });
+});
+
+function fetcher(over: Partial<TakoFetcher> = {}): TakoFetcher {
+  return {
+    get: async () => ({ ok: true, status: 200, body: JSON.stringify({ agents: [{ name: "A", slug: "a" }] }) }),
+    postJson: async () => ({ ok: true, status: 200, body: JSON.stringify({ text: "agent reply" }) }),
+    ...over,
+  };
+}
+
+describe("takoDiscover / takoCall", () => {
+  test("discover formats the registry", async () => {
+    assert.match(await takoDiscover("refactor", fetcher()), /slug: a/);
+  });
+  test("discover handles an unreachable registry", async () => {
+    assert.match(
+      await takoDiscover("x", fetcher({ get: async () => ({ ok: false, status: 0, body: "" }) })),
+      /unreachable/,
+    );
+  });
+  test("call returns the agent reply and sends a Bearer key", async () => {
+    let seenAuth = "";
+    const f = fetcher({
+      postJson: async (_u, _b, h) => {
+        seenAuth = h.authorization ?? "";
+        return { ok: true, status: 200, body: JSON.stringify({ text: "done" }) };
+      },
+    });
+    assert.equal(await takoCall("a", "do it", "sk-tako-x", f), "done");
+    assert.equal(seenAuth, "Bearer sk-tako-x");
+  });
+  test("call surfaces a 401 clearly", async () => {
+    assert.match(
+      await takoCall("a", "x", "bad", fetcher({ postJson: async () => ({ ok: false, status: 401, body: "" }) })),
+      /401/,
+    );
+  });
+});
+
+describe("takoapiTool.execute guards (no network)", () => {
+  test("call without slug/text → asks for both", async () => {
+    assert.match(await takoapiTool.execute({ action: "call", slug: "a" }, CTX), /needs both/);
+  });
+  test("call without TAKO_KEY → points to the dashboard", async () => {
+    const saved = process.env.TAKO_KEY;
+    delete process.env.TAKO_KEY;
+    try {
+      assert.match(await takoapiTool.execute({ action: "call", slug: "a", text: "x" }, CTX), /TAKO_KEY is not set/);
+    } finally {
+      if (saved !== undefined) process.env.TAKO_KEY = saved;
+    }
+  });
+});

--- a/src/tools/takoapi.ts
+++ b/src/tools/takoapi.ts
@@ -1,0 +1,172 @@
+/**
+ * `takoapi` tool — reach remote agents through TakoAPI (PLAN_DISPATCH_v1.0 D2a).
+ *
+ * TakoAPI (https://takoapi.com) is "OpenRouter for agents": one key, any
+ * registered agent. This tool lets Lisa, mid-conversation, DISCOVER a remote
+ * agent by capability and CALL it (A2A `message`) — delegating a task that a
+ * specialized remote agent handles better than she would directly. The richer
+ * native hub integration (remote agents as first-class sessions) is D2b; this
+ * is the near-free discover+call entry point.
+ *
+ * Outbound + spends the user's TAKO_KEY, so it's gated out of autonomous and
+ * remote-origin runs (see AUTONOMOUS_BLOCKED_TOOL_NAMES). The HTTP layer is
+ * injectable so the logic is unit-testable without hitting the network.
+ */
+import type { ToolDefinition } from "../types.js";
+
+const DEFAULT_BASE = "https://takoapi.com";
+function base(): string {
+  return (process.env.TAKOAPI_BASE_URL ?? DEFAULT_BASE).replace(/\/$/, "");
+}
+
+export interface HttpResponse {
+  ok: boolean;
+  status: number;
+  body: string;
+}
+export interface TakoFetcher {
+  get(url: string): Promise<HttpResponse>;
+  postJson(url: string, body: unknown, headers: Record<string, string>): Promise<HttpResponse>;
+}
+
+const defaultFetcher: TakoFetcher = {
+  async get(url) {
+    try {
+      const r = await fetch(url, { headers: { accept: "application/json" } });
+      return { ok: r.ok, status: r.status, body: await r.text() };
+    } catch (e) {
+      return { ok: false, status: 0, body: (e as Error).message };
+    }
+  },
+  async postJson(url, body, headers) {
+    try {
+      const r = await fetch(url, {
+        method: "POST",
+        headers: { "content-type": "application/json", ...headers },
+        body: JSON.stringify(body),
+      });
+      return { ok: r.ok, status: r.status, body: await r.text() };
+    } catch (e) {
+      return { ok: false, status: 0, body: (e as Error).message };
+    }
+  },
+};
+
+/** Format a /api/registry response into a readable agent list. Pure. */
+export function formatRegistry(body: string, limit = 10): string {
+  let json: unknown;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    return "(could not parse the TakoAPI registry response)";
+  }
+  const j = json as Record<string, unknown>;
+  const arr = Array.isArray(json) ? json : (j.agents ?? j.data ?? j.results ?? []);
+  if (!Array.isArray(arr) || arr.length === 0) return "(no matching agents found)";
+  return arr
+    .slice(0, limit)
+    .map((raw) => {
+      const a = raw as Record<string, unknown>;
+      const name = (a.name ?? a.slug ?? "(unnamed)") as string;
+      const slug = (a.slug ?? "") as string;
+      const desc = String(a.description ?? a.summary ?? "").replace(/\s+/g, " ").slice(0, 100);
+      const skills = Array.isArray(a.skills)
+        ? a.skills
+            .map((s) => (typeof s === "string" ? s : (s as Record<string, unknown>)?.name))
+            .filter(Boolean)
+            .slice(0, 4)
+            .join(", ")
+        : "";
+      return `- ${name}${slug ? ` (slug: ${slug})` : ""}${desc ? ` — ${desc}` : ""}${skills ? ` [${skills}]` : ""}`;
+    })
+    .join("\n");
+}
+
+/** Pull a text reply out of an A2A / OpenAI-shim response, tolerating shapes. Pure. */
+export function extractAgentReply(body: string): string {
+  let json: unknown;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    return body.slice(0, 2000); // non-JSON → return raw, truncated
+  }
+  const j = json as Record<string, any>;
+  const partsText = (parts: unknown): string | undefined =>
+    Array.isArray(parts)
+      ? parts.map((p) => (p as Record<string, unknown>)?.text).filter((t) => typeof t === "string").join("\n")
+      : undefined;
+  const candidates: Array<unknown> = [
+    j?.choices?.[0]?.message?.content, // OpenAI-compat shim
+    partsText(j?.message?.parts), // A2A message
+    partsText(j?.parts),
+    j?.text,
+    j?.reply,
+    j?.output,
+    j?.result,
+    typeof j?.message === "string" ? j.message : undefined,
+  ];
+  for (const c of candidates) if (typeof c === "string" && c.trim()) return c.trim();
+  return JSON.stringify(json).slice(0, 2000);
+}
+
+/** Discover agents in the public registry (no auth). */
+export async function takoDiscover(query: string, f: TakoFetcher = defaultFetcher): Promise<string> {
+  const url = `${base()}/api/registry?format=json${query ? `&q=${encodeURIComponent(query)}` : ""}`;
+  const res = await f.get(url);
+  if (!res.ok) return `TakoAPI registry unreachable (status ${res.status || "network error"}).`;
+  return formatRegistry(res.body);
+}
+
+/** Call an agent via the A2A message endpoint with the user's key. */
+export async function takoCall(
+  slug: string,
+  text: string,
+  key: string,
+  f: TakoFetcher = defaultFetcher,
+): Promise<string> {
+  const url = `${base()}/v1/agents/${encodeURIComponent(slug)}/message`;
+  const res = await f.postJson(url, { text }, { authorization: `Bearer ${key}` });
+  if (res.status === 401) {
+    return "TakoAPI rejected the key (401). Check TAKO_KEY at https://takoapi.com/dashboard.";
+  }
+  if (!res.ok) return `TakoAPI call to "${slug}" failed (status ${res.status || "network error"}).`;
+  return extractAgentReply(res.body);
+}
+
+interface TakoInput {
+  action: "discover" | "call";
+  query?: string;
+  slug?: string;
+  text?: string;
+}
+
+export const takoapiTool: ToolDefinition<TakoInput, string> = {
+  name: "takoapi",
+  description:
+    "Reach remote AI agents through TakoAPI (https://takoapi.com) — one key, any agent. " +
+    "action='discover' searches the agent registry (optionally by `query`); action='call' sends `text` " +
+    "to the agent with the given `slug` and returns its reply. Use when a task is better handled by a " +
+    "specialized remote agent than by you. 'call' requires TAKO_KEY (free key at /dashboard).",
+  inputSchema: {
+    type: "object",
+    properties: {
+      action: { type: "string", enum: ["discover", "call"] },
+      query: { type: "string", description: "search terms (for discover)" },
+      slug: { type: "string", description: "agent slug (for call)" },
+      text: { type: "string", description: "the request to send the agent (for call)" },
+    },
+    required: ["action"],
+  },
+  async execute(input) {
+    if (input.action === "discover") return await takoDiscover(input.query ?? "");
+    if (input.action === "call") {
+      if (!input.slug || !input.text) return "call needs both `slug` and `text`.";
+      const key = process.env.TAKO_KEY?.trim();
+      if (!key) {
+        return "TAKO_KEY is not set — create one at https://takoapi.com/dashboard and add it to ~/.lisa/config.env.";
+      }
+      return await takoCall(input.slug, input.text, key);
+    }
+    return `unknown action "${(input as { action: string }).action}" — use "discover" or "call".`;
+  },
+};


### PR DESCRIPTION
Next **Dispatch** increment (PLAN_DISPATCH_v1.0 **D1**, read side). `dispatch_agent` was fire-and-forget — spawned detached with `stdio:"ignore"`, so LISA could never see what an agent she launched actually produced. This closes the **feedback** loop.

> Independent PR off `main`.

### What changed
- **Output capture** — `dispatch_agent` now captures each agent's stdout+stderr to a per-dispatch log (`~/.lisa/dispatches/<…>.log`), detached via a real file fd so it keeps capturing after LISA's own process exits.
- **Ledger retention** — `DispatchEntry` gains `logPath`; finished dispatches (and their logs) are retained for 24h so results stay readable, then aged out. New `listRecentDispatches()` + `readDispatchOutput()`; `listLiveDispatches()` keeps its live-only return contract (the existing ledger test still passes).
- **`dispatch_status` tool** — per dispatched agent: **running vs finished** + the **tail of its captured output**. So "I dispatched X" → later "X finished, here's what it produced."

### Why reading the output is OK here
This reads the output of an agent **LISA herself launched** — that's hers to read, and deliberately distinct from the observers, which never read another session's content. It's **read-only** (no spawn, no signal). Remote-**blocked** (channel callers shouldn't pull raw agent output); **not** autonomous-blocked, since an autonomous run may legitimately read the result of work it dispatched.

### Honest scope
This is the **feedback (read) half** of the command loop. Mid-run **approval-relay** and **steering** (the write half) need a control surface that each headless CLI doesn't currently expose — so they're **deferred** rather than faked. (Per-agent support, e.g. a `claude` resume/control channel, is the path there.)

### Tests
21 (ledger `logPath` / retention / `readDispatchOutput`, `dispatch_status` running-vs-finished + by-id + output tail), plus the detached file-fd capture primitive smoke-tested on macOS. **Full suite 439/439**; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
