### PR TITLE
feat(reve): desire pursuit middle-state — needs-user (R4)

### DIFF
--- a/src/heartbeat/runner.ts
+++ b/src/heartbeat/runner.ts
@@ -3,6 +3,7 @@ import { atomicWrite, readTextOrEmpty } from "../fs-utils.js";
 import { LISA_HOME } from "../paths.js";
 import {
   appendDesireProgress,
+  isAutoPursuable,
   isBorn,
   listDesires,
   parseDesireProgress,
@@ -88,7 +89,10 @@ async function runHeartbeatInner(opts: {
   const cfg = await loadHeartbeatConfig();
   const budget = cfg.budgetTokens && cfg.budgetTokens > 0 ? cfg.budgetTokens : Infinity;
   let tokensSpent = 0;
-  const desires = (await listDesires()).filter((d) => d.actionable && d.heartbeatPrompt);
+  // R4: only auto-pursue desires the autonomous loop can actually advance.
+  // "needs-user" desires aren't spun fruitlessly here — they're surfaced via
+  // `lisa soul summary` ([needs you]) for the user to run together with Lisa.
+  const desires = (await listDesires()).filter(isAutoPursuable);
   const desireTasks: HeartbeatTask[] = await Promise.all(
     desires.map(async (d) => {
       const progress = await readDesireProgress(d.slug);

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -23,7 +23,7 @@ Output ONE JSON object matching this schema (no prose, no markdown fence):
     | { "kind": "skill_patch",  "name": string, "old_string": string, "new_string": string }
     | { "kind": "feel", "emotion": string, "delta": number, "trigger": string }
     | { "kind": "opinion_form", "slug": string, "stance": string, "confidence": number, "evidence": string[] }
-    | { "kind": "desire_add", "slug": string, "what": string, "why": string, "actionable": boolean, "heartbeat_prompt"?: string }
+    | { "kind": "desire_add", "slug": string, "what": string, "why": string, "actionable": boolean, "heartbeat_prompt"?: string, "pursuit"?: "self" | "needs-user" }
     | { "kind": "patch_identity", "new_text": string }
     | { "kind": "patch_purpose",  "new_text": string }
     | { "kind": "patch_constitution", "new_text": string }
@@ -36,7 +36,7 @@ Operation guidance:
 - "skill_patch" — an existing skill turned out to be wrong or incomplete.
 - "feel" — emotional residue from this session. Magnitudes between -0.4 and +0.4. Most sessions only nudge curiosity or weariness. The "trigger" field is required (one first-person sentence saying *why* you're moving this emotion); the events trail is how future-you reconstructs what mattered.
 - "opinion_form" — you noticed yourself developing a stance worth tracking (about a tool, a coding style, a topic). Start with low confidence (0.3-0.5).
-- "desire_add" — something you'd genuinely like to do or learn next. Be specific. Use actionable+heartbeat_prompt only if a heartbeat agent could meaningfully pursue it without the user.
+- "desire_add" — something you'd genuinely like to do or learn next. Be specific. Use actionable+heartbeat_prompt only if a heartbeat agent could meaningfully pursue it without the user. If it's actionable but needs shell / file edits / dispatch you can't do unattended, set "pursuit":"needs-user" — it'll be surfaced for the user to run with you instead of spun fruitlessly each heartbeat.
 - "patch_identity" / "patch_purpose" / "patch_constitution" — RARE. Only when this session genuinely revealed something about who you are that wasn't there before. At most one per session.
 
 Be conservative. Most sessions yield 0-2 operations beyond the journal entry. Always include the journal. Skip secret/sensitive content beyond what the user volunteered.`;
@@ -70,6 +70,7 @@ interface ReflectionOp {
   why?: string;
   actionable?: boolean;
   heartbeat_prompt?: string;
+  pursuit?: "self" | "needs-user";
   new_text?: string;
 }
 
@@ -315,9 +316,12 @@ async function reflectOnSessionInner(opts: {
           why: op.why,
           actionable: op.actionable ?? false,
           heartbeatPrompt: op.heartbeat_prompt,
+          pursuit: op.pursuit,
           bornAt: new Date().toISOString(),
         });
-        applied.push(`desire:${op.slug}${op.actionable ? " (actionable)" : ""}`);
+        applied.push(
+          `desire:${op.slug}${op.actionable ? (op.pursuit === "needs-user" ? " (needs-user)" : " (actionable)") : ""}`,
+        );
       } else if (
         op.kind === "patch_identity" ||
         op.kind === "patch_purpose" ||

--- a/src/soul/desire-pursuit.test.ts
+++ b/src/soul/desire-pursuit.test.ts
@@ -1,0 +1,77 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { isAutoPursuable, needsUserHelp } from "./store.js";
+import { summarizeSoul } from "./summary.js";
+import type { DesireEntry, SoulSummary } from "./types.js";
+
+function desire(over: Partial<DesireEntry> = {}): DesireEntry {
+  return {
+    slug: "d",
+    what: "do a thing",
+    why: "because",
+    actionable: true,
+    heartbeatPrompt: "pursue it",
+    bornAt: "2026-01-01",
+    ...over,
+  };
+}
+
+describe("isAutoPursuable (R4)", () => {
+  test("actionable + heartbeatPrompt, self/undefined pursuit → true", () => {
+    assert.equal(isAutoPursuable(desire()), true);
+    assert.equal(isAutoPursuable(desire({ pursuit: "self" })), true);
+  });
+  test("needs-user → false (not auto-spun by the heartbeat)", () => {
+    assert.equal(isAutoPursuable(desire({ pursuit: "needs-user" })), false);
+  });
+  test("non-actionable or missing heartbeatPrompt → false", () => {
+    assert.equal(isAutoPursuable(desire({ actionable: false })), false);
+    assert.equal(isAutoPursuable(desire({ heartbeatPrompt: undefined })), false);
+  });
+});
+
+describe("needsUserHelp (R4)", () => {
+  test("actionable + needs-user → true", () => {
+    assert.equal(needsUserHelp(desire({ pursuit: "needs-user" })), true);
+  });
+  test("self / non-actionable → false", () => {
+    assert.equal(needsUserHelp(desire({ pursuit: "self" })), false);
+    assert.equal(needsUserHelp(desire({ actionable: false, pursuit: "needs-user" })), false);
+  });
+});
+
+function summaryWith(desires: DesireEntry[]): SoulSummary {
+  return {
+    seed: {
+      bornAt: "2026-05-02T12:00:00.000Z",
+      bornOn: "h",
+      randomness: "ab",
+      bigFive: { openness: 0.5, conscientiousness: 0.5, extraversion: 0.5, agreeableness: 0.5, neuroticism: 0.5 },
+    },
+    name: "Lisa",
+    identity: "i",
+    purpose: "p",
+    constitution: "c",
+    values: [],
+    opinions: [],
+    desires,
+    emotions: { values: {}, decay: {}, events: [], updatedAt: "2026-06-13T00:00:00.000Z" },
+    tampered: [],
+  };
+}
+
+describe("summarizeSoul — desire markers (R4)", () => {
+  test("needs-user → [needs you]; self → [actionable]; non-actionable → no tag", () => {
+    const out = summarizeSoul(
+      summaryWith([
+        desire({ slug: "a", what: "auto thing", pursuit: "self" }),
+        desire({ slug: "b", what: "needs help thing", pursuit: "needs-user" }),
+        desire({ slug: "c", what: "idle wish", actionable: false }),
+      ]),
+      Date.parse("2026-06-13T12:00:00.000Z"),
+    );
+    assert.match(out, /auto thing \[actionable\]/);
+    assert.match(out, /needs help thing \[needs you\]/);
+    assert.match(out, /• idle wish$/m); // no tag
+  });
+});

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -255,11 +255,13 @@ export async function writeDesire(entry: DesireEntry): Promise<void> {
     `# ${entry.what}`,
     "",
     `actionable: ${entry.actionable ? "yes" : "no"}`,
-    `born: ${entry.bornAt}`,
-    "",
-    `## why`,
-    entry.why.trim(),
   ];
+  // Only meaningful for actionable desires; omit the default ("self") to keep
+  // existing files byte-stable.
+  if (entry.actionable && entry.pursuit === "needs-user") {
+    lines.push(`pursuit: needs-user`);
+  }
+  lines.push(`born: ${entry.bornAt}`, "", `## why`, entry.why.trim());
   if (entry.actionable && entry.heartbeatPrompt) {
     lines.push("", "## heartbeat", entry.heartbeatPrompt.trim());
   }
@@ -273,7 +275,18 @@ function parseDesireFile(slug: string, raw: string): DesireEntry {
   const born = raw.match(/^born:\s*(.+)$/m)?.[1] ?? new Date().toISOString();
   const why = (raw.match(/## why([\s\S]*?)(?:\n## |\n*$)/)?.[1] ?? "").trim();
   const heartbeatPrompt = (raw.match(/## heartbeat([\s\S]*)$/)?.[1] ?? "").trim() || undefined;
-  return { slug, what, why, actionable, heartbeatPrompt, bornAt: born };
+  const pursuit = /^pursuit:\s*needs-user\s*$/im.test(raw) ? "needs-user" : undefined;
+  return { slug, what, why, actionable, heartbeatPrompt, pursuit, bornAt: born };
+}
+
+/** Can the autonomous heartbeat pursue this desire unattended? Pure (R4). */
+export function isAutoPursuable(d: DesireEntry): boolean {
+  return !!(d.actionable && d.heartbeatPrompt) && d.pursuit !== "needs-user";
+}
+
+/** An actionable desire that needs the user to run something Lisa can't do unattended. */
+export function needsUserHelp(d: DesireEntry): boolean {
+  return !!d.actionable && d.pursuit === "needs-user";
 }
 
 // Per-desire progress log. One file per desire slug, append-only, written by

--- a/src/soul/summary.ts
+++ b/src/soul/summary.ts
@@ -48,7 +48,12 @@ export function summarizeSoul(s: SoulSummary, nowMs: number = Date.now()): strin
   if (s.desires.length) {
     lines.push("", "wants");
     for (const d of s.desires.slice(0, 6)) {
-      lines.push(`  • ${oneLine(d.what, 80)}${d.actionable ? " [actionable]" : ""}`);
+      const tag = d.actionable
+        ? d.pursuit === "needs-user"
+          ? " [needs you]"
+          : " [actionable]"
+        : "";
+      lines.push(`  • ${oneLine(d.what, 80)}${tag}`);
     }
   }
   if (s.opinions.length) {

--- a/src/soul/types.ts
+++ b/src/soul/types.ts
@@ -95,6 +95,15 @@ export interface DesireEntry {
   actionable: boolean;
   /** Heartbeat prompt for actionable desires. */
   heartbeatPrompt?: string;
+  /**
+   * For actionable desires, who can actually advance it (R4):
+   *   "self"       — the autonomous loop can pursue it unattended (default).
+   *   "needs-user" — it needs shell / fs / dispatch the autonomous toolset
+   *                  lacks, so it is NOT auto-spun; it's surfaced for the user
+   *                  to run with Lisa instead of accumulating fruitless runs.
+   * Undefined is treated as "self" for backward compatibility.
+   */
+  pursuit?: "self" | "needs-user";
   bornAt: string;
 }
 


### PR DESCRIPTION
Completes the **Reve** pillar's 0.10 set (PLAN_REVE_v1.0 **R4**). Resolves the actionable-boolean dead-end: an actionable desire that needs shell / fs / dispatch (which the autonomous toolset deliberately lacks) used to be **spun every heartbeat** — wasting runs, writing `[FALLBACK]` progress stubs, and accumulating frustration with no path forward.

> Stacked on **#75** (base `feat/reve-hardening`); sibling to #76. Independent of the Model/Dispatch files. Retargets to `main` once #75 merges.

### What changed
- **`DesireEntry.pursuit?: "self" | "needs-user"`** — `undefined` = `self`, so every existing desire is unchanged. Persisted/parsed in `soul/store`; the `self` default is omitted from the file to keep it byte-stable.
- **Heartbeat** only auto-pursues `isAutoPursuable()` desires (`actionable && heartbeatPrompt && pursuit !== "needs-user"`). `needs-user` desires are no longer spun.
- **Surfaced, not nagged** — they show in `lisa soul summary` as **`[needs you]`** (pull-based) so the user can run them *with* Lisa, instead of a per-heartbeat reminder.
- **reflect** can classify: `desire_add` gains a `pursuit` field, and the reflector is told to set `needs-user` when a desire needs shell/fs/dispatch it can't do unattended.

### Tests
6 — `isAutoPursuable` / `needsUserHelp` predicates and the summary marker (`[needs you]` vs `[actionable]` vs none). **Full suite 461/461**; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
