### PR TITLE
feat(sense): shell observer — surface which programs you run (S1c)

### DIFF
--- a/src/integrations/hub.ts
+++ b/src/integrations/hub.ts
@@ -45,6 +45,10 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: OrchestratorConfig = {
     // under `watchRoots`, not just AI agents. Off by default; opt in with
     // `{ "enabled": true, "watchRoots": ["~/code"] }`.
     git: { enabled: false },
+    // Shell: surfaces WHICH programs you run at the terminal (argv[0] only —
+    // never command content). Off by default (history is sensitive); opt in
+    // with `{ "enabled": true }` (auto-detects ~/.zsh_history & ~/.bash_history).
+    shell: { enabled: false },
   },
   visibility: "activity",
 };

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -58,4 +58,5 @@ export async function registerBuiltinIntegrations(): Promise<void> {
   await import("./opencode/observer.js");
   await import("./aider/observer.js");
   await import("./git/observer.js");
+  await import("./shell/observer.js");
 }

--- a/src/integrations/shell/observer.test.ts
+++ b/src/integrations/shell/observer.test.ts
@@ -1,0 +1,54 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { extractArgv0, parseHistoryArgv0s, shellActivity } from "./observer.js";
+
+describe("extractArgv0 (program name only)", () => {
+  test("plain command", () => assert.equal(extractArgv0("git status"), "git"));
+  test("strips leading env assignments", () =>
+    assert.equal(extractArgv0('NODE_ENV=prod FOO="a b" npm run build'), "npm"));
+  test("basenames a path", () => assert.equal(extractArgv0("/usr/local/bin/node script.js"), "node"));
+  test("strips a leading subshell paren", () => assert.equal(extractArgv0("(cd x && make)"), "cd"));
+  test("rejects flags / empty / comments", () => {
+    assert.equal(extractArgv0("--help"), null);
+    assert.equal(extractArgv0("   "), null);
+    assert.equal(extractArgv0("# a comment"), null);
+  });
+});
+
+describe("parseHistoryArgv0s", () => {
+  test("plain (bash) lines", () => {
+    assert.deepEqual(parseHistoryArgv0s("git status\nnpm test\n"), ["git", "npm"]);
+  });
+  test("zsh EXTENDED_HISTORY prefix", () => {
+    assert.deepEqual(parseHistoryArgv0s(": 1718337600:0;git push\n: 1718337601:2;docker ps"), ["git", "docker"]);
+  });
+  test("skips bash HISTTIMEFORMAT timestamp lines", () => {
+    assert.deepEqual(parseHistoryArgv0s("#1718337600\ngit log\n#1718337601\nls -la"), ["git", "ls"]);
+  });
+});
+
+describe("PRIVACY: only argv[0] is ever surfaced", () => {
+  test("secrets in command arguments never appear — only the program name", () => {
+    const hist = [
+      ': 1718337600:0;git commit -m "fix: AKIA-SUPER-SECRET leaked into logs"',
+      'curl -H "Authorization: Bearer sk-tok-PRIVATE" https://api.secret-host.example',
+      "export DB_PASSWORD=hunter2",
+    ].join("\n");
+    const blob = JSON.stringify(shellActivity(parseHistoryArgv0s(hist)));
+    // program names are fine to surface…
+    assert.match(blob, /git/);
+    assert.match(blob, /curl/);
+    // …but nothing from the arguments may leak.
+    assert.doesNotMatch(blob, /SECRET|PRIVATE|hunter2|Bearer|AKIA|sk-tok|secret-host/);
+  });
+});
+
+describe("shellActivity", () => {
+  test("turnCount, lastCommandName, deduped recent lastTools, no files", () => {
+    const a = shellActivity(["git", "npm", "git", "docker"]);
+    assert.equal(a.turnCount, 4);
+    assert.equal(a.lastCommandName, "docker");
+    assert.deepEqual(a.lastTools, ["npm", "git", "docker"]);
+    assert.deepEqual(a.filesTouched, []);
+  });
+});

--- a/src/integrations/shell/observer.ts
+++ b/src/integrations/shell/observer.ts
@@ -1,0 +1,242 @@
+/**
+ * Shell observer (Sense S1c — what the user runs at the terminal).
+ *
+ * Tails the shell history file(s) and surfaces ONLY which programs were run
+ * (argv[0] — "git", "npm", "docker", "ssh") plus counts/recency. This widens
+ * Sense to the user's command-line rhythm without an agent involved.
+ *
+ * PRIVACY (the whole point of this adapter): it extracts the PROGRAM NAME ONLY.
+ * Never a full command line, never arguments, never paths, never the contents
+ * of `git commit -m "..."`. A planted-secret test asserts this. Off by default
+ * — shell history is sensitive; opt in via ~/.lisa/agents.json.
+ *
+ * Mapping to a session (a shell isn't an "agent"): one session per history
+ * file, project = the shell name ("zsh"/"bash"), state = "working" while there
+ * was recent activity (older ones drop out of the active window). cwd is
+ * unavailable (history records no directory), so it's omitted.
+ */
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { EventEmitter } from "node:events";
+import { registerIntegration } from "../registry.js";
+import type {
+  AgentIntegrationConfig,
+  AgentObserver,
+  AgentSession,
+  AgentSessionState,
+  SessionActivity,
+} from "../types.js";
+
+const ACTIVE_WINDOW_MS = 30 * 60_000; // 30m
+const DEBOUNCE_MS = 500;
+const TAIL_BYTES = 16 * 1024;
+const ACTIVITY_MAX = 40; // how many recent commands to consider
+const LAST_TOOLS_MAX = 8;
+
+/**
+ * Extract argv[0] (the program name) from one history command line. Pure.
+ * Strips leading `VAR=val` assignments, takes the first token, basenames it,
+ * and returns null for anything that isn't a plain command name (flags, shell
+ * syntax). Deliberately surfaces ONLY the program name — nothing after it.
+ */
+export function extractArgv0(command: string): string | null {
+  let s = command.trim();
+  if (!s || s.startsWith("#")) return null;
+  // Drop leading environment assignments: FOO=bar BAZ="x" cmd ...
+  s = s.replace(/^(?:[A-Za-z_][A-Za-z0-9_]*=(?:"[^"]*"|'[^']*'|\S+)\s+)+/, "");
+  // Drop a leading subshell/grouping paren so "(cd x && y)" doesn't leak "(cd".
+  s = s.replace(/^[({]\s*/, "");
+  const tok = s.split(/\s+/)[0];
+  if (!tok) return null;
+  const base = (tok.split("/").pop() || tok).trim();
+  // Only a plausible program name — excludes flags, redirects, var expansions.
+  if (!base || !/^[A-Za-z0-9._@+-]+$/.test(base) || base.startsWith("-")) return null;
+  return base;
+}
+
+/**
+ * Parse a shell-history tail into a list of argv[0]s (program names only).
+ * Handles zsh EXTENDED_HISTORY (": <ts>:<elapsed>;<cmd>") and bash
+ * HISTTIMEFORMAT ("#<epoch>" lines) as well as plain command-per-line. Pure.
+ */
+export function parseHistoryArgv0s(raw: string): string[] {
+  const out: string[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (/^#\d+$/.test(trimmed)) continue; // bash timestamp comment line
+    const zsh = line.match(/^: \d+:\d+;(.*)$/); // zsh extended-history prefix
+    const cmd = zsh ? zsh[1]! : line;
+    const a = extractArgv0(cmd);
+    if (a) out.push(a);
+  }
+  return out;
+}
+
+function dedupeKeepRecent(items: string[], max: number): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (let i = items.length - 1; i >= 0; i--) {
+    if (!seen.has(items[i]!)) {
+      seen.add(items[i]!);
+      out.unshift(items[i]!);
+    }
+  }
+  return out.slice(-max);
+}
+
+/** Tier-2 structural activity from recent argv[0]s. Program names + counts only. Pure. */
+export function shellActivity(argv0s: string[]): SessionActivity {
+  const recent = argv0s.slice(-ACTIVITY_MAX);
+  return {
+    turnCount: argv0s.length,
+    lastTools: dedupeKeepRecent(recent, LAST_TOOLS_MAX),
+    filesTouched: [], // shell history carries no file info we'd surface
+    lastCommandName: recent[recent.length - 1],
+  };
+}
+
+function deriveShellState(lastMtime: number, now: number): { state: AgentSessionState; reason: string } {
+  return now - lastMtime < ACTIVE_WINDOW_MS
+    ? { state: "working", reason: "recent commands" }
+    : { state: "idle", reason: "quiet" };
+}
+
+async function readTail(file: string): Promise<string> {
+  const st = await fsp.stat(file);
+  if (st.size === 0) return "";
+  const fd = await fsp.open(file, "r");
+  try {
+    const len = Math.min(TAIL_BYTES, st.size);
+    const buf = Buffer.alloc(len);
+    await fd.read(buf, 0, len, st.size - len);
+    // latin1 avoids throwing on the non-UTF8 bytes zsh can write; we only ever
+    // keep ASCII program names out of it anyway.
+    return buf.toString("latin1");
+  } finally {
+    await fd.close();
+  }
+}
+
+/** Default history files to watch when none are configured. */
+function defaultHistoryFiles(): string[] {
+  const home = os.homedir();
+  return [path.join(home, ".zsh_history"), path.join(home, ".bash_history")];
+}
+
+interface ShellSessionInfo {
+  sessionId: string;
+  project: string;
+  lastMtime: number;
+  state: AgentSessionState;
+  stateReason: string;
+  activity?: SessionActivity;
+}
+
+export class ShellObserver extends EventEmitter implements AgentObserver {
+  readonly agent = "shell";
+  private files: string[];
+  private sessions = new Map<string, ShellSessionInfo>();
+  private watchers: fs.FSWatcher[] = [];
+  private pending = new Map<string, NodeJS.Timeout>();
+  private emitFn: ((s: AgentSession) => void) | null = null;
+  private readonly computeActivity: boolean;
+
+  constructor(cfg: AgentIntegrationConfig) {
+    super();
+    const raw = Array.isArray(cfg.files) ? (cfg.files as unknown[]) : null;
+    this.files = (raw ?? defaultHistoryFiles())
+      .filter((f): f is string => typeof f === "string")
+      .map((f) => f.replace(/^~/, os.homedir()));
+    this.computeActivity = cfg.visibility === "activity" || cfg.visibility === "intent";
+  }
+
+  async start(emit: (s: AgentSession) => void): Promise<void> {
+    this.emitFn = emit;
+    for (const file of this.files) {
+      await this.record(file);
+      this.attach(file);
+    }
+  }
+
+  list(): AgentSession[] {
+    const cutoff = Date.now() - ACTIVE_WINDOW_MS;
+    return [...this.sessions.values()]
+      .filter((s) => s.lastMtime >= cutoff)
+      .sort((a, b) => b.lastMtime - a.lastMtime)
+      .map(toAgentSession);
+  }
+
+  async stop(): Promise<void> {
+    for (const w of this.watchers) w.close();
+    this.watchers = [];
+    for (const t of this.pending.values()) clearTimeout(t);
+    this.pending.clear();
+  }
+
+  private attach(file: string): void {
+    try {
+      const w = fs.watch(file, { persistent: false }, () => {
+        const prev = this.pending.get(file);
+        if (prev) clearTimeout(prev);
+        this.pending.set(
+          file,
+          setTimeout(() => {
+            this.pending.delete(file);
+            void this.record(file).then(() => {
+              const info = this.sessions.get(file);
+              if (info && this.emitFn) this.emitFn(toAgentSession(info));
+            });
+          }, DEBOUNCE_MS),
+        );
+      });
+      w.on("error", () => w.close());
+      this.watchers.push(w);
+    } catch {
+      // file unwatchable (e.g. doesn't exist) → no-op
+    }
+  }
+
+  private async record(file: string): Promise<void> {
+    try {
+      const st = await fsp.stat(file);
+      if (!st.isFile()) return;
+      const tail = await readTail(file);
+      const argv0s = parseHistoryArgv0s(tail);
+      const { state, reason } = deriveShellState(st.mtimeMs, Date.now());
+      this.sessions.set(file, {
+        sessionId: file,
+        project: shellName(file),
+        lastMtime: st.mtimeMs,
+        state,
+        stateReason: reason,
+        activity: this.computeActivity ? shellActivity(argv0s) : undefined,
+      });
+    } catch {
+      this.sessions.delete(file); // file vanished
+    }
+  }
+}
+
+function shellName(file: string): string {
+  const base = path.basename(file); // .zsh_history / .bash_history
+  if (base.includes("zsh")) return "zsh";
+  if (base.includes("bash")) return "bash";
+  if (base.includes("fish")) return "fish";
+  return "shell";
+}
+
+function toAgentSession(i: ShellSessionInfo): AgentSession {
+  return {
+    agent: "shell",
+    sessionId: i.sessionId,
+    project: i.project,
+    state: i.state,
+    stateReason: i.stateReason,
+    lastMtime: i.lastMtime,
+    activity: i.activity,
+  };
+}
+
+registerIntegration("shell", (cfg) => new ShellObserver(cfg));


### PR DESCRIPTION
Continues **Sense** S1 (after the git observer on `main`). Widens what Lisa can see to your **terminal rhythm** — which programs you run (git, npm, docker, ssh, …) — from the shell history file. Another low-risk, opt-in work-source.

> Independent PR off `main`.

### What it does
- **`ShellObserver`** (`src/integrations/shell/observer.ts`, kind `"shell"`) watches `~/.zsh_history` & `~/.bash_history` (or a configured `files` list), per-file debounce, 30-minute active window. One session per history file (`project` = `zsh`/`bash`); `cwd` omitted (history records none).
- Pure, tested units: `extractArgv0` (program name only), `parseHistoryArgv0s` (handles **zsh EXTENDED_HISTORY**, **bash HISTTIMEFORMAT**, and plain), `shellActivity` (recent distinct programs + counts).
- Registered; **off by default** in `DEFAULT_ORCHESTRATOR_CONFIG` (`shell: { enabled: false }`) — opt in with `{ "shell": { "enabled": true } }`.

### Privacy (the whole point)
Extracts **argv[0] — the program name — ONLY**. Never a full command line, arguments, paths, or the contents of `git commit -m "..."`. A **planted-secret test** asserts that secrets in command arguments (`Bearer sk-tok-…`, `DB_PASSWORD=…`, an `AKIA…` key) never appear in the surfaced activity. Off by default because history is sensitive.

### Verified
- 10 tests (`extractArgv0` / `parseHistoryArgv0s` / `shellActivity` + the privacy test).
- Validated against a **real `~/.zsh_history`**: 110 commands parsed → only program names surfaced (`gh, brew, pnpm, dig, …`), zero content.
- **Full suite 540/540**; typecheck + build clean.

### Sense S1 status
git observer ✅ (merged) · shell observer ✅ (this PR). Remaining S1 follow-up: deepen the non-Claude agent observers' Tier-2 activity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
