### PR TITLE
perf(model): persistent embedding cache for semantic search (M2 follow-up)

### DIFF
--- a/src/memory/embedding-cache.test.ts
+++ b/src/memory/embedding-cache.test.ts
@@ -1,0 +1,82 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Embedder } from "./embedding.js";
+
+// Isolate the on-disk cache before importing the module (paths.js reads
+// LISA_HOME at import time).
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-embcache-"));
+process.env.LISA_HOME = TMP;
+
+const { docHash, embedWithCache, loadEmbeddingCache, saveEmbeddingCache } = await import("./embedding.js");
+
+function countingEmbedder(): { e: Embedder; calls: () => number } {
+  let n = 0;
+  const e: Embedder = {
+    id: "fake-embedder",
+    async embed(texts) {
+      n += texts.length;
+      return texts.map((t) => [t.length]); // vector derived from content, deterministic
+    },
+  };
+  return { e, calls: () => n };
+}
+
+describe("docHash", () => {
+  test("deterministic and content-sensitive", () => {
+    assert.equal(docHash("hello"), docHash("hello"));
+    assert.notEqual(docHash("hello"), docHash("hellp"));
+  });
+});
+
+describe("embedWithCache", () => {
+  test("first pass embeds all; second pass is a full cache hit (no new calls)", async () => {
+    const { e, calls } = countingEmbedder();
+    const r1 = await embedWithCache(["aa", "bbb"], e, {});
+    assert.equal(r1.misses, 2);
+    assert.equal(calls(), 2);
+    assert.deepEqual(r1.vectors, [[2], [3]]);
+
+    const r2 = await embedWithCache(["aa", "bbb"], e, r1.updated);
+    assert.equal(r2.misses, 0);
+    assert.equal(calls(), 2, "no further embed calls on a full hit");
+    assert.deepEqual(r2.vectors, [[2], [3]]);
+  });
+
+  test("only changed docs re-embed", async () => {
+    const { e, calls } = countingEmbedder();
+    const r1 = await embedWithCache(["aa", "bbb"], e, {});
+    const before = calls();
+    const r3 = await embedWithCache(["aa", "CHANGED"], e, r1.updated);
+    assert.equal(r3.misses, 1);
+    assert.equal(calls(), before + 1, "only the changed doc is embedded");
+  });
+
+  test("updated cache is pruned to the current doc set", async () => {
+    const { e } = countingEmbedder();
+    const r1 = await embedWithCache(["aa", "bbb"], e, {});
+    const r4 = await embedWithCache(["aa"], e, r1.updated); // "bbb" dropped
+    assert.equal(Object.keys(r4.updated).length, 1);
+    assert.ok(r4.updated[docHash("aa")]);
+  });
+
+  test("does not mutate the input cache", async () => {
+    const { e } = countingEmbedder();
+    const cache = {};
+    await embedWithCache(["aa"], e, cache);
+    assert.deepEqual(cache, {});
+  });
+});
+
+describe("load/saveEmbeddingCache (disk)", () => {
+  test("round-trips, sanitizing the embedder id into a filename", async () => {
+    await saveEmbeddingCache("ollama:nomic-embed-text", { [docHash("x")]: [1, 2, 3] });
+    const loaded = await loadEmbeddingCache("ollama:nomic-embed-text");
+    assert.deepEqual(loaded[docHash("x")], [1, 2, 3]);
+  });
+  test("missing cache → {}", async () => {
+    assert.deepEqual(await loadEmbeddingCache("never-saved-embedder"), {});
+  });
+});

--- a/src/memory/embedding.test.ts
+++ b/src/memory/embedding.test.ts
@@ -1,13 +1,18 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import {
-  cosineSimilarity,
-  parseOllamaEmbedding,
-  OllamaEmbedder,
-  type Embedder,
-  type PostJson,
-} from "./embedding.js";
-import { semanticSearch, type Index, type Document } from "./vector.js";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { Embedder, PostJson } from "./embedding.js";
+import type { Index, Document } from "./vector.js";
+
+// semanticSearch → ensureEmbeddings now reads/writes the on-disk embedding
+// cache; point it at a throwaway LISA_HOME so the suite never touches the real
+// ~/.lisa. Set before importing the modules (paths.js captures LISA_HOME once).
+process.env.LISA_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-emb-"));
+
+const { cosineSimilarity, parseOllamaEmbedding, OllamaEmbedder } = await import("./embedding.js");
+const { semanticSearch } = await import("./vector.js");
 
 describe("cosineSimilarity", () => {
   test("identical → 1", () => assert.equal(cosineSimilarity([1, 2, 3], [1, 2, 3]), 1));

--- a/src/memory/embedding.ts
+++ b/src/memory/embedding.ts
@@ -8,6 +8,10 @@
  * The HTTP POST is injectable so the logic is unit-testable without a running
  * embedding backend.
  */
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { LISA_HOME } from "../paths.js";
 import { localEndpoint } from "../model/local.js";
 
 export interface Embedder {
@@ -91,4 +95,71 @@ export class OllamaEmbedder implements Embedder {
 export function getConfiguredEmbedder(): Embedder | null {
   const model = process.env.LISA_EMBED_MODEL?.trim();
   return model ? new OllamaEmbedder(model) : null;
+}
+
+// ── persistent embedding cache (PLAN_MODEL M2 perf) ────────────────────────
+// Without this, every memory_search re-embeds ALL session docs whenever any
+// session file changes (i.e. constantly during active use), which makes the
+// semantic path slow + costly. Keying vectors by doc-content hash lets a
+// rebuild re-embed only the docs whose content actually changed.
+
+export type EmbeddingCache = Record<string, number[]>;
+
+/** Stable content key for a doc text (truncated sha256). Pure. */
+export function docHash(text: string): string {
+  return crypto.createHash("sha256").update(text).digest("hex").slice(0, 32);
+}
+
+/**
+ * Embed `texts`, reusing `cache` for unchanged content and calling the embedder
+ * only for misses (one batched call). Returns vectors in input order, an
+ * `updated` cache pruned to just the current texts (no unbounded growth), and
+ * the miss count. Does not mutate `cache`. Pure modulo the embedder call; the
+ * caller falls back to TF-IDF if the embedder throws.
+ */
+export async function embedWithCache(
+  texts: string[],
+  embedder: Embedder,
+  cache: EmbeddingCache,
+): Promise<{ vectors: number[][]; updated: EmbeddingCache; misses: number }> {
+  const hashes = texts.map(docHash);
+  const missIdx: number[] = [];
+  for (let i = 0; i < texts.length; i++) if (!cache[hashes[i]!]) missIdx.push(i);
+  const missVecs = missIdx.length ? await embedder.embed(missIdx.map((i) => texts[i]!)) : [];
+  const fresh: EmbeddingCache = {};
+  missIdx.forEach((i, k) => {
+    fresh[hashes[i]!] = missVecs[k] ?? [];
+  });
+  const vectors: number[][] = new Array(texts.length);
+  const updated: EmbeddingCache = {};
+  for (let i = 0; i < texts.length; i++) {
+    const v = fresh[hashes[i]!] ?? cache[hashes[i]!] ?? [];
+    vectors[i] = v;
+    updated[hashes[i]!] = v; // prune: keep only hashes for the current doc set
+  }
+  return { vectors, updated, misses: missIdx.length };
+}
+
+const EMBED_CACHE_DIR = path.join(LISA_HOME, "embeddings");
+function embedCacheFile(embedderId: string): string {
+  return path.join(EMBED_CACHE_DIR, `${embedderId.replace(/[^a-zA-Z0-9._-]/g, "_")}.json`);
+}
+
+/** Load the on-disk cache for an embedder; {} if missing/corrupt. */
+export async function loadEmbeddingCache(embedderId: string): Promise<EmbeddingCache> {
+  try {
+    return JSON.parse(await fs.readFile(embedCacheFile(embedderId), "utf8")) as EmbeddingCache;
+  } catch {
+    return {};
+  }
+}
+
+/** Persist the cache for an embedder. Best-effort (never throws). */
+export async function saveEmbeddingCache(embedderId: string, cache: EmbeddingCache): Promise<void> {
+  try {
+    await fs.mkdir(EMBED_CACHE_DIR, { recursive: true });
+    await fs.writeFile(embedCacheFile(embedderId), JSON.stringify(cache));
+  } catch {
+    // best-effort; a missing cache just means more re-embedding next time
+  }
 }

--- a/src/memory/vector.ts
+++ b/src/memory/vector.ts
@@ -3,7 +3,13 @@ import fs from "node:fs/promises";
 import { listSessionsOnDisk, loadSessionMessages } from "../sessions/list.js";
 import { SESSIONS_DIR } from "../paths.js";
 import { extractTextFromContent } from "../agent.js";
-import { cosineSimilarity, type Embedder } from "./embedding.js";
+import {
+  cosineSimilarity,
+  embedWithCache,
+  loadEmbeddingCache,
+  saveEmbeddingCache,
+  type Embedder,
+} from "./embedding.js";
 
 export interface Document {
   sessionId: string;
@@ -156,9 +162,14 @@ const SEMANTIC_DOC_CHARS = 2000;
 /** Populate (and cache on the index) a dense vector per doc, once per embedder. */
 async function ensureEmbeddings(index: Index, embedder: Embedder): Promise<void> {
   if (index.embedderId === embedder.id && index.embeddings) return;
-  const vecs = await embedder.embed(index.docs.map((d) => d.text.slice(0, SEMANTIC_DOC_CHARS)));
+  const texts = index.docs.map((d) => d.text.slice(0, SEMANTIC_DOC_CHARS));
+  // Reuse the persistent cache so a rebuild (triggered by ANY session change)
+  // only re-embeds docs whose content actually changed, not all of them.
+  const cache = await loadEmbeddingCache(embedder.id);
+  const { vectors, updated, misses } = await embedWithCache(texts, embedder, cache);
+  if (misses > 0) await saveEmbeddingCache(embedder.id, updated);
   const map = new Map<string, number[]>();
-  index.docs.forEach((d, i) => map.set(d.sessionId, vecs[i] ?? []));
+  index.docs.forEach((d, i) => map.set(d.sessionId, vectors[i] ?? []));
   index.embeddings = map;
   index.embedderId = embedder.id;
 }


### PR DESCRIPTION
Makes the **Model** M2 semantic path actually practical. Before this, `ensureEmbeddings` re-embedded **every** session doc on each index rebuild — and the index rebuilds whenever *any* session file changes (constantly during active use). With `LISA_EMBED_MODEL` set that's N embedding calls per search → slow + costly. Now vectors are keyed by **doc-content hash** and persisted, so a rebuild only re-embeds docs whose content actually changed.

> Independent PR off `main`. Opt-in path only (no effect unless `LISA_EMBED_MODEL` is set); the TF-IDF default is untouched.

### What changed
- `embedding.ts`:
  - `docHash(text)` — stable content key.
  - `embedWithCache(texts, embedder, cache)` — **pure**: reuses the cache for unchanged content, makes **one batched embedder call for the misses**, prunes the returned cache to the current doc set (no unbounded growth), and never mutates the input.
  - `loadEmbeddingCache` / `saveEmbeddingCache` — on-disk per-embedder cache at `~/.lisa/embeddings/<embedderId>.json` (best-effort; a missing cache just means more re-embedding).
- `vector.ts` `ensureEmbeddings` loads the cache, embeds only the misses, and persists.
- **Test hygiene:** `embedding.test.ts` now isolates `LISA_HOME` so `semanticSearch`'s `ensureEmbeddings` can't write a cache file into the real `~/.lisa` during the suite.

### Tests
7 new — `docHash` determinism, `embedWithCache` (full-hit / partial-miss / prune / no-mutate of input), and the disk round-trip. Verified a full hit makes **zero** new embedder calls and a changed doc re-embeds **only itself**. **Full suite 547/547**; typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
