### PR TITLE
docs: detailed plans for the 4 remaining hard 1.0 items

### DIFF
--- a/docs/PLAN_DISPATCH_D2B_v1.0.md
+++ b/docs/PLAN_DISPATCH_D2B_v1.0.md
@@ -1,0 +1,88 @@
+# PLAN · Dispatch D2b — A2A adapter (remote agents in the hub)
+
+> 展开 [PLAN_DISPATCH_v1.0.md](./PLAN_DISPATCH_v1.0.md) D2(b)。基线：main(v0.9.1+,D2a `takoapi` 工具已合)。
+> TakoAPI 事实见 [ROADMAP_v1.0.md §4](./ROADMAP_v1.0.md):A2A(`/v1/agents/{slug}/message`、`/stream`、TaskState)+ OpenAI shim。
+
+---
+
+## 0. 现状
+- ✅ **D2a 已合**:`src/tools/takoapi.ts` —— `discover`(GET `/api/registry`)+ `call`(POST `/v1/agents/{slug}/message`,**同步**返回回复);`LISA_BASE_URL→takoapi.com/v1` 自动用 `TAKO_KEY`。自主/远程禁用闸。
+- ❌ 远程 agent **不在 hub**:本机 observer(claude/codex/.../git/shell)进 hub,远程 TakoAPI agent 不进。
+- D2a 的 `call` 是**同步**的(发→等→拿回复),没有"在跑的远程任务"可观察。
+
+---
+
+## 1. 目标 / 非目标
+
+**目标**:让 **LISA 实际交互过的**远程 agent 以**一等 session** 出现在 hub(与本地 agent 并列),带 A2A **TaskState**;长任务可看进度。
+**关键非目标**:**绝不**把 registry 的 ~200 个 agent 全塞进 hub —— 那是 `discover` 的发现职责,不是监控职责。hub 只显示"你叫过/钉过"的远程 agent。
+
+---
+
+## 2. 设计
+
+### 核心取舍:surface 谁?
+hub 只收两类远程 agent,各有上限 + 活动窗口(同其它 observer):
+1. **called**:LISA 经 `takoapi call` 调过的 agent(本会话/近期),带其最后 TaskState。
+2. **pinned**(可选):用户在 `~/.lisa/agents.json` 显式钉的几个 slug(`{ "takoapi": { "enabled": true, "pin": ["slug-a"] } }`)。
+
+→ 发现(200 个)永远走 `discover` 工具;监控只看交互过的。
+
+### D2b-1 — 异步任务 + 调用账本
+- A2A 真正的价值在**长任务**。给 `takoapi` 加异步路径(或新 `call` 模式):`message` 返回 A2A `Task`(有 `id` + 初始 state)而非只等同步回复;用 `/v1/agents/{slug}/stream`(SSE)或轮询 task 状态跟踪。
+- 记一个**调用账本** `~/.lisa/takoapi-calls.json`(镜像 `dispatch-ledger`):`{ slug, taskId, startedAt, lastState, lastMtime }`。同步 call 也记一条(state 直接 completed)。
+
+### D2b-2 — `takoapi` observer
+- `registerIntegration("takoapi", …)`,kind `"takoapi"`,**默认关**(需 `TAKO_KEY` + opt-in)。
+- `list()`:读调用账本(called + pinned),对 in-flight 的轮询/读 SSE 拿最新 TaskState,映射成 `AgentSession`(project = slug,cwd 省略,activity = 最小)。
+- 复用 observer 的窗口 + 上限 + 注入式 fetch(同 takoapi 工具,便于测试)。
+
+**A2A TaskState → AgentSessionState(纯函数,可测)**:
+```
+submitted | working           → working
+input-required | auth-required → waiting
+completed                     → done
+failed | rejected             → error
+canceled                      → done (reason: canceled)
+unknown                       → unknown
+```
+
+### D2b-3 — 进 hub / UI
+- observer 进 `registerBuiltinIntegrations` + DEFAULT config(`takoapi: { enabled: false }`)。
+- UI 显示**依赖 [D4a 多 agent 前端消费](./PLAN_DISPATCH_D4_v1.0.md)** —— D4a 落地后,远程 agent 自动随 `agent_session_update` 出现在 roster(带 takoapi 徽标)。**D2b 应排在 D4a 之后**,否则后端有事件、前端看不到。
+
+---
+
+## 3. 分阶段 + 验收(依赖顺序)
+> 前置:**D4a(多 agent 前端)**先做,否则远程 session 进了 hub 也不显示。
+
+| 阶段 | 内容 |
+|---|---|
+| D2b-1 | 异步 task + `takoapi-calls` 账本(同步 call 也记) |
+| D2b-2 | `takoapi` observer + TaskState 映射(纯函数)+ 注入式 fetch |
+| D2b-3 | 注册 + DEFAULT(off) + 随 D4a 在 roster 显示 |
+
+- [ ] `call` 一个远程 agent 后,它作为 session 出现在 `lisa` agent 列表 / island,带 TaskState。
+- [ ] registry 的 200 个 agent **不**出现在 hub(只 called/pinned)。
+- [ ] TaskState→state 映射有单测;observer 用 mock A2A 响应测(injectable fetch)。
+- [ ] 远程来源(渠道)默认仍禁 takoapi(autonomous/remote-blocked 不变)。
+
+## 4. 测试
+- `taskStateToSessionState` 纯函数:全状态映射用例。
+- 账本:record/list/prune(镜像 dispatch-ledger 测试)。
+- observer:注入 fake fetch 返回各 TaskState → `list()` 产出正确 AgentSession;空账本→空;窗口剔除。
+- A2A 响应当 hostile:注入测试(2nd-order injection)。
+
+## 5. 隐私 / 安全
+- **出站**:把远程 agent 的响应/状态当**不可信**(2nd-order prompt injection,TakoAPI 技术文档 §11 也强调);hub 只 surface **结构化**(slug、TaskState、时间),完整回复仍经 `takoapi` 工具返回(那是 LISA 自己委派的活,可读)。
+- `TAKO_KEY` 走 `config.env`(0600);takoapi 仍 autonomous/remote-blocked(不变)。
+- 默认关:无 `TAKO_KEY`/未 opt-in 时 observer no-op。
+
+## 6. 风险
+- **TakoAPI 网关仍在演进**(Phase 2 gateway、生产 DB 升配未完)→ observer 必须容错(A2A 断路器 / 解析失败跳过),A2A async task 端点是否稳定要先验。
+- **同步 call 无可观察任务**:D2b 的真价值要 A2A async task 支持;若网关只稳定支持同步,D2b 退化为"最近调用列表"(仍有用,但弱)。
+- **别破坏"不塞 200 个"的纪律**:任何"列出 registry 进 hub"的诱惑都要拒绝。
+- 依赖 D4a:顺序不对就白做(后端有、前端不显)。
+
+## 7. 一句话
+> 让**你叫过的**远程 agent 进 hub(带 A2A TaskState),和本地 agent 并排 —— 发现归 `discover`、监控只看交互过的;先做 D4a 前端,再让远程 session 借同一条 `agent_session_update` 通道显示。

--- a/docs/PLAN_DISPATCH_D4_v1.0.md
+++ b/docs/PLAN_DISPATCH_D4_v1.0.md
@@ -1,0 +1,85 @@
+# PLAN · Dispatch D4 — multi-agent monitor + advisor actions
+
+>展开 [PLAN_DISPATCH_v1.0.md](./PLAN_DISPATCH_v1.0.md) 的 D4。基线：main（v0.9.1+，已合入四支柱首块）。
+> **先核查的结论(已对当前树验证)**：D4 里"advisor 建议可点"那一半 **0.9.1 已经做了**;真正没做的是 **多 agent 前端消费**。本计划据此收窄。
+
+---
+
+## 0. 现状(已核查,file:line)
+
+### ✅ 已完成(0.9.1, commit `e1fcc33`)——advisor 建议可点
+- `src/advisor/types.ts:26` `SuggestedAction { label, kind: approve|cancel|open|serialize|look|dispatch, arg }`;6 个 detector(`detectors.ts`)都产出带 action 的 `Suggestion`。
+- `src/web/island.ts:699–759` 渲染 advisor 卡 **真按钮**(onclick),`advisorPrefill()`(676–697)把动作 prefill 进 composer、**绝不自动执行**;✕ dismiss → `POST /api/advisor/dismiss`。
+- SSE `advisor_suggestions`(`server.ts:289`)+ `GET /api/advisor/latest`;两个假告警也已修。
+
+→ **"可点 + prefill + dismiss 学习闭环"这条 review 生死线已经合上,不用重做。**
+
+### ❌ 仍未做——多 agent 监控前端
+- 后端**已发**通用 `agent_session_update`(`server.ts:230`,覆盖所有 observer)+ 兼容用的 `claude_session_update`(232–241)。
+- 但前端**只消费 claude**:`island.ts:1115` 只有 `case 'claude_session_update'`;`lisa-client.ts:428` 同样只听 claude。→ **codex/opencode/aider/git/shell 的 session 状态变化,UI 完全看不到**(尽管它们都在 hub 里、都发了事件)。
+- `GET /api/agents/sessions`(`server.ts:678`)已能列全部 agent(初始加载用),但前端没用它建多-agent 列表。
+
+### ⚠️ 可选缺口——直接动作端点
+- advisor 的 `cancel`/`dispatch`/`approve` 目前都是 **prefill→用户发→Lisa 调工具**,没有 `/api/signal_agent` 之类**直接执行**端点。这是**有意的安全默认**(nothing auto-runs);是否要加"一键直接 cancel"是产品取舍,不是 bug。
+
+---
+
+## 1. 目标 / 非目标
+
+**目标**:让 island(和主 chat)把**所有** agent(不只 Claude)的 session 状态显示出来 —— 兑现"看你整支 agent 舰队"。
+**非目标**:不重做已完成的 advisor 可点;不默认加"自动执行"动作端点(保持 prefill 安全默认,直接端点列为可选 D4b)。
+
+---
+
+## 2. 设计
+
+### D4a — 多 agent 前端消费(核心)
+1. **统一消费 `agent_session_update`**:在 `island.ts` 的 SSE switch(~1063–1130)与 `lisa-client.ts`(~428)各加 `case 'agent_session_update'`。`agent_session_update` 已覆盖 claude-code,所以**以它为准**,`claude_session_update` 仅作旧客户端兼容(前端可不再依赖)。
+2. **一个纯 reducer(可测)**:把"收到一条 session 更新 → 更新本地 roster"抽成纯函数,绕开前端难单测的问题:
+   ```ts
+   // 放进一个可被 vm/单测加载的纯模块(或 island 内联但导出给测试)
+   export interface RosterEntry { agent: string; sessionId: string; project: string; state: string; lastMtime: number; }
+   export function mergeAgentSession(roster: RosterEntry[], u: RosterEntry, now: number, windowMs = 30*60_000): RosterEntry[]
+   //  - upsert by (agent+sessionId);按 lastMtime 排序;丢弃超出活动窗口的;去掉 done/idle 过老的
+   ```
+   前端只做 `roster = mergeAgentSession(roster, ev, Date.now())` + 渲染。
+3. **渲染**:island 现有 Claude 监控区扩成"多 agent roster":每行 `agent 图标 + project + 状态点 + 最近活动(activity.lastTools/lastCommandName)`。agent 种类用小徽标(claude/codex/opencode/aider/git/shell)。初始加载走 `GET /api/agents/sessions`。
+4. 复用现有状态点/CSS;不新增后端(后端已发齐)。
+
+### D4b —(可选)直接动作端点
+- 仅在用户明确想要"一键直接执行"时做。`POST /api/agent/signal { id, action: "cancel" }` → 复用 `signal_agent` 的 ledger-gated kill(只杀 LISA 自己派的)。
+- **必须**走 0.9.1 的 web 鉴权(loopback 或 `LISA_WEB_TOKEN`),并带确认。默认仍 prefill;direct 作为 opt-in。
+- approve/dispatch 的直接执行风险更高(代码执行),**不做**,保持 prefill。
+
+---
+
+## 3. 分阶段 + 验收
+
+**D4a(核心)**
+- [ ] island + lisa-client 各加 `agent_session_update` 消费,经 `mergeAgentSession` 维护 roster。
+- [ ] island 显示非-Claude(codex/git/shell…)session 的状态 + 活动(手动起一个 git observer 会话即可见)。
+- [ ] `mergeAgentSession` 纯函数有单测(upsert/排序/窗口剔除)。
+- [ ] 内联 JS 仍通过现有 `vm.Script` 语法校验测试(island/lisa-html snapshot)。
+
+**D4b(可选,需用户拍板)**
+- [ ] `/api/agent/signal` 仅 loopback/token 可达;只 cancel ledger 内的 pid;有测试。
+- [ ] island cancel 按钮可选"直接执行"(默认仍 prefill)。
+
+---
+
+## 4. 测试策略(前端难测的解法)
+- **抽纯 reducer**(`mergeAgentSession`)承载所有逻辑 → 单测覆盖;前端只是"调 reducer + 写 DOM"。
+- 内联 `<script>` 继续靠现有 `lisa-html`/island 的 `vm.Script` 解析测试防语法炸。
+- D4b 端点:后端单测(鉴权 + 只 cancel 自己的 pid)。
+
+## 5. 隐私 / 安全
+- 多 agent roster 只显示 hub 已有的结构化 activity(无 prompt/reply/内容)——隐私层不变。
+- D4b 直接端点严守 0.9.1 web 鉴权 + ledger 限制(signal_agent 既有保证)。
+
+## 6. 风险
+- 前端可测性低 → 用纯 reducer 缓解。
+- roster 太吵(很多 session)→ 活动窗口 + 上限 + 折叠;沿用 island 既有的 cap。
+- direct-action(D4b)是攻击面扩张 → 默认不开,prefill 优先。
+
+## 7. 一句话
+> D4 的"可点"半边 0.9.1 已合;剩下的是让前端真正消费 `agent_session_update`,把"看你所有 agent"从后端事实变成 UI 事实 —— 用一个纯 reducer 把前端逻辑做成可测的。

--- a/docs/PLAN_OBSERVER_DEEPENING_v1.0.md
+++ b/docs/PLAN_OBSERVER_DEEPENING_v1.0.md
@@ -1,0 +1,87 @@
+# PLAN · Observer Tier-2 deepening (codex / opencode / aider)
+
+> 展开 [PLAN_SENSE_v1.0.md](./PLAN_SENSE_v1.0.md) S1a。基线：main(v0.9.1+)。
+> **先核查的结论**:非-Claude observer 的 Tier-2 活动 **0.9.1 已基本铺开**(commit `db01920`);
+> 本计划只补**真正缺的字段 + 活验证**,不重做。`SessionActivity` 形状见 `src/integrations/types.ts:42`。
+
+---
+
+## 0. 现状(已核查,逐 observer)
+
+| 字段 | claude-code(基准) | codex | opencode | aider | 来源 |
+|---|:-:|:-:|:-:|:-:|---|
+| turnCount | ✅ | ✅ | ✅ | ✅ | 各自计 turn |
+| lastTools | ✅ | ✅ | ✅ | ❌`[]` | aider 无工具协议(诚实空) |
+| filesTouched | ✅ | ✅ | ✅ | ✅ | CC/codex 从 tool input;opencode part input;aider 从 SEARCH 块前的路径标签 |
+| lastCommandName | ✅ | ✅ | ✅ | ❌ | shell argv[0] |
+| lastError | ✅ | ✅ | ✅ | ✅ | 短标签 |
+| **gitBranch** | ✅ | ❌ | ❌ | ❌ | CC 读 JSONL 顶层 `.gitBranch`;其余格式不带 |
+| tokens | ✅ | ✅ | ✅ | ❌ | aider 不记 |
+| pendingPermission | ✅(显式) | ❌ | ❌ | ❌ | 仅 CC 有显式权限记录 |
+
+→ codex/opencode **5/8**、aider **3/8(其中 3 个是设计性留空)**。privacy:每个 observer 都有 planted-secret 测试,prompt/reply/内容不泄漏。
+
+**关键事实**:每个 observer 都有**现成测试 fixture**(内联 JSONL / message 对象 / markdown 样本 + `writeRollout`/`msg()`/`AIDER_SAMPLE` helper)——所以**深化可用 fixture 验证,不必依赖真实 agent**。
+
+**真正的 gap 不是字段多少,是"没对活的 agent 验证过"**(changelog 自己写了 "non-Claude depth is new and not yet battle-tested against live agents")。
+
+---
+
+## 1. 目标 / 非目标
+
+**目标**:把 codex/opencode 的可得字段补齐到接近 CC;给 non-Claude observer 一次**真实 agent 活验证**,把"看你所有 agent"从"已实现但未验证"变成"已验证"。
+**非目标**:不强行给 aider 造它没有的字段(lastTools 保持 `[]` 是对的);不发明 pendingPermission(codex/opencode 格式不暴露,造一个=假信号)。
+
+---
+
+## 2. 设计(按"可得性"排,只做真能拿到的)
+
+### O-D1 — gitBranch for codex / opencode(可得,价值高)
+codex/opencode 的 JSONL/DB 不带 branch,但 session **有 cwd**。复用刚落地的 **git observer 的 `parseGitStatus`/或一次 `git -C <cwd> rev-parse --abbrev-ref HEAD`** 派生 branch:
+- 在 observer 的 activity 提取里,若有 cwd,补 `gitBranch`(带 5s 超时 + 失败留 undefined,沿用 git observer 的 execFile 范式)。
+- 缓存(cwd→branch,短 TTL)避免每次 record 都 spawn git。
+- 验收:fixture(cwd 指向一个临时 git repo)→ activity.gitBranch 正确;非 repo → undefined。
+
+### O-D2 — 放宽窗口/上限(可得,小)
+- codex:目前只看 JSONL 尾 64KB → 长会话欠计 tools/files。评估提到 128KB 或按记录数;权衡读成本。
+- opencode:`RECENT_MSGS = 20` 上限 → 长会话欠计。提到 40 或可配。
+- 验收:fixture(超长会话)→ 尾部窗口扩大后 tools/files 计数更全;读时间仍可接受。
+
+### O-D3 — 活验证 harness(真正的 gap)
+- 写一个 `scripts/verify-observers.ts`(或 `lisa agents --verify`):对每个已启用 observer,打印它当前解析出的 `SessionActivity`,让用户**对着一个真实运行的 codex/opencode/aider 会话**核对字段是否对得上其磁盘格式的真实 schema(各家 CLI 版本会漂)。
+- 产出:每个 observer 一份"对 vX.Y 验证过"的记录(写进各 observer 顶部注释 / 一个 `OBSERVER_FIDELITY.md`)。
+- 这是把"未 battle-tested"变"已验证"的唯一办法——fixture 测逻辑,活验证测 schema 假设。
+
+### 不做
+- **pendingPermission(codex/opencode)**:格式无显式权限门 → 不造。若某 CLI 将来加了权限记录类型,再补。
+- **aider lastTools/tokens/command**:markdown 无结构化工具/token/命令 → 保持留空(造=违反隐私契约或假数据)。
+
+---
+
+## 3. 分阶段 + 验收
+| 阶段 | 内容 | 可 fixture 测? |
+|---|---|---|
+| O-D1 | codex/opencode gitBranch via cwd-git(+缓存) | ✅(临时 repo fixture) |
+| O-D2 | 窗口/上限放宽 | ✅(超长会话 fixture) |
+| O-D3 | 活验证 harness + 记录 fidelity | ⚠️ 逻辑可测;schema 对齐需真实 agent |
+
+- [ ] O-D1:每个 observer 的现有 `.test.ts` 加 gitBranch 用例(扩展现成 fixture)。
+- [ ] O-D2:加超长-会话 fixture,断言计数更全 + 无性能回退。
+- [ ] O-D3:`verify-observers` 能对真实会话打印 activity;codex/opencode/aider 各记一次"对某版本验证"。
+
+## 4. 测试
+- 全部走**现成 fixture 扩展**(audit 已确认每个 observer 都有可扩展的内联 fixture + helper)——逻辑零真实-agent 依赖。
+- 每个新字段补一条 planted-secret 断言(沿用既有 privacy 测试范式),确保深化不泄漏内容。
+- O-D3 的活验证是手动/半自动,产出记录而非 CI 测试。
+
+## 5. 隐私 / 安全
+- gitBranch 只是分支名(非内容)——安全。git 派生用 execFile(无 shell 注入)。
+- 严守既有契约:只 tool 名 / 路径 / argv[0] / 错误类 / 计数 / branch;绝不读 prompt/reply/diff/命令参数。每个深化点配 planted-secret 测试。
+
+## 6. 风险
+- **CLI schema 漂移**:各家格式会随版本变(codex rollout、opencode DB schema)→ O-D3 活验证 + 容错解析(已有"未知 schema 跳过")是缓解。
+- gitBranch 的 spawn 成本 → 缓存 + 超时。
+- 价值边际:这几个字段对 advisor detector 触发有用,但收益递减;O-D3(活验证)其实是这块最该做的(让宣传"看你所有 agent"名副其实)。
+
+## 7. 一句话
+> Tier-2 字段 0.9.1 已铺开(codex/opencode 5/8、aider 3/8);剩下的是补**可得**的 gitBranch、放宽窗口,以及最重要的 **对真实 agent 活验证**——把"已实现"变成"已验证",别再给 aider 造它没有的字段。

--- a/docs/PLAN_SENSE_S2_v1.0.md
+++ b/docs/PLAN_SENSE_S2_v1.0.md
@@ -1,0 +1,85 @@
+# PLAN · Sense S2 — ambient vision + voice (consent-gated)
+
+> 展开 [PLAN_SENSE_v1.0.md](./PLAN_SENSE_v1.0.md) S2/S3。基线：main(v0.9.1+)。
+> **这是四支柱里隐私面最危险的一块。** 头号约束:**consent 框架先行、本地优先、默认全关。**
+> 依赖 [PLAN_FOUNDATIONS_v1.0.md §1](./PLAN_FOUNDATIONS_v1.0.md)(统一 consent)——**S2 不得先于它落地。**
+
+---
+
+## 0. 现状(已知)
+- ✅ 按需视觉:`src/vision/capture.ts`(`screencapture` interactive/full,热键/📷,临时文件即删)。
+- ⚠️ 可选周期视觉:`src/screen_advisor/engine.ts`(默认关、≥10min、`~/.lisa/screen-advisor.json`,截图送模型问"下一步",卡片 prefill 不自动跑)。
+- ⚠️ 语音:`voice/transcribe.ts`(Whisper API,**需用户给文件路径**)、`speak.ts`(say)、`dictation.ts`(润色)。
+- ❌ **无 ambient 采集**(连续/低频屏幕、前台 app、录音/热听);❌ **无 consent 框架**;❌ **无本地 STT/本地判定**。
+
+---
+
+## 1. 目标 / 非目标
+
+**目标**:在用户**逐项显式授权**下,把屏幕(前台 app/窗口 + 低频截图)和语音(热键/录音→转写)作为 ambient 信号纳入 Sense,**本地优先**处理,只沉淀结构化摘要。
+**非目标**:不默认开;不持久化 raw 截图/音频;不在无 consent 下采任何东西;不做键盘记录/鼠标轨迹;v1 以 macOS 为先。
+
+---
+
+## 2. 硬前置:consent 框架(F-consent)
+**必须先实现**(详见 [PLAN_FOUNDATIONS §1](./PLAN_FOUNDATIONS_v1.0.md)):
+- `~/.lisa/consent.json` 单一事实源;每类信号(screen/voice/...)独立 `granted`,**默认 false**。
+- 一次性 consent 卡(说明:采什么、存哪、保留多久);**随时可见 + 一键全停**(island 顶栏指示灯 + popover + `revokeAll()`)。
+- 黑名单:app 级(密码/银行/隐私窗口)、路径级、PII 模式级。保留期 `retentionDays`。
+- 每个 source `start()` 前查 `isGranted()`,未授权 **no-op**(绝不"先采后问")。
+
+→ **S2 的每个 source 都建立在 consent 闸之上。没有它,S2 不上线。**
+
+---
+
+## 3. 设计
+
+抽象沿用 [PLAN_SENSE §2.1](./PLAN_SENSE_v1.0.md) 的 `SenseSource`(屏幕/语音不是 agent session,用并列抽象,不塞进 observer)。
+
+### S2-screen — ambient 屏幕
+- 把 `screen_advisor` 的"周期截图"泛化为**可配 ambient 采集**:前台 app 名 + 窗口标题(便宜、低敏)+ **可选**低频截图(`everySec`,默认较大)。
+- **本地优先判定**:先在本地判"是否值得上报"(前台 app 变了 / 出现 error 对话框 / 切到代码编辑器),**命中才**考虑送模型;**截图绝不持久化**(沿用 capture.ts 的 finally 删除)。
+- **黑名单 app 命中 → 整帧跳过**(不截、不记)。
+- consent:`screen` 默认关;开启走 consent 卡;island 实时红点"屏幕采集中"。
+
+### S2-voice — ambient 语音
+- 补**录音 + 热键(push-to-talk 默认)+ 流式转写**(现在只有"给文件路径才转")。
+- 探索**本地 STT(whisper.cpp)**作离机选项(与 [Model 本地化](./PLAN_MODEL_v1.0.md) 呼应);默认仍可用云 Whisper,但本地是隐私优选。
+- consent:`voice` 默认关;push-to-talk 优先于 always-on;island 红点"语音采集中"。
+
+### 落地架构
+- 接入 [PLAN_SENSE §2.2](./PLAN_SENSE_v1.0.md) 的 **SenseService 常驻循环**(与 chat 解耦),consent 闸在 source 启动处。
+- 蒸馏:命中的事件经低频 distill 落 `memory`(结构化摘要,非 raw),受 [Reve 反思门禁](./PLAN_REVE_v1.0.md) 约束。
+- 本地 embedding(Model M2,已合)给蒸馏检索不离机。
+
+---
+
+## 4. 分阶段 + 验收(严格顺序)
+| 阶段 | 内容 | 前置 |
+|---|---|---|
+| **F-consent** | 统一 consent 框架(FOUNDATIONS §1) | —— **必须最先** |
+| S2-screen | 前台 app/窗口 + 可选低频截图 + 本地判定 + 黑名单 | F-consent |
+| S2-voice | 录音 + 热键 + 流式转写(+ 本地 STT 探索) | F-consent |
+
+- [ ] **全新安装默认零敏感采集**(screen/voice 全关)。
+- [ ] 黑名单 app 在前台 → 对应 source **零捕获**(测试)。
+- [ ] `revokeAll()` 后所有 source 立即停 + UI 反映。
+- [ ] raw 截图/音频**绝不**进结构化事件 / 不默认落盘(每 source 一条 planted-secret/隐私测试)。
+- [ ] 截图即用即删;`retentionDays` 到期清事件。
+
+## 5. 隐私 / 安全(头号)
+- **同意是地基不是补丁**:逐类开关、默认全关、随时可见可停。
+- **本地优先**:raw 在本地完成判定/蒸馏,命中且必要才送模型;落盘永远是结构化摘要。
+- **黑名单**(密码/银行/隐私窗口)、**保留期**、**即用即删**。
+- 复用 observer 既有的 planted-secret 测试范式,扩到每个新 source。
+- 详见 [PLAN_FOUNDATIONS §1](./PLAN_FOUNDATIONS_v1.0.md)。
+
+## 6. 风险
+- **隐私/信任反噬**:这是对外叙事最大风险点——"它一直在看你屏幕"若无可信隐私故事会直接劝退。consent + 本地优先 + 黑名单是兑现承诺,不是文案。
+- **常驻 footprint**:截图/音频帧率是主成本旋钮;保守默认 + 可调 + 实测能耗([FOUNDATIONS §5])。
+- **跨平台**:系统级钩子(前台 app、录音、锁屏)macOS 先行;Linux/Windows 降级或后置。
+- **本地 STT 质量**:whisper.cpp 够不够用,还是仍需云兜底——与 Model 本地化联合验证。
+- **范围蔓延**:S2 是大件;F-consent 没就位前**坚决不上**(吸取 v0.9 review"先打深再铺宽"教训)。
+
+## 7. 一句话
+> 把屏幕/语音变成 Sense 的 ambient 信号 —— 但**先建 consent 框架、一切本地优先、默认全关**;这块的成败不在能不能采,而在隐私故事能不能让人信。

--- a/docs/ROADMAP_v1.0.md
+++ b/docs/ROADMAP_v1.0.md
@@ -23,7 +23,16 @@
 | [PLAN_MODEL_v1.0.md](./PLAN_MODEL_v1.0.md) | 模型：本地生命周期、本地 embedding、容错+自检、provider 欠账 | §6 |
 | [PLAN_FOUNDATIONS_v1.0.md](./PLAN_FOUNDATIONS_v1.0.md) | 横切：consent/隐私、安全地板、测试门禁、可观测、footprint、叙事诚实 | §7 |
 
-> 阅读顺序建议：先本文（为什么 + 顺序），再 FOUNDATIONS（地基），再按里程碑顺序读 REVE → MODEL → DISPATCH → SENSE。
+**深化子计划（剩余 hard items，2026-06-14，各含"已做 vs 仍缺"核查）：**
+
+| 文档 | 覆盖 | 关键核查结论 |
+|---|---|---|
+| [PLAN_DISPATCH_D4_v1.0.md](./PLAN_DISPATCH_D4_v1.0.md) | 多 agent 监控 + advisor 动作 | advisor 可点**已是 0.9.1 完成**；真缺口=前端消费 `agent_session_update` |
+| [PLAN_OBSERVER_DEEPENING_v1.0.md](./PLAN_OBSERVER_DEEPENING_v1.0.md) | codex/opencode/aider Tier-2 字段 | Tier-2 **0.9.1 已铺开**(5/8、3/8)；剩 gitBranch + 窗口 + **活验证** |
+| [PLAN_DISPATCH_D2B_v1.0.md](./PLAN_DISPATCH_D2B_v1.0.md) | A2A adapter（远程 agent 进 hub） | 只 surface "叫过的"，不塞 200 registry；依赖 D4a；TaskState 映射 |
+| [PLAN_SENSE_S2_v1.0.md](./PLAN_SENSE_S2_v1.0.md) | ambient 屏幕/语音 | **硬前置 = consent 框架(FOUNDATIONS §1)**；本地优先、默认全关 |
+
+> 阅读顺序建议：先本文（为什么 + 顺序），再 FOUNDATIONS（地基），再按里程碑顺序读 REVE → MODEL → DISPATCH → SENSE；剩余 hard items 见上面四个子计划。
 
 ---
 


### PR DESCRIPTION
Detailed, implementation-ready plans for the four harder remaining 1.0 items — each **grounded in a current-tree audit of "already done vs still open."** That audit reshaped two of them (both were more done than the roadmap implied), which is the point: plan against ground truth, not assumptions.

### New docs
- **[PLAN_DISPATCH_D4](docs/PLAN_DISPATCH_D4_v1.0.md)** — multi-agent monitor + advisor actions. **Verified the clickable-advisor half already shipped in 0.9.1** (`e1fcc33`: island buttons, prefill-not-autorun, dismiss endpoint). The real gap is the **frontend consuming `agent_session_update`** (`island.ts`/`lisa-client.ts` still only handle `claude_session_update`, so non-Claude agents are invisible in the UI). Plan centers a **pure `mergeAgentSession` reducer** so the frontend logic is unit-testable; direct action endpoints stay opt-in (prefill is the safe default).
- **[PLAN_OBSERVER_DEEPENING](docs/PLAN_OBSERVER_DEEPENING_v1.0.md)** — codex/opencode/aider Tier-2. **Verified Tier-2 already rolled out in 0.9.1** (codex/opencode 5/8 fields, aider 3/8 by design) with reusable fixtures. Remaining: derivable `gitBranch` (via cwd-git), window/cap limits, and the real gap — **live-agent validation**. Explicitly: don't fabricate the fields aider can't have.
- **[PLAN_DISPATCH_D2B](docs/PLAN_DISPATCH_D2B_v1.0.md)** — A2A adapter (remote agents in the hub). Resolves the "don't dump 200 registry agents" question: surface **only agents LISA actually called/pinned**, with A2A `TaskState → AgentSessionState` mapping. Depends on D4a for the UI.
- **[PLAN_SENSE_S2](docs/PLAN_SENSE_S2_v1.0.md)** — ambient screen/voice. **Hard prerequisite = the consent framework** (FOUNDATIONS §1); local-first processing, default-off, app blacklist, retention. The most privacy-sensitive pillar work.

Each follows the `PLAN_*_v1.0` house style (goals/non-goals · current state · design · phased + acceptance · tests · privacy/security · risks) and is indexed in `ROADMAP_v1.0.md`. Docs-only; no code. (`docs/paper/` remains gitignored/local by design.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
