### PR TITLE
feat(dispatch): D4a — multi-agent monitor (island + GUI sidebar)

### DIFF
--- a/src/web/agent-roster.test.ts
+++ b/src/web/agent-roster.test.ts
@@ -1,0 +1,72 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { mergeAgentSession, aggregateAgentState, type RosterSession } from "./agent-roster.js";
+
+const NOW = 1_700_000_000_000;
+const WINDOW = 30 * 60_000;
+
+function s(over: Partial<RosterSession> = {}): RosterSession {
+  return { agent: "codex", sessionId: "x", project: "p", state: "working", lastMtime: NOW - 1000, ...over };
+}
+
+describe("mergeAgentSession", () => {
+  test("inserts a new session", () => {
+    const out = mergeAgentSession([], s(), NOW, WINDOW);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.sessionId, "x");
+  });
+
+  test("updates in place by (agent, sessionId)", () => {
+    const a = s({ state: "working" });
+    const out = mergeAgentSession([a], s({ state: "done" }), NOW, WINDOW);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.state, "done");
+  });
+
+  test("same sessionId but different agent is a SEPARATE row", () => {
+    const out = mergeAgentSession([s({ agent: "codex", sessionId: "x" })], s({ agent: "git", sessionId: "x" }), NOW, WINDOW);
+    assert.equal(out.length, 2);
+  });
+
+  test("prunes sessions outside the active window", () => {
+    const stale = s({ sessionId: "old", lastMtime: NOW - 2 * WINDOW });
+    const out = mergeAgentSession([stale], s({ sessionId: "fresh" }), NOW, WINDOW);
+    assert.deepEqual(out.map((x) => x.sessionId), ["fresh"]);
+  });
+
+  test("accepts ISO-string lastMtime (the fetch shape) too", () => {
+    const out = mergeAgentSession([], s({ lastMtime: new Date(NOW - 1000).toISOString() }), NOW, WINDOW);
+    assert.equal(out.length, 1);
+  });
+});
+
+describe("aggregateAgentState (loudest wins)", () => {
+  test("error beats waiting beats working", () => {
+    assert.equal(aggregateAgentState([s({ state: "working" }), s({ agent: "git", state: "error" })], NOW, WINDOW), "error");
+    assert.equal(aggregateAgentState([s({ state: "working" }), s({ agent: "git", state: "waiting" })], NOW, WINDOW), "waiting");
+    assert.equal(aggregateAgentState([s({ state: "working" })], NOW, WINDOW), "working");
+  });
+  test("nothing recent / no active → null", () => {
+    assert.equal(aggregateAgentState([], NOW, WINDOW), null);
+    assert.equal(aggregateAgentState([s({ state: "idle" })], NOW, WINDOW), null);
+    assert.equal(aggregateAgentState([s({ lastMtime: NOW - 2 * WINDOW })], NOW, WINDOW), null);
+  });
+});
+
+describe("source-injection safety (island injects these verbatim)", () => {
+  // island.ts embeds `${mergeAgentSession}` into the page; the browser eval's
+  // the function source. Assert each is self-contained: its source eval's to a
+  // working function with no external references.
+  for (const fn of [mergeAgentSession, aggregateAgentState]) {
+    test(`${fn.name} source eval's to a working function`, () => {
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const rebuilt = new Function(`return (${fn.toString()})`)() as (...a: unknown[]) => unknown;
+      assert.equal(typeof rebuilt, "function");
+      if (fn === aggregateAgentState) {
+        assert.equal(rebuilt([s({ state: "error" })], NOW, WINDOW), "error");
+      } else {
+        assert.equal((rebuilt([], s(), NOW, WINDOW) as RosterSession[]).length, 1);
+      }
+    });
+  }
+});

--- a/src/web/agent-roster.ts
+++ b/src/web/agent-roster.ts
@@ -1,0 +1,65 @@
+/**
+ * Pure client-side reducer for the multi-agent monitor (Dispatch D4a).
+ *
+ * The island previously tracked Claude Code sessions only. These functions are
+ * the generic, agent-agnostic logic that maintains a roster across ALL agents
+ * (claude-code / codex / opencode / aider / git / shell / takoapi). They are
+ * the TESTED logic the UI runs: island.ts injects their source into the page
+ * (`${mergeAgentSession}`), so the browser executes exactly this code rather
+ * than a drifting copy.
+ *
+ * CONSTRAINT: keep these fully self-contained (no imports, no module-scope
+ * refs, only browser globals like Date/Array) so source-injection works.
+ *
+ * `lastMtime` may be epoch-ms (SSE `agent_session_update`) or an ISO string
+ * (the `/api/agents/sessions` fetch); `new Date(x)` handles both.
+ */
+
+export interface RosterSession {
+  agent?: string;
+  sessionId: string;
+  project: string;
+  state: string;
+  stateReason?: string;
+  lastMtime: number | string;
+  cwd?: string;
+  activity?: unknown;
+}
+
+/**
+ * Upsert `s` into `list` (identity = agent + sessionId) and drop sessions
+ * outside the active window. Returns a NEW array. Pure.
+ */
+export function mergeAgentSession(
+  list: RosterSession[],
+  s: RosterSession,
+  nowMs: number,
+  windowMs: number,
+): RosterSession[] {
+  // Inlined key (no named const-arrow) so the compiled source stays free of
+  // build-tool name-helpers and source-injection into the island works. The
+  // injection-safety test guards this.
+  const k = (s.agent || "agent") + "::" + s.sessionId;
+  const cutoff = nowMs - windowMs;
+  const out = list.filter((x) => (x.agent || "agent") + "::" + x.sessionId !== k);
+  out.push(s);
+  return out.filter((x) => new Date(x.lastMtime).getTime() >= cutoff);
+}
+
+/**
+ * "Loudest signal wins" aggregate state across recent sessions, for the pill
+ * dot: error > waiting > working; null if nothing recent/active. Pure.
+ */
+export function aggregateAgentState(
+  list: RosterSession[],
+  nowMs: number,
+  windowMs: number,
+): string | null {
+  const cutoff = nowMs - windowMs;
+  const recent = list.filter((x) => new Date(x.lastMtime).getTime() >= cutoff);
+  if (recent.length === 0) return null;
+  if (recent.some((x) => x.state === "error")) return "error";
+  if (recent.some((x) => x.state === "waiting")) return "waiting";
+  if (recent.some((x) => x.state === "working")) return "working";
+  return null;
+}

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -7,7 +7,13 @@
  * unread flag). See docs/MAC_ISLAND_PLAN.md.
  *
  * No build step, no framework — single string of inline HTML/CSS/JS.
+ *
+ * D4a: the multi-agent roster logic (merge/aggregate) lives in agent-roster.ts
+ * and is SOURCE-INJECTED into the inline <script> below via `${mergeAgentSession}`
+ * so the browser runs the exact unit-tested code instead of a drifting copy.
  */
+
+import { mergeAgentSession, aggregateAgentState } from "./agent-roster.js";
 
 export const ISLAND_HTML = `<!doctype html>
 <html lang="en">
@@ -272,6 +278,24 @@ export const ISLAND_HTML = `<!doctype html>
     background: rgba(255, 255, 255, 0.05);
     border: 1px solid rgba(255, 255, 255, 0.07);
   }
+  /* D4a — agent-kind chip (codex / opencode / git / …) so the multi-agent
+     roster reads at a glance which tool each row belongs to. */
+  #claude-list .agent-badge {
+    flex-shrink: 0;
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.02em;
+    text-transform: lowercase;
+    color: var(--accent-claude);
+    padding: 1px 6px;
+    border-radius: 999px;
+    background: rgba(255, 140, 66, 0.12);
+    border: 1px solid rgba(255, 140, 66, 0.22);
+    max-width: 84px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
   #claude-list .empty { padding: 8px 12px; color: var(--fg-faint); font-style: italic; }
   /* O2 — Tier-2 activity line: what the session is structurally doing. */
   #claude-list .act {
@@ -479,6 +503,19 @@ export const ISLAND_HTML = `<!doctype html>
 
 <script>
 (() => {
+  // ── Multi-agent roster reducer (Dispatch D4a) ──────────────────────
+  // Source-injected from agent-roster.ts so the browser runs the exact,
+  // unit-tested merge/aggregate logic instead of a hand-maintained copy.
+  // These must stay self-contained (no imports / closure refs) — the
+  // injection-safety test in agent-roster.test.ts guards that.
+  ${mergeAgentSession}
+  ${aggregateAgentState}
+  // Composite identity for a roster row: the same sessionId seen under two
+  // agents (e.g. a git + a shell observer) are DISTINCT rows. Mirrors the
+  // key mergeAgentSession uses; the UI keys per-row history, open-state, and
+  // notify throttling by it too.
+  function agentKey(s) { return (s.agent || 'agent') + '::' + s.sessionId; }
+
   const pill         = document.getElementById('pill');
   const avatar       = document.getElementById('avatar');
   const dot          = document.getElementById('dot');
@@ -503,7 +540,7 @@ export const ISLAND_HTML = `<!doctype html>
     desire: null,
     thinking: false,
     dreaming: false,
-    claudeSessions: [],  // [{project, sessionId, lastMtime}, …]
+    agentSessions: [],   // [{agent, project, sessionId, lastMtime, state, activity}, …] — all agents, not just Claude
     suggestion: null,    // {title, rationale, task, at} from the screen advisor
     advisor: [],         // [{id, category, urgency, text, action}] from the cross-agent advisor
   };
@@ -578,11 +615,13 @@ export const ISLAND_HTML = `<!doctype html>
   function maybeNotifyWaiting(prevState, info) {
     if (info.state !== 'waiting') return;
     if (prevState === 'waiting') return;     // already in this state
-    const last = lastNotifyAt.get(info.sessionId) || 0;
+    const nk = agentKey(info);
+    const last = lastNotifyAt.get(nk) || 0;
     if (Date.now() - last < NOTIFY_THROTTLE_MS) return;
-    lastNotifyAt.set(info.sessionId, Date.now());
+    lastNotifyAt.set(nk, Date.now());
     const reasonLabel = info.stateReason === 'permission' ? 'needs permission' : 'is waiting';
-    const title = 'Claude ' + reasonLabel + ' in ' + info.project;
+    const who = info.agent && info.agent !== 'claude-code' ? info.agent : 'Claude';
+    const title = who + ' ' + reasonLabel + ' in ' + info.project;
     const bodyText = info.sessionId.slice(0, 8) + ' · click to open Lisa';
     if (hasBridge) {
       window.webkit.messageHandlers.island.postMessage({
@@ -606,24 +645,18 @@ export const ISLAND_HTML = `<!doctype html>
   }
   function recentSessions() {
     const cutoff = Date.now() - CLAUDE_ACTIVE_WINDOW_MS;
-    return state.claudeSessions.filter(
+    return state.agentSessions.filter(
       (s) => new Date(s.lastMtime).getTime() >= cutoff
     );
   }
   /**
-   * Phase 2: aggregate Claude state for the pill dot. Priority is
-   * "loudest signal wins": an error anywhere dominates everything;
-   * otherwise a "waiting" session beats a "working" session (because
-   * "waiting" means Claude needs the user — more attention-worthy
-   * than "working" which is passive observing).
+   * Aggregate state across all agent sessions for the pill dot. Priority is
+   * "loudest signal wins": an error anywhere dominates; otherwise "waiting"
+   * (an agent needs the user) beats "working" (passive observing). Delegates
+   * to the source-injected, unit-tested reducer so the dot and the tests agree.
    */
   function aggregateClaudeState() {
-    const recent = recentSessions();
-    if (recent.length === 0) return null;
-    if (recent.some((s) => s.state === 'error'))   return 'error';
-    if (recent.some((s) => s.state === 'waiting')) return 'waiting';
-    if (recent.some((s) => s.state === 'working')) return 'working';
-    return null;
+    return aggregateAgentState(state.agentSessions, Date.now(), CLAUDE_ACTIVE_WINDOW_MS);
   }
 
   function setAvatar(slug) {
@@ -653,7 +686,7 @@ export const ISLAND_HTML = `<!doctype html>
   function refreshPanel() {
     body.classList.toggle('offline',   !state.online);
     body.classList.toggle('has-unread', state.unread);
-    body.classList.toggle('has-claude', state.claudeSessions.length > 0);
+    body.classList.toggle('has-claude', state.agentSessions.length > 0);
     desireBody.textContent = state.desire || '(nothing actively pursued)';
     idleBody.textContent   = state.idleText || '';
     btnDismiss.classList.toggle('muted', !state.unread);
@@ -810,7 +843,7 @@ export const ISLAND_HTML = `<!doctype html>
     }).slice(0, 5);
     for (const s of rows) {
       const li = document.createElement('li');
-      if (rowOpen.has(s.sessionId)) li.classList.add('row-open');
+      if (rowOpen.has(agentKey(s))) li.classList.add('row-open');
       // pip + project + relative-time render as a single horizontal
       // .head strip. The trail + actions render BELOW the head when
       // the row is open (li is flex-column).
@@ -825,6 +858,15 @@ export const ISLAND_HTML = `<!doctype html>
       when.className = 'when';
       when.textContent = relativeTime(s.lastMtime);
       head.appendChild(pip);
+      // D4a — agent-kind chip; omitted for plain Claude so existing rows read
+      // unchanged, shown for every other agent (codex / opencode / git / …).
+      if (s.agent && s.agent !== 'claude-code') {
+        const badge = document.createElement('span');
+        badge.className = 'agent-badge';
+        badge.textContent = s.agent;
+        badge.title = s.agent;
+        head.appendChild(badge);
+      }
       head.appendChild(proj);
       head.appendChild(when);
       li.appendChild(head);
@@ -855,8 +897,9 @@ export const ISLAND_HTML = `<!doctype html>
                + ' · ' + s.sessionId
                + '\\nclick: expand timeline · double-click: copy sessionId';
       li.addEventListener('click', () => {
-        if (rowOpen.has(s.sessionId)) rowOpen.delete(s.sessionId);
-        else rowOpen.add(s.sessionId);
+        const k = agentKey(s);
+        if (rowOpen.has(k)) rowOpen.delete(k);
+        else rowOpen.add(k);
         renderClaudeList();
       });
       li.addEventListener('dblclick', async (ev) => {
@@ -919,7 +962,7 @@ export const ISLAND_HTML = `<!doctype html>
   }
 
   function renderTrail(container, s) {
-    const h = stateHistory.get(s.sessionId) || [];
+    const h = stateHistory.get(agentKey(s)) || [];
     if (h.length === 0) {
       container.textContent = '(no transitions recorded yet)';
       return;
@@ -1112,15 +1155,19 @@ export const ISLAND_HTML = `<!doctype html>
           state.advisor = Array.isArray(m.suggestions) ? m.suggestions : [];
           refreshPanel();
           break;
-        case 'claude_session_update':
+        case 'agent_session_update':
+          // D4a — generalized multi-agent event (claude-code + codex + …).
+          // Payload is the normalized AgentSession (lastMtime is epoch ms;
+          // the reducer's new Date() handles that and the ISO fetch shape).
           upsertClaudeSession({
-            project: m.projectLabel,
-            projectEncoded: m.projectEncoded,
+            agent: m.agent,
+            project: m.project,
             sessionId: m.sessionId,
-            lastMtime: m.ts,
+            lastMtime: m.lastMtime,
             state: m.state || 'unknown',
             stateReason: m.stateReason || '',
             cwd: m.cwd || '',
+            activity: m.activity || null,
           });
           refreshDot();
           refreshPanel();
@@ -1139,16 +1186,17 @@ export const ISLAND_HTML = `<!doctype html>
   // ── Claude Code session helpers ────────────────────────────────────
 
   function upsertClaudeSession(s) {
-    const idx = state.claudeSessions.findIndex(
-      (x) => x.sessionId === s.sessionId
+    const k = agentKey(s);
+    const prev = state.agentSessions.find((x) => agentKey(x) === k);
+    const prevState = prev ? prev.state : null;
+    // Source-injected reducer: upserts by (agent, sessionId) and prunes the
+    // window in one pass, returning a fresh array.
+    state.agentSessions = mergeAgentSession(
+      state.agentSessions, s, Date.now(), CLAUDE_ACTIVE_WINDOW_MS,
     );
-    const prevState = idx >= 0 ? state.claudeSessions[idx].state : null;
-    if (idx >= 0) state.claudeSessions[idx] = s;
-    else state.claudeSessions.push(s);
-    pruneClaudeSessions();
 
     // Phase 3 — record transition + maybe notify on entering "waiting".
-    const transitioned = recordStateHistory(s.sessionId, {
+    const transitioned = recordStateHistory(k, {
       state: s.state,
       reason: s.stateReason,
       lastMtime: s.lastMtime,
@@ -1158,31 +1206,33 @@ export const ISLAND_HTML = `<!doctype html>
 
   function pruneClaudeSessions() {
     const cutoff = Date.now() - CLAUDE_ACTIVE_WINDOW_MS;
-    state.claudeSessions = state.claudeSessions.filter(
+    state.agentSessions = state.agentSessions.filter(
       (s) => new Date(s.lastMtime).getTime() >= cutoff
     );
   }
 
   async function fetchClaudeSessions() {
     try {
-      const r = await fetch('/api/claude/sessions', { cache: 'no-store' });
+      // D4a — the multi-agent snapshot (all agents), lastMtime as ISO string.
+      const r = await fetch('/api/agents/sessions', { cache: 'no-store' });
       if (!r.ok) return;
       const j = await r.json();
       if (Array.isArray(j.sessions)) {
-        state.claudeSessions = j.sessions.map((s) => ({
+        state.agentSessions = j.sessions.map((s) => ({
+          agent: s.agent,
           project: s.project,
-          projectEncoded: s.projectEncoded,
           sessionId: s.sessionId,
           lastMtime: s.lastMtime,
           state: s.state || 'unknown',
           stateReason: s.stateReason || '',
           cwd: s.cwd || '',
+          activity: s.activity || null,
         }));
         // Phase 3 — seed each session's history with its current state
         // so the trail isn't empty on first open. Doesn't notify (no
         // transition implied by initial load).
-        for (const s of state.claudeSessions) {
-          recordStateHistory(s.sessionId, {
+        for (const s of state.agentSessions) {
+          recordStateHistory(agentKey(s), {
             state: s.state,
             reason: s.stateReason,
             lastMtime: s.lastMtime,

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -425,9 +425,10 @@ function connectEvents() {
       e2.className = 'err';
       e2.textContent = '[idle error] ' + ev.message;
       log.appendChild(e2);
-    } else if (ev.type === 'claude_session_update') {
-      // Sidebar Claude monitor card refresh — defined later in the
-      // "sidebar live wiring" block.
+    } else if (ev.type === 'agent_session_update') {
+      // D4a — sidebar multi-agent monitor refresh (defined later in the
+      // "sidebar live wiring" block). Generalized from claude_session_update
+      // so codex / opencode / git / … sessions update the sidebar too.
       if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
     }
   });
@@ -1040,7 +1041,16 @@ if ('serviceWorker' in navigator) {
       pip.className = 'pip ' + (s.state || 'unknown');
       const name = document.createElement('div');
       name.className = 'name';
-      name.textContent = s.project;
+      // D4a — agent-kind chip inline before the project; omitted for plain
+      // Claude so existing rows read unchanged.
+      if (s.agent && s.agent !== 'claude-code') {
+        const badge = document.createElement('span');
+        badge.className = 'agent-badge';
+        badge.textContent = s.agent;
+        badge.title = s.agent;
+        name.appendChild(badge);
+      }
+      name.appendChild(document.createTextNode(s.project));
       const when = document.createElement('div');
       when.className = 'when';
       when.textContent = relativeTime(s.lastMtime);
@@ -1065,10 +1075,11 @@ if ('serviceWorker' in navigator) {
   }
 
   // Exposed so the SSE handler above can call this on
-  // claude_session_update events without redeclaring the helper.
+  // agent_session_update events without redeclaring the helper. D4a — the
+  // multi-agent snapshot (all agents), not just Claude Code.
   window.refreshClaudeSessions = async function () {
     try {
-      const r = await fetch('/api/claude/sessions');
+      const r = await fetch('/api/agents/sessions');
       if (!r.ok) return;
       const data = await r.json();
       setClaudeSessions(data.sessions || []);

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -301,6 +301,22 @@ export const MAIN_CSS = `  :root {
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+  /* D4a — agent-kind chip rendered inline before the project name, so the
+     multi-agent sidebar reads which tool each row belongs to. */
+  .session-row .agent-badge {
+    display: inline-block;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    text-transform: lowercase;
+    color: var(--claude);
+    background: rgba(255, 140, 66, 0.12);
+    border: 1px solid rgba(255, 140, 66, 0.22);
+    border-radius: 999px;
+    padding: 0 5px;
+    margin-right: 5px;
+    vertical-align: 1px;
+  }
   .session-row .when {
     color: var(--fg-3);
     font-variant-numeric: tabular-nums;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -12,13 +12,15 @@ import { MAIN_HTML } from "./lisa-html.js";
  * the real GUI, the safety net for that refactor is "the served bytes did not
  * change": identical output ⇒ identical browser behavior.
  *
- * These constants were captured from the pre-split MAIN_HTML. If you
- * intentionally change the GUI markup/CSS/JS, recompute them:
- *   node --import tsx -e 'import("./src/web/lisa-html.ts").then(m=>{const c=require("crypto");console.log(m.MAIN_HTML.length, c.createHash("sha256").update(m.MAIN_HTML).digest("hex"))})'
+ * These constants track the current served MAIN_HTML. If you intentionally
+ * change the GUI markup/CSS/JS, recompute them:
+ *   node --import tsx -e 'import("./src/web/lisa-html.ts").then(async m=>{const {createHash}=await import("node:crypto");console.log(m.MAIN_HTML.length, createHash("sha256").update(m.MAIN_HTML).digest("hex"))})'
+ *
+ * Last updated: D4a multi-agent sidebar (agent-kind badge CSS + JS, /api/agents/sessions).
  */
-const EXPECTED_LENGTH = 76071;
+const EXPECTED_LENGTH = 77174;
 const EXPECTED_SHA256 =
-  "77d2bc88b3bdb0bf0d595831dcc95118af456866d40ec1743966b92a80c80c17";
+  "f02520ca19159dc033c4b1f5f96e2ea7d90cb8b328d9207043a17e46d28f62e5";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);


### PR DESCRIPTION
## What

Dispatch **D4a** — generalize LISA's session monitor from "Claude Code only" into an **agent-agnostic roster** that surfaces every observed agent (claude-code / codex / opencode / aider / git / shell / …) in both the **island** pill and the **full-GUI sidebar**.

This is the first item in the recommended D4 execution order (multi-agent frontend), and the dependency base for D2b.

## How

- **`src/web/agent-roster.ts` (new)** — a pure, unit-tested reducer:
  - `mergeAgentSession(list, s, now, window)` — upsert + window-prune in one pass, keyed by **`(agent, sessionId)`** so the same sessionId seen under two agents is two distinct rows.
  - `aggregateAgentState(list, now, window)` — "loudest signal wins" pill state (error > waiting > working).
  - **Source-injected** into the island's inline `<script>` via `${mergeAgentSession}` so the browser runs the *exact* tested code — no drifting hand-copy. An **injection-safety test** evals each function's `.toString()` to guard self-containment (no build-tool `__name` helpers).
- **`island.ts`** — consume the generalized **`agent_session_update`** SSE event (carries `agent` + `activity` + epoch-ms `lastMtime`) instead of `claude_session_update`; fetch **`/api/agents/sessions`**; render a per-row **agent-kind badge**; key per-row history / open-state / waiting-notification by the composite key; agent-aware notification title (e.g. "codex is waiting in …").
- **`lisa-client.ts`** (full GUI sidebar) — same generalization: `agent_session_update` trigger, `/api/agents/sessions` fetch, inline agent-kind badge.
- **`lisa-css.ts`** — `.agent-badge` chip styling for the sidebar.
- **`lisa-html-snapshot.test.ts`** — updated the byte-exactness constants for the intentional GUI change; fixed the stale (ESM-broken `require`) recompute command in its doc comment.

The server already emits `agent_session_update` for **all** agents and keeps `claude_session_update` for back-compat — this moves the UI onto the generalized stream. Claude-Code rows render unchanged (badge is omitted for `claude-code`).

## Verification

- `npm run typecheck` clean
- `npm run build` clean
- **556 tests pass** (547 + 9 new `agent-roster` tests, incl. injection-safety)
- HTML-syntax guard confirms `ISLAND_HTML` + `MAIN_HTML` inline scripts parse after injection
- Shipped `dist/web/island.js` verified: both function declarations present, **no `__name` helper**, `agent_session_update` case present

🤖 Generated with [Claude Code](https://claude.com/claude-code)