### PR TITLE
feat(dispatch): D2b — remote agents (TakoAPI) as first-class hub sessions

### DIFF
--- a/src/integrations/hub.ts
+++ b/src/integrations/hub.ts
@@ -49,6 +49,11 @@ export const DEFAULT_ORCHESTRATOR_CONFIG: OrchestratorConfig = {
     // never command content). Off by default (history is sensitive); opt in
     // with `{ "enabled": true }` (auto-detects ~/.zsh_history & ~/.bash_history).
     shell: { enabled: false },
+    // TakoAPI: surfaces REMOTE agents LISA has CALLED via the `takoapi` tool
+    // (D2b), with their A2A TaskState — never the registry. Off by default; opt
+    // in with `{ "enabled": true, "pin": ["slug-a"] }`. Needs a TAKO_KEY to make
+    // any calls, so it's empty until you delegate to a remote agent.
+    takoapi: { enabled: false },
   },
   visibility: "activity",
 };

--- a/src/integrations/registry.ts
+++ b/src/integrations/registry.ts
@@ -59,4 +59,5 @@ export async function registerBuiltinIntegrations(): Promise<void> {
   await import("./aider/observer.js");
   await import("./git/observer.js");
   await import("./shell/observer.js");
+  await import("./takoapi/observer.js");
 }

--- a/src/integrations/takoapi/a2a.test.ts
+++ b/src/integrations/takoapi/a2a.test.ts
@@ -1,0 +1,47 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { taskStateToSessionState, extractTaskState } from "./a2a.js";
+
+describe("taskStateToSessionState", () => {
+  test("maps the full A2A lifecycle onto normalized states", () => {
+    assert.equal(taskStateToSessionState("submitted").state, "working");
+    assert.equal(taskStateToSessionState("working").state, "working");
+    assert.equal(taskStateToSessionState("input-required").state, "waiting");
+    assert.equal(taskStateToSessionState("auth-required").state, "waiting");
+    assert.equal(taskStateToSessionState("completed").state, "done");
+    assert.equal(taskStateToSessionState("failed").state, "error");
+    assert.equal(taskStateToSessionState("rejected").state, "error");
+    assert.deepEqual(taskStateToSessionState("canceled"), { state: "done", reason: "canceled" });
+    assert.deepEqual(taskStateToSessionState("cancelled"), { state: "done", reason: "canceled" });
+  });
+
+  test("is case-insensitive and falls back to unknown", () => {
+    assert.equal(taskStateToSessionState("WORKING").state, "working");
+    assert.equal(taskStateToSessionState("Input-Required").state, "waiting");
+    assert.equal(taskStateToSessionState("weird").state, "unknown");
+    assert.equal(taskStateToSessionState("").state, "unknown");
+  });
+});
+
+describe("extractTaskState", () => {
+  test("reads A2A status.state under JSON-RPC result, with id", () => {
+    const body = JSON.stringify({ jsonrpc: "2.0", result: { id: "t1", status: { state: "working" } } });
+    assert.deepEqual(extractTaskState(body), { state: "working", taskId: "t1" });
+  });
+
+  test("reads a flat state and a bare/nested task", () => {
+    assert.deepEqual(extractTaskState(JSON.stringify({ state: "completed" })), { state: "completed" });
+    assert.deepEqual(
+      extractTaskState(JSON.stringify({ task: { taskId: "x", state: "failed" } })),
+      { state: "failed", taskId: "x" },
+    );
+  });
+
+  test("returns null for a plain reply / non-JSON / no state", () => {
+    assert.equal(extractTaskState("just some text"), null);
+    assert.equal(extractTaskState(JSON.stringify({ choices: [{ message: { content: "hi" } }] })), null);
+    assert.equal(extractTaskState("{ broken"), null);
+    assert.equal(extractTaskState(JSON.stringify({ result: { id: "t" } })), null); // id but no state
+    assert.equal(extractTaskState("null"), null);
+  });
+});

--- a/src/integrations/takoapi/a2a.ts
+++ b/src/integrations/takoapi/a2a.ts
@@ -1,0 +1,82 @@
+/**
+ * A2A task-state helpers for the TakoAPI observer (Dispatch D2b). Pure — the
+ * unit under test. No I/O, no fs, so the mapping and parsing are verifiable
+ * without the (still-evolving) live gateway.
+ */
+import type { AgentSessionState } from "../types.js";
+
+/**
+ * Map an A2A TaskState onto LISA's normalized session state. The A2A spec's
+ * lifecycle states collapse onto our six:
+ *   submitted | working           → working
+ *   input-required | auth-required → waiting (the agent needs the user)
+ *   completed                     → done
+ *   failed | rejected             → error
+ *   canceled                      → done (reason: canceled)
+ *   anything else                 → unknown
+ * Case-insensitive; tolerates the British "cancelled" spelling.
+ */
+export function taskStateToSessionState(
+  taskState: string,
+): { state: AgentSessionState; reason: string } {
+  switch ((taskState || "").toLowerCase()) {
+    case "submitted":
+    case "working":
+      return { state: "working", reason: taskState };
+    case "input-required":
+    case "auth-required":
+      return { state: "waiting", reason: taskState };
+    case "completed":
+      return { state: "done", reason: "completed" };
+    case "failed":
+    case "rejected":
+      return { state: "error", reason: taskState };
+    case "canceled":
+    case "cancelled":
+      return { state: "done", reason: "canceled" };
+    default:
+      return { state: "unknown", reason: taskState || "unknown" };
+  }
+}
+
+/**
+ * Pull an A2A Task's state + id out of a /message response body, tolerating the
+ * shapes a gateway/agent might return: a bare Task, one nested under JSON-RPC
+ * `result`, or one under `task`; with the state at `status.state` (A2A) or a
+ * flat `state`. Returns null when the body carries no task object (e.g. a plain
+ * text reply or non-JSON) — the caller then treats a successful call as
+ * `completed`. Pure.
+ *
+ * SECURITY: the response comes from an untrusted remote agent (2nd-order prompt
+ * injection). We read ONLY the structural state/id strings here; the full reply
+ * never enters the ledger or the hub.
+ */
+export function extractTaskState(
+  body: string,
+): { state: string; taskId?: string } | null {
+  let json: unknown;
+  try {
+    json = JSON.parse(body);
+  } catch {
+    return null; // non-JSON (plain text reply) → no task object
+  }
+  if (!json || typeof json !== "object") return null;
+  const j = json as Record<string, any>;
+  // A2A task objects appear bare, under JSON-RPC `result`, or under `task`.
+  const candidates = [j.result, j.task, j].filter(
+    (t): t is Record<string, any> => !!t && typeof t === "object",
+  );
+  for (const task of candidates) {
+    const state =
+      (typeof task.status?.state === "string" && task.status.state) ||
+      (typeof task.state === "string" && task.state) ||
+      "";
+    if (!state) continue;
+    const taskId =
+      (typeof task.id === "string" && task.id) ||
+      (typeof task.taskId === "string" && task.taskId) ||
+      "";
+    return taskId ? { state, taskId } : { state };
+  }
+  return null;
+}

--- a/src/integrations/takoapi/ledger.test.ts
+++ b/src/integrations/takoapi/ledger.test.ts
@@ -1,0 +1,66 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { recordTakoCall, listTakoCalls, loadTakoLedger } from "./ledger.js";
+
+// LISA_HOME-tmp isolation: the ledger resolves its path lazily (reads LISA_HOME
+// at call time), so a per-test tmp dir keeps writes off the real ~/.lisa.
+let home: string;
+let prev: string | undefined;
+beforeEach(() => {
+  prev = process.env.LISA_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-tako-"));
+  process.env.LISA_HOME = home;
+});
+afterEach(() => {
+  if (prev === undefined) delete process.env.LISA_HOME;
+  else process.env.LISA_HOME = prev;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe("takoapi call ledger", () => {
+  test("records a call and lists it", () => {
+    recordTakoCall({ slug: "a", state: "completed", now: 1000 });
+    const all = listTakoCalls(1000);
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.slug, "a");
+    assert.equal(all[0]!.lastState, "completed");
+  });
+
+  test("upserts by slug (latest call wins), preserving startedAt", () => {
+    recordTakoCall({ slug: "a", state: "working", now: 1000 });
+    recordTakoCall({ slug: "a", state: "completed", now: 2000 });
+    const all = listTakoCalls(2000);
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.lastState, "completed");
+    assert.equal(all[0]!.startedAt, 1000);
+    assert.equal(all[0]!.lastMtime, 2000);
+  });
+
+  test("keeps the prior taskId when a later call omits it", () => {
+    recordTakoCall({ slug: "a", state: "working", taskId: "t1", now: 1000 });
+    recordTakoCall({ slug: "a", state: "completed", now: 2000 });
+    assert.equal(loadTakoLedger().find((e) => e.slug === "a")!.taskId, "t1");
+  });
+
+  test("separate slugs are separate rows, newest first", () => {
+    recordTakoCall({ slug: "a", state: "completed", now: 1000 });
+    recordTakoCall({ slug: "b", state: "working", now: 2000 });
+    assert.deepEqual(listTakoCalls(2000).map((e) => e.slug), ["b", "a"]);
+  });
+
+  test("prunes calls older than the retention window", () => {
+    recordTakoCall({ slug: "old", state: "completed", now: 0 });
+    const dayPlus = 25 * 60 * 60_000;
+    recordTakoCall({ slug: "fresh", state: "completed", now: dayPlus });
+    assert.deepEqual(listTakoCalls(dayPlus).map((e) => e.slug), ["fresh"]);
+  });
+
+  test("missing or corrupt file → empty, never throws", () => {
+    assert.deepEqual(loadTakoLedger(), []);
+    fs.writeFileSync(path.join(home, "takoapi-calls.json"), "{ not json");
+    assert.deepEqual(loadTakoLedger(), []);
+  });
+});

--- a/src/integrations/takoapi/ledger.ts
+++ b/src/integrations/takoapi/ledger.ts
@@ -1,0 +1,121 @@
+/**
+ * TakoAPI call ledger (Dispatch D2b) — a small persistent record of the REMOTE
+ * agents LISA has called via the `takoapi` tool, so the orchestrator hub can
+ * surface them as first-class sessions (with their last A2A TaskState) alongside
+ * local agents. Mirrors dispatch-ledger.ts.
+ *
+ * DISCIPLINE: this records only agents LISA actually CALLED — never the
+ * ~200-agent registry. Discovery stays in the `takoapi discover` tool; the hub
+ * only ever shows agents you've interacted with (called) plus an explicit pin
+ * list (config).
+ *
+ * PRIVACY: structural only — slug, A2A task id, TaskState, timestamps. Never the
+ * prompt sent or the reply received (those flow through the tool, not here).
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { EventEmitter } from "node:events";
+
+export interface TakoCallEntry {
+  /** Agent slug — the session identity (one entry per slug; latest call wins). */
+  slug: string;
+  /** A2A task id, if the response carried one. */
+  taskId?: string;
+  /** Epoch ms of the first recorded call to this slug. */
+  startedAt: number;
+  /** Epoch ms of the most recent update. */
+  lastMtime: number;
+  /** Last observed A2A TaskState string (e.g. "completed", "working"). */
+  lastState: string;
+}
+
+/** How long a call is retained for readback after its last update. */
+const RETAIN_MS = 24 * 60 * 60_000;
+
+/**
+ * Fires "change" after every successful write so the in-process observer can
+ * push a live update. The `takoapi` tool and the hub share one process, so an
+ * in-process event is enough (and simpler/safer than fs.watch).
+ */
+export const takoLedgerEvents = new EventEmitter();
+takoLedgerEvents.setMaxListeners(64);
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+
+/** Resolved lazily (reads env at call time) so tests can point LISA_HOME at a tmp dir. */
+function ledgerPath(): string {
+  return path.join(lisaHome(), "takoapi-calls.json");
+}
+
+/** Read the ledger; tolerant of a missing or corrupt file (returns []). */
+export function loadTakoLedger(): TakoCallEntry[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(ledgerPath(), "utf8");
+  } catch {
+    return []; // no file yet
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (e): e is TakoCallEntry =>
+        !!e &&
+        typeof (e as TakoCallEntry).slug === "string" &&
+        typeof (e as TakoCallEntry).lastState === "string" &&
+        typeof (e as TakoCallEntry).lastMtime === "number",
+    );
+  } catch {
+    return []; // corrupt JSON — treat as empty rather than throwing
+  }
+}
+
+function saveTakoLedger(entries: TakoCallEntry[]): void {
+  const file = ledgerPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(entries, null, 2));
+}
+
+/** Record (upsert by slug) a call LISA made to a remote agent. Returns the entry. */
+export function recordTakoCall(d: {
+  slug: string;
+  state: string;
+  taskId?: string;
+  /** Override the clock (tests). */
+  now?: number;
+}): TakoCallEntry {
+  const now = d.now ?? Date.now();
+  const existing = loadTakoLedger();
+  const prior = existing.find((e) => e.slug === d.slug);
+  const entry: TakoCallEntry = {
+    slug: d.slug,
+    lastState: d.state,
+    lastMtime: now,
+    startedAt: prior?.startedAt ?? now,
+    // Keep the freshest task id; fall back to the prior one if this call had none.
+    ...(d.taskId
+      ? { taskId: d.taskId }
+      : prior?.taskId
+        ? { taskId: prior.taskId }
+        : {}),
+  };
+  // Replace the same-slug entry and age out calls older than the retention window.
+  const cutoff = now - RETAIN_MS;
+  const next = existing.filter((e) => e.slug !== d.slug && e.lastMtime >= cutoff);
+  next.push(entry);
+  saveTakoLedger(next);
+  takoLedgerEvents.emit("change");
+  return entry;
+}
+
+/** All retained calls, newest first; prunes aged-out entries as a side effect. */
+export function listTakoCalls(now = Date.now()): TakoCallEntry[] {
+  const all = loadTakoLedger();
+  const cutoff = now - RETAIN_MS;
+  const keep = all.filter((e) => e.lastMtime >= cutoff);
+  if (keep.length !== all.length) saveTakoLedger(keep);
+  return keep.sort((a, b) => b.lastMtime - a.lastMtime);
+}

--- a/src/integrations/takoapi/observer.test.ts
+++ b/src/integrations/takoapi/observer.test.ts
@@ -1,0 +1,94 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { buildTakoSessions, pinsOf, TakoApiObserver } from "./observer.js";
+import { recordTakoCall, type TakoCallEntry } from "./ledger.js";
+
+const NOW = 1_700_000_000_000;
+const HOUR = 60 * 60_000;
+function entry(o: Partial<TakoCallEntry> = {}): TakoCallEntry {
+  return { slug: "a", lastState: "completed", lastMtime: NOW - 1000, startedAt: NOW - 1000, ...o };
+}
+
+describe("buildTakoSessions (pure)", () => {
+  test("maps a called agent to a takoapi session with its TaskState", () => {
+    const out = buildTakoSessions([entry({ slug: "a", lastState: "working" })], [], NOW);
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.agent, "takoapi");
+    assert.equal(out[0]!.sessionId, "a");
+    assert.equal(out[0]!.project, "a");
+    assert.equal(out[0]!.state, "working");
+  });
+
+  test("drops calls outside the active window", () => {
+    assert.equal(buildTakoSessions([entry({ lastMtime: NOW - 5 * HOUR })], [], NOW).length, 0);
+  });
+
+  test("pinned-but-uncalled shows idle; pinned-AND-called keeps its real state", () => {
+    const out = buildTakoSessions(
+      [entry({ slug: "called", lastState: "working" })],
+      ["called", "idlePin"],
+      NOW,
+    );
+    const byId = Object.fromEntries(out.map((s) => [s.sessionId, s]));
+    assert.equal(byId["called"]!.state, "working"); // a called pin is NOT overwritten
+    assert.equal(byId["idlePin"]!.state, "idle");
+    assert.equal(byId["idlePin"]!.stateReason, "pinned");
+  });
+
+  test("never invents registry agents — empty calls + no pins ⇒ empty", () => {
+    assert.deepEqual(buildTakoSessions([], [], NOW), []);
+  });
+});
+
+describe("pinsOf", () => {
+  test("reads a string[] pin and ignores junk / absence", () => {
+    assert.deepEqual(pinsOf({ pin: ["a", 1, "b"] }), ["a", "b"]);
+    assert.deepEqual(pinsOf({}), []);
+    assert.deepEqual(pinsOf({ pin: "nope" }), []);
+  });
+});
+
+describe("TakoApiObserver (ledger-driven, LISA_HOME-tmp)", () => {
+  let home: string;
+  let prev: string | undefined;
+  beforeEach(() => {
+    prev = process.env.LISA_HOME;
+    home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-tako-obs-"));
+    process.env.LISA_HOME = home;
+  });
+  afterEach(() => {
+    if (prev === undefined) delete process.env.LISA_HOME;
+    else process.env.LISA_HOME = prev;
+    fs.rmSync(home, { recursive: true, force: true });
+  });
+
+  test("emits a session live when the tool records a call", async () => {
+    const obs = new TakoApiObserver({ enabled: true });
+    const seen: string[] = [];
+    await obs.start((s) => seen.push(`${s.sessionId}:${s.state}`));
+    recordTakoCall({ slug: "remote-x", state: "completed" });
+    await obs.stop();
+    assert.ok(seen.includes("remote-x:done"), `expected a live emit, got ${JSON.stringify(seen)}`);
+  });
+
+  test("list() reflects the ledger snapshot", async () => {
+    recordTakoCall({ slug: "y", state: "working" });
+    const obs = new TakoApiObserver({ enabled: true });
+    const got = obs.list();
+    assert.equal(got.length, 1);
+    assert.equal(got[0]!.sessionId, "y");
+    assert.equal(got[0]!.state, "working");
+  });
+
+  test("stop() unsubscribes — no emit after stop", async () => {
+    const obs = new TakoApiObserver({ enabled: true });
+    const seen: string[] = [];
+    await obs.start((s) => seen.push(s.sessionId));
+    await obs.stop();
+    recordTakoCall({ slug: "after-stop", state: "completed" });
+    assert.ok(!seen.includes("after-stop"), `should not emit after stop, got ${JSON.stringify(seen)}`);
+  });
+});

--- a/src/integrations/takoapi/observer.ts
+++ b/src/integrations/takoapi/observer.ts
@@ -1,0 +1,117 @@
+/**
+ * TakoAPI observer (Dispatch D2b) — surfaces the REMOTE agents LISA has called
+ * (or the user pinned) as first-class sessions in the orchestrator hub, with
+ * their last A2A TaskState, alongside local agents.
+ *
+ * Source of truth is the call ledger (takoapi-calls.json), written by the
+ * `takoapi` tool when LISA delegates a task. The observer NEVER lists the
+ * registry — discovery is the tool's job (`takoapi discover`); monitoring shows
+ * only agents you've interacted with (called) plus a small explicit pin list:
+ *   ~/.lisa/agents.json → { "takoapi": { "enabled": true, "pin": ["slug-a"] } }
+ *
+ * Off by default. With no calls and no pins it lists nothing (effective no-op).
+ * PRIVACY: structural only — slug, TaskState, timestamps; no prompts/replies.
+ */
+import { EventEmitter } from "node:events";
+import { registerIntegration } from "../registry.js";
+import type {
+  AgentIntegrationConfig,
+  AgentObserver,
+  AgentSession,
+} from "../types.js";
+import { taskStateToSessionState } from "./a2a.js";
+import { listTakoCalls, takoLedgerEvents, type TakoCallEntry } from "./ledger.js";
+
+/** Remote delegations linger longer than chat sessions but shouldn't pile up. */
+const ACTIVE_WINDOW_MS = 3 * 60 * 60_000; // 3h
+const MAX_LISTED = 10;
+
+/** Read the `pin` list off the integration config, ignoring junk. */
+export function pinsOf(cfg: AgentIntegrationConfig): string[] {
+  const raw = (cfg as Record<string, unknown>).pin;
+  return Array.isArray(raw)
+    ? raw.filter((s): s is string => typeof s === "string")
+    : [];
+}
+
+/**
+ * Build the hub session list from ledger entries + pinned slugs. Pure given its
+ * inputs (the unit under test):
+ *   - called agents within the active window → their mapped TaskState
+ *   - pinned slugs with no recent call       → idle ("pinned"), kept visible
+ * One row per slug (a called pin uses its real call state, not "pinned").
+ */
+export function buildTakoSessions(
+  calls: TakoCallEntry[],
+  pins: string[],
+  now: number,
+): AgentSession[] {
+  const cutoff = now - ACTIVE_WINDOW_MS;
+  const bySlug = new Map<string, AgentSession>();
+  for (const c of calls) {
+    if (c.lastMtime < cutoff) continue;
+    const { state, reason } = taskStateToSessionState(c.lastState);
+    bySlug.set(c.slug, {
+      agent: "takoapi",
+      sessionId: c.slug,
+      project: c.slug,
+      state,
+      stateReason: reason,
+      lastMtime: c.lastMtime,
+    });
+  }
+  // Pins the user wants always visible, even when idle. A pin that WAS called
+  // recently keeps its real state (set above); only never-/stale-called pins
+  // are added as idle, stamped `now` so the frontend's window keeps them.
+  for (const slug of pins) {
+    if (!bySlug.has(slug)) {
+      bySlug.set(slug, {
+        agent: "takoapi",
+        sessionId: slug,
+        project: slug,
+        state: "idle",
+        stateReason: "pinned",
+        lastMtime: now,
+      });
+    }
+  }
+  return [...bySlug.values()]
+    .sort((a, b) => b.lastMtime - a.lastMtime)
+    .slice(0, MAX_LISTED);
+}
+
+export class TakoApiObserver extends EventEmitter implements AgentObserver {
+  readonly agent = "takoapi";
+  private pins: string[];
+  private emitFn: ((s: AgentSession) => void) | null = null;
+  private readonly onChange = () => this.flush();
+
+  constructor(cfg: AgentIntegrationConfig) {
+    super();
+    this.pins = pinsOf(cfg);
+  }
+
+  async start(emit: (s: AgentSession) => void): Promise<void> {
+    this.emitFn = emit;
+    // The tool records calls in this same process; re-emit on each ledger change
+    // so a fresh delegation shows up live (not just on the next snapshot fetch).
+    takoLedgerEvents.on("change", this.onChange);
+    this.flush(); // surface any past calls / pins immediately
+  }
+
+  list(): AgentSession[] {
+    return buildTakoSessions(listTakoCalls(), this.pins, Date.now());
+  }
+
+  async stop(): Promise<void> {
+    takoLedgerEvents.off("change", this.onChange);
+    this.emitFn = null;
+  }
+
+  private flush(): void {
+    if (!this.emitFn) return;
+    for (const s of this.list()) this.emitFn(s);
+  }
+}
+
+registerIntegration("takoapi", (cfg) => new TakoApiObserver(cfg));

--- a/src/tools/takoapi.ts
+++ b/src/tools/takoapi.ts
@@ -13,6 +13,8 @@
  * injectable so the logic is unit-testable without hitting the network.
  */
 import type { ToolDefinition } from "../types.js";
+import { extractTaskState } from "../integrations/takoapi/a2a.js";
+import { recordTakoCall } from "../integrations/takoapi/ledger.js";
 
 const DEFAULT_BASE = "https://takoapi.com";
 function base(): string {
@@ -117,6 +119,59 @@ export async function takoDiscover(query: string, f: TakoFetcher = defaultFetche
   return formatRegistry(res.body);
 }
 
+export interface TakoCallResult {
+  /** Did we reach the agent and get a non-error response? */
+  ok: boolean;
+  status: number;
+  /** Formatted reply (or a human error string) — what the tool returns to LISA. */
+  reply: string;
+  /** A2A TaskState observed for the call (D2b ledger). "completed" for a plain
+   *  sync reply; the agent's own task state if the response carried a Task. */
+  taskState: string;
+  /** A2A task id, if the response carried one. */
+  taskId?: string;
+}
+
+/**
+ * Call an agent via the A2A message endpoint with the user's key, returning both
+ * the reply and the observed A2A task state (for the D2b call ledger). Pure
+ * w.r.t. fs — recording is the caller's job, so existing `takoCall` tests stay
+ * side-effect-free.
+ */
+export async function takoCallDetailed(
+  slug: string,
+  text: string,
+  key: string,
+  f: TakoFetcher = defaultFetcher,
+): Promise<TakoCallResult> {
+  const url = `${base()}/v1/agents/${encodeURIComponent(slug)}/message`;
+  const res = await f.postJson(url, { text }, { authorization: `Bearer ${key}` });
+  if (res.status === 401) {
+    return {
+      ok: false,
+      status: 401,
+      reply: "TakoAPI rejected the key (401). Check TAKO_KEY at https://takoapi.com/dashboard.",
+      taskState: "rejected",
+    };
+  }
+  if (!res.ok) {
+    return {
+      ok: false,
+      status: res.status,
+      reply: `TakoAPI call to "${slug}" failed (status ${res.status || "network error"}).`,
+      taskState: "failed",
+    };
+  }
+  const task = extractTaskState(res.body); // {state, taskId} | null
+  return {
+    ok: true,
+    status: res.status,
+    reply: extractAgentReply(res.body),
+    taskState: task?.state ?? "completed",
+    ...(task?.taskId ? { taskId: task.taskId } : {}),
+  };
+}
+
 /** Call an agent via the A2A message endpoint with the user's key. */
 export async function takoCall(
   slug: string,
@@ -124,13 +179,7 @@ export async function takoCall(
   key: string,
   f: TakoFetcher = defaultFetcher,
 ): Promise<string> {
-  const url = `${base()}/v1/agents/${encodeURIComponent(slug)}/message`;
-  const res = await f.postJson(url, { text }, { authorization: `Bearer ${key}` });
-  if (res.status === 401) {
-    return "TakoAPI rejected the key (401). Check TAKO_KEY at https://takoapi.com/dashboard.";
-  }
-  if (!res.ok) return `TakoAPI call to "${slug}" failed (status ${res.status || "network error"}).`;
-  return extractAgentReply(res.body);
+  return (await takoCallDetailed(slug, text, key, f)).reply;
 }
 
 interface TakoInput {
@@ -165,7 +214,20 @@ export const takoapiTool: ToolDefinition<TakoInput, string> = {
       if (!key) {
         return "TAKO_KEY is not set — create one at https://takoapi.com/dashboard and add it to ~/.lisa/config.env.";
       }
-      return await takoCall(input.slug, input.text, key);
+      const r = await takoCallDetailed(input.slug, input.text, key);
+      // D2b — record the delegation so the agent shows up as a session in the
+      // hub (with its A2A TaskState). Best-effort: a ledger write must never
+      // break the reply. Only successful calls are recorded (so transient
+      // transport errors don't manufacture error-sessions); a genuine agent
+      // task failure arrives as ok=true with taskState="failed".
+      if (r.ok) {
+        try {
+          recordTakoCall({ slug: input.slug, state: r.taskState, taskId: r.taskId });
+        } catch {
+          /* ledger unavailable — surface the reply anyway */
+        }
+      }
+      return r.reply;
     }
     return `unknown action "${(input as { action: string }).action}" — use "discover" or "call".`;
   },


### PR DESCRIPTION
## What

Dispatch **D2b** — surface the **remote** agents LISA has **called** via the `takoapi` tool as first-class sessions in the orchestrator hub, alongside local agents and with their **A2A TaskState**. Builds directly on [D4a](https://github.com/oratis/LISA/pull/84): a called remote agent now appears automatically in the island + GUI sidebar (with a `takoapi` badge) over the same `agent_session_update` stream.

**The core discipline (non-goal):** never list the ~200-agent registry. Discovery stays in `takoapi discover`; the hub only ever shows agents you've **interacted with** (called) plus an explicit **pin** list.

## How

- **`takoapi/a2a.ts`** (pure):
  - `taskStateToSessionState` — maps the A2A lifecycle (`submitted`/`working` → working; `input-required`/`auth-required` → waiting; `completed` → done; `failed`/`rejected` → error; `canceled` → done) onto LISA's six normalized states.
  - `extractTaskState` — pulls a Task's `state`+`id` out of a `/message` response (JSON-RPC `result` / bare / nested; `status.state` or flat `state`), or `null` for a plain reply. Treats the remote response as **untrusted** (2nd-order injection) — reads only the structural state/id; the full reply never enters the ledger/hub.
- **`takoapi/ledger.ts`** — persistent call ledger (`~/.lisa/takoapi-calls.json`), mirroring `dispatch-ledger`: upsert by slug, 24h retention, structural-only (slug, taskId, TaskState, timestamps). Emits an in-process `change` event so the observer pushes a **live** update (tool + hub share one process).
- **`takoapi/observer.ts`** — `TakoApiObserver` (`AgentObserver`) lists called agents (within an active window) + pinned slugs (shown idle), one row per slug. `buildTakoSessions` is the pure unit under test; re-emits on ledger change.
- **`takoapi` tool** — `takoCallDetailed` returns the reply **and** the observed TaskState; `execute` records successful calls to the ledger (best-effort — a ledger write never breaks the reply). The tool stays **autonomous/remote-blocked** (unchanged).
- **registry + hub** — register the observer as a builtin; `DEFAULT` config `takoapi: { enabled: false }` (opt-in; needs `TAKO_KEY` to make any calls). Pin via `~/.lisa/agents.json` → `{ "takoapi": { "enabled": true, "pin": ["slug-a"] } }`.

## Degraded mode

The TakoAPI gateway is a sync proxy and its async/task endpoints are still evolving. With sync-only calls this degrades to a *"recently delegated remote agents"* view — still useful — and it still captures a genuine **agent-task failure** when a sync response carries an A2A Task with `state=failed`.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **575 tests pass** (+19 new across `a2a` / `ledger` / `observer`), incl. full TaskState mapping, response-shape parsing, ledger upsert/prune/corrupt-tolerance, and the observer's live-emit + `list()` snapshot (LISA_HOME-tmp isolated)
- Existing `takoapi` tool tests still green (the `takoCall` refactor is back-compat)
- Runtime check: `takoapi` is a registered builtin, **default-disabled**; the 200-agent registry never enters the hub (only called/pinned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)