### PR TITLE
feat(sense): observer deepening — gitBranch for codex/opencode, wider windows, live-verify harness

### DIFF
--- a/docs/OBSERVER_FIDELITY.md
+++ b/docs/OBSERVER_FIDELITY.md
@@ -1,0 +1,71 @@
+# Observer fidelity — field availability + live-verification log
+
+> Observer deepening **O-D3**. Companion to [PLAN_OBSERVER_DEEPENING_v1.0.md](./PLAN_OBSERVER_DEEPENING_v1.0.md).
+
+LISA observes several CLI agents by reading their on-disk session formats. Two
+very different things must both be true for "LISA can see all your agents" to
+hold:
+
+1. **The parse LOGIC is correct** — proven by unit tests over fixtures
+   (`src/integrations/*/observer.test.ts`). These run in CI and never touch a
+   real agent.
+2. **The parse SCHEMA assumptions still match reality** — each CLI's format
+   drifts across versions (codex rollout schema, opencode DB schema, aider
+   markdown). Fixtures can silently fall out of date. Only running against a
+   **real, current** agent proves the assumptions still hold.
+
+This file tracks (2): the live-verification log. Run the harness, eyeball the
+parsed fields against what the agent is actually doing, and add a row.
+
+## Running the harness
+
+```sh
+# Respect ~/.lisa/agents.json (whatever you actually have enabled):
+npx tsx scripts/verify-observers.ts
+
+# Or force-enable specific observers at the "activity" tier for a check:
+VERIFY_AGENTS=codex,opencode npx tsx scripts/verify-observers.ts
+
+# Or every known observer:
+VERIFY_ALL=1 npx tsx scripts/verify-observers.ts
+```
+
+It's read-only and prints structural metadata only (tool names, file paths,
+argv[0], counts, branch, tokens) — never prompts, replies, or file content.
+
+## Field availability (by design)
+
+| field | claude-code | codex | opencode | aider | notes |
+|---|:-:|:-:|:-:|:-:|---|
+| turnCount | ✅ | ✅ | ✅ | ✅ | each counts its own turns |
+| lastTools | ✅ | ✅ | ✅ | ➖ | aider has no tool protocol (honestly empty) |
+| filesTouched | ✅ | ✅ | ✅ | ✅ | from tool input / part input / SEARCH-block path labels |
+| lastCommandName | ✅ | ✅ | ✅ | ➖ | shell argv[0] only |
+| lastError | ✅ | ✅ | ✅ | ✅ | short label |
+| **gitBranch** | ✅ | ✅¹ | ✅¹ | ➖ | ¹ **O-D1**: derived from session cwd (`git symbolic-ref`), not stored by the agent |
+| tokens | ✅ | ✅ | ✅ | ➖ | aider doesn't record |
+| pendingPermission | ✅ | ➖ | ➖ | ➖ | only Claude Code records an explicit permission gate |
+
+✅ available · ➖ not available **by design** (format doesn't expose it; inventing
+it would be dishonest or violate the privacy contract). Don't "fill in" a ➖.
+
+**Window/caps (O-D2):** codex activity reads the last **128 KB** of the rollout
+(was 64 KB); opencode scans the last **40** messages per session (was 20). Both
+widen coverage on long sessions without changing what's extracted.
+
+## Verification log
+
+Add a row each time you confirm an observer against a live agent. "Result" is
+your eyeball judgement: do the printed fields match what the agent was doing?
+
+| observer | CLI version | date | result | notes |
+|---|---|---|---|---|
+| claude-code | Claude Code (this machine) | 2026-06-14 | ✅ matches | harness showed 9 live sessions; state/branch/tools/files/tokens all correct |
+| codex | _pending_ | — | — | run `VERIFY_AGENTS=codex` against a live Codex session |
+| opencode | _pending_ | — | — | run `VERIFY_AGENTS=opencode` against a live OpenCode session |
+| aider | _pending_ | — | — | run `VERIFY_AGENTS=aider` (needs `watchRoots` set) against a live aider session |
+
+> The non-Claude observers are implemented and fixture-tested but were authored
+> against captured samples, not continuously verified against live tools. Adding
+> rows here is how we turn "implemented" into "verified" — and how we catch a
+> schema drift early (a column going blank in the harness output is the signal).

--- a/scripts/verify-observers.ts
+++ b/scripts/verify-observers.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env tsx
+/**
+ * Live observer verification (Observer deepening O-D3).
+ *
+ * Unit tests prove the PARSING logic against fixtures; they cannot prove the
+ * fixtures still match what a given CLI version writes to disk. Agent session
+ * formats drift (codex rollout schema, opencode DB schema, aider markdown), so
+ * "LISA can see all your agents" is only true if the parse SCHEMA assumptions
+ * still hold against the real, current tools.
+ *
+ * This harness starts the orchestrator hub against your real machine and prints,
+ * per observer, the SessionActivity LISA currently parses — so you can eyeball
+ * it against what the agent is actually doing, then log the result in
+ * docs/OBSERVER_FIDELITY.md.
+ *
+ * Usage:
+ *   npx tsx scripts/verify-observers.ts            # uses ~/.lisa/agents.json
+ *   VERIFY_ALL=1 npx tsx scripts/verify-observers.ts   # force-enable every observer
+ *   VERIFY_AGENTS=codex,opencode npx tsx scripts/verify-observers.ts  # only these
+ *
+ * It prints structural metadata only (the same fields the hub surfaces) — never
+ * prompts, replies, or file content. Read-only; it never writes to any session.
+ */
+import os from "node:os";
+import path from "node:path";
+import {
+  OrchestratorHub,
+  loadOrchestratorConfig,
+  DEFAULT_ORCHESTRATOR_CONFIG,
+  type OrchestratorConfig,
+} from "../src/integrations/hub.js";
+import { listAvailableIntegrations, registerBuiltinIntegrations } from "../src/integrations/registry.js";
+import type { AgentSession } from "../src/integrations/types.js";
+
+const LISA_HOME = process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+
+function rel(ms: number): string {
+  const d = Date.now() - ms;
+  if (d < 60_000) return `${Math.round(d / 1000)}s ago`;
+  if (d < 3_600_000) return `${Math.round(d / 60_000)}m ago`;
+  return `${Math.round(d / 3_600_000)}h ago`;
+}
+
+/** Build the run config: respect ~/.lisa/agents.json, or force-enable per env. */
+async function buildConfig(): Promise<OrchestratorConfig> {
+  await registerBuiltinIntegrations();
+  const all = listAvailableIntegrations();
+  const onlyEnv = (process.env.VERIFY_AGENTS ?? "").split(",").map((s) => s.trim()).filter(Boolean);
+  const forceAll = process.env.VERIFY_ALL === "1" || onlyEnv.length > 0;
+
+  if (!forceAll) {
+    const cfg = await loadOrchestratorConfig(path.join(LISA_HOME, "agents.json"));
+    return { ...cfg, visibility: "activity" }; // activity tier so we see the fields
+  }
+  const targets = onlyEnv.length > 0 ? onlyEnv : all;
+  const integrations: OrchestratorConfig["integrations"] = {};
+  for (const name of all) {
+    const base = DEFAULT_ORCHESTRATOR_CONFIG.integrations[name] ?? {};
+    integrations[name] = { ...base, enabled: targets.includes(name) };
+  }
+  return { integrations, visibility: "activity" };
+}
+
+function printSession(s: AgentSession): void {
+  const head = `  • ${s.project}  [${s.state}${s.stateReason ? `:${s.stateReason}` : ""}]  ${rel(s.lastMtime)}`;
+  console.log(head);
+  if (s.cwd) console.log(`      cwd: ${s.cwd}`);
+  const a = s.activity;
+  if (!a) {
+    console.log("      activity: (none — metadata tier or no Tier-2 content)");
+    return;
+  }
+  const bits: string[] = [`turns=${a.turnCount}`];
+  if (a.lastTools?.length) bits.push(`tools=[${a.lastTools.join(", ")}]`);
+  if (a.filesTouched?.length) bits.push(`files=[${a.filesTouched.join(", ")}]`);
+  if (a.lastCommandName) bits.push(`cmd=${a.lastCommandName}`);
+  if (a.lastError) bits.push(`error=${a.lastError}`);
+  if (a.gitBranch) bits.push(`branch=${a.gitBranch}`);
+  if (a.tokens) bits.push(`tokens=${a.tokens.input}/${a.tokens.output}`);
+  if (a.pendingPermission) bits.push(`pending=${a.pendingPermission}`);
+  console.log(`      activity: ${bits.join("  ")}`);
+}
+
+async function main(): Promise<void> {
+  const cfg = await buildConfig();
+  const enabled = Object.entries(cfg.integrations)
+    .filter(([, e]) => e.enabled !== false)
+    .map(([n]) => n);
+  console.log(`LISA observer fidelity check — LISA_HOME=${LISA_HOME}`);
+  console.log(`Enabled observers (visibility=${cfg.visibility}): ${enabled.join(", ") || "(none)"}\n`);
+
+  const hub = new OrchestratorHub(cfg, { log: (m) => console.error(m) });
+  await hub.start();
+  // Give file-watch / poll a beat to settle before snapshotting.
+  await new Promise((r) => setTimeout(r, 800));
+
+  const sessions = hub.list();
+  const byAgent = new Map<string, AgentSession[]>();
+  for (const s of sessions) {
+    const arr = byAgent.get(s.agent) ?? [];
+    arr.push(s);
+    byAgent.set(s.agent, arr);
+  }
+
+  for (const name of enabled) {
+    const list = byAgent.get(name) ?? [];
+    console.log(`── ${name} (${list.length} active session${list.length === 1 ? "" : "s"}) ──`);
+    if (list.length === 0) {
+      console.log("  (none active — start a real session in this agent, then re-run)\n");
+      continue;
+    }
+    for (const s of list) printSession(s);
+    console.log();
+  }
+
+  console.log("Eyeball each field against what the agent is actually doing, then");
+  console.log("record the result (CLI version + date) in docs/OBSERVER_FIDELITY.md.");
+  await hub.stop();
+  // Observers hold unref'd timers / watchers; exit explicitly.
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error("verify-observers failed:", e);
+  process.exit(1);
+});

--- a/src/integrations/codex/observer.test.ts
+++ b/src/integrations/codex/observer.test.ts
@@ -281,3 +281,77 @@ describe("CodexObserver — visibility gating of activity", () => {
     }
   });
 });
+
+describe("CodexObserver — O-D1 gitBranch from cwd", () => {
+  async function homeWithCwd(label: string, cwd: string | null): Promise<string> {
+    const home = await fsp.mkdtemp(path.join(os.tmpdir(), `lisa-codex-od1-${label}-`));
+    const roll = path.join(home, "sessions", "2026", "06", "10", "rollout-b.jsonl");
+    await fsp.mkdir(path.dirname(roll), { recursive: true });
+    const user: Record<string, unknown> = { type: "message", role: "user", content: "go" };
+    const asst: Record<string, unknown> = { type: "response", role: "assistant" };
+    if (cwd) { user.cwd = cwd; asst.cwd = cwd; }
+    await fsp.writeFile(roll, [user, asst].map((l) => JSON.stringify(l)).join("\n") + "\n");
+    return home;
+  }
+
+  test("enriches activity.gitBranch from the session cwd (tier ≥ activity)", async () => {
+    const home = await homeWithCwd("on", "/Users/me/proj");
+    try {
+      const obs = new CodexObserver({
+        home,
+        visibility: "activity",
+        gitBranch: async (cwd) => (cwd ? "feat-od1" : undefined),
+      });
+      await obs.start(() => {});
+      const listed = obs.list();
+      await obs.stop();
+      assert.equal(listed[0]!.activity!.gitBranch, "feat-od1");
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+
+  test("resolver is never consulted at metadata tier (no activity)", async () => {
+    const home = await homeWithCwd("meta", "/Users/me/proj");
+    try {
+      let called = false;
+      const obs = new CodexObserver({
+        home,
+        visibility: "metadata",
+        gitBranch: async () => { called = true; return "nope"; },
+      });
+      await obs.start(() => {});
+      const listed = obs.list();
+      await obs.stop();
+      assert.equal(listed[0]!.activity, undefined);
+      assert.equal(called, false, "branch resolver must not run when activity is off");
+    } finally {
+      await fsp.rm(home, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("parseCodexActivity — O-D2 widened 128KB tail", () => {
+  test("captures a file touched early in a >64KB session", async () => {
+    const lines: object[] = [
+      { type: "function_call", name: "Read", arguments: JSON.stringify({ file_path: "early.ts" }) },
+    ];
+    const pad = "x".repeat(220);
+    for (let i = 0; i < 400; i++) lines.push({ type: "user", note: pad });
+    lines.push({ type: "function_call", name: "Edit", arguments: JSON.stringify({ file_path: "late.ts" }) });
+    const f = await writeRollout("od2/rollout-long.jsonl", lines);
+
+    const size = (await fsp.stat(f)).size;
+    assert.ok(
+      size > 64 * 1024 && size < 128 * 1024,
+      `fixture should sit in the 64–128KB widened-only band, got ${size}`,
+    );
+    const a = await parseCodexActivity(f);
+    assert.ok(a, "activity present");
+    assert.ok(
+      a!.filesTouched.includes("early.ts"),
+      "early file (only reachable with the 128KB tail) captured",
+    );
+    assert.ok(a!.filesTouched.includes("late.ts"), "late file captured");
+  });
+});

--- a/src/integrations/codex/observer.ts
+++ b/src/integrations/codex/observer.ts
@@ -27,6 +27,7 @@ import path from "node:path";
 import os from "node:os";
 import { EventEmitter } from "node:events";
 import { registerIntegration } from "../registry.js";
+import { cwdGitBranch, type GitBranchResolver } from "../git/branch.js";
 import type {
   AgentIntegrationConfig,
   AgentObserver,
@@ -34,6 +35,11 @@ import type {
   AgentSessionState,
   SessionActivity,
 } from "../types.js";
+
+/** Constructor options — config plus an injectable branch resolver (tests). */
+export interface CodexObserverOptions extends AgentIntegrationConfig {
+  gitBranch?: GitBranchResolver;
+}
 
 const ACTIVE_WINDOW_MS = 30 * 60_000;
 const MAX_LISTED = 10;
@@ -59,8 +65,10 @@ export class CodexObserver extends EventEmitter implements AgentObserver {
   private pending = new Map<string, NodeJS.Timeout>();
   private emitFn: ((s: AgentSession) => void) | null = null;
   private readonly computeActivity: boolean;
+  /** O-D1: derive gitBranch from a session's cwd (Codex rollouts don't store one). */
+  private readonly resolveBranch: GitBranchResolver;
 
-  constructor(cfg: AgentIntegrationConfig) {
+  constructor(cfg: CodexObserverOptions) {
     super();
     const home = cfg.home
       ? (cfg.home as string).replace(/^~/, os.homedir())
@@ -71,6 +79,7 @@ export class CodexObserver extends EventEmitter implements AgentObserver {
     // privacy-minimal default) — mirrors the claude-code observer.
     this.computeActivity =
       cfg.visibility === "activity" || cfg.visibility === "intent";
+    this.resolveBranch = cfg.gitBranch ?? cwdGitBranch;
   }
 
   async start(emit: (s: AgentSession) => void): Promise<void> {
@@ -139,9 +148,16 @@ export class CodexObserver extends EventEmitter implements AgentObserver {
       const st = await fsp.stat(full);
       if (!st.isFile()) return;
       const { state, reason, cwd } = await parseCodexState(full);
-      const activity = this.computeActivity
+      let activity = this.computeActivity
         ? await parseCodexActivity(full)
         : undefined;
+      // O-D1: enrich with the branch derived from cwd (Codex doesn't record one).
+      if (this.computeActivity && cwd) {
+        const gitBranch = await this.resolveBranch(cwd);
+        if (gitBranch) {
+          activity = { ...(activity ?? { turnCount: 0, lastTools: [], filesTouched: [] }), gitBranch };
+        }
+      }
       this.sessions.set(full, {
         sessionId: path.basename(full, ".jsonl").replace(/^rollout-/, ""),
         project: cwd ? path.basename(cwd) : path.basename(path.dirname(full)),
@@ -266,7 +282,8 @@ export async function parseCodexState(
 // test plants a unique secret in arguments, reasoning, and message content and
 // asserts it never appears in the output.
 
-const ACTIVITY_TAIL_BYTES = 64 * 1024;
+// O-D2: 128KB tail (was 64KB) so long sessions don't under-count tools/files.
+const ACTIVITY_TAIL_BYTES = 128 * 1024;
 const MAX_TOOLS = 6;
 const MAX_FILES = 10;
 /** Known path-bearing keys inside a function_call's parsed arguments. */

--- a/src/integrations/git/branch.test.ts
+++ b/src/integrations/git/branch.test.ts
@@ -1,0 +1,56 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { cwdGitBranch, _clearCwdBranchCache } from "./branch.js";
+
+const pexec = promisify(execFile);
+
+// One real-git integration test for the resolver itself; observers inject a
+// fake resolver (see their tests), so this is the only place real git runs.
+describe("cwdGitBranch (real git)", () => {
+  let dir: string;
+  beforeEach(async () => {
+    _clearCwdBranchCache();
+    dir = await fsp.mkdtemp(path.join(os.tmpdir(), "lisa-branch-"));
+  });
+  afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+  test("a git repo → a non-empty branch name", async () => {
+    const repo = path.join(dir, "repo");
+    await fsp.mkdir(repo);
+    await pexec("git", ["-C", repo, "init"]);
+    const branch = await cwdGitBranch(repo);
+    assert.equal(typeof branch, "string");
+    assert.ok((branch as string).length > 0, `expected a branch name, got ${branch}`);
+  });
+
+  test("a non-repo directory → undefined", async () => {
+    const plain = path.join(dir, "plain");
+    await fsp.mkdir(plain);
+    assert.equal(await cwdGitBranch(plain), undefined);
+  });
+
+  test("undefined cwd → undefined (no spawn)", async () => {
+    assert.equal(await cwdGitBranch(undefined), undefined);
+  });
+
+  test("caches within the TTL (second call doesn't see a moved branch)", async () => {
+    const repo = path.join(dir, "cached");
+    await fsp.mkdir(repo);
+    await pexec("git", ["-C", repo, "init"]);
+    const t0 = 1_000_000;
+    const first = await cwdGitBranch(repo, t0);
+    // Switch branch on disk, but query again inside the TTL → cached value.
+    await pexec("git", ["-C", repo, "checkout", "-b", "another-branch"]);
+    const cached = await cwdGitBranch(repo, t0 + 1_000);
+    assert.equal(cached, first);
+    // Past the TTL → re-resolves to the new branch.
+    const fresh = await cwdGitBranch(repo, t0 + 60_000);
+    assert.equal(fresh, "another-branch");
+  });
+});

--- a/src/integrations/git/branch.ts
+++ b/src/integrations/git/branch.ts
@@ -1,0 +1,55 @@
+/**
+ * Derive the current git branch for a working directory (Observer deepening
+ * O-D1). The codex / opencode session formats don't record a branch the way
+ * Claude Code's JSONL does, but they DO record the session's cwd — so we derive
+ * the branch from disk, cheaply and safely.
+ *
+ * `git symbolic-ref --short HEAD` returns the branch name even before the first
+ * commit, and exits non-zero on a detached HEAD / non-repo / missing git — all
+ * of which map to `undefined` (honest: "no branch"). execFile (no shell) avoids
+ * injection; a short TTL cache keeps us from spawning git on every record.
+ *
+ * PRIVACY: a branch NAME only — never a diff, commit message, or file content.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+const pexec = promisify(execFile);
+
+/** cwd → last resolved branch, with the time it was resolved. */
+const CACHE = new Map<string, { branch: string | undefined; at: number }>();
+const TTL_MS = 30_000;
+const GIT_TIMEOUT_MS = 5_000;
+
+/** A resolver injectable into observers so their unit tests need no real git. */
+export type GitBranchResolver = (
+  cwd: string | undefined,
+  now?: number,
+) => Promise<string | undefined>;
+
+/**
+ * Current branch for `cwd`, or undefined (detached / not a repo / no git /
+ * timeout). Cached for a short TTL per cwd. Pass `now` to control the clock in
+ * tests.
+ */
+export const cwdGitBranch: GitBranchResolver = async (cwd, now = Date.now()) => {
+  if (!cwd) return undefined;
+  const hit = CACHE.get(cwd);
+  if (hit && now - hit.at < TTL_MS) return hit.branch;
+  let branch: string | undefined;
+  try {
+    const { stdout } = await pexec("git", ["-C", cwd, "symbolic-ref", "--short", "HEAD"], {
+      timeout: GIT_TIMEOUT_MS,
+    });
+    branch = stdout.trim() || undefined;
+  } catch {
+    branch = undefined; // not a repo / detached / git missing / timeout
+  }
+  CACHE.set(cwd, { branch, at: now });
+  return branch;
+};
+
+/** Test hook — drop the cache between cases. */
+export function _clearCwdBranchCache(): void {
+  CACHE.clear();
+}

--- a/src/integrations/opencode/observer.test.ts
+++ b/src/integrations/opencode/observer.test.ts
@@ -5,6 +5,7 @@ import {
   parseLastMessage,
   parseRecentMessages,
   extractActivity,
+  buildQuery,
   OpencodeObserver,
   type OpencodeRow,
 } from "./observer.js";
@@ -367,5 +368,43 @@ describe("OpencodeObserver — visibility wiring", () => {
     const s = obs.list()[0]!;
     // recent_msgs is ignored at metadata tier; no tokens here → no activity.
     assert.equal(s.activity, undefined);
+  });
+});
+
+describe("OpencodeObserver — O-D1 gitBranch from directory", () => {
+  const row: OpencodeRow = { id: "ses_b", directory: "/Users/me/proj", title: "t", time_updated: 1 };
+
+  test("enriches activity.gitBranch from the session directory (tier ≥ activity)", async () => {
+    const obs = new OpencodeObserver({
+      enabled: true,
+      visibility: "activity",
+      fetchRows: async () => [row],
+      gitBranch: async (cwd) => (cwd ? "feat-od1" : undefined),
+      activeWindowMs: 10 ** 12,
+      now: () => 2,
+    });
+    await obs.poll();
+    assert.equal(obs.list()[0]!.activity!.gitBranch, "feat-od1");
+  });
+
+  test("resolver is never consulted at metadata tier", async () => {
+    let called = false;
+    const obs = new OpencodeObserver({
+      enabled: true,
+      visibility: "metadata",
+      fetchRows: async () => [row],
+      gitBranch: async () => { called = true; return "nope"; },
+      activeWindowMs: 10 ** 12,
+      now: () => 2,
+    });
+    await obs.poll();
+    assert.equal(obs.list()[0]!.activity, undefined);
+    assert.equal(called, false, "branch resolver must not run when activity is off");
+  });
+});
+
+describe("buildQuery — O-D2 widened message window", () => {
+  test("fetches 40 recent messages per session (was 20)", () => {
+    assert.match(buildQuery(true), /LIMIT 40\)/, "per-session recent-message LIMIT should be 40");
   });
 });

--- a/src/integrations/opencode/observer.ts
+++ b/src/integrations/opencode/observer.ts
@@ -37,6 +37,7 @@ import { EventEmitter } from "node:events";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { registerIntegration } from "../registry.js";
+import { cwdGitBranch, type GitBranchResolver } from "../git/branch.js";
 import type {
   AgentIntegrationConfig,
   AgentObserver,
@@ -54,8 +55,9 @@ const MAX_LISTED = 12;
 // Tier-2 extraction caps (mirror the Claude Code parser).
 const MAX_TOOLS = 6;
 const MAX_FILES = 10;
-/** How many of a session's most-recent messages to scan for activity. */
-const RECENT_MSGS = 20;
+/** How many of a session's most-recent messages to scan for activity.
+ *  O-D2: 40 (was 20) so long sessions don't under-count tools/files. */
+const RECENT_MSGS = 40;
 /** Known path-bearing keys in a tool part's input. We NEVER read other keys. */
 const PATH_KEYS = ["path", "filePath", "file", "filename"];
 
@@ -356,7 +358,7 @@ const COL_RECENT_MSGS =
   `(SELECT m.data AS d FROM message m WHERE m.session_id = s.id ORDER BY m.time_created DESC LIMIT ${RECENT_MSGS}) ` +
   "ORDER BY rowid DESC) AS recent_msgs";
 
-function buildQuery(withActivity: boolean): string {
+export function buildQuery(withActivity: boolean): string {
   const cols = [
     "s.id AS id",
     "s.directory AS directory",
@@ -398,6 +400,8 @@ export interface OpencodeObserverOptions extends AgentIntegrationConfig {
   pollMs?: number;
   activeWindowMs?: number;
   now?: () => number;
+  /** O-D1: derive gitBranch from a session's directory (injectable for tests). */
+  gitBranch?: GitBranchResolver;
 }
 
 export class OpencodeObserver extends EventEmitter implements AgentObserver {
@@ -411,6 +415,8 @@ export class OpencodeObserver extends EventEmitter implements AgentObserver {
   private readonly now: () => number;
   /** Tier-2 gate: only at visibility ≥ "activity" do we deep-extract. */
   private readonly computeActivity: boolean;
+  /** O-D1: derive gitBranch from a session's directory (OpenCode stores none). */
+  private readonly resolveBranch: GitBranchResolver;
 
   constructor(cfg: OpencodeObserverOptions) {
     super();
@@ -419,6 +425,7 @@ export class OpencodeObserver extends EventEmitter implements AgentObserver {
     // "intent". At "metadata"/"off" we stay metadata-only (cheaper, and the
     // privacy-minimal default) — same gate as the Claude Code observer.
     this.computeActivity = cfg.visibility === "activity" || cfg.visibility === "intent";
+    this.resolveBranch = cfg.gitBranch ?? cwdGitBranch;
     this.fetcher = cfg.fetchRows ?? (() => sqliteFetch(db, this.computeActivity));
     this.pollMs = typeof cfg.pollMs === "number" && cfg.pollMs > 0 ? cfg.pollMs : POLL_MS_DEFAULT;
     this.windowMs =
@@ -458,6 +465,13 @@ export class OpencodeObserver extends EventEmitter implements AgentObserver {
     }
     for (const row of rows) {
       const s = mapOpencodeSession(row, this.computeActivity);
+      // O-D1: enrich with the branch derived from the session's cwd.
+      if (this.computeActivity && s.cwd) {
+        const gitBranch = await this.resolveBranch(s.cwd);
+        if (gitBranch) {
+          s.activity = { ...(s.activity ?? { turnCount: 0, lastTools: [], filesTouched: [] }), gitBranch };
+        }
+      }
       const prev = this.sessions.get(s.sessionId);
       this.sessions.set(s.sessionId, s);
       if (this.emitFn && (!prev || prev.state !== s.state || prev.lastMtime !== s.lastMtime)) {


### PR DESCRIPTION
## What

Observer deepening (Sense S1a) — bring the non-Claude observers closer to parity and, crucially, make **"LISA can see all your agents"** *verifiable against real tools*, not just fixtures. Implements all three items from [PLAN_OBSERVER_DEEPENING_v1.0.md](docs/PLAN_OBSERVER_DEEPENING_v1.0.md).

## O-D1 — `gitBranch` for codex / opencode

codex rollouts and the opencode DB don't store a branch (Claude Code's JSONL does), but they record the session's **cwd** — so we derive it from disk.

- **`src/integrations/git/branch.ts`** — `cwdGitBranch` runs `git symbolic-ref --short HEAD` (returns the branch even before the first commit; detached / non-repo / no-git / timeout → `undefined`). `execFile` (no shell injection), 5s timeout, 30s per-cwd cache. Injectable (`GitBranchResolver`) so observer tests need no real git. **Branch name only** — never a diff or content.
- codex (`record()`) + opencode (`poll()`) enrich `activity.gitBranch` from cwd at visibility ≥ `activity`; the resolver never runs at the `metadata` tier.

## O-D2 — widen coverage on long sessions

- codex activity tail **64 KB → 128 KB**; opencode recent-message scan **20 → 40**. Same fields extracted, just less under-counting on long sessions.

## O-D3 — live-verification harness (the real gap)

Fixtures prove the parse *logic*; they can't prove the *schema* still matches a drifting CLI. So:

- **`scripts/verify-observers.ts`** starts the hub against your machine and prints the `SessionActivity` each observer currently parses, to eyeball against what the agent is actually doing. Read-only; structural metadata only.
  - Smoke-tested live: correctly surfaced **9 active claude-code sessions** with state / branch / tools / files / tokens.
- **`docs/OBSERVER_FIDELITY.md`** — field-availability table + a **verification log** to turn "implemented" into "verified per CLI version" (a column going blank in the harness output is the drift signal).

## Honest non-goals kept

No `pendingPermission` for codex/opencode (their formats have no explicit permission gate); no `lastTools`/`tokens`/`command` for aider (markdown has no structured tools). Inventing these would be a false signal or violate the privacy contract.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **585 tests pass (+10)**: branch resolver (real-git temp repo, non-repo, cache TTL), codex + opencode gitBranch wiring (injected resolver; never at metadata tier), codex 128 KB-tail fixture (early file in a >64 KB session captured), opencode `LIMIT 40` query
- Privacy: gitBranch derivation is `execFile` (no shell); existing planted-secret tests still green

🤖 Generated with [Claude Code](https://claude.com/claude-code)