### PR TITLE
feat(foundations): F-consent — unified consent framework (the Sense prerequisite)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -59,6 +59,9 @@ INSPECTION
                                Defaults to the last 7 days.
   lisa model <sub>             Local model lifecycle (Ollama): list, install
                                <model>, use local://<model> to switch, health.
+  lisa consent <sub>           Consent for sensitive ambient signals (default
+                               all off): list, grant <signal>, revoke <signal>,
+                               revoke-all.
 
 LIFECYCLE
   lisa birth                   Run the birth ritual (auto-runs on first launch).
@@ -162,7 +165,8 @@ interface ParsedArgs {
     | "doctor"
     | "monitor"
     | "autonomy"
-    | "model";
+    | "model"
+    | "consent";
   subargs: string[];
   serveWeb: boolean;
   serveImessage: boolean;
@@ -281,7 +285,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       first === "doctor" ||
       first === "monitor" ||
       first === "autonomy" ||
-      first === "model"
+      first === "model" ||
+      first === "consent"
     ) {
       out.subcommand = first;
       out.subargs = positional.slice(1);
@@ -460,6 +465,11 @@ async function main(): Promise<void> {
   if (args.subcommand === "model") {
     const { runModelCommand } = await import("./cli/model.js");
     process.exit(await runModelCommand(args.subargs));
+  }
+
+  if (args.subcommand === "consent") {
+    const { runConsentCommand } = await import("./cli/consent.js");
+    process.exit(await runConsentCommand(args.subargs));
   }
 
   if (args.subcommand === "sessions") {

--- a/src/cli/consent.ts
+++ b/src/cli/consent.ts
@@ -1,0 +1,70 @@
+/**
+ * `lisa consent <list|grant|revoke|revoke-all>` — view and control the unified
+ * consent for sensitive ambient signals (FOUNDATIONS §1). Thin CLI over
+ * src/consent/store.ts. This is the "always visible + one-tap stop" surface
+ * until the island SENSE indicator lands with the first source.
+ */
+import {
+  listGrants,
+  grant,
+  revoke,
+  revokeAll,
+  SENSE_SIGNALS,
+  SIGNAL_DESCRIPTIONS,
+} from "../consent/store.js";
+
+function printList(): void {
+  console.log("Consent — sensitive ambient signals (default: all off):\n");
+  for (const row of listGrants()) {
+    const mark = row.granted ? "● on " : "○ off";
+    const desc = SIGNAL_DESCRIPTIONS[row.signal] ?? "";
+    const when = row.granted && row.grantedAt ? `  (since ${row.grantedAt.slice(0, 10)})` : "";
+    console.log(`  ${mark}  ${row.signal.padEnd(10)} ${desc}${when}`);
+  }
+  console.log("\n  lisa consent grant <signal> | revoke <signal> | revoke-all");
+}
+
+export async function runConsentCommand(subargs: string[]): Promise<number> {
+  const sub = subargs[0] ?? "list";
+
+  if (sub === "list" || sub === "status") {
+    printList();
+    return 0;
+  }
+
+  if (sub === "grant") {
+    const signal = subargs[1];
+    if (!signal) {
+      console.error(`grant needs a signal — one of: ${SENSE_SIGNALS.join(", ")}`);
+      return 1;
+    }
+    // The consent "card": say plainly what enabling captures before granting.
+    const desc = SIGNAL_DESCRIPTIONS[signal] ?? "(custom signal)";
+    console.log(`Granting "${signal}" lets LISA capture: ${desc}.`);
+    console.log("Local-first: raw is judged/distilled on-device; only structured summaries are stored.");
+    console.log("Revoke any time with `lisa consent revoke " + signal + "` (or `revoke-all`).");
+    grant(signal);
+    console.log(`\n✓ ${signal} granted.`);
+    return 0;
+  }
+
+  if (sub === "revoke") {
+    const signal = subargs[1];
+    if (!signal) {
+      console.error("revoke needs a signal (or use `revoke-all`).");
+      return 1;
+    }
+    revoke(signal);
+    console.log(`✓ ${signal} revoked.`);
+    return 0;
+  }
+
+  if (sub === "revoke-all" || sub === "stop") {
+    revokeAll();
+    console.log("✓ all sensitive capture stopped.");
+    return 0;
+  }
+
+  console.error(`unknown consent subcommand "${sub}" — use list | grant | revoke | revoke-all.`);
+  return 1;
+}

--- a/src/consent/blacklist.test.ts
+++ b/src/consent/blacklist.test.ts
@@ -1,0 +1,49 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isBlacklistedApp,
+  isBlacklistedPath,
+  containsPII,
+  redactPII,
+} from "./blacklist.js";
+
+describe("isBlacklistedApp", () => {
+  test("matches password managers / finance, case-insensitive substring", () => {
+    assert.equal(isBlacklistedApp("1Password 8"), true);
+    assert.equal(isBlacklistedApp("Chase Banking"), true);
+    assert.equal(isBlacklistedApp("Coinbase"), true);
+    assert.equal(isBlacklistedApp("Visual Studio Code"), false);
+    assert.equal(isBlacklistedApp(undefined), false);
+  });
+  test("honors user-supplied extras", () => {
+    assert.equal(isBlacklistedApp("My Diary", ["diary"]), true);
+  });
+});
+
+describe("isBlacklistedPath", () => {
+  test("matches secrets / keys / credentials", () => {
+    assert.equal(isBlacklistedPath("/home/me/.env"), true);
+    assert.equal(isBlacklistedPath("/home/me/project/.env.local"), true);
+    assert.equal(isBlacklistedPath("/keys/server.pem"), true);
+    assert.equal(isBlacklistedPath("/home/me/.ssh/id_rsa"), true);
+    assert.equal(isBlacklistedPath("/secrets/db.txt"), true);
+    assert.equal(isBlacklistedPath("/home/me/notes.md"), false);
+    assert.equal(isBlacklistedPath(undefined), false);
+  });
+});
+
+describe("PII detection + redaction", () => {
+  test("containsPII detects email / ssn / card; clean text → false", () => {
+    assert.equal(containsPII("ping me at a@b.com"), true);
+    assert.equal(containsPII("ssn 123-45-6789"), true);
+    assert.equal(containsPII("card 4111 1111 1111 1111"), true);
+    assert.equal(containsPII("nothing sensitive here"), false);
+  });
+
+  test("redactPII replaces with typed placeholders and is repeatable (no /g lastIndex leak)", () => {
+    const t = "mail a@b.com and c@d.org";
+    assert.equal(redactPII(t), "mail [email] and [email]");
+    assert.equal(redactPII(t), "mail [email] and [email]"); // second call identical
+    assert.ok(!containsPII(redactPII("ssn 123-45-6789")), "redacted text has no PII");
+  });
+});

--- a/src/consent/blacklist.ts
+++ b/src/consent/blacklist.ts
@@ -1,0 +1,78 @@
+/**
+ * Consent blacklists (FOUNDATIONS §1) — the "never capture this" filters that
+ * sit UNDER consent: even a granted source must skip blacklisted apps, paths,
+ * and PII. Pure functions (no I/O) so they're exhaustively testable and can run
+ * on the hot path of every capture frame.
+ *
+ * These are conservative DEFAULTS; a source merges user-configured extras on top
+ * (never replacing the defaults). Matching is deliberately broad — a false
+ * "blacklisted" (skip a frame) is harmless; a false "allowed" leaks.
+ */
+
+/** Foreground apps whose presence means "capture nothing this frame". */
+export const DEFAULT_APP_BLACKLIST: string[] = [
+  "1password",
+  "keychain access",
+  "bitwarden",
+  "lastpass",
+  "dashlane",
+  "nordpass",
+  "proton pass",
+  "authy",
+  // banking / finance surfaces (substring match catches "… Banking", etc.)
+  "bank",
+  "venmo",
+  "paypal",
+  "coinbase",
+  "robinhood",
+  "wallet",
+];
+
+/** Path/title patterns for sensitive files (secrets, keys, credentials). */
+export const DEFAULT_PATH_BLACKLIST: RegExp[] = [
+  /(^|[./])\.env($|[./])/i,
+  /\.(key|pem|p12|pfx|keystore)$/i,
+  /id_(rsa|ed25519|ecdsa)\b/i,
+  /\bsecrets?\b/i,
+  /\bcredentials?\b/i,
+  /\.ssh\//i,
+  /\.aws\//i,
+];
+
+/** PII patterns we redact from any captured text before it's distilled/stored. */
+export const PII_PATTERNS: { name: string; re: RegExp }[] = [
+  { name: "email", re: /\b[\w.+-]+@[\w-]+\.[\w.-]+\b/g },
+  { name: "ssn", re: /\b\d{3}-\d{2}-\d{4}\b/g },
+  // 13–19 digit runs (optionally space/dash grouped) — credit-card-ish.
+  { name: "card", re: /\b(?:\d[ -]?){13,19}\b/g },
+];
+
+/** Is `appName` a blacklisted foreground app? Case-insensitive substring. */
+export function isBlacklistedApp(appName: string | undefined, extra: string[] = []): boolean {
+  if (!appName) return false;
+  const n = appName.toLowerCase();
+  return [...DEFAULT_APP_BLACKLIST, ...extra].some((b) => b && n.includes(b.toLowerCase()));
+}
+
+/** Is `p` a blacklisted path / window title (secrets, keys, credentials)? */
+export function isBlacklistedPath(p: string | undefined, extra: RegExp[] = []): boolean {
+  if (!p) return false;
+  return [...DEFAULT_PATH_BLACKLIST, ...extra].some((re) => re.test(p));
+}
+
+/** Does `text` contain any PII pattern? */
+export function containsPII(text: string): boolean {
+  if (!text) return false;
+  // `.test` on a /g regex advances lastIndex; build fresh each call to stay pure.
+  return PII_PATTERNS.some(({ re }) => new RegExp(re.source, re.flags).test(text));
+}
+
+/** Replace every PII match with a typed placeholder, e.g. "[email]". Pure. */
+export function redactPII(text: string): string {
+  if (!text) return text;
+  let out = text;
+  for (const { name, re } of PII_PATTERNS) {
+    out = out.replace(new RegExp(re.source, re.flags), `[${name}]`);
+  }
+  return out;
+}

--- a/src/consent/store.test.ts
+++ b/src/consent/store.test.ts
@@ -1,0 +1,88 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import {
+  isGranted,
+  grant,
+  revoke,
+  revokeAll,
+  listGrants,
+  loadConsent,
+  isExpired,
+  SENSE_SIGNALS,
+} from "./store.js";
+
+let home: string;
+let prev: string | undefined;
+beforeEach(() => {
+  prev = process.env.LISA_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-consent-"));
+  process.env.LISA_HOME = home;
+});
+afterEach(() => {
+  if (prev === undefined) delete process.env.LISA_HOME;
+  else process.env.LISA_HOME = prev;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+describe("consent store — default-off gate", () => {
+  test("fresh install → every sense signal denied", () => {
+    for (const sig of SENSE_SIGNALS) assert.equal(isGranted(sig), false);
+    assert.equal(isGranted("anything-unknown"), false);
+  });
+
+  test("grant flips the gate on, records grantedAt + options; others stay off", () => {
+    grant("screen", { retentionDays: 7 }, 1000);
+    assert.equal(isGranted("screen"), true);
+    assert.equal(isGranted("voice"), false);
+    const row = listGrants().find((r) => r.signal === "screen")!;
+    assert.equal(row.granted, true);
+    assert.equal(row.grantedAt, new Date(1000).toISOString());
+    assert.deepEqual(row.options, { retentionDays: 7 });
+  });
+
+  test("revoke turns one off, leaves the rest", () => {
+    grant("screen");
+    grant("voice");
+    revoke("screen");
+    assert.equal(isGranted("screen"), false);
+    assert.equal(isGranted("voice"), true);
+  });
+
+  test("revokeAll stops everything (one-tap)", () => {
+    grant("screen");
+    grant("voice");
+    grant("clipboard");
+    revokeAll();
+    for (const sig of SENSE_SIGNALS) assert.equal(isGranted(sig), false);
+    assert.equal(isGranted("clipboard"), false);
+  });
+
+  test("corrupt file fails closed (denied)", () => {
+    fs.writeFileSync(path.join(home, "consent.json"), "{ not json");
+    assert.equal(isGranted("screen"), false);
+    assert.deepEqual(loadConsent(), { grants: {} });
+  });
+
+  test("listGrants always includes every canonical signal", () => {
+    const sigs = listGrants().map((r) => r.signal);
+    for (const s of SENSE_SIGNALS) assert.ok(sigs.includes(s), `missing ${s}`);
+  });
+});
+
+describe("isExpired — retention", () => {
+  const DAY = 24 * 60 * 60_000;
+  test("within window → false; past window → true", () => {
+    const now = 10 * DAY;
+    assert.equal(isExpired(now - 1 * DAY, 7, now), false);
+    assert.equal(isExpired(now - 8 * DAY, 7, now), true);
+  });
+  test("retentionDays ≤ 0 / non-finite → expire immediately (fail safe)", () => {
+    const now = 10 * DAY;
+    assert.equal(isExpired(now, 0, now), true);
+    assert.equal(isExpired(now, -1, now), true);
+    assert.equal(isExpired(now, NaN, now), true);
+  });
+});

--- a/src/consent/store.ts
+++ b/src/consent/store.ts
@@ -1,0 +1,168 @@
+/**
+ * Unified consent store (FOUNDATIONS §1 — the master constraint for Sense).
+ *
+ * Single source of truth at ~/.lisa/consent.json. Every sensitive ambient
+ * signal source (screen / voice / clipboard / selection) must check
+ * `isGranted(signal)` before it captures anything — ungranted → no-op, never
+ * "capture first, ask later". Default is ALL OFF: an absent signal is denied.
+ *
+ * This is the framework S2 (ambient vision/voice) builds on; it ships before any
+ * source so the gate exists from day one. UI surfacing (island SENSE indicator
+ * + one-tap revoke) lands with the first source — the CLI (`lisa consent`) gives
+ * control in the meantime.
+ *
+ * Back-compat: a brand-new, independent file; its absence means "nothing
+ * granted", i.e. exactly the pre-existing behavior.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+/** A sensitive ambient signal. Open-ended, but these are the canonical ones. */
+export type ConsentSignal =
+  | "screen"
+  | "voice"
+  | "clipboard"
+  | "selection"
+  | (string & {});
+
+/** The ambient-sense signals — all OFF until the user explicitly grants each. */
+export const SENSE_SIGNALS: ConsentSignal[] = ["screen", "voice", "clipboard", "selection"];
+
+/** Human-facing "what does enabling this capture?" — shown on the consent card. */
+export const SIGNAL_DESCRIPTIONS: Record<string, string> = {
+  screen: "foreground app/window names and (optionally) low-frequency screenshots",
+  voice: "microphone audio for push-to-talk transcription",
+  clipboard: "clipboard contents when you copy",
+  selection: "text you select / point at",
+};
+
+export interface ConsentGrant {
+  granted: boolean;
+  /** ISO timestamp of the most recent grant. */
+  grantedAt?: string;
+  /** Per-signal options (e.g. { retentionDays, everySec }). */
+  options?: Record<string, unknown>;
+}
+
+export interface ConsentState {
+  grants: Record<string, ConsentGrant>;
+}
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+
+/** Resolved lazily so tests can point LISA_HOME at a tmp dir. */
+function consentPath(): string {
+  return path.join(lisaHome(), "consent.json");
+}
+
+/** Read the consent state; tolerant of a missing or corrupt file (all-off). */
+export function loadConsent(): ConsentState {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(consentPath(), "utf8");
+  } catch {
+    return { grants: {} }; // no file yet → nothing granted
+  }
+  try {
+    const parsed = JSON.parse(raw) as Partial<ConsentState>;
+    if (!parsed || typeof parsed !== "object" || typeof parsed.grants !== "object" || !parsed.grants) {
+      return { grants: {} };
+    }
+    return { grants: parsed.grants as Record<string, ConsentGrant> };
+  } catch {
+    return { grants: {} }; // corrupt → treat as nothing granted (fail closed)
+  }
+}
+
+function saveConsent(state: ConsentState): void {
+  const file = consentPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(state, null, 2));
+}
+
+/**
+ * THE GATE. True only if the signal has been explicitly granted. Absent /
+ * revoked / corrupt-file → false (fail closed). Every source calls this before
+ * capturing.
+ */
+export function isGranted(signal: ConsentSignal): boolean {
+  return loadConsent().grants[signal]?.granted === true;
+}
+
+/** Grant a signal (records grantedAt + optional options). Returns new state. */
+export function grant(
+  signal: ConsentSignal,
+  options?: Record<string, unknown>,
+  now: number = Date.now(),
+): ConsentState {
+  const state = loadConsent();
+  state.grants[signal] = {
+    granted: true,
+    grantedAt: new Date(now).toISOString(),
+    ...(options ? { options } : {}),
+  };
+  saveConsent(state);
+  return state;
+}
+
+/** Revoke one signal (keeps a record that it's off). Returns new state. */
+export function revoke(signal: ConsentSignal): ConsentState {
+  const state = loadConsent();
+  state.grants[signal] = { granted: false };
+  saveConsent(state);
+  return state;
+}
+
+/** One-tap stop-all: flip every known grant off. Returns new state. */
+export function revokeAll(): ConsentState {
+  const state = loadConsent();
+  for (const key of Object.keys(state.grants)) {
+    state.grants[key] = { granted: false };
+  }
+  // Also ensure every canonical signal is explicitly recorded off, so a UI
+  // listing shows them as deliberately-stopped rather than merely absent.
+  for (const sig of SENSE_SIGNALS) {
+    if (!state.grants[sig]) state.grants[sig] = { granted: false };
+  }
+  saveConsent(state);
+  return state;
+}
+
+export interface ConsentRow {
+  signal: string;
+  granted: boolean;
+  grantedAt?: string;
+  options?: Record<string, unknown>;
+}
+
+/** All canonical signals + any extra recorded ones, with current status. */
+export function listGrants(): ConsentRow[] {
+  const state = loadConsent();
+  const keys = new Set<string>([...SENSE_SIGNALS, ...Object.keys(state.grants)]);
+  return [...keys].sort().map((signal) => {
+    const g = state.grants[signal];
+    return {
+      signal,
+      granted: g?.granted === true,
+      ...(g?.grantedAt ? { grantedAt: g.grantedAt } : {}),
+      ...(g?.options ? { options: g.options } : {}),
+    };
+  });
+}
+
+/**
+ * Retention primitive: is a captured item past its retention window? Pure;
+ * sources/cleanup call this so raw never lingers past `retentionDays`.
+ * retentionDays ≤ 0 / non-finite → treated as "expire immediately" (fail safe).
+ */
+export function isExpired(
+  capturedAtMs: number,
+  retentionDays: number,
+  now: number = Date.now(),
+): boolean {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) return true;
+  return now - capturedAtMs > retentionDays * 24 * 60 * 60_000;
+}


### PR DESCRIPTION
## What

**F-consent** (FOUNDATIONS §1) — the master constraint for Sense: a single source of truth for consent to sensitive ambient signals, defaulting to **ALL OFF**, so the ambient sources (S2: screen / voice / clipboard / selection) have a gate to build on *before any of them exists*.

Per the plan, S2's ambient capture is the **riskiest and largest** piece and is **hard-gated** on this framework landing first. This PR is the **framework only** — no capture sources, no island UI yet.

Brand-new, independent files; the absence of `consent.json` means exactly today's behavior (nothing captured) — fully back-compatible.

## How

- **`src/consent/store.ts`** — `~/.lisa/consent.json` single source of truth.
  - `isGranted(signal)` is **THE gate**: a source no-ops unless the signal was explicitly granted. Absent / revoked / corrupt file → `false` (**fail closed**).
  - `grant` / `revoke` / `revokeAll` (one-tap stop) / `listGrants`.
  - `isExpired(capturedAt, retentionDays)` retention primitive (≤0 / NaN → expire immediately, **fail safe**).
- **`src/consent/blacklist.ts`** — pure "never capture this" filters that sit **under** consent (even a granted source must skip these):
  - app blacklist (password managers, finance), path blacklist (`.env` / `.key` / `.pem` / `.ssh` / credentials), and PII **detect + redact** (email / SSN / card).
  - conservative defaults + user extras; over-blocking is harmless, under-blocking leaks.
- **`src/cli/consent.ts` + `cli.ts`** — `lisa consent list | grant <signal> | revoke <signal> | revoke-all`: the "always visible + one-tap stop" surface (grant prints a plain-language consent card) until the island SENSE indicator ships with the first source.

## Acceptance (from the plan, covered by tests)

- ✅ Fresh install → every sense signal denied (`screen`/`voice`/`clipboard`/`selection`)
- ✅ `grant` flips only that signal on (records `grantedAt` + options); others stay off
- ✅ `revokeAll()` stops everything in one call
- ✅ corrupt `consent.json` → fail closed (denied)
- ✅ blacklist matches secrets / finance / PII; redaction is repeatable (no `/g` lastIndex leak)

The remaining plan acceptances (blacklisted app in foreground → zero capture; raw bytes never persisted; planted-secret per source) are **per-source** and land with S2, on top of this gate.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **598 tests pass (+13)** across store (default-off gate, grant/revoke/revoke-all, fail-closed, retention) and blacklist (app/path/PII)
- `lisa consent` smoke-tested end-to-end (list → grant w/ card → revoke-all)

🤖 Generated with [Claude Code](https://claude.com/claude-code)