### PR TITLE
feat(sense): island consent UI — "always visible + one-tap stop" for sensing

### DIFF
--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -378,6 +378,64 @@ export const ISLAND_HTML = `<!doctype html>
   #claude-list .trail .tdot.error   { background: #ff5577; }
   /* (older stub removed — .head is a real flex strip now, see above) */
 
+  /* ── Sense consent (FOUNDATIONS §1) — "always visible + one-tap stop" ── */
+  #sense-list { list-style: none; margin: 6px 0 0; padding: 0; }
+  #sense-list li {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 6px 4px;
+    font-size: 11.5px;
+  }
+  #sense-list li + li { border-top: 1px solid rgba(255, 255, 255, 0.05); }
+  #sense-list .s-name { font-weight: 600; flex-shrink: 0; }
+  #sense-list .s-desc {
+    color: var(--fg-faint);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 10px;
+  }
+  /* Toggle pill: off is muted, on is amber. Click flips it (grant shows the
+     description inline so the user sees what they're enabling). */
+  #sense-list .s-toggle {
+    flex-shrink: 0;
+    cursor: pointer;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    padding: 2px 8px;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 255, 255, 0.12);
+    background: rgba(255, 255, 255, 0.05);
+    color: var(--fg-dim);
+  }
+  #sense-list .s-toggle.on {
+    color: #0b0e18;
+    background: var(--accent-warm);
+    border-color: var(--accent-warm);
+  }
+  /* The label glows amber while anything is being sensed. */
+  body.sensing #sense-label { color: var(--accent-warm); }
+  #sense-stop {
+    display: none;
+    margin-top: 8px;
+    width: 100%;
+    padding: 7px 12px;
+    border-radius: 10px;
+    border: 1px solid rgba(255, 85, 119, 0.35);
+    background: rgba(255, 85, 119, 0.12);
+    color: #ffd6de;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+  }
+  #sense-stop:hover { background: rgba(255, 85, 119, 0.2); }
+  body.sensing #sense-stop { display: block; }
+
   /* Phase 3 — notification opt-in chip */
   #notify-cta {
     display: none;
@@ -495,6 +553,11 @@ export const ISLAND_HTML = `<!doctype html>
       <ul id="claude-list"></ul>
       <div id="notify-cta" role="button" tabindex="0">🔔 Notify me when Claude is waiting</div>
     </div>
+    <div id="sense-section">
+      <div class="section-label" id="sense-label">👁 sense · <span id="sense-summary">all off</span></div>
+      <ul id="sense-list"></ul>
+      <button id="sense-stop" type="button">Stop all sensing</button>
+    </div>
     <div id="actions">
       <button id="btn-open">Open chat</button>
       <button id="btn-dismiss" class="muted">Dismiss ★</button>
@@ -530,6 +593,9 @@ export const ISLAND_HTML = `<!doctype html>
   const suggTitle    = document.getElementById('suggestion-title');
   const suggRationale= document.getElementById('suggestion-rationale');
   const suggAct      = document.getElementById('suggestion-act');
+  const senseList    = document.getElementById('sense-list');
+  const senseSummary = document.getElementById('sense-summary');
+  const senseStop    = document.getElementById('sense-stop');
   const body         = document.body;
 
   const state = {
@@ -543,6 +609,7 @@ export const ISLAND_HTML = `<!doctype html>
     agentSessions: [],   // [{agent, project, sessionId, lastMtime, state, activity}, …] — all agents, not just Claude
     suggestion: null,    // {title, rationale, task, at} from the screen advisor
     advisor: [],         // [{id, category, urgency, text, action}] from the cross-agent advisor
+    sense: [],           // [{signal, granted, grantedAt}] from /api/consent (FOUNDATIONS §1)
   };
 
   // 30-min activity window matches the watcher's ACTIVE_WINDOW_MS.
@@ -699,6 +766,7 @@ export const ISLAND_HTML = `<!doctype html>
     body.classList.toggle('has-advisor', state.advisor.length > 0);
     renderAdvisorList();
     renderClaudeList();
+    renderSense();
   }
 
   // ── Cross-agent advisor card ───────────────────────────────────────
@@ -1244,6 +1312,70 @@ export const ISLAND_HTML = `<!doctype html>
     }
   }
 
+  // ── Sense consent (FOUNDATIONS §1) ─────────────────────────────────
+  // "Always visible + one-tap stop": list each sensitive signal with a
+  // toggle; the label + Stop-all button light up while anything is on.
+  function renderSense() {
+    const grants = state.sense || [];
+    const onCount = grants.filter((g) => g.granted).length;
+    senseSummary.textContent = onCount > 0 ? (onCount + ' on') : 'all off';
+    body.classList.toggle('sensing', onCount > 0);
+    while (senseList.firstChild) senseList.removeChild(senseList.firstChild);
+    for (const g of grants) {
+      const li = document.createElement('li');
+      const name = document.createElement('span');
+      name.className = 's-name';
+      name.textContent = g.signal;
+      const desc = document.createElement('span');
+      desc.className = 's-desc';
+      desc.textContent = g.description || '';
+      desc.title = g.description || '';
+      const toggle = document.createElement('span');
+      toggle.className = 's-toggle' + (g.granted ? ' on' : '');
+      toggle.textContent = g.granted ? 'on' : 'off';
+      toggle.setAttribute('role', 'button');
+      toggle.tabIndex = 0;
+      toggle.addEventListener('click', (e) => {
+        e.stopPropagation();
+        setSenseSignal(g.signal, !g.granted);
+      });
+      li.appendChild(name);
+      li.appendChild(desc);
+      li.appendChild(toggle);
+      senseList.appendChild(li);
+    }
+  }
+
+  function applyConsent(j) {
+    if (j && Array.isArray(j.grants)) { state.sense = j.grants; renderSense(); }
+  }
+
+  async function fetchConsent() {
+    try {
+      const r = await fetch('/api/consent', { cache: 'no-store' });
+      if (r.ok) applyConsent(await r.json());
+    } catch (_) { /* older server without /api/consent — silent */ }
+  }
+
+  async function setSenseSignal(signal, on) {
+    try {
+      const r = await fetch('/api/consent/' + (on ? 'grant' : 'revoke'), {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ signal: signal }),
+      });
+      if (r.ok) applyConsent(await r.json());
+    } catch (_) {}
+  }
+
+  async function stopAllSensing() {
+    try {
+      const r = await fetch('/api/consent/revoke-all', { method: 'POST' });
+      if (r.ok) applyConsent(await r.json());
+    } catch (_) {}
+  }
+  senseStop.addEventListener('click', (e) => { e.stopPropagation(); stopAllSensing(); });
+
   // Phase 3 — notification permission opt-in. The CTA is only visible
   // when permission is in the default (un-asked) state.
   notifyCta.addEventListener('click', (e) => {
@@ -1258,6 +1390,7 @@ export const ISLAND_HTML = `<!doctype html>
   setAvatar('neutral');
   pollPing();
   fetchClaudeSessions().then(() => { refreshDot(); refreshPanel(); });
+  fetchConsent();
   subscribe();
   refreshNotifyCta();
   // A fresh island picks up the most recent screen-advisor suggestion (if the
@@ -1280,6 +1413,8 @@ export const ISLAND_HTML = `<!doctype html>
   // (laptop sleep, network blip) and we need to refresh state.
   setInterval(pollPing, 30_000);
   setInterval(fetchClaudeSessions, 60_000);
+  // Pick up consent changes made elsewhere (e.g. the lisa consent CLI).
+  setInterval(fetchConsent, 30_000);
   // Re-render every 15s so "Xs ago" / "Xm ago" labels stay fresh and
   // stale sessions fall off the list without a fresh update event.
   setInterval(() => {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -32,6 +32,7 @@ import type { AgentSession } from "../integrations/types.js";
 import { captureScreenshot, captureSupported, type CaptureMode } from "../vision/capture.js";
 import { transcribeAudio } from "../voice/transcribe.js";
 import { polishDictation, type DictationProvider } from "../voice/dictation.js";
+import { listGrants, grant, revoke, revokeAll, SENSE_SIGNALS, SIGNAL_DESCRIPTIONS } from "../consent/store.js";
 import {
   loadScreenAdvisorConfig,
   saveScreenAdvisorConfig,
@@ -669,6 +670,53 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       }
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    // ── Consent (FOUNDATIONS §1) ────────────────────────────────────────
+    // The island's "always visible + one-tap stop" surface. GET lists every
+    // sense signal + status; the POSTs grant/revoke/stop-all. Sources gate on
+    // isGranted() server-side regardless — this is control, not the gate.
+    if (req.method === "GET" && url === "/api/consent") {
+      const grants = listGrants().map((g) => ({
+        ...g,
+        description: SIGNAL_DESCRIPTIONS[g.signal] ?? "",
+      }));
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ grants }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/consent/revoke-all") {
+      revokeAll();
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, grants: listGrants() }));
+      return;
+    }
+    if (
+      req.method === "POST" &&
+      (url === "/api/consent/grant" || url === "/api/consent/revoke")
+    ) {
+      let cBody = "";
+      for await (const chunk of req) cBody += chunk.toString("utf8");
+      let payload: { signal?: unknown };
+      try {
+        payload = JSON.parse(cBody || "{}");
+      } catch {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("bad json");
+        return;
+      }
+      const signal = payload.signal;
+      // Only the canonical sense signals are togglable from the UI.
+      if (typeof signal !== "string" || !SENSE_SIGNALS.includes(signal)) {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end(`signal must be one of: ${SENSE_SIGNALS.join(", ")}`);
+        return;
+      }
+      if (url === "/api/consent/grant") grant(signal);
+      else revoke(signal);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, grants: listGrants() }));
       return;
     }
 


### PR DESCRIPTION
## What

Surfaces the [F-consent](https://github.com/oratis/LISA/pull/87) framework in the **island**, delivering the FOUNDATIONS §1 *"always visible + one-tap stop"* promise — **before** any ambient source exists, so the control surface is there from day one. First of the three S2 steps (① consent UI → ② S2-screen → ③ S2-voice).

## How

- **server** — `GET /api/consent` (each signal + status + plain-language description), `POST /api/consent/grant|revoke {signal}` (validated against `SENSE_SIGNALS`), `POST /api/consent/revoke-all`. Thin wrappers over the **already-tested** consent store; sources still gate on `isGranted()` server-side — this is *control*, not the gate.
- **island** — a `👁 sense` section in the expand panel listing each signal with its description and an **on/off toggle**; the section label + a red **"Stop all sensing"** button light up (`body.sensing`) whenever anything is granted. Polls `/api/consent` on load and resyncs every 30s, so `lisa consent` CLI changes reflect live.

No ambient capture in this PR — this is the visibility/control surface that S2's screen/voice sources will light up. Fresh state shows all four signals (`screen` / `voice` / `clipboard` / `selection`) **off**.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **598 tests pass**; the `ISLAND_HTML` inline `<script>` parses (html-syntax guard — caught a backtick-in-comment that would've broken the template literal), `MAIN_HTML` snapshot unchanged (island-only change)
- Underlying grant/revoke/revoke-all + validation are covered by the F-consent store tests

> Endpoints are thin wrappers over the tested store; there's no server-integration harness in the repo, so they're validated via typecheck + the store's unit tests + the inline-script parse guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)