### PR TITLE
feat(sense): S2-screen — foreground-app ambient signal (consent-gated, local-only)

### DIFF
--- a/src/sense/log.test.ts
+++ b/src/sense/log.test.ts
@@ -1,0 +1,56 @@
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { appendSenseEvent, readSenseEvents } from "./log.js";
+import type { SenseEvent } from "./types.js";
+
+let home: string;
+let prev: string | undefined;
+beforeEach(() => {
+  prev = process.env.LISA_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-sense-"));
+  process.env.LISA_HOME = home;
+});
+afterEach(() => {
+  if (prev === undefined) delete process.env.LISA_HOME;
+  else process.env.LISA_HOME = prev;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+function ev(over: Partial<SenseEvent> = {}): SenseEvent {
+  return { signal: "screen", kind: "foreground-app", app: "Code", summary: "switched to Code", ts: 1000, ...over };
+}
+
+describe("sense event log", () => {
+  test("append then read round-trips", () => {
+    appendSenseEvent(ev({ app: "Safari", ts: 1000 }), 1000);
+    appendSenseEvent(ev({ app: "Code", ts: 2000 }), 2000);
+    const all = readSenseEvents(2000);
+    assert.deepEqual(all.map((e) => e.app), ["Safari", "Code"]);
+  });
+
+  test("missing file → []", () => {
+    assert.deepEqual(readSenseEvents(1000), []);
+  });
+
+  test("corrupt lines are skipped, valid ones kept", () => {
+    fs.mkdirSync(path.join(home, "sense"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, "sense", "events.jsonl"),
+      "{ broken\n" + JSON.stringify(ev({ app: "Code", ts: 1000 })) + "\n",
+    );
+    const all = readSenseEvents(1000);
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.app, "Code");
+  });
+
+  test("events past the retention window are dropped on read", () => {
+    const DAY = 24 * 60 * 60_000;
+    appendSenseEvent(ev({ app: "Old", ts: 0 }), 0);
+    const now = 10 * DAY;
+    appendSenseEvent(ev({ app: "Fresh", ts: now }), now);
+    assert.deepEqual(readSenseEvents(now, 7).map((e) => e.app), ["Fresh"]);
+  });
+});

--- a/src/sense/log.ts
+++ b/src/sense/log.ts
@@ -1,0 +1,70 @@
+/**
+ * Sense event log (PLAN_SENSE S2 + FOUNDATIONS §4 observability) — a bounded,
+ * retention-capped JSONL of distilled SenseEvents at ~/.lisa/sense/events.jsonl.
+ *
+ * Only STRUCTURED events land here (the sources already redact/skip); raw bytes
+ * never reach this file. Bounded by a max-line cap AND a retention window so it
+ * can't grow without limit and stale context ages out.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isExpired } from "../consent/store.js";
+import type { SenseEvent } from "./types.js";
+
+const MAX_EVENTS = 1000;
+const DEFAULT_RETENTION_DAYS = 7;
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+function logPath(): string {
+  return path.join(lisaHome(), "sense", "events.jsonl");
+}
+
+/** Read all valid, non-expired events (oldest → newest). Tolerant of junk. */
+export function readSenseEvents(
+  now: number = Date.now(),
+  retentionDays: number = DEFAULT_RETENTION_DAYS,
+): SenseEvent[] {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(logPath(), "utf8");
+  } catch {
+    return [];
+  }
+  const out: SenseEvent[] = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const e = JSON.parse(line) as SenseEvent;
+      if (e && typeof e.signal === "string" && typeof e.ts === "number" && !isExpired(e.ts, retentionDays, now)) {
+        out.push(e);
+      }
+    } catch {
+      // skip a corrupt line
+    }
+  }
+  return out;
+}
+
+/**
+ * Append one event, then keep the file bounded: drop expired events and cap to
+ * the most recent MAX_EVENTS. Best-effort — never throws into the caller.
+ */
+export function appendSenseEvent(
+  e: SenseEvent,
+  now: number = Date.now(),
+  retentionDays: number = DEFAULT_RETENTION_DAYS,
+): void {
+  try {
+    const existing = readSenseEvents(now, retentionDays);
+    existing.push(e);
+    const kept = existing.slice(-MAX_EVENTS);
+    const file = logPath();
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(file, kept.map((x) => JSON.stringify(x)).join("\n") + "\n");
+  } catch {
+    // disk unavailable — drop the event rather than crash the sense loop
+  }
+}

--- a/src/sense/screen.test.ts
+++ b/src/sense/screen.test.ts
@@ -1,0 +1,118 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { shouldEmitForeground, ScreenSource, type ForegroundProbe } from "./screen.js";
+import type { SenseEvent } from "./types.js";
+
+const NOW = 1_700_000_000_000;
+
+describe("shouldEmitForeground (pure, privacy-critical)", () => {
+  test("new foreground app → event with app name + summary", () => {
+    const ev = shouldEmitForeground(undefined, { app: "Visual Studio Code" }, NOW);
+    assert.ok(ev);
+    assert.equal(ev!.signal, "screen");
+    assert.equal(ev!.kind, "foreground-app");
+    assert.equal(ev!.app, "Visual Studio Code");
+    assert.equal(ev!.summary, "switched to Visual Studio Code");
+    assert.equal(ev!.ts, NOW);
+  });
+
+  test("unchanged app → null", () => {
+    assert.equal(shouldEmitForeground("Safari", { app: "Safari" }, NOW), null);
+  });
+
+  test("no app → null", () => {
+    assert.equal(shouldEmitForeground("Safari", {}, NOW), null);
+  });
+
+  test("blacklisted app (password manager) → null (frame skipped)", () => {
+    assert.equal(shouldEmitForeground("Safari", { app: "1Password" }, NOW), null);
+    assert.equal(shouldEmitForeground("Safari", { app: "Chase Banking" }, NOW), null);
+  });
+
+  test("window title: secret-path dropped, PII redacted, normal kept", () => {
+    const secret = shouldEmitForeground(undefined, { app: "Terminal", title: "vim /home/me/.env" }, NOW);
+    assert.equal(secret!.title, undefined, "secret-path title dropped");
+
+    const pii = shouldEmitForeground(undefined, { app: "Mail", title: "to alice@example.com" }, NOW);
+    assert.equal(pii!.title, "to [email]", "PII in title redacted");
+
+    const ok = shouldEmitForeground(undefined, { app: "Notes", title: "Grocery list" }, NOW);
+    assert.equal(ok!.title, "Grocery list");
+  });
+
+  test("never carries raw screen content — only app/title/summary keys", () => {
+    const ev = shouldEmitForeground(undefined, { app: "X", title: "y" }, NOW)!;
+    assert.deepEqual(
+      Object.keys(ev).sort(),
+      ["app", "kind", "signal", "summary", "title", "ts"].sort(),
+    );
+  });
+});
+
+describe("ScreenSource (consent-gated, change-detecting)", () => {
+  function probeSeq(seq: Array<{ app?: string; title?: string }>): ForegroundProbe {
+    let i = 0;
+    return async () => seq[Math.min(i++, seq.length - 1)] ?? {};
+  }
+
+  test("captures nothing when consent is not granted", async () => {
+    const emitted: SenseEvent[] = [];
+    const src = new ScreenSource({
+      granted: () => false,
+      probe: probeSeq([{ app: "Safari" }]),
+      now: () => NOW,
+    });
+    await src.start((e) => emitted.push(e));
+    await src.tick();
+    await src.stop();
+    assert.equal(emitted.length, 0);
+  });
+
+  test("emits once per change when granted", async () => {
+    const emitted: SenseEvent[] = [];
+    const src = new ScreenSource({
+      granted: () => true,
+      probe: probeSeq([{ app: "Safari" }, { app: "Safari" }, { app: "Code" }]),
+      now: () => NOW,
+    });
+    await src.start((e) => emitted.push(e));
+    await src.tick(); // Safari (new)
+    await src.tick(); // Safari (no change)
+    await src.tick(); // Code (change)
+    await src.stop();
+    assert.deepEqual(emitted.map((e) => e.app), ["Safari", "Code"]);
+  });
+
+  test("switching THROUGH a blacklisted app leaves no trace and no false change", async () => {
+    const emitted: SenseEvent[] = [];
+    const src = new ScreenSource({
+      granted: () => true,
+      probe: probeSeq([{ app: "Safari" }, { app: "1Password" }, { app: "Safari" }]),
+      now: () => NOW,
+    });
+    await src.start((e) => emitted.push(e));
+    await src.tick(); // Safari
+    await src.tick(); // 1Password → skipped, prev stays Safari
+    await src.tick(); // Safari → unchanged vs prev → no event
+    await src.stop();
+    assert.deepEqual(emitted.map((e) => e.app), ["Safari"]);
+  });
+
+  test("a mid-run revoke stops emission and forgets context", async () => {
+    const emitted: SenseEvent[] = [];
+    let allow = true;
+    const src = new ScreenSource({
+      granted: () => allow,
+      probe: probeSeq([{ app: "Safari" }, { app: "Code" }, { app: "Code" }]),
+      now: () => NOW,
+    });
+    await src.start((e) => emitted.push(e));
+    await src.tick(); // Safari
+    allow = false;
+    await src.tick(); // revoked → nothing, prev reset
+    allow = true;
+    await src.tick(); // Code, but prev was reset → counts as new → 1 event
+    await src.stop();
+    assert.deepEqual(emitted.map((e) => e.app), ["Safari", "Code"]);
+  });
+});

--- a/src/sense/screen.ts
+++ b/src/sense/screen.ts
@@ -1,0 +1,129 @@
+/**
+ * Screen sense source (PLAN_SENSE S2-screen) — the user's foreground context as
+ * an ambient signal: WHICH app is in front, emitted only when it changes.
+ *
+ * Deliberately the cheap, low-sensitivity slice of S2-screen: app NAME (and an
+ * optional, blacklist-checked + PII-redacted window title). It does NOT capture
+ * screen pixels — there is no screenshot here; raw screen content never enters a
+ * SenseEvent. (The optional low-frequency screenshot→model path is a follow-up
+ * that reuses the existing screen-advisor, and would persist nothing.)
+ *
+ * Consent + privacy (FOUNDATIONS §1):
+ *   - captures nothing unless `screen` is granted; re-checks every tick so a
+ *     revoke takes effect within one interval (and resets state).
+ *   - a blacklisted foreground app (password manager / bank) → whole frame
+ *     skipped: no event, and prev stays put so the app is invisible to the
+ *     timeline (switching THROUGH it leaves no trace).
+ *   - a window title is dropped if it looks like a secret path, else PII-redacted.
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { isGranted } from "../consent/store.js";
+import { isBlacklistedApp, isBlacklistedPath, redactPII } from "../consent/blacklist.js";
+import type { SenseEvent, SenseSource } from "./types.js";
+
+const pexec = promisify(execFile);
+const DEFAULT_INTERVAL_MS = 15_000;
+
+/** Probes the current foreground app (+ optional title). Injectable for tests. */
+export type ForegroundProbe = () => Promise<{ app?: string; title?: string }>;
+
+/** macOS foreground app via System Events. {} off-darwin / on any failure. */
+export const defaultForegroundProbe: ForegroundProbe = async () => {
+  if (process.platform !== "darwin") return {};
+  try {
+    const { stdout } = await pexec(
+      "osascript",
+      ["-e", 'tell application "System Events" to get name of first application process whose frontmost is true'],
+      { timeout: 3_000 },
+    );
+    return { app: stdout.trim() || undefined };
+  } catch {
+    return {}; // no permission / not darwin / timeout → capture nothing
+  }
+};
+
+/**
+ * Decide whether a foreground probe should produce an event. Pure — the privacy-
+ * critical unit. Returns null for: no app, a blacklisted app (skip frame), or no
+ * change since prevApp. A surfaced title is secret-path-dropped + PII-redacted.
+ */
+export function shouldEmitForeground(
+  prevApp: string | undefined,
+  cur: { app?: string; title?: string },
+  now: number,
+  appBlacklist: string[] = [],
+): SenseEvent | null {
+  const app = cur.app;
+  if (!app) return null;
+  if (isBlacklistedApp(app, appBlacklist)) return null; // skip whole frame
+  if (app === prevApp) return null; // unchanged → nothing to record
+  let title = cur.title;
+  if (title) {
+    title = isBlacklistedPath(title) ? undefined : redactPII(title);
+  }
+  return {
+    signal: "screen",
+    kind: "foreground-app",
+    app,
+    ...(title ? { title } : {}),
+    summary: "switched to " + app,
+    ts: now,
+  };
+}
+
+export interface ScreenSourceOptions {
+  probe?: ForegroundProbe;
+  intervalMs?: number;
+  /** Extra app-name blacklist entries merged on top of the defaults. */
+  appBlacklist?: string[];
+  now?: () => number;
+  /** Injectable consent check (tests); defaults to the real consent store. */
+  granted?: () => boolean;
+}
+
+export class ScreenSource implements SenseSource {
+  readonly signal = "screen";
+  private timer: NodeJS.Timeout | null = null;
+  private emitFn: ((e: SenseEvent) => void) | null = null;
+  private prevApp: string | undefined;
+  private readonly probe: ForegroundProbe;
+  private readonly intervalMs: number;
+  private readonly appBlacklist: string[];
+  private readonly now: () => number;
+  private readonly granted: () => boolean;
+
+  constructor(opts: ScreenSourceOptions = {}) {
+    this.probe = opts.probe ?? defaultForegroundProbe;
+    this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.appBlacklist = opts.appBlacklist ?? [];
+    this.now = opts.now ?? Date.now;
+    this.granted = opts.granted ?? (() => isGranted("screen"));
+  }
+
+  async start(emit: (e: SenseEvent) => void): Promise<void> {
+    this.emitFn = emit;
+    this.timer = setInterval(() => void this.tick(), this.intervalMs);
+    this.timer.unref?.();
+  }
+
+  /** One capture cycle. Exposed for deterministic tests. */
+  async tick(): Promise<void> {
+    if (!this.granted()) {
+      this.prevApp = undefined; // revoked → stop emitting + forget context
+      return;
+    }
+    const cur = await this.probe();
+    const ev = shouldEmitForeground(this.prevApp, cur, this.now(), this.appBlacklist);
+    // Track prev only for a present, non-blacklisted app (blacklisted frames
+    // leave prev untouched so they never appear in the timeline).
+    if (cur.app && !isBlacklistedApp(cur.app, this.appBlacklist)) this.prevApp = cur.app;
+    if (ev && this.emitFn) this.emitFn(ev);
+  }
+
+  async stop(): Promise<void> {
+    if (this.timer) clearInterval(this.timer);
+    this.timer = null;
+    this.emitFn = null;
+  }
+}

--- a/src/sense/service.ts
+++ b/src/sense/service.ts
@@ -1,0 +1,40 @@
+/**
+ * SenseService (PLAN_SENSE §2.2) — the resident loop that owns ambient sources,
+ * decoupled from chat. Each source self-gates on consent every cycle, so the
+ * service simply starts them all and lets ungranted ones no-op; `stopAll()` is
+ * for shutdown. This is the registration point S2-voice plugs into next.
+ */
+import type { SenseEvent, SenseSource } from "./types.js";
+
+export class SenseService {
+  private readonly sources: SenseSource[] = [];
+  private started = false;
+
+  register(source: SenseSource): void {
+    this.sources.push(source);
+  }
+
+  /** Start every registered source. Idempotent. Sources gate on consent. */
+  async start(emit: (e: SenseEvent) => void): Promise<void> {
+    if (this.started) return;
+    this.started = true;
+    for (const s of this.sources) {
+      try {
+        await s.start(emit);
+      } catch {
+        // one bad source must not take down the others / the server
+      }
+    }
+  }
+
+  async stopAll(): Promise<void> {
+    for (const s of this.sources) {
+      try {
+        await s.stop();
+      } catch {
+        // ignore
+      }
+    }
+    this.started = false;
+  }
+}

--- a/src/sense/types.ts
+++ b/src/sense/types.ts
@@ -1,0 +1,36 @@
+/**
+ * Sense — ambient signal sources (PLAN_SENSE S2). These are NOT agent sessions,
+ * so they get their own abstraction parallel to AgentObserver rather than being
+ * shoved into the orchestrator hub.
+ *
+ * Every source is consent-gated (FOUNDATIONS §1): it captures nothing unless the
+ * user has granted its signal, and it surfaces only STRUCTURED metadata — never
+ * raw screen bytes, raw audio, or unredacted content.
+ */
+
+/** A distilled, structured observation from an ambient source. Never raw bytes. */
+export interface SenseEvent {
+  /** The consent signal this came from, e.g. "screen" / "voice". */
+  signal: string;
+  /** Source-specific event kind, e.g. "foreground-app". */
+  kind: string;
+  /** Foreground app name (structural, low-sensitivity). */
+  app?: string;
+  /** Window title — only when safe (blacklist-checked + PII-redacted). */
+  title?: string;
+  /** Short structured summary for display / distillation. */
+  summary: string;
+  /** Epoch ms. */
+  ts: number;
+}
+
+/**
+ * An ambient source. Stateful (holds a timer between start/stop). It must check
+ * consent itself on every capture — start() does not imply permission, and a
+ * mid-run revoke must take effect within one cycle.
+ */
+export interface SenseSource {
+  readonly signal: string;
+  start(emit: (e: SenseEvent) => void): Promise<void>;
+  stop(): Promise<void>;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -33,6 +33,9 @@ import { captureScreenshot, captureSupported, type CaptureMode } from "../vision
 import { transcribeAudio } from "../voice/transcribe.js";
 import { polishDictation, type DictationProvider } from "../voice/dictation.js";
 import { listGrants, grant, revoke, revokeAll, SENSE_SIGNALS, SIGNAL_DESCRIPTIONS } from "../consent/store.js";
+import { SenseService } from "../sense/service.js";
+import { ScreenSource } from "../sense/screen.js";
+import { appendSenseEvent } from "../sense/log.js";
 import {
   loadScreenAdvisorConfig,
   saveScreenAdvisorConfig,
@@ -349,6 +352,18 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   if (screenCfg.enabled) {
     console.error(`[screen-advisor] enabled — every ${screenCfg.intervalMinutes}m`);
   }
+
+  // ── Sense ambient sources (S2) ──────────────────────────────────────
+  // The resident loop owns consent-gated ambient sources. ScreenSource ticks
+  // continuously but captures NOTHING until `screen` is granted (it re-checks
+  // each tick), so this is a no-op by default. On-change foreground-app events
+  // are distilled to the bounded sense log; nothing raw is persisted.
+  const senseService = new SenseService();
+  senseService.register(new ScreenSource());
+  void senseService.start((e) => {
+    appendSenseEvent(e);
+    broadcast({ type: "sense_event", ...e });
+  });
 
   // ── Island unread tracking (Phase 1 of MAC_ISLAND_PLAN) ─────────────
   // The island widget caches "last idle_message" so a fresh tab opening


### PR DESCRIPTION
## What

The **first real ambient Sense source** (PLAN_SENSE S2-screen), built on [F-consent](https://github.com/oratis/LISA/pull/87). It surfaces the user's foreground context — **which app is in front, emitted only when it changes** — as a structured signal.

Deliberately the **cheap, low-sensitivity slice**: it captures the app **name** (+ an optional sanitized window title), **not screen pixels**. There is no screenshot in this PR; raw screen content never enters an event.

## How

- **`src/sense/types.ts`** — `SenseSource` / `SenseEvent`, parallel to `AgentObserver` (ambient signals aren't agent sessions). Structured metadata only.
- **`src/sense/screen.ts`** — `ScreenSource` + the pure, privacy-critical **`shouldEmitForeground`**:
  - skips blacklisted apps (password managers / banks) **whole-frame**,
  - emits only on **change**,
  - **drops** secret-path window titles and **PII-redacts** the rest.
  - macOS foreground probe via `osascript` (injectable for tests).
  - **re-checks consent every tick** → a revoke takes effect within one interval and forgets context; switching *through* a blacklisted app leaves no trace.
- **`src/sense/service.ts`** — `SenseService` resident loop (the registration point S2-voice plugs into next); sources self-gate, `stopAll()` for shutdown.
- **`src/sense/log.ts`** — bounded, retention-capped `~/.lisa/sense/events.jsonl` (structured events only, max 1000, 7-day window).
- **server** — registers `ScreenSource` in a `SenseService` and starts it. It ticks continuously but captures **nothing** until `screen` is granted (**default off**), so it's a no-op out of the box; the island consent toggle (from #88) arms it.

## Privacy acceptance (tested)

- ✅ ungranted → **zero capture**
- ✅ blacklisted app in foreground → **zero-capture frame** (and invisible to the timeline)
- ✅ mid-run revoke → emission stops + context forgotten
- ✅ events carry only `app` / `title` / `summary` keys (**no raw screen**); titles are secret-path-dropped + PII-redacted

## Scope note

The **optional low-frequency screenshot→model** path (S2-screen's heavier, riskier half) is a deliberate follow-up that would reuse the existing screen-advisor and persist nothing — left out here to keep this source's footprint to **app names**.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **612 tests pass (+14)** across `shouldEmitForeground` (privacy-critical), `ScreenSource` (consent gating / change-detection / blacklist pass-through / mid-run revoke), and the bounded retention log

🤖 Generated with [Claude Code](https://claude.com/claude-code)