### PR TITLE
feat(sense): S2-voice — push-to-talk transcripts as a consent-gated ambient signal

### DIFF
--- a/src/consent/blacklist.ts
+++ b/src/consent/blacklist.ts
@@ -29,9 +29,11 @@ export const DEFAULT_APP_BLACKLIST: string[] = [
 ];
 
 /** Path/title patterns for sensitive files (secrets, keys, credentials). */
+// Word-boundary (not just path-anchored) so these also catch a secret named in
+// free text — e.g. a voice transcript "open my .env file", not only a path.
 export const DEFAULT_PATH_BLACKLIST: RegExp[] = [
-  /(^|[./])\.env($|[./])/i,
-  /\.(key|pem|p12|pfx|keystore)$/i,
+  /(^|[\s./])\.env\b/i,
+  /\.(key|pem|p12|pfx|keystore)\b/i,
   /id_(rsa|ed25519|ecdsa)\b/i,
   /\bsecrets?\b/i,
   /\bcredentials?\b/i,

--- a/src/sense/voice.test.ts
+++ b/src/sense/voice.test.ts
@@ -1,0 +1,73 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { distillVoiceTranscript, VoiceSource } from "./voice.js";
+import type { SenseEvent } from "./types.js";
+
+const NOW = 1_700_000_000_000;
+
+describe("distillVoiceTranscript (pure)", () => {
+  test("normal speech → a voice-transcript event", () => {
+    const ev = distillVoiceTranscript("remind me to push the branch", NOW)!;
+    assert.equal(ev.signal, "voice");
+    assert.equal(ev.kind, "voice-transcript");
+    assert.equal(ev.summary, "remind me to push the branch");
+    assert.equal(ev.ts, NOW);
+  });
+
+  test("empty / whitespace → null", () => {
+    assert.equal(distillVoiceTranscript("", NOW), null);
+    assert.equal(distillVoiceTranscript("   ", NOW), null);
+  });
+
+  test("PII is redacted in the summary", () => {
+    const ev = distillVoiceTranscript("email me at a@b.com", NOW)!;
+    assert.equal(ev.summary, "email me at [email]");
+  });
+
+  test("a transcript naming a secret path is dropped entirely", () => {
+    assert.equal(distillVoiceTranscript("open ~/project/.env and read it", NOW), null);
+  });
+
+  test("long transcripts are length-capped", () => {
+    const long = "word ".repeat(200).trim();
+    const ev = distillVoiceTranscript(long, NOW)!;
+    assert.ok(ev.summary.length <= 281, `summary should be capped, got ${ev.summary.length}`);
+    assert.ok(ev.summary.endsWith("…"));
+  });
+
+  test("never carries audio — only signal/kind/summary/ts keys", () => {
+    const ev = distillVoiceTranscript("hi", NOW)!;
+    assert.deepEqual(Object.keys(ev).sort(), ["kind", "signal", "summary", "ts"].sort());
+  });
+});
+
+describe("VoiceSource (consent-gated ingest)", () => {
+  test("ingest is a no-op until voice is granted", async () => {
+    const emitted: SenseEvent[] = [];
+    const src = new VoiceSource({ granted: () => false, now: () => NOW });
+    await src.start((e) => emitted.push(e));
+    const r = src.ingest("hello there");
+    await src.stop();
+    assert.equal(r, null);
+    assert.equal(emitted.length, 0);
+  });
+
+  test("ingest distills + emits when granted", async () => {
+    const emitted: SenseEvent[] = [];
+    const src = new VoiceSource({ granted: () => true, now: () => NOW });
+    await src.start((e) => emitted.push(e));
+    const r = src.ingest("ship the PR");
+    await src.stop();
+    assert.equal(r!.summary, "ship the PR");
+    assert.deepEqual(emitted.map((e) => e.summary), ["ship the PR"]);
+  });
+
+  test("granted but empty transcript → nothing emitted", async () => {
+    const emitted: SenseEvent[] = [];
+    const src = new VoiceSource({ granted: () => true, now: () => NOW });
+    await src.start((e) => emitted.push(e));
+    assert.equal(src.ingest("  "), null);
+    await src.stop();
+    assert.equal(emitted.length, 0);
+  });
+});

--- a/src/sense/voice.ts
+++ b/src/sense/voice.ts
@@ -1,0 +1,72 @@
+/**
+ * Voice sense source (PLAN_SENSE S2-voice) — push-to-talk transcripts as an
+ * ambient signal, built on F-consent.
+ *
+ * It rides the EXISTING transcribe pipeline (browser MediaRecorder → Whisper)
+ * rather than opening the mic itself: the user already speaks intentionally
+ * (push-to-talk, the plan's default over always-on). What S2-voice adds is, when
+ * `voice` is granted, distilling those transcripts into the ambient sense log as
+ * context. Default off → dictation works exactly as before and nothing is logged.
+ *
+ * Privacy: raw AUDIO is never stored (there is none here — only the transcript
+ * the user chose to speak); the persisted summary is PII-redacted and dropped
+ * entirely if it names a secret path. Always-on listening and a local STT
+ * (whisper.cpp) for off-device transcription are deliberate follow-ups.
+ */
+import { isGranted } from "../consent/store.js";
+import { redactPII, isBlacklistedPath } from "../consent/blacklist.js";
+import type { SenseEvent, SenseSource } from "./types.js";
+
+const MAX_SUMMARY = 280;
+
+/**
+ * Distill a transcript into a structured SenseEvent. Pure. PII-redacted and
+ * length-capped; null for empty text or text that names a secret path. Never
+ * touches audio bytes.
+ */
+export function distillVoiceTranscript(transcript: string, now: number): SenseEvent | null {
+  const text = (transcript || "").trim();
+  if (!text) return null;
+  if (isBlacklistedPath(text)) return null; // mentions a secret path → don't log
+  const redacted = redactPII(text);
+  const summary = redacted.length > MAX_SUMMARY ? redacted.slice(0, MAX_SUMMARY) + "…" : redacted;
+  return { signal: "voice", kind: "voice-transcript", summary, ts: now };
+}
+
+export interface VoiceSourceOptions {
+  now?: () => number;
+  /** Injectable consent check (tests); defaults to the real consent store. */
+  granted?: () => boolean;
+}
+
+export class VoiceSource implements SenseSource {
+  readonly signal = "voice";
+  private emitFn: ((e: SenseEvent) => void) | null = null;
+  private readonly now: () => number;
+  private readonly granted: () => boolean;
+
+  constructor(opts: VoiceSourceOptions = {}) {
+    this.now = opts.now ?? Date.now;
+    this.granted = opts.granted ?? (() => isGranted("voice"));
+  }
+
+  // Event-driven (not polled): start just wires the sink, stop unwires it.
+  async start(emit: (e: SenseEvent) => void): Promise<void> {
+    this.emitFn = emit;
+  }
+  async stop(): Promise<void> {
+    this.emitFn = null;
+  }
+
+  /**
+   * Feed a push-to-talk transcript. Distills + emits IFF `voice` is granted;
+   * a no-op (returns null) otherwise — ambient capture always requires consent.
+   * Returns the event (for tests / callers) or null.
+   */
+  ingest(transcript: string): SenseEvent | null {
+    if (!this.granted()) return null;
+    const ev = distillVoiceTranscript(transcript, this.now());
+    if (ev && this.emitFn) this.emitFn(ev);
+    return ev;
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -35,6 +35,7 @@ import { polishDictation, type DictationProvider } from "../voice/dictation.js";
 import { listGrants, grant, revoke, revokeAll, SENSE_SIGNALS, SIGNAL_DESCRIPTIONS } from "../consent/store.js";
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
+import { VoiceSource } from "../sense/voice.js";
 import { appendSenseEvent } from "../sense/log.js";
 import {
   loadScreenAdvisorConfig,
@@ -359,7 +360,11 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   // each tick), so this is a no-op by default. On-change foreground-app events
   // are distilled to the bounded sense log; nothing raw is persisted.
   const senseService = new SenseService();
+  // VoiceSource is event-driven (fed by the transcribe endpoint when `voice` is
+  // granted); ScreenSource polls. Both no-op until their signal is granted.
+  const voiceSource = new VoiceSource();
   senseService.register(new ScreenSource());
+  senseService.register(voiceSource);
   void senseService.start((e) => {
     appendSenseEvent(e);
     broadcast({ type: "sense_event", ...e });
@@ -609,6 +614,10 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         await fs.writeFile(tmp, Buffer.from(payload.data, "base64"));
         console.error(`[voice] transcribing ${Buffer.from(payload.data, "base64").length} bytes (${ext})`);
         const transcript = await transcribeAudio({ audioPath: tmp });
+        // S2-voice: when `voice` is granted, distill this push-to-talk transcript
+        // into the ambient sense log (PII-redacted, no audio). No-op otherwise,
+        // so dictation works unchanged when voice consent is off.
+        voiceSource.ingest(transcript);
         // Dictation mode (Typeless-equivalent): polish the raw transcript into
         // the clean text the speaker intended (filler/repetition removed,
         // self-corrections applied, punctuation + formatting), to drop into the


### PR DESCRIPTION
## What

The third and final S2 source. Rather than opening the mic itself (always-on listening is the scariest path and the plan's non-default), it **rides the existing transcribe pipeline** (browser MediaRecorder → Whisper, already push-to-talk): when `voice` is granted, each transcript is distilled into the ambient sense log as context. **Default off → dictation works exactly as before and nothing is logged.**

## How

- **`src/sense/voice.ts`** — `distillVoiceTranscript` (pure): PII-redacts + length-caps the transcript into a structured summary; returns `null` for empty text or text **naming a secret path**. Raw **audio is never stored** (there is none — only the transcript the user chose to speak). `VoiceSource.ingest()` gates on `isGranted("voice")` and no-ops otherwise.
- **server** — registers `VoiceSource` in the `SenseService`; `/api/voice/transcribe` feeds each transcript to `ingest()` (a no-op unless voice is granted), so the existing dictation flow is unchanged when consent is off.
- **`consent/blacklist.ts`** — broadens the path patterns to **word boundaries** so a secret named in free text (a spoken ".env file") is caught, not just a literal path. Screen titles benefit too; existing path/title tests still pass.

## Privacy acceptance (tested)

- ✅ ungranted → `ingest` is a no-op
- ✅ empty transcript → nothing emitted
- ✅ PII redacted in the summary
- ✅ a transcript naming a secret path is dropped entirely
- ✅ events carry only `signal` / `kind` / `summary` / `ts` (no audio)

## Scope note

Always-on listening and a **local STT (whisper.cpp)** off-device option are deliberate follow-ups; v1 stays **push-to-talk + the existing cloud Whisper**.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **621 tests pass (+9)** across `distillVoiceTranscript` (PII/secret-path/length/keys) and `VoiceSource` ingest gating; the blacklist broadening kept all existing path/title/screen tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)