### PR TITLE
test(foundations): F-core — agent tool-dispatch + approval gate coverage

### DIFF
--- a/src/agent.dispatch.test.ts
+++ b/src/agent.dispatch.test.ts
@@ -1,0 +1,224 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import type Anthropic from "@anthropic-ai/sdk";
+import { runAgent, type RunAgentOptions } from "./agent.js";
+import type { Provider, ProviderResult, ProviderRunOpts, ProviderUsage } from "./providers/types.js";
+import type { ToolContext, ToolDefinition, StoredMessage } from "./types.js";
+
+// Complements agent.test.ts (which covers stop conditions / empty-content /
+// abort) with the TOOL-DISPATCH path: execute → result, unregistered/throwing
+// tools, multi-tool turns, and the approval + hook gates. These need a provider
+// that can emit arbitrary/multiple tool_use blocks, so it returns each scripted
+// ProviderResult verbatim rather than synthesizing a single echo call.
+
+let idN = 0;
+function textBlock(text: string): Anthropic.ContentBlock {
+  return { type: "text", text } as Anthropic.ContentBlock;
+}
+function toolUseBlock(name: string, input: unknown = {}): Anthropic.ContentBlock {
+  return { type: "tool_use", id: `tu_${++idN}`, name, input } as Anthropic.ContentBlock;
+}
+function usage(o: Partial<ProviderUsage> = {}): ProviderUsage {
+  return { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, ...o };
+}
+function turn(content: Anthropic.ContentBlock[], stopReason: string): ProviderResult {
+  return { content, stopReason, usage: usage() };
+}
+
+/** Replays scripted turns verbatim; repeats `tail` once the queue drains. */
+function scriptedProvider(queue: ProviderResult[], tail?: ProviderResult): Provider {
+  let i = 0;
+  return {
+    name: "fake",
+    async runTurn(_opts: ProviderRunOpts): Promise<ProviderResult> {
+      if (i < queue.length) return queue[i++]!;
+      if (tail) return tail;
+      throw new Error("scriptedProvider queue exhausted");
+    },
+  };
+}
+
+function ctx(): ToolContext {
+  return { cwd: "/tmp", signal: new AbortController().signal, log: () => {} };
+}
+
+function echoTool(over: Partial<ToolDefinition> = {}): ToolDefinition {
+  return {
+    name: "echo",
+    description: "echo the input back",
+    inputSchema: { type: "object" } as Anthropic.Tool.InputSchema,
+    async execute(input) {
+      return "echoed:" + JSON.stringify(input);
+    },
+    ...over,
+  } as ToolDefinition;
+}
+
+function baseOpts(over: Partial<RunAgentOptions>): RunAgentOptions {
+  return {
+    provider: scriptedProvider([turn([textBlock("hi")], "end_turn")]),
+    systemPrompt: "sys",
+    tools: [echoTool()],
+    toolCtx: ctx(),
+    history: [],
+    userMessage: "do it",
+    model: "test-model",
+    ...over,
+  };
+}
+
+/** All tool_use ids (assistant) and tool_result ids (user) across history. */
+function pairing(history: StoredMessage[]): { uses: string[]; results: string[] } {
+  const uses: string[] = [];
+  const results: string[] = [];
+  for (const m of history) {
+    if (!Array.isArray(m.content)) continue;
+    for (const b of m.content as Anthropic.ContentBlockParam[]) {
+      if (b.type === "tool_use") uses.push(b.id);
+      if (b.type === "tool_result") results.push(b.tool_use_id);
+    }
+  }
+  return { uses, results };
+}
+
+function allResults(history: StoredMessage[]): Anthropic.ToolResultBlockParam[] {
+  return (history.flatMap((m) => (Array.isArray(m.content) ? m.content : [])) as Anthropic.ContentBlockParam[])
+    .filter((b): b is Anthropic.ToolResultBlockParam => b.type === "tool_result");
+}
+
+describe("runAgent — tool dispatch", () => {
+  test("executes the tool with the model's input and pairs the result", async () => {
+    const seen: unknown[] = [];
+    const provider = scriptedProvider([
+      turn([toolUseBlock("echo", { x: 1 })], "tool_use"),
+      turn([textBlock("done")], "end_turn"),
+    ]);
+    const r = await runAgent(
+      baseOpts({ provider, tools: [echoTool({ async execute(i) { seen.push(i); return "RAN"; } })] }),
+    );
+    assert.deepEqual(seen, [{ x: 1 }]);
+    const { uses, results } = pairing(r.history);
+    assert.deepEqual(uses, results);
+    assert.equal(allResults(r.history)[0]!.content, "RAN");
+    assert.equal(r.stopReason, "end_turn");
+  });
+
+  test("renderResultForModel shapes the tool_result content", async () => {
+    const provider = scriptedProvider([
+      turn([toolUseBlock("echo", {})], "tool_use"),
+      turn([textBlock("ok")], "end_turn"),
+    ]);
+    const r = await runAgent(
+      baseOpts({
+        provider,
+        tools: [echoTool({ async execute() { return { n: 7 }; }, renderResultForModel: (o) => `rendered:${(o as { n: number }).n}` })],
+      }),
+    );
+    assert.equal(allResults(r.history)[0]!.content, "rendered:7");
+  });
+
+  test("multiple tool_use in one turn → all paired in a single tool_result message", async () => {
+    const provider = scriptedProvider([
+      turn([toolUseBlock("echo", { a: 1 }), toolUseBlock("echo", { b: 2 })], "tool_use"),
+      turn([textBlock("done")], "end_turn"),
+    ]);
+    const r = await runAgent(baseOpts({ provider }));
+    const { uses, results } = pairing(r.history);
+    assert.equal(uses.length, 2);
+    assert.deepEqual(new Set(uses), new Set(results));
+    const toolMsg = r.history.find(
+      (m) => Array.isArray(m.content) && (m.content as Anthropic.ContentBlockParam[]).length > 0 &&
+        (m.content as Anthropic.ContentBlockParam[]).every((b) => b.type === "tool_result"),
+    );
+    assert.equal((toolMsg!.content as Anthropic.ContentBlockParam[]).length, 2);
+  });
+
+  test("unregistered tool → paired is_error result, loop recovers", async () => {
+    const provider = scriptedProvider([
+      turn([toolUseBlock("ghost", {})], "tool_use"),
+      turn([textBlock("recovered")], "end_turn"),
+    ]);
+    const r = await runAgent(baseOpts({ provider }));
+    const { uses, results } = pairing(r.history);
+    assert.deepEqual(uses, results, "no orphan tool_use");
+    assert.equal(allResults(r.history)[0]!.is_error, true);
+    assert.equal(r.stopReason, "end_turn");
+  });
+
+  test("a throwing tool → paired is_error result carrying the message, loop continues", async () => {
+    const provider = scriptedProvider([
+      turn([toolUseBlock("boom", {})], "tool_use"),
+      turn([textBlock("ok")], "end_turn"),
+    ]);
+    const r = await runAgent(
+      baseOpts({ provider, tools: [echoTool({ name: "boom", async execute() { throw new Error("kaboom"); } })] }),
+    );
+    const res = allResults(r.history)[0]!;
+    assert.equal(res.is_error, true);
+    assert.match(String(res.content), /kaboom/);
+    assert.equal(r.stopReason, "end_turn");
+  });
+});
+
+describe("runAgent — approval + hook gating (security-relevant)", () => {
+  test("denied tool is NOT executed and yields a paired [denied] error", async () => {
+    let ran = false;
+    const provider = scriptedProvider([
+      turn([toolUseBlock("echo", {})], "tool_use"),
+      turn([textBlock("ok")], "end_turn"),
+    ]);
+    const r = await runAgent(
+      baseOpts({
+        provider,
+        tools: [echoTool({ async execute() { ran = true; return "x"; } })],
+        approval: async () => ({ allow: false, reason: "nope" }),
+      }),
+    );
+    assert.equal(ran, false);
+    const res = allResults(r.history)[0]!;
+    assert.equal(res.is_error, true);
+    assert.match(String(res.content), /denied/);
+  });
+
+  test("approval allow lets the tool run", async () => {
+    let ran = false;
+    const provider = scriptedProvider([
+      turn([toolUseBlock("echo", {})], "tool_use"),
+      turn([textBlock("ok")], "end_turn"),
+    ]);
+    await runAgent(
+      baseOpts({
+        provider,
+        tools: [echoTool({ async execute() { ran = true; return "x"; } })],
+        approval: async () => ({ allow: true }),
+      }),
+    );
+    assert.equal(ran, true);
+  });
+
+  test("preToolHook block prevents execution and yields a paired error", async () => {
+    let ran = false;
+    const provider = scriptedProvider([
+      turn([toolUseBlock("echo", {})], "tool_use"),
+      turn([textBlock("ok")], "end_turn"),
+    ]);
+    const r = await runAgent(
+      baseOpts({
+        provider,
+        tools: [echoTool({ async execute() { ran = true; return "x"; } })],
+        preToolHook: async () => ({ block: "policy" }),
+      }),
+    );
+    assert.equal(ran, false);
+    assert.match(String(allResults(r.history)[0]!.content), /hook blocked/);
+  });
+
+  test("postToolHook can rewrite the tool result the model sees", async () => {
+    const provider = scriptedProvider([
+      turn([toolUseBlock("echo", {})], "tool_use"),
+      turn([textBlock("ok")], "end_turn"),
+    ]);
+    const r = await runAgent(baseOpts({ provider, postToolHook: async () => ({ rewriteResult: "REWRITTEN" }) }));
+    assert.equal(allResults(r.history)[0]!.content, "REWRITTEN");
+  });
+});

--- a/src/approval.test.ts
+++ b/src/approval.test.ts
@@ -1,0 +1,67 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildApprovalCallback,
+  DEFAULT_MUTATING_TOOLS,
+  type ApprovalConfig,
+} from "./approval.js";
+
+function cfg(over: Partial<ApprovalConfig> = {}): ApprovalConfig {
+  return { mode: "ask", mutatingTools: new Set(DEFAULT_MUTATING_TOOLS), ...over };
+}
+
+describe("buildApprovalCallback — mode gating", () => {
+  test("'auto' → no callback (everything auto-allowed)", () => {
+    assert.equal(buildApprovalCallback(cfg({ mode: "auto" })), undefined);
+  });
+
+  test("'ask-mutating' auto-allows a non-mutating tool WITHOUT prompting", async () => {
+    let prompted = false;
+    const cb = buildApprovalCallback(cfg({ mode: "ask-mutating", readLine: async () => { prompted = true; return "y"; } }))!;
+    const d = await cb("read", { path: "x" });
+    assert.deepEqual(d, { allow: true });
+    assert.equal(prompted, false, "non-mutating tools must not trigger a prompt");
+  });
+
+  test("'ask-mutating' prompts for a mutating tool", async () => {
+    const cb = buildApprovalCallback(cfg({ mode: "ask-mutating", readLine: async () => "y" }))!;
+    assert.deepEqual(await cb("bash", { cmd: "ls" }), { allow: true });
+  });
+
+  test("DEFAULT_MUTATING_TOOLS covers the write/exec tools", () => {
+    for (const t of ["write", "edit", "apply_patch", "bash"]) {
+      assert.ok(DEFAULT_MUTATING_TOOLS.has(t), `expected ${t} to be mutating`);
+    }
+    assert.equal(DEFAULT_MUTATING_TOOLS.has("read"), false);
+  });
+});
+
+describe("buildApprovalCallback — answer parsing (security-critical)", () => {
+  test("'y' / 'yes' (any case) → allow", async () => {
+    for (const ans of ["y", "yes", "Y", "YES", "  yes  "]) {
+      const cb = buildApprovalCallback(cfg({ mode: "ask", readLine: async () => ans }))!;
+      assert.deepEqual(await cb("bash", {}), { allow: true }, `"${ans}" should allow`);
+    }
+  });
+
+  test("'n' / empty / anything else → deny (default-deny)", async () => {
+    const cb = buildApprovalCallback(cfg({ mode: "ask", readLine: async () => "n" }))!;
+    const d = await cb("bash", {});
+    assert.equal(d.allow, false);
+
+    const empty = buildApprovalCallback(cfg({ mode: "ask", readLine: async () => "" }))!;
+    assert.equal((await empty("bash", {})).allow, false, "empty input defaults to deny");
+  });
+
+  test("a non-yes answer is captured as the denial reason", async () => {
+    const cb = buildApprovalCallback(cfg({ mode: "ask", readLine: async () => "too risky" }))!;
+    const d = await cb("bash", {});
+    assert.equal(d.allow, false);
+    assert.equal(d.reason, "too risky");
+  });
+
+  test("'yes' is matched exactly — 'yesterday' does NOT allow", async () => {
+    const cb = buildApprovalCallback(cfg({ mode: "ask", readLine: async () => "yesterday" }))!;
+    assert.equal((await cb("bash", {})).allow, false, "substring of 'yes' must not auto-allow");
+  });
+});

--- a/src/approval.ts
+++ b/src/approval.ts
@@ -6,6 +6,8 @@ export type ApprovalMode = "auto" | "ask" | "ask-mutating";
 export interface ApprovalConfig {
   mode: ApprovalMode;
   mutatingTools: Set<string>;
+  /** Injectable prompt reader (tests); defaults to reading one stdin line. */
+  readLine?: () => Promise<string>;
 }
 
 export const DEFAULT_MUTATING_TOOLS = new Set([
@@ -27,7 +29,7 @@ export function buildApprovalCallback(
     process.stderr.write(
       `\n[approval] ${toolName}(${preview})\n  [y]es / [n]o (default n) > `,
     );
-    const answer = await readSingleLine();
+    const answer = await (cfg.readLine ?? readSingleLine)();
     if (/^y(es)?$/i.test(answer.trim())) {
       return { allow: true };
     }


### PR DESCRIPTION
## What

FOUNDATIONS §3 — close the core-loop test debt the v0.9 review flagged ("the most critical code runs naked"). 

On audit, several flagged items were **already addressed** since the plan doc was written: `agent.ts` has stop-condition / empty-content / abort tests (`agent.test.ts`), the three providers (`anthropic`/`openai`/`gemini`) are tested, and the **release gate is live** (`release.yml` runs `npm test`, `ci.yml` runs tests, `prepublishOnly` has typecheck+test+build). This PR fills the two real remaining gaps nearest the loop.

## How

- **`src/agent.dispatch.test.ts`** (new) — the tool-**dispatch** path `agent.test.ts` doesn't cover:
  - `execute` → result + `renderResultForModel`, multiple `tool_use` in one turn, an **unregistered** tool, a **throwing** tool — each asserting the invariant that **every `tool_use` gets a paired `tool_result`** (no orphans, which the Anthropic API rejects).
  - the security-relevant gates: approval **deny**/allow, `preToolHook` **block**, `postToolHook` **rewrite**.
  - Uses a provider that replays scripted turns *verbatim*, so it can emit arbitrary / multiple tool calls (the existing fake hardcodes a single echo call).
- **`src/approval.ts`** — make the prompt line-reader **injectable** (`readLine`), so the approve/deny parsing is testable without stdin. No behavior change.
- **`src/approval.test.ts`** (new) — mode gating (`auto` → no callback; `ask-mutating` skips non-mutating tools **without** prompting) and the **security-critical answer parsing**: `y`/`yes` (any case/whitespace) → allow; `n` / empty / anything else → **default-deny**; a non-yes answer captured as the reason; `"yesterday"` does **not** allow (exact match).

## Scope / next

Still untested and good follow-ups for F-core: `src/sessions/*` (resume), `src/subagent.ts`, `src/mcp/*`, `src/hooks/`. Done separately to keep this PR cohesive (loop + approval gate).

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **638 tests pass (+17)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)