### PR TITLE
test(foundations): F-core — sessions resume + MCP config round-trip coverage

### DIFF
--- a/src/mcp/config.test.ts
+++ b/src/mcp/config.test.ts
@@ -1,0 +1,90 @@
+import { test, describe, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// CONFIG_PATH (mcp.json) is derived from LISA_HOME at import; set a tmp home
+// before importing (dynamic import). Per-file process isolation keeps it local.
+let mod: typeof import("./config.js");
+let home: string;
+
+before(async () => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-mcp-"));
+  process.env.LISA_HOME = home;
+  mod = await import("./config.js");
+});
+after(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+beforeEach(() => {
+  // Each test starts from a clean mcp.json.
+  fs.rmSync(path.join(home, "mcp.json"), { force: true });
+});
+
+describe("mcp config — load/save/delete", () => {
+  test("no file → empty list", async () => {
+    assert.deepEqual(await mod.loadMcpConfig(), []);
+  });
+
+  test("save then load applies defaults for omitted fields", async () => {
+    await mod.saveMcpServer("fs", { command: "npx" });
+    const all = await mod.loadMcpConfig();
+    assert.equal(all.length, 1);
+    assert.deepEqual(all[0], {
+      name: "fs",
+      command: "npx",
+      args: [],
+      env: undefined,
+      enabled: true,
+      alwaysLoad: false,
+    });
+  });
+
+  test("explicit fields round-trip", async () => {
+    await mod.saveMcpServer("git", {
+      command: "uvx",
+      args: ["mcp-server-git"],
+      env: { TOKEN: "x" },
+      enabled: false,
+      alwaysLoad: true,
+    });
+    const [s] = await mod.loadMcpConfig();
+    assert.deepEqual(s!.args, ["mcp-server-git"]);
+    assert.deepEqual(s!.env, { TOKEN: "x" });
+    assert.equal(s!.enabled, false);
+    assert.equal(s!.alwaysLoad, true);
+  });
+
+  test("save upserts by name", async () => {
+    await mod.saveMcpServer("a", { command: "one" });
+    await mod.saveMcpServer("a", { command: "two" });
+    const all = await mod.loadMcpConfig();
+    assert.equal(all.length, 1);
+    assert.equal(all[0]!.command, "two");
+  });
+
+  test("delete removes a server and reports presence", async () => {
+    await mod.saveMcpServer("a", { command: "x" });
+    await mod.saveMcpServer("b", { command: "y" });
+    assert.equal(await mod.deleteMcpServer("a"), true);
+    assert.deepEqual((await mod.loadMcpConfig()).map((s) => s.name), ["b"]);
+    assert.equal(await mod.deleteMcpServer("a"), false, "second delete reports not-present");
+  });
+
+  test("delete on a missing file → false", async () => {
+    assert.equal(await mod.deleteMcpServer("anything"), false);
+  });
+
+  test("loadMcpConfig throws on corrupt JSON", async () => {
+    fs.writeFileSync(path.join(home, "mcp.json"), "{ not json");
+    await assert.rejects(mod.loadMcpConfig(), /failed to parse/);
+  });
+
+  test("saveMcpServer recovers from a corrupt file (starts fresh, keeps the add)", async () => {
+    fs.writeFileSync(path.join(home, "mcp.json"), "{ corrupt");
+    await mod.saveMcpServer("fresh", { command: "ok" });
+    const all = await mod.loadMcpConfig();
+    assert.deepEqual(all.map((s) => s.name), ["fresh"]);
+  });
+});

--- a/src/sessions/store.test.ts
+++ b/src/sessions/store.test.ts
@@ -1,0 +1,95 @@
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { StoredMessage } from "../types.js";
+
+// SESSIONS_DIR is resolved from LISA_HOME at import time, so set a tmp home
+// BEFORE importing the store (dynamic import). node --test isolates each file in
+// its own process, so this env mutation can't leak to other suites.
+let SessionStore: typeof import("./store.js").SessionStore;
+let home: string;
+
+before(async () => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-sess-"));
+  process.env.LISA_HOME = home;
+  ({ SessionStore } = await import("./store.js"));
+});
+after(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+function msg(i: number): StoredMessage {
+  return { role: i % 2 === 0 ? "user" : "assistant", content: "m" + i };
+}
+
+describe("SessionStore — create / open round-trip", () => {
+  test("create writes a header that open() reads back", async () => {
+    const s = await SessionStore.create({ cwd: "/work/proj", model: "test-model" });
+    assert.equal(s.header.type, "session");
+    assert.equal(s.header.cwd, "/work/proj");
+    assert.equal(s.header.model, "test-model");
+
+    const reopened = await SessionStore.open(s.id);
+    assert.equal(reopened.id, s.id);
+    assert.equal(reopened.header.cwd, "/work/proj");
+    assert.equal(reopened.header.model, "test-model");
+  });
+
+  test("open() rejects a missing session", async () => {
+    await assert.rejects(SessionStore.open("does-not-exist"));
+  });
+
+  test("open() rejects an empty session file", async () => {
+    const empty = path.join(home, "sessions", "empty-one.jsonl");
+    fs.mkdirSync(path.dirname(empty), { recursive: true });
+    fs.writeFileSync(empty, "");
+    await assert.rejects(SessionStore.open("empty-one"), /empty/);
+  });
+});
+
+describe("SessionStore — message persistence + resume", () => {
+  test("appended messages come back in chronological order", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    for (let i = 0; i < 3; i++) await s.appendMessage(msg(i));
+
+    // Resume from disk (the real path: a fresh process re-opens by id).
+    const resumed = await SessionStore.open(s.id);
+    const page = await resumed.readMessagePage(0);
+    assert.deepEqual(page.messages.map((m) => m.content), ["m0", "m1", "m2"]);
+    assert.equal(page.hasMore, false);
+  });
+
+  test("reflections do not appear in message pages", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    await s.appendMessage(msg(0));
+    await s.appendReflection("a private reflection");
+    await s.appendMessage(msg(1));
+    const page = await s.readMessagePage(0);
+    assert.deepEqual(page.messages.map((m) => m.content), ["m0", "m1"]);
+  });
+
+  test("pagination: latest page first, chronological within a page, hasMore set", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    for (let i = 0; i < 25; i++) await s.appendMessage(msg(i));
+
+    const p0 = await s.readMessagePage(0, 20);
+    assert.equal(p0.messages.length, 20);
+    assert.equal(p0.messages[0]!.content, "m5", "page 0 starts at the 6th-from-newest");
+    assert.equal(p0.messages[19]!.content, "m24", "page 0 ends at the newest");
+    assert.equal(p0.hasMore, true);
+
+    const p1 = await s.readMessagePage(1, 20);
+    assert.deepEqual(p1.messages.map((m) => m.content), ["m0", "m1", "m2", "m3", "m4"]);
+    assert.equal(p1.hasMore, false);
+  });
+
+  test("reading past the end returns empty, not an error", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    await s.appendMessage(msg(0));
+    const page = await s.readMessagePage(5, 20);
+    assert.deepEqual(page.messages, []);
+    assert.equal(page.hasMore, false);
+  });
+});


### PR DESCRIPTION
## What

Continues closing the core-loop test debt (FOUNDATIONS §3) with two more flagged-but-untested modules. **No production changes** — tests only.

Both persist to `LISA_HOME`-derived paths resolved at import, so the tests set a tmp home **before** a dynamic import (`node --test`'s per-file process isolation keeps the env mutation local).

## How

- **`src/sessions/store.test.ts`** — the **resume-critical** round-trip:
  - `create` writes a header that `open()` reads back;
  - appended messages come back in **chronological order after re-opening by id** (the real resume path a fresh process takes);
  - reflections never leak into message pages;
  - pagination — latest page first, chronological within a page, `hasMore` correct;
  - reading past the end is empty (not an error); `open()` rejects missing / empty sessions.
- **`src/mcp/config.test.ts`** — load/save/delete CRUD:
  - no file → `[]`; defaults applied for omitted fields; explicit fields round-trip; `save` upserts by name; `delete` reports presence;
  - corrupt JSON **throws** on load but `saveMcpServer` **recovers** (starts fresh, keeps the add).

## Scope / next

Remaining F-core gaps: `src/subagent.ts` (thin wrapper over the now-tested `runAgent`, but `providerForModel` isn't injectable — needs a small refactor to test meaningfully), `src/mcp/client.ts`, `src/hooks/`. Left for follow-up.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **653 tests pass (+15)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)