### PR TITLE
feat(foundations): tool input validation — guard execute() against malformed LLM input

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -7,6 +7,7 @@ import type {
 } from "./types.js";
 import type { Provider } from "./providers/types.js";
 import { moodBus } from "./mood-bus.js";
+import { validateToolInput } from "./tools/validate.js";
 
 export interface ApprovalDecision {
   allow: boolean;
@@ -371,6 +372,26 @@ async function runAgentLoop(opts: RunAgentOptions): Promise<RunAgentResult> {
           });
           continue;
         }
+      }
+
+      // FOUNDATIONS §2.3 — validate the model's input against the tool's schema
+      // before running it. Malformed input never reaches execute(); the model
+      // gets a friendly error to correct on the next turn.
+      const valid = validateToolInput(tool.inputSchema, call.input);
+      if (!valid.ok) {
+        toolResults.push({
+          type: "tool_result",
+          tool_use_id: call.id,
+          content: `[invalid input] ${valid.error}`,
+          is_error: true,
+        });
+        onEvent?.({
+          type: "tool_call_end",
+          toolName: call.name,
+          isError: true,
+          toolResult: valid.error ?? "invalid input",
+        });
+        continue;
       }
 
       try {

--- a/src/tools/validate.test.ts
+++ b/src/tools/validate.test.ts
@@ -1,0 +1,94 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import type Anthropic from "@anthropic-ai/sdk";
+import { validateToolInput } from "./validate.js";
+import { runAgent } from "../agent.js";
+import type { Provider, ProviderResult } from "../providers/types.js";
+import type { ToolContext, ToolDefinition } from "../types.js";
+
+function schema(o: object): Anthropic.Tool.InputSchema {
+  return { type: "object", ...o } as Anthropic.Tool.InputSchema;
+}
+
+describe("validateToolInput (pure)", () => {
+  test("non-object input is rejected", () => {
+    assert.equal(validateToolInput(schema({}), "str").ok, false);
+    assert.equal(validateToolInput(schema({}), 42).ok, false);
+    assert.equal(validateToolInput(schema({}), null).ok, false);
+    assert.equal(validateToolInput(schema({}), []).ok, false);
+  });
+
+  test("empty schema accepts any object", () => {
+    assert.equal(validateToolInput(schema({}), { anything: 1 }).ok, true);
+  });
+
+  test("missing required field → error naming it", () => {
+    const r = validateToolInput(schema({ required: ["slug"], properties: { slug: { type: "string" } } }), {});
+    assert.equal(r.ok, false);
+    assert.match(r.error!, /slug/);
+  });
+
+  test("present required field → ok", () => {
+    const r = validateToolInput(schema({ required: ["slug"], properties: { slug: { type: "string" } } }), { slug: "a" });
+    assert.equal(r.ok, true);
+  });
+
+  test("primitive type mismatch → error; match → ok", () => {
+    assert.equal(validateToolInput(schema({ properties: { n: { type: "number" } } }), { n: "x" }).ok, false);
+    assert.equal(validateToolInput(schema({ properties: { n: { type: "number" } } }), { n: 5 }).ok, true);
+    assert.equal(validateToolInput(schema({ properties: { b: { type: "boolean" } } }), { b: true }).ok, true);
+  });
+
+  test("integer rejects a float", () => {
+    assert.equal(validateToolInput(schema({ properties: { n: { type: "integer" } } }), { n: 5 }).ok, true);
+    assert.equal(validateToolInput(schema({ properties: { n: { type: "integer" } } }), { n: 5.5 }).ok, false);
+  });
+
+  test("enum membership is enforced", () => {
+    const s = schema({ properties: { action: { type: "string", enum: ["discover", "call"] } } });
+    assert.equal(validateToolInput(s, { action: "call" }).ok, true);
+    const bad = validateToolInput(s, { action: "nope" });
+    assert.equal(bad.ok, false);
+    assert.match(bad.error!, /discover, call/);
+  });
+
+  test("permissive where it should be: optional-absent ok, unknown type ok, extra props ok", () => {
+    assert.equal(validateToolInput(schema({ properties: { opt: { type: "string" } } }), {}).ok, true);
+    assert.equal(validateToolInput(schema({ properties: { x: { type: "weird" } } }), { x: 1 }).ok, true);
+    assert.equal(validateToolInput(schema({ properties: { a: { type: "string" } } }), { a: "x", extra: 9 }).ok, true);
+  });
+});
+
+describe("validateToolInput — agent-loop integration (fail-closed)", () => {
+  test("a malformed tool call is rejected before execute, with a paired is_error", async () => {
+    let ran = false;
+    let id = 0;
+    const usage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+    const queue: ProviderResult[] = [
+      {
+        content: [{ type: "tool_use", id: `v${++id}`, name: "needsSlug", input: {} } as Anthropic.ContentBlock],
+        stopReason: "tool_use",
+        usage,
+      },
+      { content: [{ type: "text", text: "ok" } as Anthropic.ContentBlock], stopReason: "end_turn", usage },
+    ];
+    let i = 0;
+    const provider: Provider = { name: "fake", async runTurn() { return queue[i++]!; } };
+    const tool: ToolDefinition = {
+      name: "needsSlug",
+      description: "requires slug",
+      inputSchema: { type: "object", required: ["slug"], properties: { slug: { type: "string" } } } as Anthropic.Tool.InputSchema,
+      async execute() { ran = true; return "ran"; },
+    };
+    const ctx: ToolContext = { cwd: "/tmp", signal: new AbortController().signal, log: () => {} };
+    const r = await runAgent({
+      provider, systemPrompt: "s", tools: [tool], toolCtx: ctx, history: [], userMessage: "go", model: "m",
+    });
+    assert.equal(ran, false, "malformed input must not reach execute()");
+    const res = (r.history.flatMap((m) => (Array.isArray(m.content) ? m.content : [])) as Anthropic.ContentBlockParam[])
+      .find((b) => b.type === "tool_result") as Anthropic.ToolResultBlockParam;
+    assert.equal(res.is_error, true);
+    assert.match(String(res.content), /invalid input/);
+    assert.equal(r.stopReason, "end_turn", "loop recovers after the rejected call");
+  });
+});

--- a/src/tools/validate.ts
+++ b/src/tools/validate.ts
@@ -1,0 +1,79 @@
+/**
+ * Tool input validation (FOUNDATIONS §2.3) — a guard between LLM-produced tool
+ * input and `tool.execute()`. The review flagged that model-generated input goes
+ * straight into execute with no schema check; this catches malformed calls
+ * (wrong shape / missing required field / bad enum) and returns a friendly error
+ * the model can correct, BEFORE the tool runs (fail-closed).
+ *
+ * Deliberately lightweight — validates against the JSON-Schema `inputSchema`
+ * every ToolDefinition already declares (no new dependency, no separate schema
+ * to drift). It checks the high-value, low-false-positive rules: input is an
+ * object, required fields are present, declared property types match, and enum
+ * membership holds. It does NOT deep-validate nested objects or reject extra
+ * properties — over-strictness would block valid calls the tools handle fine.
+ * Pure.
+ */
+import type Anthropic from "@anthropic-ai/sdk";
+
+export interface ValidationResult {
+  ok: boolean;
+  error?: string;
+}
+
+export function validateToolInput(
+  schema: Anthropic.Tool.InputSchema,
+  input: unknown,
+): ValidationResult {
+  // Tools take a JSON object. Anything else is malformed.
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    return { ok: false, error: "input must be a JSON object" };
+  }
+  const obj = input as Record<string, unknown>;
+  const s = schema as {
+    required?: unknown;
+    properties?: Record<string, { type?: string; enum?: unknown[] }>;
+  };
+
+  const required = Array.isArray(s.required) ? (s.required as string[]) : [];
+  for (const key of required) {
+    if (!(key in obj) || obj[key] === undefined || obj[key] === null) {
+      return { ok: false, error: `missing required field "${key}"` };
+    }
+  }
+
+  const props = s.properties;
+  if (props) {
+    for (const [key, spec] of Object.entries(props)) {
+      if (!(key in obj) || obj[key] === undefined) continue; // optional + absent → fine
+      const val = obj[key];
+      if (spec?.type && !matchesType(val, spec.type)) {
+        return { ok: false, error: `field "${key}" should be ${spec.type}` };
+      }
+      if (Array.isArray(spec?.enum) && spec.enum.length > 0 && !spec.enum.includes(val)) {
+        return { ok: false, error: `field "${key}" must be one of: ${spec.enum.join(", ")}` };
+      }
+    }
+  }
+  return { ok: true };
+}
+
+function matchesType(val: unknown, type: string): boolean {
+  switch (type) {
+    case "string":
+      return typeof val === "string";
+    case "number":
+      return typeof val === "number";
+    case "integer":
+      return typeof val === "number" && Number.isInteger(val);
+    case "boolean":
+      return typeof val === "boolean";
+    case "object":
+      return val !== null && typeof val === "object" && !Array.isArray(val);
+    case "array":
+      return Array.isArray(val);
+    case "null":
+      return val === null;
+    default:
+      return true; // unknown/compound type → don't block
+  }
+}


### PR DESCRIPTION
## What

FOUNDATIONS §2.3 — a flagged pre-1.0 **security** debt: model-generated tool input went straight into `tool.execute()` with **no schema check**. This adds a lightweight guard in the agent loop that rejects malformed calls **before** the tool runs and returns a friendly, paired error the model can correct on the next turn (**fail-closed**).

## How

- **`src/tools/validate.ts`** — `validateToolInput(schema, input)`, pure. Validates against the JSON-Schema `inputSchema` **every `ToolDefinition` already declares** — no new dependency, no second schema to drift. Checks the high-value / low-false-positive rules: input is an object, required fields present, declared property **types** match, **enum** membership holds. Intentionally **not** strict about nested objects or extra props — over-strictness would block valid calls tools handle fine.
- **`src/agent.ts`** — calls it right before `execute()` (after approval + `preToolHook`). On failure: a **paired** `is_error` tool_result `[invalid input] …`, a `tool_call_end` event, and the loop continues. No execute, no orphan `tool_use`.

This hardens **all** tools uniformly (not just the flagged dispatch / bash / A2A-inbound) using their own declared contracts.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **662 tests pass (+9)** — the pure rules (object/required/type/integer/enum/permissiveness) + an **agent-loop integration test** proving a malformed call never reaches `execute()` and yields a paired `[invalid input]` error
- The permissive design left **every existing tool/integration test green** (the loop-wiring risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)