### PR TITLE
test(foundations): F-core — subagent, MCP tool mapping, hook runner coverage

### DIFF
--- a/src/hooks/runner.test.ts
+++ b/src/hooks/runner.test.ts
@@ -1,0 +1,76 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { runHook, fireHooks, type HookEnv } from "./runner.js";
+import type { HookSpec } from "../plugins/types.js";
+
+const CWD = process.cwd();
+const ENV: HookEnv = {};
+
+// runHook spawns /bin/bash -lc, so these use real (harmless) shell commands —
+// the actual mechanism, deterministic and fast for echo/exit.
+
+describe("runHook", () => {
+  test("captures stdout + exit code 0", async () => {
+    const out = await runHook({ event: "PreToolUse", command: "echo hello" }, ENV, CWD);
+    assert.equal(out.exitCode, 0);
+    assert.match(out.stdout, /hello/);
+  });
+
+  test("captures stderr + a non-zero exit code", async () => {
+    const out = await runHook({ event: "PreToolUse", command: "echo oops >&2; exit 2" }, ENV, CWD);
+    assert.equal(out.exitCode, 2);
+    assert.match(out.stderr, /oops/);
+  });
+
+  test("passes HookEnv through to the command", async () => {
+    const out = await runHook({ event: "PreToolUse", command: 'echo "$TOOL_NAME"' }, { TOOL_NAME: "bash" }, CWD);
+    assert.match(out.stdout, /bash/);
+  });
+});
+
+describe("fireHooks — matching + exit-code-2 semantics", () => {
+  test("PreToolUse exit 2 → blocked, carrying stderr as the reason", async () => {
+    const hooks: HookSpec[] = [{ event: "PreToolUse", command: "echo no-thanks >&2; exit 2" }];
+    const r = await fireHooks("PreToolUse", hooks, ENV, CWD);
+    assert.equal(r.blocked.length, 1);
+    assert.match(r.blocked[0]!, /no-thanks/);
+  });
+
+  test("PostToolUse exit 2 → rewriteResult from stdout (not a block)", async () => {
+    const hooks: HookSpec[] = [{ event: "PostToolUse", command: "echo REWRITTEN; exit 2" }];
+    const r = await fireHooks("PostToolUse", hooks, ENV, CWD);
+    assert.equal(r.blocked.length, 0);
+    assert.match(r.rewriteResult ?? "", /REWRITTEN/);
+  });
+
+  test("exit 0 is a no-op (not blocked, no rewrite)", async () => {
+    const hooks: HookSpec[] = [{ event: "PreToolUse", command: "echo fine; exit 0" }];
+    const r = await fireHooks("PreToolUse", hooks, ENV, CWD);
+    assert.deepEqual(r.blocked, []);
+    assert.equal(r.rewriteResult, undefined);
+  });
+
+  test("only hooks for the fired event run", async () => {
+    const hooks: HookSpec[] = [
+      { event: "PostToolUse", command: "echo wrong-event >&2; exit 2" },
+    ];
+    const r = await fireHooks("PreToolUse", hooks, ENV, CWD);
+    assert.deepEqual(r.blocked, [], "a PostToolUse hook must not fire on PreToolUse");
+  });
+
+  test("matcher: regex on TOOL_NAME gates the hook", async () => {
+    const hooks: HookSpec[] = [{ event: "PreToolUse", matcher: "^bash$", command: "echo blocked >&2; exit 2" }];
+    const hit = await fireHooks("PreToolUse", hooks, { TOOL_NAME: "bash" }, CWD);
+    assert.equal(hit.blocked.length, 1);
+    const miss = await fireHooks("PreToolUse", hooks, { TOOL_NAME: "read" }, CWD);
+    assert.equal(miss.blocked.length, 0);
+  });
+
+  test("an invalid matcher regex falls back to a literal match", async () => {
+    const hooks: HookSpec[] = [{ event: "PreToolUse", matcher: "[unclosed", command: "exit 2" }];
+    const literal = await fireHooks("PreToolUse", hooks, { TOOL_NAME: "[unclosed" }, CWD);
+    assert.equal(literal.blocked.length, 1, "literal match on the bad-regex string");
+    const other = await fireHooks("PreToolUse", hooks, { TOOL_NAME: "bash" }, CWD);
+    assert.equal(other.blocked.length, 0);
+  });
+});

--- a/src/mcp/client.test.ts
+++ b/src/mcp/client.test.ts
@@ -1,0 +1,58 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { mcpToolToLisaTool } from "./client.js";
+
+// A minimal fake MCP client — only callTool is exercised by the mapping.
+function fakeClient(impl: (args: { name: string; arguments: Record<string, unknown> }) => unknown): Client {
+  return { callTool: async (a: { name: string; arguments: Record<string, unknown> }) => impl(a) } as unknown as Client;
+}
+
+describe("mcpToolToLisaTool — mapping", () => {
+  test("prefixes the tool name and tags the description by server", () => {
+    const t = mcpToolToLisaTool("files", fakeClient(() => ({ content: [] })), { name: "read", description: "Read a file" }, () => {});
+    assert.equal(t.name, "mcp__files__read");
+    assert.match(t.description, /\[mcp:files\]/);
+    assert.match(t.description, /Read a file/);
+  });
+
+  test("falls back to a default description when none is given", () => {
+    const t = mcpToolToLisaTool("git", fakeClient(() => ({ content: [] })), { name: "status" }, () => {});
+    assert.match(t.description, /\[mcp:git\] status/);
+  });
+
+  test("coerces a non-object inputSchema to an empty object schema", () => {
+    const t = mcpToolToLisaTool("x", fakeClient(() => ({ content: [] })), { name: "y", inputSchema: undefined }, () => {});
+    assert.deepEqual(t.inputSchema, { type: "object", properties: {} });
+    const t2 = mcpToolToLisaTool("x", fakeClient(() => ({ content: [] })), { name: "y", inputSchema: { type: "object", properties: { a: { type: "string" } } } }, () => {});
+    assert.equal((t2.inputSchema as { type: string }).type, "object");
+  });
+});
+
+describe("mcpToolToLisaTool — execute() result flattening", () => {
+  test("joins text blocks; passes the input through as arguments", async () => {
+    let passed: Record<string, unknown> | undefined;
+    const t = mcpToolToLisaTool("s", fakeClient((a) => { passed = a.arguments; return { content: [{ type: "text", text: "line1" }, { type: "text", text: "line2" }] }; }), { name: "go" }, () => {});
+    const out = await t.execute({ q: 1 } as never, {} as never);
+    assert.equal(out, "line1\nline2");
+    assert.deepEqual(passed, { q: 1 });
+  });
+
+  test("non-text content renders as a [type] placeholder", async () => {
+    const t = mcpToolToLisaTool("s", fakeClient(() => ({ content: [{ type: "image" }, { type: "text", text: "ok" }] })), { name: "go" }, () => {});
+    assert.equal(await t.execute({} as never, {} as never), "[image]\nok");
+  });
+
+  test("empty content → \"(empty)\"", async () => {
+    const t = mcpToolToLisaTool("s", fakeClient(() => ({ content: [] })), { name: "go" }, () => {});
+    assert.equal(await t.execute({} as never, {} as never), "(empty)");
+  });
+
+  test("isError is logged but the text is still returned", async () => {
+    const logs: string[] = [];
+    const t = mcpToolToLisaTool("s", fakeClient(() => ({ content: [{ type: "text", text: "boom" }], isError: true })), { name: "go" }, (m) => logs.push(m));
+    const out = await t.execute({} as never, {} as never);
+    assert.equal(out, "boom");
+    assert.ok(logs.some((l) => /isError/.test(l)));
+  });
+});

--- a/src/mcp/client.ts
+++ b/src/mcp/client.ts
@@ -56,7 +56,7 @@ async function connectOne(
   };
 }
 
-function mcpToolToLisaTool(
+export function mcpToolToLisaTool(
   serverName: string,
   client: Client,
   mcpTool: { name: string; description?: string; inputSchema?: object },

--- a/src/subagent.test.ts
+++ b/src/subagent.test.ts
@@ -1,0 +1,76 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import type Anthropic from "@anthropic-ai/sdk";
+import { runSubagent, type SubagentOptions } from "./subagent.js";
+import type { Provider, ProviderResult, ProviderUsage } from "./providers/types.js";
+import type { ToolDefinition } from "./types.js";
+
+let idN = 0;
+function usage(o: Partial<ProviderUsage> = {}): ProviderUsage {
+  return { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0, ...o };
+}
+function textTurn(text: string, u: Partial<ProviderUsage> = {}): ProviderResult {
+  return { content: [{ type: "text", text } as Anthropic.ContentBlock], stopReason: "end_turn", usage: usage(u) };
+}
+function toolTurn(name: string, u: Partial<ProviderUsage> = {}): ProviderResult {
+  return {
+    content: [{ type: "tool_use", id: `t${++idN}`, name, input: {} } as Anthropic.ContentBlock],
+    stopReason: "tool_use",
+    usage: usage(u),
+  };
+}
+function scripted(queue: ProviderResult[], tail?: ProviderResult): Provider {
+  let i = 0;
+  return { name: "fake", async runTurn() { return i < queue.length ? queue[i++]! : tail ?? (() => { throw new Error("drained"); })(); } };
+}
+const echoTool: ToolDefinition = {
+  name: "echo",
+  description: "echo",
+  inputSchema: { type: "object" } as Anthropic.Tool.InputSchema,
+  execute: async () => "ok",
+};
+function opts(over: Partial<SubagentOptions>): SubagentOptions {
+  return {
+    prompt: "do it",
+    systemPrompt: "sys",
+    tools: [echoTool],
+    cwd: "/tmp",
+    signal: new AbortController().signal,
+    model: "test-model",
+    ...over,
+  };
+}
+
+describe("runSubagent", () => {
+  test("returns the final text and maps token usage + stopReason", async () => {
+    const provider = scripted([textTurn("the answer", { inputTokens: 10, outputTokens: 4 })]);
+    const r = await runSubagent(opts({ provider }));
+    assert.equal(r.text, "the answer");
+    assert.equal(r.inputTokens, 10);
+    assert.equal(r.outputTokens, 4);
+    assert.equal(r.stopReason, "end_turn");
+    assert.equal(r.toolCallCount, 0);
+  });
+
+  test("counts tool calls across turns", async () => {
+    const provider = scripted([toolTurn("echo"), toolTurn("echo"), textTurn("done")]);
+    const r = await runSubagent(opts({ provider }));
+    assert.equal(r.toolCallCount, 2);
+    assert.equal(r.stopReason, "end_turn");
+  });
+
+  test("surfaces truncation via stopReason (budget breaker)", async () => {
+    const provider = scripted([], toolTurn("echo", { inputTokens: 100, outputTokens: 100 }));
+    const r = await runSubagent(opts({ provider, budgetTokens: 150 }));
+    assert.equal(r.stopReason, "budget_exceeded");
+  });
+
+  test("surfaces truncation via stopReason (max_iterations)", async () => {
+    const provider = scripted([], toolTurn("echo"));
+    // maxIterations is fixed at 32 inside runSubagent; a tail that always wants a
+    // tool eventually hits it. Keep the assertion to the observable contract.
+    const r = await runSubagent(opts({ provider }));
+    assert.equal(r.stopReason, "max_iterations");
+    assert.equal(r.toolCallCount, 32);
+  });
+});

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -1,6 +1,7 @@
 import { runAgent } from "./agent.js";
 import { DEFAULT_MODEL } from "./llm.js";
 import { providerForModel } from "./providers/registry.js";
+import type { Provider } from "./providers/types.js";
 import type { ToolDefinition } from "./types.js";
 
 export interface SubagentOptions {
@@ -14,6 +15,8 @@ export interface SubagentOptions {
   thinking?: boolean;
   /** Cumulative (input+output) token ceiling; stops the run early when reached. */
   budgetTokens?: number;
+  /** Injectable provider (tests); defaults to providerForModel(model). */
+  provider?: Provider;
 }
 
 export interface SubagentResult {
@@ -27,7 +30,7 @@ export interface SubagentResult {
 
 export async function runSubagent(opts: SubagentOptions): Promise<SubagentResult> {
   const model = opts.model ?? DEFAULT_MODEL;
-  const provider = providerForModel(model);
+  const provider = opts.provider ?? providerForModel(model);
   let toolCallCount = 0;
   const result = await runAgent({
     provider,


### PR DESCRIPTION
## What

Closes the remaining core-loop test gaps (FOUNDATIONS §3): `subagent`, `mcp/client`, and the `hooks` runner — modules the v0.9 review flagged as untested.

## How

- **`src/subagent.ts`** — accept an optional injectable `provider` (defaults to `providerForModel`). **`src/subagent.test.ts`**: final-text + token/stopReason mapping, tool-call counting across turns, truncation surfacing (`budget_exceeded` / `max_iterations`).
- **`src/mcp/client.ts`** — export `mcpToolToLisaTool`. **`src/mcp/client.test.ts`**: name prefixing (`mcp__<server>__<tool>`), server-tagged description + fallback, non-object `inputSchema` coercion, and `execute()` result flattening (text join, `[type]` placeholders, `"(empty)"`, `isError` logged-but-returned) via a fake client. (`connectOne` uses a real stdio transport — not unit-testable, left out.)
- **`src/hooks/runner.test.ts`** — `runHook` (real bash: stdout/stderr/exit, env passthrough) and `fireHooks` semantics: `PreToolUse` exit 2 → **blocked** w/ stderr, `PostToolUse` exit 2 → **rewrite** from stdout, exit 0 no-op, event filtering, and matcher regex on `TOOL_NAME` with a **literal-match fallback** on a bad regex.

No behavior change beyond the subagent injection seam.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **682 tests pass (+20)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)