### PR TITLE
feat(sense): observability — lisa sense CLI + island "recently sensed" feed

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,6 +62,7 @@ INSPECTION
   lisa consent <sub>           Consent for sensitive ambient signals (default
                                all off): list, grant <signal>, revoke <signal>,
                                revoke-all.
+  lisa sense [list]            Recent ambient sense events + granted signals.
 
 LIFECYCLE
   lisa birth                   Run the birth ritual (auto-runs on first launch).
@@ -166,7 +167,8 @@ interface ParsedArgs {
     | "monitor"
     | "autonomy"
     | "model"
-    | "consent";
+    | "consent"
+    | "sense";
   subargs: string[];
   serveWeb: boolean;
   serveImessage: boolean;
@@ -286,7 +288,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       first === "monitor" ||
       first === "autonomy" ||
       first === "model" ||
-      first === "consent"
+      first === "consent" ||
+      first === "sense"
     ) {
       out.subcommand = first;
       out.subargs = positional.slice(1);
@@ -470,6 +473,11 @@ async function main(): Promise<void> {
   if (args.subcommand === "consent") {
     const { runConsentCommand } = await import("./cli/consent.js");
     process.exit(await runConsentCommand(args.subargs));
+  }
+
+  if (args.subcommand === "sense") {
+    const { runSenseCommand } = await import("./cli/sense.js");
+    process.exit(await runSenseCommand(args.subargs));
   }
 
   if (args.subcommand === "sessions") {

--- a/src/cli/sense.ts
+++ b/src/cli/sense.ts
@@ -1,0 +1,36 @@
+/**
+ * `lisa sense <list>` — print recent ambient sense events + which signals are
+ * granted (FOUNDATIONS §4 observability: "one `lisa <domain>` command per
+ * pillar"). Read-only over the bounded sense log; structural summaries only.
+ */
+import { readSenseEvents } from "../sense/log.js";
+import { listGrants } from "../consent/store.js";
+
+function rel(ms: number): string {
+  if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
+  if (ms < 3_600_000) return `${Math.round(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.round(ms / 3_600_000)}h ago`;
+  return `${Math.round(ms / 86_400_000)}d ago`;
+}
+
+export async function runSenseCommand(subargs: string[]): Promise<number> {
+  const sub = subargs[0] ?? "list";
+
+  if (sub === "list" || sub === "recent" || sub === "status") {
+    const granted = listGrants().filter((g) => g.granted).map((g) => g.signal);
+    console.log(`Sense — granted: ${granted.length ? granted.join(", ") : "(none; all off — `lisa consent grant <signal>`)"}\n`);
+    const events = readSenseEvents();
+    if (events.length === 0) {
+      console.log("  (no recent ambient events)");
+      return 0;
+    }
+    const now = Date.now();
+    for (const e of events.slice(-30).reverse()) {
+      console.log(`  ${rel(now - e.ts).padStart(8)}  [${e.signal}] ${e.summary}`);
+    }
+    return 0;
+  }
+
+  console.error(`unknown sense subcommand "${sub}" — use list.`);
+  return 1;
+}

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -435,6 +435,19 @@ export const ISLAND_HTML = `<!doctype html>
   }
   #sense-stop:hover { background: rgba(255, 85, 119, 0.2); }
   body.sensing #sense-stop { display: block; }
+  /* Live "recently sensed" feed — structural summaries only. */
+  #sense-events { list-style: none; margin: 8px 0 0; padding: 0; }
+  #sense-events li {
+    display: flex;
+    gap: 8px;
+    align-items: baseline;
+    padding: 3px 4px;
+    font-size: 10.5px;
+    color: var(--fg-dim);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  #sense-events .se-when { color: var(--fg-faint); flex-shrink: 0; font-variant-numeric: tabular-nums; }
+  #sense-events .se-sum { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
   /* Phase 3 — notification opt-in chip */
   #notify-cta {
@@ -557,6 +570,7 @@ export const ISLAND_HTML = `<!doctype html>
       <div class="section-label" id="sense-label">👁 sense · <span id="sense-summary">all off</span></div>
       <ul id="sense-list"></ul>
       <button id="sense-stop" type="button">Stop all sensing</button>
+      <ul id="sense-events"></ul>
     </div>
     <div id="actions">
       <button id="btn-open">Open chat</button>
@@ -596,6 +610,7 @@ export const ISLAND_HTML = `<!doctype html>
   const senseList    = document.getElementById('sense-list');
   const senseSummary = document.getElementById('sense-summary');
   const senseStop    = document.getElementById('sense-stop');
+  const senseEvents  = document.getElementById('sense-events');
   const body         = document.body;
 
   const state = {
@@ -610,6 +625,7 @@ export const ISLAND_HTML = `<!doctype html>
     suggestion: null,    // {title, rationale, task, at} from the screen advisor
     advisor: [],         // [{id, category, urgency, text, action}] from the cross-agent advisor
     sense: [],           // [{signal, granted, grantedAt}] from /api/consent (FOUNDATIONS §1)
+    senseEvents: [],     // [{signal, summary, ts}] recent ambient events (S2)
   };
 
   // 30-min activity window matches the watcher's ACTIVE_WINDOW_MS.
@@ -1223,6 +1239,11 @@ export const ISLAND_HTML = `<!doctype html>
           state.advisor = Array.isArray(m.suggestions) ? m.suggestions : [];
           refreshPanel();
           break;
+        case 'sense_event':
+          // Newest first; cap the in-memory feed.
+          state.senseEvents = [m].concat(state.senseEvents || []).slice(0, 30);
+          renderSenseEvents();
+          break;
         case 'agent_session_update':
           // D4a — generalized multi-agent event (claude-code + codex + …).
           // Payload is the normalized AgentSession (lastMtime is epoch ms;
@@ -1376,6 +1397,33 @@ export const ISLAND_HTML = `<!doctype html>
   }
   senseStop.addEventListener('click', (e) => { e.stopPropagation(); stopAllSensing(); });
 
+  // Recently-sensed feed (structural summaries only).
+  function renderSenseEvents() {
+    while (senseEvents.firstChild) senseEvents.removeChild(senseEvents.firstChild);
+    for (const e of (state.senseEvents || []).slice(0, 8)) {
+      const li = document.createElement('li');
+      const when = document.createElement('span');
+      when.className = 'se-when';
+      when.textContent = relativeTime(e.ts);
+      const sum = document.createElement('span');
+      sum.className = 'se-sum';
+      sum.textContent = '[' + (e.signal || '?') + '] ' + (e.summary || '');
+      sum.title = sum.textContent;
+      li.appendChild(when);
+      li.appendChild(sum);
+      senseEvents.appendChild(li);
+    }
+  }
+
+  async function fetchSenseEvents() {
+    try {
+      const r = await fetch('/api/sense/recent', { cache: 'no-store' });
+      if (!r.ok) return;
+      const j = await r.json();
+      if (Array.isArray(j.events)) { state.senseEvents = j.events; renderSenseEvents(); }
+    } catch (_) { /* older server without the endpoint — silent */ }
+  }
+
   // Phase 3 — notification permission opt-in. The CTA is only visible
   // when permission is in the default (un-asked) state.
   notifyCta.addEventListener('click', (e) => {
@@ -1391,6 +1439,7 @@ export const ISLAND_HTML = `<!doctype html>
   pollPing();
   fetchClaudeSessions().then(() => { refreshDot(); refreshPanel(); });
   fetchConsent();
+  fetchSenseEvents();
   subscribe();
   refreshNotifyCta();
   // A fresh island picks up the most recent screen-advisor suggestion (if the

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -36,7 +36,7 @@ import { listGrants, grant, revoke, revokeAll, SENSE_SIGNALS, SIGNAL_DESCRIPTION
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
 import { VoiceSource } from "../sense/voice.js";
-import { appendSenseEvent } from "../sense/log.js";
+import { appendSenseEvent, readSenseEvents } from "../sense/log.js";
 import {
   loadScreenAdvisorConfig,
   saveScreenAdvisorConfig,
@@ -708,6 +708,13 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       }));
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ grants }));
+      return;
+    }
+    // Recent ambient sense events, for the island's "recently sensed" list.
+    if (req.method === "GET" && url === "/api/sense/recent") {
+      const events = readSenseEvents().slice(-30).reverse(); // newest first
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ events }));
       return;
     }
     if (req.method === "POST" && url === "/api/consent/revoke-all") {


### PR DESCRIPTION
## What

Makes the ambient **Sense** pillar legible (FOUNDATIONS §4: one `lisa <domain>` command per pillar + "give it to a human to read"), completing the S2 loop so a granted source's output is **visible**, not just logged to disk.

## How

- **`src/cli/sense.ts` + `cli.ts`** — `lisa sense [list]` prints which signals are granted and the recent ambient events (structural summaries only) from the bounded sense log.
- **server** — `GET /api/sense/recent` (newest-first, capped) for the island's initial load; the live path already broadcasts `sense_event` over SSE.
- **island** — a "recently sensed" feed under the consent toggles: fetches `/api/sense/recent` on open and prepends each `sense_event` from SSE (capped). The consent toggles *arm* a source (#88); this shows what it then *sees*.

Read-only, structural-only — same privacy contract as the sources.

## Verification

- `npm run typecheck` clean, `npm run build` clean
- **682 tests pass**; `ISLAND_HTML` inline script parses (html-syntax guard), `MAIN_HTML` snapshot unchanged (island-only change)
- `lisa sense` smoke-tested (fresh → "all off / no recent ambient events")

🤖 Generated with [Claude Code](https://claude.com/claude-code)