### PR TITLE
docs(foundations): honesty pass — accurate LOC, complete completions, local-model clarity

### DIFF
--- a/PITCH.md
+++ b/PITCH.md
@@ -80,7 +80,7 @@ client, plugins, hooks, sandboxed bash, sub-agents, session resume + TF-IDF
 search across past sessions, context compaction, **vision** (global-hotkey
 screenshot → talk about it), **voice** (record → she transcribes + summarizes),
 six IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), a
-native Mac app + Dynamic-Island widget, pixel-art web UI. ~22k lines of
+native Mac app + Dynamic-Island widget, pixel-art web UI. ~27k lines of
 TypeScript, MIT, no hosted backend, no telemetry, no account.
 
 But capability parity is just admission. The reason people remember LISA is the

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ### LISA = pi-mono + OpenClaw + hermes + claude-code + codex + *something none of them have*
 
-Standing on five of the best open-source agents, LISA ships **the full superset of their capabilities** — streaming agent loop, multi-provider LLMs (Anthropic + OpenAI + Gemini, plus 20+ OpenAI-compatible providers), MCP client, plugins, hooks, sandboxed bash, sub-agents, session resume, context compaction, voice in/out, six IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), apply-patch, approval modes, TF-IDF over past sessions, pixel-art web UI. ~22k lines of TypeScript, MIT.
+Standing on five of the best open-source agents, LISA ships **the full superset of their capabilities** — streaming agent loop, multi-provider LLMs (Anthropic + OpenAI + Gemini, plus 20+ OpenAI-compatible providers), MCP client, plugins, hooks, sandboxed bash, sub-agents, session resume, context compaction, voice in/out, six IM channels (Telegram / Discord / Slack / Feishu / iMessage / Webhook), apply-patch, approval modes, TF-IDF over past sessions, pixel-art web UI. ~27k lines of TypeScript, MIT.
 
 What none of them have:
 

--- a/completions/_lisa
+++ b/completions/_lisa
@@ -42,6 +42,9 @@ _lisa() {
                 skills)   _lisa_skills ;;
                 heartbeat) _lisa_heartbeat ;;
                 autostart) _lisa_autostart ;;
+                model)    _lisa_model ;;
+                consent)  _lisa_consent ;;
+                sense)    _lisa_sense ;;
             esac
             ;;
     esac
@@ -64,6 +67,10 @@ _lisa_first() {
         'status:one-shot snapshot'
         'doctor:health check'
         'monitor:TUI live dashboard'
+        'autonomy:summarize recent autonomous runs'
+        'model:local model lifecycle (list/install/use/health)'
+        'consent:consent for sensitive ambient signals'
+        'sense:recent ambient sense events'
     )
     _describe 'subcommand' subcommands
 }
@@ -110,6 +117,40 @@ _lisa_autostart() {
             'status:show whether autostart is installed / loaded'
         )
         _describe 'autostart action' actions
+    fi
+}
+
+_lisa_model() {
+    if (( CURRENT == 2 )); then
+        local -a actions
+        actions=(
+            'list:list installed local models + backend health'
+            'install:pull a local model'
+            'use:switch to local://<model>'
+            'health:check the local backend'
+        )
+        _describe 'model action' actions
+    fi
+}
+
+_lisa_consent() {
+    if (( CURRENT == 2 )); then
+        local -a actions
+        actions=(
+            'list:show signals + status'
+            'grant:grant a signal'
+            'revoke:revoke a signal'
+            'revoke-all:stop all sensing'
+        )
+        _describe 'consent action' actions
+    elif (( CURRENT == 3 )) && [[ "$line[2]" == (grant|revoke) ]]; then
+        _describe 'signal' '(screen voice clipboard selection)'
+    fi
+}
+
+_lisa_sense() {
+    if (( CURRENT == 2 )); then
+        _describe 'sense action' '(list:show recent ambient events + granted signals)'
     fi
 }
 

--- a/completions/lisa.bash
+++ b/completions/lisa.bash
@@ -12,12 +12,16 @@ _lisa_completion() {
     local cur prev words cword
     _init_completion -n : 2>/dev/null || _get_comp_words_by_ref -n : cur prev words cword
 
-    local subcommands="resume sessions serve heartbeat autostart search birth soul channels skills wishlist status doctor monitor"
+    local subcommands="resume sessions serve heartbeat autostart search birth soul channels skills wishlist status doctor monitor autonomy model consent sense"
     local global_flags="--model --provider --think --no-reflect --compact --approval --no-mcp --no-plugins --voice --idle --no-idle --help -h --version -v"
     local serve_flags="--web --imessage --channels --port"
     local skills_actions="list approve disable enable audit"
     local heartbeat_actions="run install uninstall"
     local autostart_actions="install uninstall status"
+    local model_actions="list install use health"
+    local consent_actions="list grant revoke revoke-all"
+    local consent_signals="screen voice clipboard selection"
+    local sense_actions="list"
     local approval_modes="auto ask ask-mutating"
     local providers="anthropic openai gemini"
     local models="claude-sonnet-4-5-20250929 claude-opus-4 claude-haiku-4 gpt-5 gpt-4o o3 o4-mini gemini-2.5-pro gemini-2.5-flash deepseek-chat deepseek-reasoner doubao-1.5-pro-32k qwen3-72b-instruct moonshot-v1-32k kimi-128k grok-2-latest glm-4.5"
@@ -83,6 +87,29 @@ _lisa_completion() {
         autostart)
             if [ ${cword} -eq 2 ]; then
                 COMPREPLY=( $(compgen -W "${autostart_actions}" -- "${cur}") )
+                return 0
+            fi
+            ;;
+        model)
+            if [ ${cword} -eq 2 ]; then
+                COMPREPLY=( $(compgen -W "${model_actions}" -- "${cur}") )
+                return 0
+            fi
+            ;;
+        consent)
+            if [ ${cword} -eq 2 ]; then
+                COMPREPLY=( $(compgen -W "${consent_actions}" -- "${cur}") )
+                return 0
+            fi
+            # `grant`/`revoke` take a signal
+            if [ "${words[2]}" = "grant" ] || [ "${words[2]}" = "revoke" ]; then
+                COMPREPLY=( $(compgen -W "${consent_signals}" -- "${cur}") )
+                return 0
+            fi
+            ;;
+        sense)
+            if [ ${cword} -eq 2 ]; then
+                COMPREPLY=( $(compgen -W "${sense_actions}" -- "${cur}") )
                 return 0
             fi
             ;;

--- a/completions/lisa.fish
+++ b/completions/lisa.fish
@@ -17,7 +17,7 @@ end
 # ── helper: did the user already type a subcommand? ─────────────────
 function __lisa_no_subcommand
     set cmd (commandline -opc)
-    set sub resume sessions serve heartbeat autostart search birth soul channels skills wishlist status doctor monitor
+    set sub resume sessions serve heartbeat autostart search birth soul channels skills wishlist status doctor monitor autonomy model consent sense
     for word in $cmd[2..-1]
         if contains -- $word $sub
             return 1
@@ -51,6 +51,16 @@ complete -c lisa -n __lisa_no_subcommand -f -a wishlist   -d "Lisa's own toolset
 complete -c lisa -n __lisa_no_subcommand -f -a status     -d "one-shot snapshot"
 complete -c lisa -n __lisa_no_subcommand -f -a doctor     -d "health check"
 complete -c lisa -n __lisa_no_subcommand -f -a monitor    -d "TUI live dashboard"
+complete -c lisa -n __lisa_no_subcommand -f -a autonomy   -d "summarize autonomous runs"
+complete -c lisa -n __lisa_no_subcommand -f -a model      -d "local model lifecycle"
+complete -c lisa -n __lisa_no_subcommand -f -a consent    -d "consent for ambient signals"
+complete -c lisa -n __lisa_no_subcommand -f -a sense      -d "recent ambient sense events"
+
+# ── model / consent / sense sub-actions ─────────────────────────────
+complete -c lisa -n "__lisa_using_subcommand model" -f -a "list install use health" -d "model action"
+complete -c lisa -n "__lisa_using_subcommand consent" -f -a "list grant revoke revoke-all" -d "consent action"
+complete -c lisa -n "__lisa_using_subcommand consent" -f -a "screen voice clipboard selection" -d "signal"
+complete -c lisa -n "__lisa_using_subcommand sense" -f -a list -d "recent events"
 
 # ── skills sub-actions ──────────────────────────────────────────────
 complete -c lisa -n "__lisa_using_subcommand skills" -f -a list     -d "list executable skills"

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -167,6 +167,10 @@ lisa --model qwen2.5-32b-instruct
 
 Ollama's OpenAI-compat is at `/v1`. Tool use depends on the underlying model — `qwen2.5` and `llama3.1` both support it; smaller models often don't.
 
+**Two ways to use local models, to be clear about what LISA does:**
+- **Bring your own endpoint** (above) — you run Ollama / LM Studio / vLLM and point `LISA_BASE_URL` at it. LISA is just an OpenAI-compat client; it does not manage the server.
+- **Managed lifecycle** — `lisa model list / install <model> / use local://<model> / health` drives a local Ollama backend for you (pull + switch). Same runtime as above; it just automates the pull and the config switch. It does **not** bundle or fine-tune a model.
+
 ---
 
 ## Recipe 6: Moonshot (Kimi, China)


### PR DESCRIPTION
## What

FOUNDATIONS §5.3 — *narrative = code*. Audited README / PITCH / shell completions / PROVIDERS against the current tree.

Several previously-flagged items were **already fixed** in the v0.9.1 docs pass (the standalone-LisaIsland fold is now explained honestly in the README; no stale `0.2.0` version claims remain). The remaining real discrepancies:

- **LOC** — README + PITCH said "~22k lines of TypeScript"; the tree is **26,664 non-test** (34,220 incl tests) → corrected to **"~27k"**.
- **Shell completions** were missing the newer subcommands. Added `model`, `autonomy`, `consent`, `sense` (+ sub-actions: `model list/install/use/health`, `consent list/grant/revoke/revoke-all` with signal completion, `sense list`) to all three — `lisa.bash`, `_lisa` (zsh), `lisa.fish`. (`autostart`, the item the plan named, was already present.)
- **PROVIDERS.md Recipe 5** — distinguish the two local-model paths honestly: *bring your own endpoint* (LISA is just an OpenAI-compat client) vs the `lisa model` **managed lifecycle** (automates pull + config switch; does **not** bundle or fine-tune a model).

Docs/completions only — no code change. `bash -n` validates `lisa.bash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)