### PR TITLE
feat(foundations): gate dispatch/signal/github writes under --approval ask-mutating

### DIFF
--- a/src/approval.test.ts
+++ b/src/approval.test.ts
@@ -2,12 +2,19 @@ import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 import {
   buildApprovalCallback,
+  isMutatingCall,
   DEFAULT_MUTATING_TOOLS,
+  DEFAULT_MUTATING_ACTIONS,
   type ApprovalConfig,
 } from "./approval.js";
 
 function cfg(over: Partial<ApprovalConfig> = {}): ApprovalConfig {
-  return { mode: "ask", mutatingTools: new Set(DEFAULT_MUTATING_TOOLS), ...over };
+  return {
+    mode: "ask",
+    mutatingTools: new Set(DEFAULT_MUTATING_TOOLS),
+    mutatingActions: DEFAULT_MUTATING_ACTIONS,
+    ...over,
+  };
 }
 
 describe("buildApprovalCallback — mode gating", () => {
@@ -28,11 +35,45 @@ describe("buildApprovalCallback — mode gating", () => {
     assert.deepEqual(await cb("bash", { cmd: "ls" }), { allow: true });
   });
 
-  test("DEFAULT_MUTATING_TOOLS covers the write/exec tools", () => {
-    for (const t of ["write", "edit", "apply_patch", "bash"]) {
+  test("DEFAULT_MUTATING_TOOLS covers write/exec + dispatch/signal", () => {
+    for (const t of ["write", "edit", "apply_patch", "bash", "dispatch_agent", "signal_agent"]) {
       assert.ok(DEFAULT_MUTATING_TOOLS.has(t), `expected ${t} to be mutating`);
     }
     assert.equal(DEFAULT_MUTATING_TOOLS.has("read"), false);
+  });
+
+  test("dispatch_agent / signal_agent prompt under ask-mutating", async () => {
+    for (const t of ["dispatch_agent", "signal_agent"]) {
+      let prompted = false;
+      const cb = buildApprovalCallback(cfg({ mode: "ask-mutating", readLine: async () => { prompted = true; return "y"; } }))!;
+      await cb(t, {});
+      assert.equal(prompted, true, `${t} should prompt`);
+    }
+  });
+});
+
+describe("action-aware mutating gate (github reads safe, writes gated)", () => {
+  test("isMutatingCall: github writes mutate, reads don't", () => {
+    const c = cfg();
+    assert.equal(isMutatingCall(c, "github", { action: "pr_merge" }), true);
+    assert.equal(isMutatingCall(c, "github", { action: "pr_create" }), true);
+    assert.equal(isMutatingCall(c, "github", { action: "pr_view" }), false);
+    assert.equal(isMutatingCall(c, "github", { action: "issue_list" }), false);
+    assert.equal(isMutatingCall(c, "github", {}), false, "no action → not mutating");
+    assert.equal(isMutatingCall(c, "dispatch_agent", {}), true, "whole-tool mutating still works");
+  });
+
+  test("under ask-mutating: a github read auto-allows, a github write prompts", async () => {
+    let prompted = false;
+    const reader = async () => { prompted = true; return "y"; };
+
+    const readCb = buildApprovalCallback(cfg({ mode: "ask-mutating", readLine: reader }))!;
+    assert.deepEqual(await readCb("github", { action: "pr_view" }), { allow: true });
+    assert.equal(prompted, false, "a github read must not prompt");
+
+    const writeCb = buildApprovalCallback(cfg({ mode: "ask-mutating", readLine: reader }))!;
+    await writeCb("github", { action: "pr_merge" });
+    assert.equal(prompted, true, "a github write must prompt");
   });
 });
 

--- a/src/approval.ts
+++ b/src/approval.ts
@@ -6,6 +6,9 @@ export type ApprovalMode = "auto" | "ask" | "ask-mutating";
 export interface ApprovalConfig {
   mode: ApprovalMode;
   mutatingTools: Set<string>;
+  /** Per-tool action-level mutating gate, for action-dispatched tools whose
+   *  reads are safe but writes aren't (e.g. github). tool → mutating actions. */
+  mutatingActions?: Record<string, string[]>;
   /** Injectable prompt reader (tests); defaults to reading one stdin line. */
   readLine?: () => Promise<string>;
 }
@@ -15,14 +18,41 @@ export const DEFAULT_MUTATING_TOOLS = new Set([
   "edit",
   "apply_patch",
   "bash",
+  // Local execution / process control — always state-changing.
+  "dispatch_agent",
+  "signal_agent",
 ]);
+
+/**
+ * Action-dispatched tools where only SOME actions mutate. Reads (issue_view,
+ * pr_view, …) stay un-gated under ask-mutating; only these write actions prompt.
+ * Mirrors github.ts's own "reads are safe; create/comment/merge are writes".
+ */
+export const DEFAULT_MUTATING_ACTIONS: Record<string, string[]> = {
+  github: ["issue_create", "issue_comment", "pr_create", "pr_comment", "pr_merge"],
+};
+
+/** Does this tool call change state (so ask-mutating should prompt)? */
+export function isMutatingCall(
+  cfg: ApprovalConfig,
+  toolName: string,
+  input: unknown,
+): boolean {
+  if (cfg.mutatingTools.has(toolName)) return true;
+  const actions = cfg.mutatingActions?.[toolName];
+  if (actions && input && typeof input === "object") {
+    const action = (input as Record<string, unknown>).action;
+    if (typeof action === "string" && actions.includes(action)) return true;
+  }
+  return false;
+}
 
 export function buildApprovalCallback(
   cfg: ApprovalConfig,
 ): ApprovalCallback | undefined {
   if (cfg.mode === "auto") return undefined;
   return async (toolName: string, toolInput: unknown): Promise<ApprovalDecision> => {
-    if (cfg.mode === "ask-mutating" && !cfg.mutatingTools.has(toolName)) {
+    if (cfg.mode === "ask-mutating" && !isMutatingCall(cfg, toolName, toolInput)) {
       return { allow: true };
     }
     const preview = previewInput(toolInput);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,7 +10,7 @@ import { dirname, resolve as resolvePath } from "node:path";
 import { configureProxyFromEnv } from "./proxy-bootstrap.js";
 configureProxyFromEnv({ log: (m) => console.error(m) });
 import { runAgent } from "./agent.js";
-import { buildApprovalCallback, type ApprovalMode, DEFAULT_MUTATING_TOOLS } from "./approval.js";
+import { buildApprovalCallback, type ApprovalMode, DEFAULT_MUTATING_TOOLS, DEFAULT_MUTATING_ACTIONS } from "./approval.js";
 import { CONFIG_ENV_PATH, loadConfigEnv } from "./env.js";
 import { ensureDir } from "./fs-utils.js";
 import { runHeartbeatOnce } from "./heartbeat/runner.js";
@@ -784,6 +784,7 @@ async function main(): Promise<void> {
   const approval = buildApprovalCallback({
     mode: args.approval,
     mutatingTools: DEFAULT_MUTATING_TOOLS,
+    mutatingActions: DEFAULT_MUTATING_ACTIONS,
   });
 
   const rebuildPrompt = makeHotReloadRebuilder(initialFingerprint, snapshot.text);


### PR DESCRIPTION
## What

FOUNDATIONS §6 / DISPATCH acceptance 144 — write-capable tools were **not** in the mutating set, so `--approval ask-mutating` didn't prompt before them. A real gap: the `github` tool's own doc already *assumed* this was closed ("create/comment/merge are write actions gated by the host approval layer").

## How

- **`DEFAULT_MUTATING_TOOLS`** += `dispatch_agent`, `signal_agent` (local execution / process control — always state-changing).
- **`DEFAULT_MUTATING_ACTIONS`** (new) — action-level gate for action-dispatched tools whose reads are safe but writes aren't: `github` → `issue_create` / `issue_comment` / `pr_create` / `pr_comment` / `pr_merge`. github **reads** (`pr_view`, `issue_list`, …) stay un-gated, matching the tool's own "reads are safe" design.
- **`isMutatingCall(cfg, name, input)`** — mutating if whole-tool OR the action matches. `cli.ts` wires `DEFAULT_MUTATING_ACTIONS` into the approval config.

These tools are already in `AUTONOMOUS_BLOCKED` (autonomous/remote runs); this adds the **interactive** `ask-mutating` gate that was missing.

## Verification

- **685 tests pass** (+3): dispatch/signal prompt under ask-mutating; `isMutatingCall` github write=true/read=false; a github read auto-allows while a write prompts
- `npm run typecheck` + `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)