### PR TITLE
feat(dispatch): D4b — /api/agent/signal endpoint (list/cancel dispatched agents)

### DIFF
--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -33,6 +33,7 @@ import { captureScreenshot, captureSupported, type CaptureMode } from "../vision
 import { transcribeAudio } from "../voice/transcribe.js";
 import { polishDictation, type DictationProvider } from "../voice/dictation.js";
 import { listGrants, grant, revoke, revokeAll, isGranted, SENSE_SIGNALS, SIGNAL_DESCRIPTIONS } from "../consent/store.js";
+import { signalAgentTool } from "../tools/signal_agent.js";
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
 import { VoiceSource } from "../sense/voice.js";
@@ -733,6 +734,39 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       res.end(JSON.stringify({ grants }));
       return;
     }
+    // D4b — list/cancel LISA's OWN dispatched agents over HTTP. Behind the auth
+    // gate like every endpoint (loopback or token). Reuses signal_agent, so it
+    // can ONLY touch dispatch-ledger pids — never an arbitrary process.
+    if (req.method === "POST" && url === "/api/agent/signal") {
+      let sigBody = "";
+      for await (const chunk of req) sigBody += chunk.toString("utf8");
+      let payload: { action?: unknown; target?: unknown; force?: unknown };
+      try {
+        payload = JSON.parse(sigBody || "{}");
+      } catch {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("bad json");
+        return;
+      }
+      const action = payload.action === "list" ? "list" : payload.action === "cancel" ? "cancel" : null;
+      if (!action) {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("action must be 'list' or 'cancel'");
+        return;
+      }
+      const result = await signalAgentTool.execute(
+        {
+          action,
+          target: typeof payload.target === "string" ? payload.target : undefined,
+          force: payload.force === true,
+        },
+        { cwd: process.cwd(), signal: new AbortController().signal, log: () => {} },
+      );
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, result }));
+      return;
+    }
+
     // Recent ambient sense events, for the island's "recently sensed" list.
     if (req.method === "GET" && url === "/api/sense/recent") {
       const events = readSenseEvents().slice(-30).reverse(); // newest first


### PR DESCRIPTION
## What

The HTTP primitive for D4b: list or cancel the agents **LISA herself dispatched**, over the web API.

```
POST /api/agent/signal  { action: "list" | "cancel", target?, force? }
```

## How

- Behind the **existing auth gate** like every endpoint (loopback or `LISA_WEB_TOKEN`).
- **Reuses `signalAgentTool`**, so it can ONLY target dispatch-ledger pids (LISA's own dispatched agents) — never an arbitrary process. The SIGTERM→SIGKILL escalation + ledger cleanup are inherited from the tool (no duplicated kill logic).

## Scope note

Per the D4 plan (line 66, which marks the island button **"可选/optional, default still prefill"**), the island affordance is intentionally **not** added here:
- the advisor card deliberately **prefills** every action (never auto-runs) as a safety default, and
- LISA can already cancel via the `signal_agent` tool in chat.

This endpoint is the enabling primitive; a direct-cancel button (sourced from the ledger `list`, the only safe target set) is the optional remaining UI bit.

## Verification

- **690 tests pass**; `npm run typecheck` + `npm run build` clean
- Reuses `signal_agent` (covered by `signal_agent.test.ts`); endpoint is a thin auth-gated wrapper (consistent with the other `/api/*` routes that have no server-integration harness)

🤖 Generated with [Claude Code](https://claude.com/claude-code)