### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible majors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/release-mac-apps.yml
+++ b/.github/workflows/release-mac-apps.yml
@@ -45,12 +45,12 @@ jobs:
       # Apple Developer ID secrets are wired.
       HAS_APPLE_SIGNING: ${{ secrets.APPLE_TEAM_ID != '' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # workflow_dispatch may target a different tag than the default ref
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -189,7 +189,7 @@ jobs:
         # Tolerates the release already existing (created by release.yml
         # on the same tag). action-gh-release appends/updates assets when
         # called with a tag that already has a release.
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
           name: Lisa ${{ steps.ver.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,13 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           # If triggered manually with a tag input, fetch that ref;
           # otherwise the default ref (the pushed tag) is fine.
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -92,7 +92,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Create / update GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ steps.ver.outputs.tag }}
           name: Lisa ${{ steps.ver.outputs.tag }}

--- a/.github/workflows/website-deploy.yml
+++ b/.github/workflows/website-deploy.yml
@@ -30,9 +30,9 @@ jobs:
     outputs:
       have-secrets: ${{ steps.check-secrets.outputs.have }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: "22"
           cache: "npm"
@@ -61,7 +61,7 @@ jobs:
           ls -la dist/
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: website-dist
           path: website/dist/
@@ -82,9 +82,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: website-dist
           path: website/dist/
@@ -93,7 +93,7 @@ jobs:
       # name `lisa-website` must already exist in the user's Cloudflare
       # account; first-time setup is documented in docs/PUBLISH.md §3.
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@v4
         with:
           apiToken: ${{ secrets.CF_API_TOKEN }}
           accountId: ${{ secrets.CF_ACCOUNT_ID }}


### PR DESCRIPTION
## What

GitHub forces Actions to **Node 24 on 2026-06-16** and removes Node 20. The v0.10.0 release run warned that `checkout@v4` / `setup-node@v4` / `action-gh-release@v2` still run on Node 20. This bumps every action to its current latest major (all Node 24):

| action | from → to |
|---|---|
| actions/checkout | v4 → **v6** |
| actions/setup-node | v4 → **v6** |
| actions/upload-artifact | v4 → **v7** |
| actions/download-artifact | v4 → **v8** |
| softprops/action-gh-release | v2 → **v3** (its changelog: pure Node 20→24 runtime bump) |
| cloudflare/wrangler-action | v3 → **v4** |

Pure version swaps (14 `uses:` lines; nothing else changed). Input usage is unchanged and stable across these majors (checkout `ref`; setup-node `node-version`/`cache`; artifact `name`/`path`/`if-no-files-found`/`retention-days`; gh-release `tag_name`/`files`/…; wrangler `pages deploy`, no `wrangler.toml`).

## Validation

- This PR's **ci.yml** run exercises `checkout@v6` + `setup-node@v6` (the most-used pair) live.
- `action-gh-release@v3` is a confirmed pure-runtime bump; the release + website-deploy actions validate on their next trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)