### PR TITLE
feat(agents): adopt idle external claude sessions via `claude --resume` (Phase 6)

### DIFF
--- a/docs/PTY_AGENTS.md
+++ b/docs/PTY_AGENTS.md
@@ -19,6 +19,28 @@ In the GUI agents card these appear under their **real kind** (`claude-code` /
 `codex`), marked controllable: a **type-into-the-CLI** box, a **▤ output** button
 (shows the captured terminal tail in a modal), and **⏹ cancel**.
 
+## Adopting sessions LISA didn't start (`--resume`)
+
+The headline of this spike: controlling `claude` sessions **LISA never spawned** —
+your own from the app/terminal. You can't tap a *live* session's pipe (the app
+owns its stdin/stdout), but every session has a stable `sessionId`, and
+`claude --resume <id>` continues that exact transcript in a fresh process. So:
+
+- In the agents card, an **idle** claude session (its owning process is gone)
+  shows an **⇲ adopt** button. Click it → LISA spawns `claude --resume <id>`
+  under its own PTY → you now drive a *continuation* of that conversation
+  (send / answer / cancel / ▤ output). New turns append to the same transcript,
+  so they show up in the app's history too.
+- **Liveness guard (important):** LISA refuses (`409`) to adopt a session that's
+  currently live — two writers to one JSONL transcript interleave and corrupt it.
+  `liveClaudeSessionIds()` reads `~/.claude/sessions/<pid>.json` and checks the
+  pid; only sessions with no running owner are marked `resumable` / adoptable.
+- **Honest limit:** a session **open and running in the app right now** still
+  can't be commanded from outside — close it first, then adopt. (Live control
+  would require the app's undocumented `peerProtocol`, which we don't touch.)
+- Binary: LISA resumes with `LISA_PTY_CLAUDE_CMD` → the newest app-bundled
+  `claude` (version-matched to your sessions) → PATH `claude`.
+
 ## Enabling it
 
 1. Install the optional native dep (it has zero JS deps; if your machine can't
@@ -56,7 +78,8 @@ Binary resolution is env-overridable: `LISA_PTY_CLAUDE_CMD`, `LISA_PTY_CODEX_CMD
 
 | Method + path | Body | Effect |
 | --- | --- | --- |
-| `POST /api/agents/pty/start` | `{ agent, task, cwd? }` | spawn a PTY agent (503 if flag off) |
+| `POST /api/agents/pty/start` | `{ agent, task, cwd? }` | spawn a fresh PTY agent (503 if flag off) |
+| `POST /api/agents/pty/start` | `{ agent:"claude", resumeSessionId, cwd? }` | **adopt** an idle session (409 if it's live) |
 | `POST /api/agents/pty/<id>/send` | `{ text }` | type a line into the CLI |
 | `POST /api/agents/pty/<id>/cancel` | — | kill the CLI |
 | `GET /api/agents/pty/<id>/output` | — | ANSI-stripped terminal tail |
@@ -68,6 +91,8 @@ Binary resolution is env-overridable: `LISA_PTY_CLAUDE_CMD`, `LISA_PTY_CODEX_CMD
   fallback, flag gate.
 - `src/integrations/pty/observer.ts` — surfaces PTY agents in the hub roster
   (real kind, `controllable: "pty"`).
+- `src/integrations/claude-code/liveness.ts` — `liveClaudeSessionIds()` (the
+  adopt guard) + `resumable` enrichment in `/api/agents/sessions`.
 - `src/web/server.ts` — the endpoints above.
 - GUI: delegate kind picker + `controllable`-family row controls in
   `lisa-html.ts` / `lisa-client.ts` / `lisa-css.ts`.

--- a/src/agents/pty.test.ts
+++ b/src/agents/pty.test.ts
@@ -35,13 +35,22 @@ function fakePty() {
       killed = true;
     },
   };
-  const module: PtyModuleLike = { spawn: () => proc };
+  let spawnFile = "";
+  let spawnArgs: string[] = [];
+  const module: PtyModuleLike = {
+    spawn: (file, args) => {
+      spawnFile = file;
+      spawnArgs = args;
+      return proc;
+    },
+  };
   return {
     module,
     written,
     emitData: (s: string) => dataCb?.(s),
     emitExit: (code: number) => exitCb?.({ exitCode: code }),
     isKilled: () => killed,
+    getSpawn: () => ({ file: spawnFile, args: spawnArgs }),
   };
 }
 
@@ -110,6 +119,7 @@ test("start types the task; send appends; data drives state; cancel kills", asyn
       agent: "claude",
       task: "do the thing",
       cwd: "/Users/me/myproj",
+      cli: "claude", // pin so the assertion doesn't depend on a host claude install
       ptyModule: f.module,
       now: () => clock.t,
     });
@@ -143,6 +153,32 @@ test("start types the task; send appends; data drives state; cancel kills", asyn
     assert.equal(f.written.length, writes);
     reg.cancel(v.id); // idempotent, no throw
     assert.equal(reg.list()[0].state, "done");
+  });
+});
+
+test("resumeSessionId adopts an existing session via `--resume <id>`", async () => {
+  await withFlag(async () => {
+    const f = fakePty();
+    const reg = new PtyRegistry();
+    await reg.start({
+      agent: "claude",
+      task: "", // adopt: continue the conversation, no initial message
+      cwd: "/tmp/p",
+      resumeSessionId: "abc-123",
+      cli: "claude",
+      ptyModule: f.module,
+    });
+    assert.deepEqual(f.getSpawn().args.slice(0, 2), ["--resume", "abc-123"]);
+    assert.equal(f.written.length, 0); // empty task ⇒ nothing typed
+  });
+});
+
+test("resume is claude-only (codex ignores resumeSessionId)", async () => {
+  await withFlag(async () => {
+    const f = fakePty();
+    const reg = new PtyRegistry();
+    await reg.start({ agent: "codex", task: "", cwd: "/tmp/p", resumeSessionId: "abc-123", cli: "codex", ptyModule: f.module });
+    assert.equal(f.getSpawn().args.includes("--resume"), false);
   });
 });
 

--- a/src/agents/pty.ts
+++ b/src/agents/pty.ts
@@ -19,6 +19,9 @@
  *    folded into the structural cross-agent roster.
  */
 import { EventEmitter } from "node:events";
+import { readdirSync, existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 export type PtyState = "working" | "waiting" | "error" | "done";
 
@@ -43,6 +46,13 @@ export interface PtyStartOpts {
   agent: string;
   task: string;
   cwd: string;
+  /**
+   * Adopt an EXISTING claude session by id — spawns `claude --resume <id>` so
+   * LISA drives a continuation of a session the user started elsewhere. The
+   * caller MUST ensure the session is idle (see liveClaudeSessionIds) — resuming
+   * a live one corrupts its transcript.
+   */
+  resumeSessionId?: string;
   /** Override the binary (else resolved from `agent`). */
   cli?: string;
   /** Override argv (else interactive: []). */
@@ -96,6 +106,38 @@ export function normalizeAgentKind(agent: string): string {
   if (a === "codex") return "codex";
   if (a === "claude" || a === "claude-code") return "claude-code";
   return agent;
+}
+
+/**
+ * Best binary to drive a claude session: env override → the newest app-bundled
+ * claude (matches the version that wrote the sessions, best for --resume) → the
+ * PATH `claude`. The app-bundle probe is macOS-specific and silently no-ops
+ * elsewhere. Falls back to resolveCli for non-claude agents.
+ */
+export function detectClaudeBinary(): string {
+  if (process.env.LISA_PTY_CLAUDE_CMD) return process.env.LISA_PTY_CLAUDE_CMD;
+  try {
+    const root = join(homedir(), "Library", "Application Support", "Claude", "claude-code");
+    const versions = readdirSync(root)
+      .filter((v) => /^\d+\.\d+\.\d+/.test(v))
+      .sort((a, b) => cmpVersion(b, a)); // newest first
+    for (const v of versions) {
+      const bin = join(root, v, "claude.app", "Contents", "MacOS", "claude");
+      if (existsSync(bin)) return bin;
+    }
+  } catch {
+    /* not macOS / not installed → fall through */
+  }
+  return "claude";
+}
+
+function cmpVersion(a: string, b: string): number {
+  const pa = a.split(".").map((n) => parseInt(n, 10) || 0);
+  const pb = b.split(".").map((n) => parseInt(n, 10) || 0);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) !== (pb[i] || 0)) return (pa[i] || 0) - (pb[i] || 0);
+  }
+  return 0;
 }
 
 // Strip ANSI / VT100 escape sequences so the captured tail is plain-ish text.
@@ -188,9 +230,13 @@ export class PtyAgent {
     if (!pty) {
       throw new Error("node-pty is not installed — run `npm i node-pty` to enable PTY agents");
     }
-    const cli = opts.cli ?? resolveCli(opts.agent);
+    const kind = normalizeAgentKind(opts.agent);
+    const cli = opts.cli ?? (kind === "claude-code" ? detectClaudeBinary() : resolveCli(opts.agent));
+    // Adopt an existing session by id (claude only): `claude --resume <id>`.
+    const resumeArgs = opts.resumeSessionId && kind === "claude-code" ? ["--resume", opts.resumeSessionId] : [];
+    const args = [...resumeArgs, ...(opts.args ?? [])];
     const now = opts.now ?? Date.now;
-    const proc = pty.spawn(cli, opts.args ?? [], {
+    const proc = pty.spawn(cli, args, {
       name: "xterm-256color",
       cols: opts.cols ?? 120,
       rows: opts.rows ?? 32,

--- a/src/integrations/claude-code/liveness.test.ts
+++ b/src/integrations/claude-code/liveness.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { liveClaudeSessionIds, pidAlive } from "./liveness.js";
+
+const DEAD_PID = 2147483646; // absurdly high → no such process
+
+test("pidAlive: self is alive, absurd/invalid pids are not", () => {
+  assert.equal(pidAlive(process.pid), true);
+  assert.equal(pidAlive(DEAD_PID), false);
+  assert.equal(pidAlive(-1), false);
+  assert.equal(pidAlive(0), false);
+});
+
+test("liveClaudeSessionIds returns only sessions whose pid is alive", () => {
+  const home = mkdtempSync(join(tmpdir(), "lisa-live-"));
+  const dir = join(home, ".claude", "sessions");
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, process.pid + ".json"), JSON.stringify({ pid: process.pid, sessionId: "live-1" }));
+  writeFileSync(join(dir, "9999999.json"), JSON.stringify({ pid: DEAD_PID, sessionId: "dead-1" }));
+  writeFileSync(join(dir, "garbage.json"), "{ not json");
+  writeFileSync(join(dir, "ignored.txt"), JSON.stringify({ pid: process.pid, sessionId: "not-json-ext" }));
+  try {
+    const live = liveClaudeSessionIds(home);
+    assert.equal(live.has("live-1"), true);
+    assert.equal(live.has("dead-1"), false);
+    assert.equal(live.has("not-json-ext"), false); // non-.json files are skipped
+    assert.equal(live.size, 1);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test("liveClaudeSessionIds is empty when the sessions dir is absent", () => {
+  const home = mkdtempSync(join(tmpdir(), "lisa-live-empty-"));
+  try {
+    assert.equal(liveClaudeSessionIds(home).size, 0);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});

--- a/src/integrations/claude-code/liveness.ts
+++ b/src/integrations/claude-code/liveness.ts
@@ -1,0 +1,62 @@
+/**
+ * Claude session liveness — which on-disk claude sessions are CURRENTLY running.
+ *
+ * Claude Code writes ~/.claude/sessions/<pid>.json for each running session:
+ *   {"pid":43828,"sessionId":"f859…","cwd":"…","version":"2.1.177",
+ *    "peerProtocol":1,"kind":"interactive","entrypoint":"claude-desktop"}
+ *
+ * We use it for one purpose: deciding whether a session is safe to ADOPT via
+ * `claude --resume <id>`. Resuming a session that's still live (open in the app
+ * or a terminal) would create a second writer to the same JSONL transcript and
+ * interleave/corrupt it — so the control plane only ever resumes IDLE sessions.
+ * (We never speak the undocumented peerProtocol; we only read pid + sessionId.)
+ */
+import { readdirSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function claudeSessionsDir(home: string = homedir()): string {
+  return join(home, ".claude", "sessions");
+}
+
+/** True if a pid is still running (EPERM = alive but not ours; ESRCH = gone). */
+export function pidAlive(pid: number): boolean {
+  if (!Number.isInteger(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (e) {
+    return (e as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+/**
+ * sessionIds whose owning process is still alive — i.e. currently driven by the
+ * app/terminal and therefore UNSAFE to resume. Best-effort: unreadable or stale
+ * pid-files are skipped. Returns an empty set if the directory is absent.
+ */
+export function liveClaudeSessionIds(home: string = homedir()): Set<string> {
+  const live = new Set<string>();
+  const dir = claudeSessionsDir(home);
+  let files: string[];
+  try {
+    files = readdirSync(dir);
+  } catch {
+    return live;
+  }
+  for (const f of files) {
+    if (!f.endsWith(".json")) continue;
+    try {
+      const meta = JSON.parse(readFileSync(join(dir, f), "utf8")) as {
+        pid?: unknown;
+        sessionId?: unknown;
+      };
+      if (typeof meta.sessionId === "string" && typeof meta.pid === "number" && pidAlive(meta.pid)) {
+        live.add(meta.sessionId);
+      }
+    } catch {
+      /* skip garbage / partial writes */
+    }
+  }
+  return live;
+}

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -83,6 +83,12 @@ export interface AgentSession {
    * Absent ⇒ observe-only (an externally-started CLI; no control channel).
    */
   controllable?: "managed" | "pty";
+  /**
+   * Observe-only claude session that LISA can ADOPT — it's idle (its process is
+   * gone), so `claude --resume <sessionId>` can safely continue it under LISA's
+   * control. Set by the API layer for claude-code sessions not currently live.
+   */
+  resumable?: boolean;
 }
 
 /** Visibility tier — how deeply LISA may inspect a session. See plan §3. */

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1163,6 +1163,29 @@ if ('serviceWorker' in navigator) {
         }
         if (ctrl.childNodes.length) row.appendChild(ctrl);
       }
+      // Idle external claude session → adopt it: LISA resumes it under a PTY and
+      // drives the continuation (then it shows as a controllable pty row). Only
+      // offered for idle sessions; a live one can't be resumed without corrupting
+      // its transcript (the server 409s, surfaced in the modal).
+      if (s.resumable) {
+        const ctrl = document.createElement('div');
+        ctrl.className = 'session-ctrl';
+        const adopt = document.createElement('button');
+        adopt.className = 'mc adopt'; adopt.textContent = '⇲ adopt';
+        adopt.title = 'Resume this session under LISA — then send / answer / cancel / view it';
+        adopt.addEventListener('click', function (e) {
+          e.stopPropagation();
+          fetch('/api/agents/pty/start', {
+            method: 'POST', headers: { 'content-type': 'application/json' },
+            body: JSON.stringify({ agent: 'claude', resumeSessionId: s.sessionId, cwd: s.cwd || '' }),
+          }).then(function (r) {
+            if (!r.ok) { return r.text().then(function (t) { openModal('adopt', '<pre>' + escapeHtml(t) + '</pre>'); }); }
+            if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
+          }).catch(function () {});
+        });
+        ctrl.appendChild(adopt);
+        row.appendChild(ctrl);
+      }
       row.title = (s.stateReason ? s.state + ' · ' + s.stateReason : s.state) + ' · ' + s.project + ' · ' + s.sessionId;
       sbClaudeRows.appendChild(row);
     }

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -354,6 +354,7 @@ export const MAIN_CSS = `  :root {
   .session-ctrl .mc.approve { color: var(--green, #6bff9d); border-color: rgba(107,255,157,0.4); }
   .session-ctrl .mc.deny,
   .session-ctrl .mc.cancel { color: var(--err-color, #ff5577); border-color: rgba(255,85,119,0.4); }
+  .session-ctrl .mc.adopt { color: var(--brand, #6ad4ff); border-color: rgba(106,212,255,0.4); }
   .session-ctrl .mc:hover { background: rgba(255,255,255,0.10); }
   .session-ctrl .mc-send {
     flex: 1;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -16,12 +16,12 @@ import { MAIN_HTML } from "./lisa-html.js";
  * change the GUI markup/CSS/JS, recompute them:
  *   node --import tsx -e 'import("./src/web/lisa-html.ts").then(async m=>{const {createHash}=await import("node:crypto");console.log(m.MAIN_HTML.length, createHash("sha256").update(m.MAIN_HTML).digest("hex"))})'
  *
- * Last updated: PTY-agent spike controls (delegate kind picker + per-row pty
- * send/output/cancel + controllable-family routing).
+ * Last updated: adopt-idle-session control (⇲ adopt button on resumable
+ * external claude rows → claude --resume under a PTY).
  */
-const EXPECTED_LENGTH = 86661;
+const EXPECTED_LENGTH = 88080;
 const EXPECTED_SHA256 =
-  "6443ecf6afae341ce84ac6d3301a45420dd351e466692ea880a4340da9676037";
+  "fe6ff9c8dd9c279297d15709e9d1862f2484aec7a96a4c990a39204c6407c763";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -36,6 +36,7 @@ import { listGrants, grant, revoke, revokeAll, isGranted, SENSE_SIGNALS, SIGNAL_
 import { signalAgentTool } from "../tools/signal_agent.js";
 import { managedRegistry } from "../agents/managed.js";
 import { ptyRegistry, ptyEnabled } from "../agents/pty.js";
+import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
 import { VoiceSource } from "../sense/voice.js";
@@ -831,7 +832,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     if (req.method === "POST" && url === "/api/agents/pty/start") {
       let pBody = "";
       for await (const chunk of req) pBody += chunk.toString("utf8");
-      let payload: { agent?: unknown; task?: unknown; cwd?: unknown };
+      let payload: { agent?: unknown; task?: unknown; cwd?: unknown; resumeSessionId?: unknown };
       try { payload = JSON.parse(pBody || "{}"); } catch {
         res.writeHead(400, { "content-type": "text/plain" }); res.end("bad json"); return;
       }
@@ -841,12 +842,26 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         return;
       }
       const agent = typeof payload.agent === "string" && payload.agent.trim() ? payload.agent : "claude";
-      if (typeof payload.task !== "string" || !payload.task.trim()) {
+      const resumeSessionId =
+        typeof payload.resumeSessionId === "string" && payload.resumeSessionId ? payload.resumeSessionId : undefined;
+      // Adopting an existing session needs no task (it continues the convo); a
+      // fresh agent does. Guard: never resume a session that's currently live.
+      if (!resumeSessionId && (typeof payload.task !== "string" || !payload.task.trim())) {
         res.writeHead(400, { "content-type": "text/plain" }); res.end("task required"); return;
+      }
+      if (resumeSessionId && liveClaudeSessionIds().has(resumeSessionId)) {
+        res.writeHead(409, { "content-type": "text/plain" });
+        res.end("that session is currently live (open in the app/terminal) — close it first; resuming a live session would corrupt its transcript");
+        return;
       }
       const cwd = typeof payload.cwd === "string" && payload.cwd.startsWith("/") ? payload.cwd : process.cwd();
       try {
-        const view = await ptyRegistry.start({ agent, task: payload.task, cwd });
+        const view = await ptyRegistry.start({
+          agent,
+          task: typeof payload.task === "string" ? payload.task : "",
+          cwd,
+          resumeSessionId,
+        });
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: true, agent: view }));
       } catch (err) {
@@ -933,9 +948,15 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     // across all integrations, normalized. activity (Tier 2) is present
     // when the integration runs at visibility ≥ "activity".
     if (req.method === "GET" && url === "/api/agents/sessions") {
+      // Mark idle claude sessions as adoptable: not currently live (no running
+      // owner ⇒ `claude --resume` is safe) and not already a LISA-controlled row.
+      const live = liveClaudeSessionIds();
       const sessions = hub.list().map((s) => ({
         ...s,
         lastMtime: new Date(s.lastMtime).toISOString(),
+        ...(s.agent === "claude-code" && !s.controllable && !live.has(s.sessionId)
+          ? { resumable: true }
+          : {}),
       }));
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ sessions }));


### PR DESCRIPTION
## What

The headline gap from the control plane: **command sessions LISA did *not* spawn** — your own `claude` sessions from the app/terminal.

You can't tap a **live** session (the Claude app owns its stdin/stdout pipe — confirmed by inspecting the running processes: every session is driven over `--input-format stream-json`). But every session has a stable `sessionId`, and `claude --resume <id>` continues that exact transcript in a fresh process. So:

- An **idle** claude session in the agents card now shows an **⇲ adopt** button → LISA spawns `claude --resume <id>` under its own PTY → you drive a *continuation* (send / answer / cancel / ▤ output). New turns append to the same transcript (visible in the app's history too).

## Safety — this touches real session data

- **Liveness guard:** `liveClaudeSessionIds()` reads `~/.claude/sessions/<pid>.json` and checks the pid; only sessions with **no running owner** are marked `resumable`. The start endpoint **409s** on a live session — two writers to one JSONL transcript interleave and corrupt it.
- **Smoke-tested** (no mutation): adopting *this* live session → **409**; `/api/agents/sessions` correctly split 9 claude rows into **5 idle / 4 live**; missing-task → 400.
- **Honest limit (documented):** a session open+running in the app *right now* still can't be commanded from outside — close it, then adopt. (Live control would need the undocumented `peerProtocol`; not touched.)

## Implementation

- `src/integrations/claude-code/liveness.ts` — `liveClaudeSessionIds()` + `pidAlive()`.
- `pty.ts` — `PtyStartOpts.resumeSessionId` → `--resume <id>` (claude only); `detectClaudeBinary()` prefers `LISA_PTY_CLAUDE_CMD` → newest app-bundled claude (version-matched to your sessions) → PATH `claude`.
- `AgentSession.resumable`; `/api/agents/sessions` enriches idle claude rows; `/api/agents/pty/start` accepts `resumeSessionId` with the 409 guard (task optional when resuming).
- GUI: ⇲ adopt button on resumable rows (errors surface in the modal). Snapshot updated.
- `docs/PTY_AGENTS.md`.

## Verification

**719 tests pass, 1 skip** (real-node-pty round-trip); `typecheck` + `build` clean; live endpoints smoke-tested as above.

Still flagged behind `LISA_PTY_AGENTS=1` (it spawns real claude under a PTY).

🤖 Generated with [Claude Code](https://claude.com/claude-code)