### PR TITLE
feat(control): remote-control policy — gate high-risk actions from remote callers

### DIFF
--- a/src/control/policy.test.ts
+++ b/src/control/policy.test.ts
@@ -1,0 +1,48 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Isolate the policy file to a throwaway dir (read lazily via LISA_HOME).
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-policy-"));
+process.env.LISA_HOME = TMP;
+const FILE = path.join(TMP, "control-policy.json");
+
+const { defaultControlPolicy, normalizeControlPolicy, loadControlPolicy, saveControlPolicy } =
+  await import("./policy.js");
+
+beforeEach(() => {
+  fs.rmSync(FILE, { force: true });
+});
+
+describe("control policy", () => {
+  test("default: may control own agents, may NOT adopt external sessions", () => {
+    assert.deepEqual(defaultControlPolicy(), { remoteControl: true, remoteAdoptExternal: false });
+  });
+
+  test("missing file → defaults", () => {
+    assert.deepEqual(loadControlPolicy(), defaultControlPolicy());
+  });
+
+  test("normalize coerces missing / ill-typed / null to defaults", () => {
+    assert.deepEqual(normalizeControlPolicy({}), defaultControlPolicy());
+    assert.deepEqual(normalizeControlPolicy(null), defaultControlPolicy());
+    assert.deepEqual(normalizeControlPolicy({ remoteControl: "yes" as unknown as boolean }), defaultControlPolicy());
+    assert.deepEqual(normalizeControlPolicy({ remoteAdoptExternal: true }), {
+      remoteControl: true,
+      remoteAdoptExternal: true,
+    });
+  });
+
+  test("save normalizes a partial (fills missing with defaults) and round-trips", () => {
+    const saved = saveControlPolicy({ remoteAdoptExternal: true });
+    assert.deepEqual(saved, { remoteControl: true, remoteAdoptExternal: true });
+    assert.deepEqual(loadControlPolicy(), { remoteControl: true, remoteAdoptExternal: true });
+  });
+
+  test("corrupt JSON → defaults (no throw)", () => {
+    fs.writeFileSync(FILE, "{not json");
+    assert.deepEqual(loadControlPolicy(), defaultControlPolicy());
+  });
+});

--- a/src/control/policy.ts
+++ b/src/control/policy.ts
@@ -1,0 +1,68 @@
+/**
+ * Remote-control policy — the Mac-side opt-in that gates high-risk control
+ * actions when they come from a REMOTE (non-loopback) caller, e.g. the phone.
+ *
+ * The auth gate (token) already proves "a trusted device"; this adds a second
+ * axis: *which* actions a trusted remote device may take. The local user
+ * (loopback) is never gated. Defaults:
+ *   - remoteControl: true  — a remote may control LISA's OWN agents (managed/pty:
+ *       start / send / cancel / approve). These are LISA-owned and lower-risk.
+ *   - remoteAdoptExternal: false — adopting the user's EXTERNAL sessions
+ *       (`claude --resume` of an idle session) touches a real transcript, so a
+ *       remote device may not do it until the Mac owner explicitly opts in.
+ *
+ * Persisted to ~/.lisa/control-policy.json; changeable only from localhost
+ * (POST /api/control/policy is loopback-only), like the API-key save.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+export interface ControlPolicy {
+  /** Remote callers may control LISA's own agents (managed/pty). */
+  remoteControl: boolean;
+  /** Remote callers may adopt the user's external sessions (pty resume-adopt). */
+  remoteAdoptExternal: boolean;
+}
+
+export function defaultControlPolicy(): ControlPolicy {
+  return { remoteControl: true, remoteAdoptExternal: false };
+}
+
+/** Coerce an arbitrary object into a valid ControlPolicy (defaults for missing/ill-typed). Pure. */
+export function normalizeControlPolicy(p: Partial<ControlPolicy> | null | undefined): ControlPolicy {
+  const base = defaultControlPolicy();
+  if (!p || typeof p !== "object") return base;
+  return {
+    remoteControl: typeof p.remoteControl === "boolean" ? p.remoteControl : base.remoteControl,
+    remoteAdoptExternal:
+      typeof p.remoteAdoptExternal === "boolean" ? p.remoteAdoptExternal : base.remoteAdoptExternal,
+  };
+}
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+
+/** Resolved lazily so tests can point LISA_HOME at a tmp dir. */
+function policyPath(): string {
+  return path.join(lisaHome(), "control-policy.json");
+}
+
+/** Read the policy, merged over defaults; tolerant of a missing/corrupt file. */
+export function loadControlPolicy(): ControlPolicy {
+  try {
+    const raw = fs.readFileSync(policyPath(), "utf8");
+    return normalizeControlPolicy(JSON.parse(raw) as Partial<ControlPolicy>);
+  } catch {
+    return defaultControlPolicy();
+  }
+}
+
+export function saveControlPolicy(p: Partial<ControlPolicy>): ControlPolicy {
+  const next = normalizeControlPolicy(p);
+  const file = policyPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(next, null, 2));
+  return next;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -38,6 +38,7 @@ import { managedRegistry } from "../agents/managed.js";
 import { ptyRegistry, ptyEnabled } from "../agents/pty.js";
 import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
 import { listRecentDispatches, isAlive, toDispatchView } from "../integrations/dispatch-ledger.js";
+import { loadControlPolicy, saveControlPolicy, type ControlPolicy } from "../control/policy.js";
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
 import { VoiceSource } from "../sense/voice.js";
@@ -483,6 +484,27 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       }
     }
 
+    // Per-request gate for high-risk control actions from REMOTE callers. The Mac
+    // owner (loopback) is never gated; a remote (token) device may take only what
+    // the Mac-side policy permits. denyRemote() writes the 403 and returns true
+    // when blocked, so call sites read `if (denyRemote(...)) return;`. See
+    // src/control/policy.ts (default: control own agents yes, adopt external no).
+    const remoteControlAllowed = (need: "control" | "adoptExternal"): boolean => {
+      if (isLoopbackAddress(remoteAddr)) return true;
+      const pol = loadControlPolicy();
+      return need === "adoptExternal" ? pol.remoteAdoptExternal : pol.remoteControl;
+    };
+    const denyRemote = (need: "control" | "adoptExternal"): boolean => {
+      if (remoteControlAllowed(need)) return false;
+      res.writeHead(403, { "content-type": "text/plain" });
+      res.end(
+        need === "adoptExternal"
+          ? "adopting external sessions from a remote device is disabled — enable remoteAdoptExternal on the Mac (POST /api/control/policy from localhost)"
+          : "remote control is disabled — enable remoteControl on the Mac (POST /api/control/policy from localhost)",
+      );
+      return true;
+    };
+
     if (req.method === "GET" && (url === "/" || url.startsWith("/?"))) {
       res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
       res.end(MAIN_HTML);
@@ -758,6 +780,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end("action must be 'list' or 'cancel'");
         return;
       }
+      if (action === "cancel" && denyRemote("control")) return;
       const result = await signalAgentTool.execute(
         {
           action,
@@ -775,6 +798,36 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     // LISA's own controllable agents: start a task, send follow-ups, cancel,
     // and approve/deny each mutating tool. Behind the auth gate like every
     // endpoint. They appear in the roster via the "managed" hub observer.
+    // Remote-control policy: GET (any authed caller) reports it; POST sets it,
+    // but only from localhost (the Mac owner) — like the API-key save.
+    if (req.method === "GET" && url === "/api/control/policy") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(loadControlPolicy()));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/control/policy") {
+      if (!isLoopbackAddress(remoteAddr)) {
+        res.writeHead(403, { "content-type": "text/plain" });
+        res.end("control policy can only be changed from the Mac (localhost)");
+        return;
+      }
+      let cpBody = "";
+      for await (const chunk of req) cpBody += chunk.toString("utf8");
+      let payload: Partial<ControlPolicy>;
+      try { payload = JSON.parse(cpBody || "{}"); } catch {
+        res.writeHead(400, { "content-type": "text/plain" }); res.end("bad json"); return;
+      }
+      try {
+        const saved = saveControlPolicy({ ...loadControlPolicy(), ...payload });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, ...saved }));
+      } catch (err) {
+        res.writeHead(500, { "content-type": "text/plain" });
+        res.end((err as Error).message);
+      }
+      return;
+    }
+
     // Structured view of the agents LISA dispatched fire-and-forget (the ledger).
     // Complements /api/agent/signal's action:"list" (which returns prose): this is
     // JSON for clients (the iOS roster). Structural only — never the captured log.
@@ -786,6 +839,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     }
 
     if (req.method === "POST" && url === "/api/agents/managed/start") {
+      if (denyRemote("control")) return;
       let mBody = "";
       for await (const chunk of req) mBody += chunk.toString("utf8");
       let payload: { task?: unknown; cwd?: unknown; model?: unknown };
@@ -814,6 +868,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
     if (req.method === "POST" && url.startsWith("/api/agents/managed/")) {
+      if (denyRemote("control")) return;
       const rest = url.slice("/api/agents/managed/".length);
       const slash = rest.indexOf("/");
       const id = slash >= 0 ? rest.slice(0, slash) : rest;
@@ -855,6 +910,9 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       const agent = typeof payload.agent === "string" && payload.agent.trim() ? payload.agent : "claude";
       const resumeSessionId =
         typeof payload.resumeSessionId === "string" && payload.resumeSessionId ? payload.resumeSessionId : undefined;
+      // Adopting an external session is the highest-risk control action — gate it
+      // behind remoteAdoptExternal; starting a fresh agent is ordinary control.
+      if (denyRemote(resumeSessionId ? "adoptExternal" : "control")) return;
       // Adopting an existing session needs no task (it continues the convo); a
       // fresh agent does. Guard: never resume a session that's currently live.
       if (!resumeSessionId && (typeof payload.task !== "string" || !payload.task.trim())) {
@@ -882,6 +940,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
     if (req.method === "GET" && url.startsWith("/api/agents/pty/") && url.endsWith("/output")) {
+      if (denyRemote("control")) return;
       const id = url.slice("/api/agents/pty/".length, -"/output".length);
       const out = ptyRegistry.output(decodeURIComponent(id));
       if (out === null) {
@@ -896,6 +955,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     // each new ANSI-stripped chunk as it arrives. Drives `lisa agents pty`
     // (adopt-at-launch) and a remote live-output view. Same auth gate; 404 if unknown.
     if (req.method === "GET" && url.startsWith("/api/agents/pty/") && url.endsWith("/stream")) {
+      if (denyRemote("control")) return;
       const id = decodeURIComponent(url.slice("/api/agents/pty/".length, -"/stream".length));
       const initial = ptyRegistry.output(id);
       if (initial === null) {
@@ -936,6 +996,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
     if (req.method === "POST" && url.startsWith("/api/agents/pty/")) {
+      if (denyRemote("control")) return;
       const rest = url.slice("/api/agents/pty/".length);
       const slash = rest.indexOf("/");
       const id = decodeURIComponent(slash >= 0 ? rest.slice(0, slash) : rest);


### PR DESCRIPTION
> Stacked on #113 (base = `feat/ios-companion-and-pty-cli`). Retarget to `main` once #113 merges.

## What

Closes the security gap from #113's follow-ups: a phone holding a valid token could call **every** control endpoint, including adopting the user's real `claude` sessions. This adds a second authorization axis — a **Mac-side policy** that gates high-risk control actions from **remote** (non-loopback) callers. The local user (loopback) is never gated.

`src/control/policy.ts` — `ControlPolicy`:
- `remoteControl` (default **true**) — a remote may control LISA's **own** agents (managed/pty: start/send/cancel/approve). Lower-risk, LISA-owned.
- `remoteAdoptExternal` (default **false**) — a remote may **adopt the user's external sessions** (`pty/start` with `resumeSessionId`, i.e. `claude --resume`). Touches a real transcript → off until the Mac owner opts in.

Persisted to `~/.lisa/control-policy.json`; tolerant of missing/corrupt files.

## How

- `GET /api/control/policy` (any authed caller) reports it; `POST /api/control/policy` sets it but **only from localhost** (like the API-key save).
- A per-request `denyRemote(need)` helper (loopback ⇒ allow; else consult policy) writes the 403 and short-circuits. Applied to: managed `start` / `send` / `cancel` / `approve`; pty `start` (→ `adoptExternal` when `resumeSessionId` is present, else `control`), `send`, `cancel`, `output`, `stream`; and `signal` **cancel** (list stays open — it's telemetry).

## Verification

- `npm run typecheck` + `npm run build` clean; **733 tests / 732 pass / 1 skip / 0 fail** (new: 5 policy unit tests).
- **Live-checked from a non-loopback LAN IP** (`--host 0.0.0.0` + token):
  - `GET policy` → `{remoteControl:true, remoteAdoptExternal:false}`
  - adopt-external from remote → **403** (default deny)
  - `POST policy` from remote → **403**; from loopback → **200**
  - after `remoteControl:false`: managed/start from remote → **403**
  - loopback calls never gated.

## Follow-ups (unchanged from #113)

Next in queue: roster de-dup (resume-adopt vs claude-code observer) + gated `/api/dispatch/status` log tail; then the iOS-facing backend (pairing/devices/push) and PWA polish. The native SwiftUI app (ActivityKit/WidgetKit/APNs) will be scaffolded but can't be compiled/verified in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
