### PR TITLE
feat(web): per-device pairing tokens — a revocable credential per phone

### DIFF
--- a/src/web/devices.test.ts
+++ b/src/web/devices.test.ts
@@ -30,6 +30,11 @@ describe("device tokens", () => {
     assert.match(raw, /tokenHash/);
   });
 
+  test("the token-hash store is written private (0600), like config.env", { skip: process.platform === "win32" }, () => {
+    mintDevice("x", "ios");
+    assert.equal(fs.statSync(FILE).mode & 0o777, 0o600);
+  });
+
   test("revoke → token no longer verifies; revoking an unknown id → false", () => {
     const { id, token } = mintDevice("x", "ios");
     assert.ok(verifyDeviceToken(token));

--- a/src/web/devices.test.ts
+++ b/src/web/devices.test.ts
@@ -1,0 +1,62 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-devices-"));
+process.env.LISA_HOME = TMP;
+const FILE = path.join(TMP, "devices.json");
+
+const { mintDevice, verifyDeviceToken, touchDevice, listDevices, revokeDevice, loadDevices } =
+  await import("./devices.js");
+
+beforeEach(() => {
+  fs.rmSync(FILE, { force: true });
+});
+
+describe("device tokens", () => {
+  test("mint → verify matches; wrong / empty token → null", () => {
+    const { id, token } = mintDevice("iPhone", "ios");
+    assert.equal(verifyDeviceToken(token)?.id, id);
+    assert.equal(verifyDeviceToken("wrong"), null);
+    assert.equal(verifyDeviceToken(""), null);
+  });
+
+  test("the raw token is never persisted — only its hash", () => {
+    const { token } = mintDevice("x", "ios");
+    const raw = fs.readFileSync(FILE, "utf8");
+    assert.equal(raw.includes(token), false);
+    assert.match(raw, /tokenHash/);
+  });
+
+  test("revoke → token no longer verifies; revoking an unknown id → false", () => {
+    const { id, token } = mintDevice("x", "ios");
+    assert.ok(verifyDeviceToken(token));
+    assert.equal(revokeDevice(id), true);
+    assert.equal(verifyDeviceToken(token), null);
+    assert.equal(revokeDevice("nope"), false);
+  });
+
+  test("listDevices excludes the hash; touch updates lastSeenAt", () => {
+    const { id } = mintDevice("x", "ios", 1000);
+    const [pub] = listDevices();
+    assert.equal("tokenHash" in pub, false);
+    assert.equal(pub.lastSeenAt, 1000);
+    touchDevice(id, 5000);
+    assert.equal(listDevices()[0].lastSeenAt, 5000);
+  });
+
+  test("multiple devices: each token maps to its own record", () => {
+    const a = mintDevice("A", "ios");
+    const b = mintDevice("B", "android");
+    assert.equal(verifyDeviceToken(a.token)?.id, a.id);
+    assert.equal(verifyDeviceToken(b.token)?.id, b.id);
+    assert.equal(loadDevices().length, 2);
+  });
+
+  test("corrupt file → empty list (no throw)", () => {
+    fs.writeFileSync(FILE, "{not json");
+    assert.deepEqual(loadDevices(), []);
+  });
+});

--- a/src/web/devices.ts
+++ b/src/web/devices.ts
@@ -1,0 +1,126 @@
+/**
+ * Per-device pairing tokens — a revocable credential per phone/tablet, layered
+ * on top of the global LISA_WEB_TOKEN.
+ *
+ * The global token is what binds the server to a non-loopback host and what the
+ * owner uses; a device token is minted per device (QR pairing) so each can be
+ * revoked individually without rotating the global secret. Only the SHA-256 hash
+ * of each device token is stored (`~/.lisa/devices.json`) — the raw token is
+ * returned exactly once, at mint time, for the QR.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+export interface DeviceRecord {
+  id: string;
+  name: string;
+  platform: string;
+  /** SHA-256 hex of the device token — never the token itself. */
+  tokenHash: string;
+  createdAt: number;
+  lastSeenAt: number;
+}
+
+/** Device info safe to expose over the API (no hash). */
+export type PublicDevice = Omit<DeviceRecord, "tokenHash">;
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+function devicesPath(): string {
+  return path.join(lisaHome(), "devices.json");
+}
+
+function sha256hex(s: string): string {
+  return crypto.createHash("sha256").update(s).digest("hex");
+}
+
+export function loadDevices(): DeviceRecord[] {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(devicesPath(), "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (d): d is DeviceRecord =>
+        !!d && typeof (d as DeviceRecord).id === "string" && typeof (d as DeviceRecord).tokenHash === "string",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveDevices(list: DeviceRecord[]): void {
+  const file = devicesPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(list, null, 2));
+}
+
+export function toPublicDevice(d: DeviceRecord): PublicDevice {
+  return { id: d.id, name: d.name, platform: d.platform, createdAt: d.createdAt, lastSeenAt: d.lastSeenAt };
+}
+
+/** Mint a device token + record. Returns the raw token ONCE (for the QR). */
+export function mintDevice(
+  name: string,
+  platform: string,
+  now: number = Date.now(),
+): { id: string; token: string; device: PublicDevice } {
+  const token = crypto.randomBytes(24).toString("hex");
+  const id = crypto.randomBytes(6).toString("hex");
+  const rec: DeviceRecord = {
+    id,
+    name: name.slice(0, 80) || "device",
+    platform: platform.slice(0, 32) || "unknown",
+    tokenHash: sha256hex(token),
+    createdAt: now,
+    lastSeenAt: now,
+  };
+  const list = loadDevices();
+  list.push(rec);
+  saveDevices(list);
+  return { id, token, device: toPublicDevice(rec) };
+}
+
+/** Constant-time compare a presented token against a stored hash. */
+function tokenMatchesHash(presented: string, hash: string): boolean {
+  const a = crypto.createHash("sha256").update(presented).digest();
+  let b: Buffer;
+  try {
+    b = Buffer.from(hash, "hex");
+  } catch {
+    return false;
+  }
+  return a.length === b.length && crypto.timingSafeEqual(a, b);
+}
+
+/** Return the device whose token matches `presented`, or null. Does not mutate. */
+export function verifyDeviceToken(presented: string): DeviceRecord | null {
+  if (!presented) return null;
+  for (const d of loadDevices()) {
+    if (tokenMatchesHash(presented, d.tokenHash)) return d;
+  }
+  return null;
+}
+
+/** Update a device's lastSeenAt (best-effort). */
+export function touchDevice(id: string, now: number = Date.now()): void {
+  const list = loadDevices();
+  const d = list.find((x) => x.id === id);
+  if (!d) return;
+  d.lastSeenAt = now;
+  saveDevices(list);
+}
+
+export function listDevices(): PublicDevice[] {
+  return loadDevices().map(toPublicDevice);
+}
+
+/** Remove a device by id. Returns true if one was removed. */
+export function revokeDevice(id: string): boolean {
+  const list = loadDevices();
+  const next = list.filter((d) => d.id !== id);
+  if (next.length === list.length) return false;
+  saveDevices(next);
+  return true;
+}

--- a/src/web/devices.ts
+++ b/src/web/devices.ts
@@ -52,8 +52,17 @@ export function loadDevices(): DeviceRecord[] {
 
 function saveDevices(list: DeviceRecord[]): void {
   const file = devicesPath();
-  fs.mkdirSync(path.dirname(file), { recursive: true });
-  fs.writeFileSync(file, JSON.stringify(list, null, 2));
+  // Records hold per-device token HASHES — credentials. Keep the store private
+  // (0600 file inside a 0700 dir), matching how config.env is written in env.ts.
+  // writeFileSync's mode only applies on create, so chmod after to tighten a
+  // pre-existing loose file.
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, JSON.stringify(list, null, 2), { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // best effort — non-POSIX filesystems may reject chmod
+  }
 }
 
 export function toPublicDevice(d: DeviceRecord): PublicDevice {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,6 +39,7 @@ import { ptyRegistry, ptyEnabled } from "../agents/pty.js";
 import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
 import { listRecentDispatches, isAlive, toDispatchView, readDispatchOutput } from "../integrations/dispatch-ledger.js";
 import { loadControlPolicy, saveControlPolicy, type ControlPolicy } from "../control/policy.js";
+import { mintDevice, verifyDeviceToken, touchDevice, listDevices, revokeDevice } from "./devices.js";
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
 import { VoiceSource } from "../sense/voice.js";
@@ -467,7 +468,16 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     const remoteAddr = req.socket.remoteAddress ?? "";
     if (!isLoopbackAddress(remoteAddr)) {
       const presented = webToken ? presentedToken(req, url) : null;
-      if (!isRequestAuthorized(remoteAddr, webToken, presented)) {
+      // Authorized by the global LISA_WEB_TOKEN OR a non-revoked per-device token.
+      let authed = isRequestAuthorized(remoteAddr, webToken, presented);
+      if (!authed && presented) {
+        const device = verifyDeviceToken(presented);
+        if (device) {
+          authed = true;
+          touchDevice(device.id);
+        }
+      }
+      if (!authed) {
         res.writeHead(401, { "content-type": "text/plain" });
         res.end("unauthorized");
         return;
@@ -798,6 +808,48 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     // LISA's own controllable agents: start a task, send follow-ups, cancel,
     // and approve/deny each mutating tool. Behind the auth gate like every
     // endpoint. They appear in the roster via the "managed" hub observer.
+    // Device pairing: mint a per-device token (loopback-only — the Mac owner
+    // pairs a phone by showing the returned token as a QR). The raw token is
+    // returned ONCE; only its hash is stored. The phone then authenticates with
+    // it like the global token (Bearer / ?token= / cookie).
+    if (req.method === "POST" && url === "/api/pair/start") {
+      if (!isLoopbackAddress(remoteAddr)) {
+        res.writeHead(403, { "content-type": "text/plain" });
+        res.end("pairing can only be started from the Mac (localhost)");
+        return;
+      }
+      let prBody = "";
+      for await (const chunk of req) prBody += chunk.toString("utf8");
+      let payload: { name?: unknown; platform?: unknown } = {};
+      try { payload = prBody ? JSON.parse(prBody) : {}; } catch { /* tolerate */ }
+      const name = typeof payload.name === "string" ? payload.name : "device";
+      const platform = typeof payload.platform === "string" ? payload.platform : "ios";
+      const { id, token, device } = mintDevice(name, platform);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, id, token, port: opts.port, device }));
+      return;
+    }
+    if (req.method === "GET" && url === "/api/devices") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ devices: listDevices() }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/devices/revoke") {
+      if (!isLoopbackAddress(remoteAddr)) {
+        res.writeHead(403, { "content-type": "text/plain" });
+        res.end("device revocation is a Mac-owner action (localhost only)");
+        return;
+      }
+      let rvBody = "";
+      for await (const chunk of req) rvBody += chunk.toString("utf8");
+      let payload: { id?: unknown } = {};
+      try { payload = rvBody ? JSON.parse(rvBody) : {}; } catch { /* tolerate */ }
+      const removed = revokeDevice(typeof payload.id === "string" ? payload.id : "");
+      res.writeHead(removed ? 200 : 404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: removed }));
+      return;
+    }
+
     // Remote-control policy: GET (any authed caller) reports it; POST sets it,
     // but only from localhost (the Mac owner) — like the API-key save.
     if (req.method === "GET" && url === "/api/control/policy") {


### PR DESCRIPTION
> Stacked on #115 → #114 → #113. Retarget to `main` once those merge.

## What

The iOS app needs each phone to have its **own, revocable** credential rather than sharing the global `LISA_WEB_TOKEN`. This adds per-device pairing tokens layered on top of the global token.

`src/web/devices.ts`:
- `mintDevice(name, platform)` → a fresh token; only its **SHA-256 hash** is persisted (`~/.lisa/devices.json`). The raw token is returned **once** (for the QR).
- `verifyDeviceToken(presented)` → constant-time match against stored hashes.
- `listDevices()` (no hashes), `revokeDevice(id)`, `touchDevice(id)` (lastSeen).

Auth gate (`server.ts`): a non-loopback request is now authorized by the global token **or** any non-revoked device token (and bumps that device's `lastSeen`). The global token still gates *binding* non-loopback; device tokens gate *individual* access.

Endpoints:
- `POST /api/pair/start` (loopback-only) → `{ id, token, port, device }` — the Mac shows the token as a QR.
- `GET /api/devices` → `{ devices: [...] }` (no hashes).
- `POST /api/devices/revoke {id}` (loopback-only).

## Verification

- `npm run typecheck` + `npm run build` clean; **741 tests / 740 pass / 1 skip / 0 fail** (6 new device-token tests: mint/verify, hash-not-persisted, revoke, list-excludes-hash, multi-device, corrupt-file).
- **Live end-to-end from a LAN IP** (`--host 0.0.0.0`, global token set):
  - `pair/start` (loopback) mints a token; from remote → **403**.
  - remote request with the **device** token (not the global) → **200**.
  - wrong token → **401**.
  - `revoke` (loopback) → **200**; the revoked token → **401**.
  - `/api/devices` never exposes `tokenHash`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
