### PR TITLE
feat(providers): Anthropic gateway bearer auth (ANTHROPIC_AUTH_TOKEN)

### DIFF
--- a/src/providers/anthropic.ts
+++ b/src/providers/anthropic.ts
@@ -10,15 +10,20 @@ export class AnthropicProvider implements Provider {
   readonly name = "anthropic";
   private client: Anthropic;
 
-  constructor(opts: { apiKey?: string; baseURL?: string } = {}) {
+  constructor(opts: { apiKey?: string; authToken?: string; baseURL?: string } = {}) {
     // proxyAwareFetch passes through cleanly when no proxy is installed;
     // when one is, it re-injects Content-Type for proxies (Clash et al)
     // that strip response headers through CONNECT tunnels.
     // baseURL overrides the default https://api.anthropic.com — used to
     // route through an Anthropic-compatible proxy (one-api, openrouter,
     // self-hosted relay) when direct access is blocked.
+    // authToken sends `Authorization: Bearer …` instead of the default
+    // `x-api-key` header — the sanctioned path for an Anthropic-compatible
+    // LLM gateway / proxy (matches Claude Code's ANTHROPIC_AUTH_TOKEN). When
+    // set it takes precedence over apiKey, so callers pass one or the other.
     this.client = new Anthropic({
       apiKey: opts.apiKey,
+      authToken: opts.authToken,
       baseURL: opts.baseURL,
       fetch: proxyAwareFetch,
     });

--- a/src/providers/registry.test.ts
+++ b/src/providers/registry.test.ts
@@ -1,6 +1,6 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { detectProvider, OPENAI_COMPAT_PRESETS } from "./registry.js";
+import { detectProvider, resolveAnthropicAuth, OPENAI_COMPAT_PRESETS } from "./registry.js";
 
 // detectProvider reads a few env vars as fallbacks. Snapshot + restore them
 // so tests are hermetic regardless of the dev's shell.
@@ -84,6 +84,29 @@ describe("detectProvider — env overrides", () => {
     // claude model still routes to anthropic even if the env says gemini.
     process.env.LISA_PROVIDER = "gemini";
     assert.equal(detectProvider("claude-sonnet-4-6"), "anthropic");
+  });
+});
+
+describe("resolveAnthropicAuth — Bearer gateway vs x-api-key", () => {
+  test("ANTHROPIC_AUTH_TOKEN → authToken (Bearer), no apiKey", () => {
+    assert.deepEqual(resolveAnthropicAuth({ ANTHROPIC_AUTH_TOKEN: "tok" }), { authToken: "tok" });
+  });
+  test("only ANTHROPIC_API_KEY → apiKey (x-api-key)", () => {
+    assert.deepEqual(resolveAnthropicAuth({ ANTHROPIC_API_KEY: "sk-ant" }), { apiKey: "sk-ant" });
+  });
+  test("AUTH_TOKEN wins when both are set (Claude Code precedence)", () => {
+    assert.deepEqual(
+      resolveAnthropicAuth({ ANTHROPIC_AUTH_TOKEN: "tok", ANTHROPIC_API_KEY: "sk-ant" }),
+      { authToken: "tok" },
+    );
+  });
+  test("blank/whitespace AUTH_TOKEN is ignored → falls back to apiKey", () => {
+    assert.deepEqual(resolveAnthropicAuth({ ANTHROPIC_AUTH_TOKEN: "  ", ANTHROPIC_API_KEY: "sk" }), {
+      apiKey: "sk",
+    });
+  });
+  test("neither set → apiKey undefined", () => {
+    assert.deepEqual(resolveAnthropicAuth({}), { apiKey: undefined });
   });
 });
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -158,11 +158,24 @@ export function detectProvider(model: string): ProviderName {
   return "anthropic";
 }
 
+/**
+ * Anthropic auth from env. ANTHROPIC_AUTH_TOKEN (sent as `Authorization: Bearer`,
+ * for an Anthropic-compatible gateway/proxy) takes precedence over
+ * ANTHROPIC_API_KEY (`x-api-key`), matching Claude Code's precedence. Pure.
+ */
+export function resolveAnthropicAuth(
+  env: Record<string, string | undefined> = process.env,
+): { apiKey?: string; authToken?: string } {
+  const authToken = env.ANTHROPIC_AUTH_TOKEN?.trim();
+  if (authToken) return { authToken };
+  return { apiKey: env.ANTHROPIC_API_KEY };
+}
+
 export function makeProvider(name: ProviderName): Provider {
   switch (name) {
     case "anthropic":
       return new AnthropicProvider({
-        apiKey: process.env.ANTHROPIC_API_KEY,
+        ...resolveAnthropicAuth(),
         baseURL: process.env.ANTHROPIC_BASE_URL,
       });
     case "openai":
@@ -187,7 +200,7 @@ function resolveProvider(model: string): Provider {
   const provider = detectProvider(model);
   if (provider === "anthropic") {
     return new AnthropicProvider({
-      apiKey: process.env.ANTHROPIC_API_KEY,
+      ...resolveAnthropicAuth(),
       baseURL: process.env.ANTHROPIC_BASE_URL,
     });
   }
@@ -243,7 +256,7 @@ export function providerForModel(model: string): Provider {
  */
 export function resolveDefaultModel(): string {
   if (process.env.LISA_MODEL?.trim()) return process.env.LISA_MODEL.trim();
-  if (process.env.ANTHROPIC_API_KEY) return DEFAULT_MODEL;
+  if (process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN) return DEFAULT_MODEL;
   if (process.env.OPENAI_API_KEY) return "gpt-4o";
   return DEFAULT_MODEL;
 }
@@ -251,7 +264,10 @@ export function resolveDefaultModel(): string {
 /** For docs / CLI listing. */
 export function listConfiguredProviders(): Array<{ name: string; configured: boolean }> {
   const out: Array<{ name: string; configured: boolean }> = [
-    { name: "Anthropic", configured: !!process.env.ANTHROPIC_API_KEY },
+    {
+      name: "Anthropic",
+      configured: !!(process.env.ANTHROPIC_API_KEY || process.env.ANTHROPIC_AUTH_TOKEN),
+    },
     { name: "OpenAI", configured: !!process.env.OPENAI_API_KEY },
     {
       name: "Google Gemini",


### PR DESCRIPTION
**Independent of the coding-plan PRs (#112, #116); branches off `main`.** The sanctioned in-process gateway path — *not* subscription-OAuth reuse.

## Problem
LISA's Anthropic client only ever sent `x-api-key`, silently ignoring `ANTHROPIC_AUTH_TOKEN`. Anthropic-compatible **LLM gateways / proxies** (and Claude Code itself) authenticate with `Authorization: Bearer` instead — so gateway users couldn't point LISA at their relay.

## Change
- `AnthropicProvider` accepts `authToken` → passed to the `@anthropic-ai/sdk` client (Bearer header).
- `registry.resolveAnthropicAuth(env)` — `ANTHROPIC_AUTH_TOKEN` (Bearer) takes precedence over `ANTHROPIC_API_KEY` (`x-api-key`), matching Claude Code's precedence. Used by both `makeProvider` and `resolveProvider`.
- `resolveDefaultModel` + `listConfiguredProviders` now recognize `ANTHROPIC_AUTH_TOKEN` as "configured" (a token-only setup picks the right default model + reports configured).
- OpenAI-compatible gateways already get Bearer via `apiKey`, so no change there.

## Verification
`npm run typecheck` clean (confirms the SDK accepts `authToken`); full suite **723 passed / 0 failed**; new `resolveAnthropicAuth` precedence tests (5 cases).

## Note
This is the "one sanctioned in-process win" from `docs/CODING_PLANS.md` (added in #112). It does **not** touch subscription OAuth — it's purely for gateway/Bedrock/Vertex-style bearer auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)