### PR TITLE
feat(push): operational push notifications (ntfy) for agent events

### DIFF
--- a/src/web/push.test.ts
+++ b/src/web/push.test.ts
@@ -1,0 +1,139 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { AgentSession } from "../integrations/types.js";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-push-"));
+process.env.LISA_HOME = TMP;
+const FILE = path.join(TMP, "push.json");
+
+const {
+  defaultPushPrefs,
+  normalizePushPrefs,
+  agentPushEvents,
+  sendNtfy,
+  PushBridge,
+  registerPush,
+  unregisterPush,
+  listPush,
+  setPushPrefs,
+} = await import("./push.js");
+
+beforeEach(() => fs.rmSync(FILE, { force: true }));
+
+const sess = (o: Partial<AgentSession>): AgentSession => ({
+  agent: "claude-code",
+  sessionId: "s1",
+  project: "proj",
+  state: "working",
+  stateReason: "",
+  lastMtime: 0,
+  ...o,
+});
+const withPending = (p: string) =>
+  sess({ activity: { turnCount: 1, lastTools: [], filesTouched: [], pendingPermission: p } });
+
+describe("push prefs", () => {
+  test("defaults: done/error/permission/idle on, advisor off", () => {
+    assert.deepEqual(defaultPushPrefs(), { done: true, error: true, permission: true, idle: true, advisor: false });
+  });
+  test("normalize coerces non-bool / missing / null to defaults", () => {
+    assert.deepEqual(normalizePushPrefs({ advisor: true }), { ...defaultPushPrefs(), advisor: true });
+    assert.deepEqual(normalizePushPrefs({ done: "no" as unknown as boolean }), defaultPushPrefs());
+    assert.deepEqual(normalizePushPrefs(null), defaultPushPrefs());
+  });
+});
+
+describe("agentPushEvents (pure trigger)", () => {
+  test("working→done fires done", () => {
+    assert.deepEqual(agentPushEvents(sess({ state: "working" }), sess({ state: "done" })).map((e) => e.pref), ["done"]);
+  });
+  test("working→error fires error (high) with the reason", () => {
+    const [e] = agentPushEvents(sess({ state: "working" }), sess({ state: "error", stateReason: "build failed" }));
+    assert.equal(e.pref, "error");
+    assert.equal(e.priority, "high");
+    assert.match(e.body, /build failed/);
+  });
+  test("pendingPermission appearing fires permission", () => {
+    const [e] = agentPushEvents(sess({}), withPending("Bash"));
+    assert.equal(e.pref, "permission");
+    assert.match(e.body, /Bash/);
+  });
+  test("no transition / unchanged pending → nothing", () => {
+    assert.deepEqual(agentPushEvents(sess({ state: "working" }), sess({ state: "working" })), []);
+    assert.deepEqual(agentPushEvents(withPending("Bash"), withPending("Bash")), []);
+  });
+  test("first sight already done (prev undefined) → fires", () => {
+    assert.equal(agentPushEvents(undefined, sess({ state: "done" }))[0]!.pref, "done");
+  });
+});
+
+describe("sendNtfy", () => {
+  test("POSTs body + Title/Priority headers to <server>/<topic>", async () => {
+    let captured: { url: string; init: { body: string; headers: Record<string, string> } } | null = null;
+    const ok = await sendNtfy(
+      "https://ntfy.sh/",
+      "my-topic",
+      { title: "T", body: "B", priority: "high" },
+      async (url, init) => {
+        captured = { url, init };
+        return { ok: true };
+      },
+    );
+    assert.equal(ok, true);
+    assert.equal(captured!.url, "https://ntfy.sh/my-topic");
+    assert.equal(captured!.init.body, "B");
+    assert.equal(captured!.init.headers.Title, "T");
+    assert.equal(captured!.init.headers.Priority, "high");
+  });
+  test("network throw → false", async () => {
+    const ok = await sendNtfy("https://x", "t", { title: "a", body: "b", priority: "default" }, async () => {
+      throw new Error("net");
+    });
+    assert.equal(ok, false);
+  });
+});
+
+describe("PushBridge", () => {
+  test("delivers to subs whose pref is on; skips pref-off subs", () => {
+    const delivered: Array<{ id: string; tag: string }> = [];
+    const subs = [
+      { id: "a", kind: "ntfy" as const, target: "ta", prefs: defaultPushPrefs(), createdAt: 0 },
+      { id: "b", kind: "ntfy" as const, target: "tb", prefs: { ...defaultPushPrefs(), done: false }, createdAt: 0 },
+    ];
+    const bridge = new PushBridge({ subs: () => subs, now: () => 1000, deliver: (s, ev) => void delivered.push({ id: s.id, tag: ev.tag }) });
+    bridge.onAgentUpdate(sess({ state: "working" }));
+    bridge.onAgentUpdate(sess({ state: "done" }));
+    assert.deepEqual(delivered, [{ id: "a", tag: "done" }]); // only "a" (b has done:false)
+  });
+
+  test("throttles a repeat of the same tag within the window", () => {
+    const delivered: string[] = [];
+    const subs = [{ id: "a", kind: "ntfy" as const, target: "t", prefs: defaultPushPrefs(), createdAt: 0 }];
+    let t = 0;
+    const bridge = new PushBridge({ subs: () => subs, now: () => t, throttleMs: 1000, deliver: (_s, ev) => void delivered.push(ev.tag) });
+    bridge.onAgentUpdate(withPending("Bash")); // fires permission @0
+    t = 100;
+    bridge.onAgentUpdate(withPending("Write")); // new pending → event, but throttled (<1000)
+    t = 2000;
+    bridge.onAgentUpdate(withPending("Edit")); // throttle elapsed → fires
+    assert.deepEqual(delivered, ["permission", "permission"]);
+  });
+});
+
+describe("push storage", () => {
+  test("register → list; same target replaces; unregister; setPrefs", () => {
+    const a = registerPush({ kind: "ntfy", target: "topic-1", prefs: { advisor: true } }, 1);
+    assert.equal(listPush().length, 1);
+    assert.equal(listPush()[0]!.prefs.advisor, true);
+    registerPush({ kind: "ntfy", target: "topic-1" }, 2); // same target → replace
+    assert.equal(listPush().length, 1);
+    const updated = setPushPrefs(listPush()[0]!.id, { error: false });
+    assert.equal(updated!.prefs.error, false);
+    assert.equal(unregisterPush(a.target), true);
+    assert.equal(listPush().length, 0);
+    assert.equal(unregisterPush("nope"), false);
+  });
+});

--- a/src/web/push.ts
+++ b/src/web/push.ts
@@ -1,0 +1,221 @@
+/**
+ * Operational push notifications — tell the phone when a dispatched/managed agent
+ * finishes, errors, or blocks on a permission, or when Reve left a "while you were
+ * away" note. OPT-IN and event-scoped — NOT proactive emotional outreach (that
+ * stays a ROADMAP non-goal); this is closer to a CI notification.
+ *
+ * Transport is pluggable:
+ *  - `ntfy` works today with zero Apple infra — a plain HTTP POST to a topic on
+ *    ntfy.sh (or your self-hosted server); the topic name is the shared secret.
+ *  - `apns` is the iOS-native path and needs an Apple push key, so it's a
+ *    documented stub here (logs "would notify").
+ * Payloads carry low-sensitivity metadata only (agent / project / state / reason)
+ * — never prompts, replies, full commands, or terminal output.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+import type { AgentSession } from "../integrations/types.js";
+
+export interface PushPrefs {
+  done: boolean;
+  error: boolean;
+  permission: boolean;
+  idle: boolean;
+  advisor: boolean;
+}
+export function defaultPushPrefs(): PushPrefs {
+  return { done: true, error: true, permission: true, idle: true, advisor: false };
+}
+export function normalizePushPrefs(p: Partial<PushPrefs> | null | undefined): PushPrefs {
+  const base = defaultPushPrefs();
+  if (!p || typeof p !== "object") return base;
+  const pick = (k: keyof PushPrefs): boolean => (typeof p[k] === "boolean" ? (p[k] as boolean) : base[k]);
+  return { done: pick("done"), error: pick("error"), permission: pick("permission"), idle: pick("idle"), advisor: pick("advisor") };
+}
+
+export interface PushSubscription {
+  id: string;
+  kind: "ntfy" | "apns";
+  /** ntfy topic, or APNs device token. */
+  target: string;
+  /** ntfy server base (default https://ntfy.sh); ignored for apns. */
+  server?: string;
+  prefs: PushPrefs;
+  createdAt: number;
+}
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+function pushPath(): string {
+  return path.join(lisaHome(), "push.json");
+}
+
+export function loadPush(): PushSubscription[] {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(pushPath(), "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter(
+        (s): s is PushSubscription =>
+          !!s && typeof (s as PushSubscription).id === "string" && typeof (s as PushSubscription).target === "string",
+      )
+      .map((s) => ({ ...s, kind: s.kind === "apns" ? "apns" : "ntfy", prefs: normalizePushPrefs(s.prefs) }));
+  } catch {
+    return [];
+  }
+}
+function savePush(list: PushSubscription[]): void {
+  const file = pushPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(list, null, 2));
+}
+
+export function registerPush(
+  input: { kind?: string; target: string; server?: string; prefs?: Partial<PushPrefs> },
+  now: number = Date.now(),
+): PushSubscription {
+  const kind = input.kind === "apns" ? "apns" : "ntfy";
+  const sub: PushSubscription = {
+    id: crypto.randomBytes(6).toString("hex"),
+    kind,
+    target: input.target,
+    ...(input.server ? { server: input.server } : {}),
+    prefs: normalizePushPrefs(input.prefs),
+    createdAt: now,
+  };
+  // Replace any existing subscription for the same (kind, target).
+  const list = loadPush().filter((s) => !(s.kind === kind && s.target === input.target));
+  list.push(sub);
+  savePush(list);
+  return sub;
+}
+export function unregisterPush(idOrTarget: string): boolean {
+  const list = loadPush();
+  const next = list.filter((s) => s.id !== idOrTarget && s.target !== idOrTarget);
+  if (next.length === list.length) return false;
+  savePush(next);
+  return true;
+}
+export function listPush(): PushSubscription[] {
+  return loadPush();
+}
+export function setPushPrefs(id: string, prefs: Partial<PushPrefs>): PushSubscription | null {
+  const list = loadPush();
+  const s = list.find((x) => x.id === id);
+  if (!s) return null;
+  s.prefs = normalizePushPrefs({ ...s.prefs, ...prefs });
+  savePush(list);
+  return s;
+}
+
+// ── pure trigger ──────────────────────────────────────────────────────────
+export interface PushEvent {
+  pref: keyof PushPrefs;
+  title: string;
+  body: string;
+  priority: "high" | "default";
+  /** Throttle/dedup tag within a session. */
+  tag: string;
+}
+
+/** Which notifications a session's prev→next transition warrants. Pure. */
+export function agentPushEvents(prev: AgentSession | undefined, next: AgentSession): PushEvent[] {
+  const out: PushEvent[] = [];
+  const who = `${next.agent} · ${next.project || next.agent}`;
+  if (next.state === "done" && prev?.state !== "done")
+    out.push({ pref: "done", title: `${who} — done`, body: "Finished.", priority: "default", tag: "done" });
+  if (next.state === "error" && prev?.state !== "error")
+    out.push({ pref: "error", title: `${who} — error`, body: next.stateReason || "errored", priority: "high", tag: "error" });
+  const pend = next.activity?.pendingPermission;
+  if (pend && pend !== prev?.activity?.pendingPermission)
+    out.push({ pref: "permission", title: `${who} — needs permission`, body: `waiting on: ${pend}`, priority: "high", tag: "permission" });
+  return out;
+}
+
+// ── ntfy transport (injectable fetch for tests) ───────────────────────────
+type FetchLike = (
+  url: string,
+  init: { method: string; body: string; headers: Record<string, string> },
+) => Promise<{ ok: boolean }>;
+
+export async function sendNtfy(
+  server: string,
+  topic: string,
+  ev: { title: string; body: string; priority: "high" | "default" },
+  fetchImpl: FetchLike = fetch as unknown as FetchLike,
+): Promise<boolean> {
+  try {
+    const base = (server || "https://ntfy.sh").replace(/\/+$/, "");
+    const res = await fetchImpl(`${base}/${encodeURIComponent(topic)}`, {
+      method: "POST",
+      body: ev.body,
+      headers: { Title: ev.title, Priority: ev.priority === "high" ? "high" : "default" },
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ── bridge: hub/idle events → throttled per-subscription delivery ──────────
+export interface PushBridgeOpts {
+  subs?: () => PushSubscription[];
+  /** Injected delivery (tests). Default: real ntfy / apns-stub. */
+  deliver?: (sub: PushSubscription, ev: PushEvent) => void | Promise<void>;
+  now?: () => number;
+  log?: (m: string) => void;
+  throttleMs?: number;
+}
+
+export class PushBridge {
+  private readonly prev = new Map<string, AgentSession>();
+  private readonly lastSent = new Map<string, number>();
+  private readonly subs: () => PushSubscription[];
+  private readonly deliverFn: (sub: PushSubscription, ev: PushEvent) => void | Promise<void>;
+  private readonly now: () => number;
+  private readonly log: (m: string) => void;
+  private readonly throttleMs: number;
+
+  constructor(opts: PushBridgeOpts = {}) {
+    this.subs = opts.subs ?? listPush;
+    this.now = opts.now ?? Date.now;
+    this.log = opts.log ?? (() => {});
+    this.throttleMs = opts.throttleMs ?? 30_000;
+    this.deliverFn = opts.deliver ?? ((sub, ev) => this.defaultDeliver(sub, ev));
+  }
+
+  onAgentUpdate(next: AgentSession): void {
+    const key = `${next.agent}/${next.sessionId}`;
+    const events = agentPushEvents(this.prev.get(key), next);
+    this.prev.set(key, next);
+    for (const ev of events) this.fire(ev, `${key}#${ev.tag}`);
+  }
+
+  onIdleMessage(text: string): void {
+    this.fire(
+      { pref: "idle", title: "Lisa — while you were away", body: text.slice(0, 200), priority: "default", tag: "idle" },
+      `idle#${this.now()}`,
+    );
+  }
+
+  private fire(ev: PushEvent, throttleKey: string): void {
+    const subs = this.subs().filter((s) => s.prefs[ev.pref]);
+    if (subs.length === 0) return;
+    // -Infinity default ⇒ the FIRST event for a key is never throttled (even when now() is small).
+    if (this.now() - (this.lastSent.get(throttleKey) ?? -Infinity) < this.throttleMs) return;
+    this.lastSent.set(throttleKey, this.now());
+    for (const sub of subs) void Promise.resolve(this.deliverFn(sub, ev)).catch(() => {});
+  }
+
+  private async defaultDeliver(sub: PushSubscription, ev: PushEvent): Promise<void> {
+    if (sub.kind === "ntfy") {
+      const ok = await sendNtfy(sub.server ?? "https://ntfy.sh", sub.target, ev);
+      if (!ok) this.log(`[push] ntfy send failed for ${sub.id}`);
+    } else {
+      this.log(`[push] apns not wired (needs an Apple push key) — would notify ${sub.id}: ${ev.title}`);
+    }
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -40,6 +40,7 @@ import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
 import { listRecentDispatches, isAlive, toDispatchView, readDispatchOutput } from "../integrations/dispatch-ledger.js";
 import { loadControlPolicy, saveControlPolicy, type ControlPolicy } from "../control/policy.js";
 import { mintDevice, verifyDeviceToken, touchDevice, listDevices, revokeDevice } from "./devices.js";
+import { PushBridge, listPush, registerPush, unregisterPush, setPushPrefs, type PushPrefs } from "./push.js";
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
 import { VoiceSource } from "../sense/voice.js";
@@ -247,11 +248,15 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   const hub = new OrchestratorHub(orchestratorCfg, {
     log: (msg) => console.error(msg),
   });
+  // Operational push: notify subscribed phones on agent done/error/permission +
+  // Reve idle messages. Opt-in, ntfy by default (apns is a stub). See push.ts.
+  const pushBridge = new PushBridge({ log: (m) => console.error(m) });
   hub.on("update", (session: AgentSession) => {
     // L6 — record the transition in the orchestrator journal so the
     // cross-agent recap can answer "what happened while I was away?" even for
     // sessions that have since ended. (Dedups consecutive same-state events.)
     recordEvent(session);
+    pushBridge.onAgentUpdate(session);
     // New generalized event for the multi-agent UI.
     broadcast({ type: "agent_session_update", ...session });
     // Back-compat: the island still listens for claude_session_update as a
@@ -301,6 +306,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         const at = new Date().toISOString();
         lastIdleMessage = { text, at };
         broadcast({ type: "idle_message", text, at, source: "advisor" });
+        pushBridge.onIdleMessage(text);
         // Structured twin of the digest: same suggestions with id / urgency /
         // action attached so the island can render per-suggestion buttons
         // (act → prefill chat, ✕ → dismiss feeds the learning loop).
@@ -441,6 +447,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           });
           lastIdleMessage = { text: result.text, at: startedAt };
           broadcast({ type: "idle_message", text: result.text, at: startedAt });
+          pushBridge.onIdleMessage(result.text);
         }
       } catch (err) {
         const msg = (err as Error).message;
@@ -847,6 +854,54 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       const removed = revokeDevice(typeof payload.id === "string" ? payload.id : "");
       res.writeHead(removed ? 200 : 404, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: removed }));
+      return;
+    }
+
+    // Push registration: a phone registers its own delivery target (ntfy topic or
+    // APNs token) + prefs — authed (the device does this remotely). Low-sensitivity
+    // metadata only; see push.ts.
+    if (req.method === "POST" && url === "/api/push/register") {
+      let puBody = "";
+      for await (const chunk of req) puBody += chunk.toString("utf8");
+      let payload: { kind?: unknown; target?: unknown; server?: unknown; prefs?: Partial<PushPrefs> } = {};
+      try { payload = puBody ? JSON.parse(puBody) : {}; } catch { /* tolerate */ }
+      if (typeof payload.target !== "string" || !payload.target.trim()) {
+        res.writeHead(400, { "content-type": "text/plain" }); res.end("target required (ntfy topic or apns token)"); return;
+      }
+      const sub = registerPush({
+        kind: typeof payload.kind === "string" ? payload.kind : "ntfy",
+        target: payload.target,
+        server: typeof payload.server === "string" ? payload.server : undefined,
+        prefs: payload.prefs,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, subscription: sub }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/push/unregister") {
+      let puBody = "";
+      for await (const chunk of req) puBody += chunk.toString("utf8");
+      let payload: { id?: unknown; target?: unknown } = {};
+      try { payload = puBody ? JSON.parse(puBody) : {}; } catch { /* tolerate */ }
+      const key = typeof payload.id === "string" ? payload.id : typeof payload.target === "string" ? payload.target : "";
+      const removed = unregisterPush(key);
+      res.writeHead(removed ? 200 : 404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: removed }));
+      return;
+    }
+    if (req.method === "GET" && url === "/api/push/list") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ subscriptions: listPush() }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/push/prefs") {
+      let puBody = "";
+      for await (const chunk of req) puBody += chunk.toString("utf8");
+      let payload: { id?: unknown; prefs?: Partial<PushPrefs> } = {};
+      try { payload = puBody ? JSON.parse(puBody) : {}; } catch { /* tolerate */ }
+      const sub = typeof payload.id === "string" ? setPushPrefs(payload.id, payload.prefs ?? {}) : null;
+      res.writeHead(sub ? 200 : 404, { "content-type": "application/json" });
+      res.end(JSON.stringify(sub ? { ok: true, subscription: sub } : { ok: false }));
       return;
     }
 


### PR DESCRIPTION
> Stacked on #117 → #115 → #114 → #113. Retarget to `main` once those merge.

## What

Operational push (the "agent done / errored / needs-permission" + "Reve left a note" alerts the iOS plan calls for). **Opt-in, event-scoped — not proactive emotional outreach** (that stays a ROADMAP non-goal); think CI notification.

Transport is pluggable, and **ntfy works today with zero Apple infrastructure** — delivery is a plain HTTP POST to a topic on `ntfy.sh` (or your self-hosted server), so the privacy-first path the plan recommended is fully functional now. `apns` is the iOS-native path and needs an Apple push key, so it's a clearly-marked stub.

`src/web/push.ts`:
- subscriptions (`~/.lisa/push.json`): `{ kind: "ntfy"|"apns", target, server?, prefs }`; `prefs` = `{done, error, permission, idle, advisor}` (advisor off by default).
- `agentPushEvents(prev, next)` — **pure** trigger: fires on `→done`, `→error` (high), and a newly-appearing `pendingPermission`.
- `sendNtfy(...)` — injectable fetch; `PushBridge` throttles per (session, kind) and fans out to matching subscriptions on hub `update` events + Reve `idle_message`.
- Payloads are low-sensitivity metadata only (agent · project · state · reason) — never prompts, replies, or terminal output.

Endpoints: `POST /api/push/register` (authed — a phone self-registers), `POST /api/push/unregister`, `GET /api/push/list`, `POST /api/push/prefs`.

Also fixed a latent throttle edge (default `lastSent` of `0` suppressed the first event when `now()` was small) → `-Infinity`.

## Verification

- `npm run typecheck` + `npm run build` clean; **753 tests / 752 pass / 1 skip / 0 fail** (12 new: prefs, the pure trigger's transitions/edge-dedup, ntfy POST shape via mock fetch, bridge pref-filtering + throttle, storage).
- Live-checked the endpoints: register → list → prefs → unregister, plus `400` on a missing target.
- Not exercised live: an actual POST to a real ntfy server (external publish) and APNs delivery (needs an Apple key). The ntfy send path is covered by the mock-fetch unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
