### PR TITLE
feat(ios): Live Activity + Dynamic Island for a pinned agent (compile-verified)

### DIFF
--- a/packaging/ios-companion/README.md
+++ b/packaging/ios-companion/README.md
@@ -21,10 +21,12 @@ iOS 17+ target). It covers:
 - **Chat** — streams `POST /chat`.
 - **Settings** — pairing (paste a `lisa-pair://…` / `?token=` string → Keychain),
   ntfy push registration, and a read-only view of the remote-control policy.
+- **Glance** — a **Live Activity / Dynamic Island** for a pinned agent (Lock Screen +
+  compact / expanded / minimal Dynamic Island), via a WidgetKit extension target.
 
-**Not yet** (follow-ups): Live Activity / Dynamic Island + Widgets (a separate
-widget-extension target), APNs (needs an Apple push key — ntfy works today), and
-a QR scanner (you can paste the pairing string for now).
+**Not yet** (follow-ups): live Live-Activity updates via APNs (so a pinned agent stays
+fresh while backgrounded — needs an Apple push key; ntfy push works today), a home-screen
+Widget, and a QR scanner (you can paste the pairing string for now).
 
 ## Build / verify
 

--- a/packaging/ios-companion/Shared/AgentActivityAttributes.swift
+++ b/packaging/ios-companion/Shared/AgentActivityAttributes.swift
@@ -1,0 +1,17 @@
+import ActivityKit
+import Foundation
+
+/// The Live Activity payload for a pinned agent. Shared by the app (which starts /
+/// updates the activity) and the widget extension (which renders it on the Lock
+/// Screen + Dynamic Island).
+struct AgentActivityAttributes: ActivityAttributes {
+    public struct ContentState: Codable, Hashable {
+        var state: String      // working | waiting | error | done | …
+        var detail: String     // stateReason / pending permission / last tool
+        var turns: Int
+    }
+
+    var agent: String
+    var project: String
+    var sessionId: String
+}

--- a/packaging/ios-companion/Sources/LiveActivityController.swift
+++ b/packaging/ios-companion/Sources/LiveActivityController.swift
@@ -1,0 +1,37 @@
+import ActivityKit
+import Foundation
+
+/// Starts the Live Activity for a pinned agent. (Updating it as state changes is a
+/// follow-up — ideally driven by APNs Live Activity remote updates so it stays
+/// fresh while the app is backgrounded.)
+enum LiveActivityController {
+    @discardableResult
+    static func start(for session: AgentSession) -> String? {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return nil }
+        let attributes = AgentActivityAttributes(
+            agent: session.agent,
+            project: session.project,
+            sessionId: session.sessionId
+        )
+        let state = AgentActivityAttributes.ContentState(
+            state: session.state,
+            detail: detail(for: session),
+            turns: session.activity?.turnCount ?? 0
+        )
+        do {
+            let activity = try Activity.request(
+                attributes: attributes,
+                content: .init(state: state, staleDate: nil)
+            )
+            return activity.id
+        } catch {
+            return nil
+        }
+    }
+
+    static func detail(for s: AgentSession) -> String {
+        if let pending = s.activity?.pendingPermission { return "⚠ \(pending)" }
+        if !s.stateReason.isEmpty { return s.stateReason }
+        return s.activity?.lastTools?.last ?? s.state
+    }
+}

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -174,6 +174,17 @@ struct SessionDetailView: View {
                 if let cwd = session.cwd { LabeledContent("cwd", value: cwd) }
             }
             controlSection
+            Section("Glance") {
+                Button {
+                    if LiveActivityController.start(for: session) != nil {
+                        status = "Pinned to the Live Activity."
+                    } else {
+                        status = "Live Activities are unavailable here (enable in iOS Settings, or run on a device)."
+                    }
+                } label: {
+                    Label("Pin to Live Activity", systemImage: "pin")
+                }
+            }
             if !status.isEmpty {
                 Section { Text(status).font(.caption).foregroundStyle(.secondary) }
             }

--- a/packaging/ios-companion/Widgets/AgentLiveActivity.swift
+++ b/packaging/ios-companion/Widgets/AgentLiveActivity.swift
@@ -1,0 +1,55 @@
+import ActivityKit
+import WidgetKit
+import SwiftUI
+
+/// The pinned agent's status on the Lock Screen + Dynamic Island — the iOS twin
+/// of the Mac "island" (docs/IOS_COMPANION_PLAN.md §3.4).
+struct AgentLiveActivity: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: AgentActivityAttributes.self) { context in
+            // Lock Screen / banner
+            HStack(spacing: 10) {
+                Circle().fill(activityColor(context.state.state)).frame(width: 10, height: 10)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(context.attributes.agent) · \(context.attributes.project)")
+                        .font(.headline).lineLimit(1)
+                    Text(context.state.detail).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                Spacer()
+                Text("\(context.state.turns)t").font(.caption.monospacedDigit()).foregroundStyle(.secondary)
+            }
+            .padding()
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Label(context.attributes.agent, systemImage: "cpu").font(.caption)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text(context.state.state)
+                        .font(.caption.bold())
+                        .foregroundStyle(activityColor(context.state.state))
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text("\(context.attributes.project) — \(context.state.detail)")
+                        .font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+            } compactLeading: {
+                Circle().fill(activityColor(context.state.state)).frame(width: 8, height: 8)
+            } compactTrailing: {
+                Text("\(context.state.turns)").font(.caption2.monospacedDigit())
+            } minimal: {
+                Circle().fill(activityColor(context.state.state)).frame(width: 8, height: 8)
+            }
+        }
+    }
+}
+
+func activityColor(_ state: String) -> Color {
+    switch state {
+    case "working": return .blue
+    case "waiting": return .yellow
+    case "error": return .red
+    case "done": return .green
+    default: return .gray
+    }
+}

--- a/packaging/ios-companion/Widgets/LisaWidgetsBundle.swift
+++ b/packaging/ios-companion/Widgets/LisaWidgetsBundle.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+import WidgetKit
+
+@main
+struct LisaWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        AgentLiveActivity()
+    }
+}

--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -1,7 +1,7 @@
 # XcodeGen spec for Lisa Pocket — the iOS companion (docs/IOS_COMPANION_PLAN.md).
-# Generate the project with `xcodegen generate` (or ./build.sh), then build/verify
-# for the simulator (no signing needed). Single app target for now; a Live Activity
-# / Widget extension is a follow-up target.
+# Two targets: the app + a WidgetKit extension that hosts the Live Activity /
+# Dynamic Island. `AgentActivityAttributes` (Shared/) is compiled into both.
+# Generate + build/verify with ./build.sh (simulator, no signing).
 name: LisaPocket
 options:
   bundleIdPrefix: ai.meetlisa
@@ -14,7 +14,6 @@ settings:
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
     TARGETED_DEVICE_FAMILY: "1,2"
-    # Simulator verification needs no code signing.
     CODE_SIGNING_REQUIRED: NO
     CODE_SIGNING_ALLOWED: NO
     CODE_SIGN_IDENTITY: ""
@@ -24,14 +23,33 @@ targets:
     platform: iOS
     sources:
       - path: Sources
+      - path: Shared
+    dependencies:
+      - target: LisaPocketWidgets
     info:
       path: Sources/Info.plist
       properties:
         CFBundleDisplayName: Lisa Pocket
         UILaunchScreen: {}
-        # The companion talks HTTP to the user's own Mac on the local network.
+        NSSupportsLiveActivities: true
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: ai.meetlisa.pocket
+
+  LisaPocketWidgets:
+    type: app-extension
+    platform: iOS
+    sources:
+      - path: Widgets
+      - path: Shared
+    info:
+      path: Widgets/Info.plist
+      properties:
+        CFBundleDisplayName: Lisa Widgets
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: ai.meetlisa.pocket.widgets


### PR DESCRIPTION
> Stacked on #122. Retarget to main as the stack merges.

## What

The centerpiece the plan emphasized (§3.4): a **Live Activity / Dynamic Island** for a pinned agent — the iOS twin of the Mac island.

- New WidgetKit **extension target** `LisaPocketWidgets` with an `ActivityConfiguration`: Lock-Screen banner + Dynamic Island (compact / expanded / minimal) showing the agent, project, state (color-coded), detail, and turn count.
- `Shared/AgentActivityAttributes.swift` is compiled into **both** the app and the extension.
- `LiveActivityController.start()` requests the activity; a **Pin to Live Activity** button in the session detail wires it up.

## Verified

`** BUILD SUCCEEDED **` — the app **and** the embedded `LisaPocketWidgets.appex` — against the iOS 26.5 SDK with Xcode 26.5 (via ./build.sh). 

Follow-up: keep it fresh in the background via **APNs Live Activity remote updates** (needs an Apple push key), plus a home-screen Widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)