### PR TITLE
fix(web): delegate-a-task → button + modal (was a cramped sidebar form)

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1292,31 +1292,64 @@ if ('serviceWorker' in navigator) {
     } catch {}
   };
 
-  // "Delegate a task" → start an agent. managed = LISA-run (controllable);
-  // claude/codex = a real CLI under a PTY (Stage C spike, needs LISA_PTY_AGENTS=1
-  // — a 503 surfaces its hint in the modal).
-  const sbDelegate = document.getElementById('sbDelegate');
-  if (sbDelegate) {
-    sbDelegate.addEventListener('submit', function (e) {
-      e.preventDefault();
-      const inp = document.getElementById('sbDelegateTask');
-      const kindEl = document.getElementById('sbDelegateKind');
-      const task = inp && inp.value.trim();
-      if (!task) return;
+  // "Delegate a task" → open a modal to pick the agent kind + write the task.
+  // (A roomy dialog beats the cramped 280px sidebar.) managed = LISA-run
+  // (controllable); claude/codex = a real CLI under a PTY (needs LISA_PTY_AGENTS=1
+  // — a 503/error surfaces inline in the dialog).
+  function openDelegateModal() {
+    openModal(
+      'Delegate a task',
+      '<div class="delegate-modal">' +
+        '<label class="dm-label">Agent</label>' +
+        '<select id="dmKind" class="dm-kind">' +
+          '<option value="managed">managed — LISA runs it (approve each step)</option>' +
+          '<option value="claude">claude — real CLI under a PTY</option>' +
+          '<option value="codex">codex — real CLI under a PTY</option>' +
+        '</select>' +
+        '<label class="dm-label">Task</label>' +
+        '<textarea id="dmTask" class="dm-task" rows="5" placeholder="Describe the task… (⌘/Ctrl+Enter to start)"></textarea>' +
+        '<div class="dm-actions"><button id="dmStart" class="dm-start" type="button">Start agent →</button></div>' +
+        '<div id="dmErr" class="dm-err"></div>' +
+      '</div>'
+    );
+    const kindEl = document.getElementById('dmKind');
+    const taskEl = document.getElementById('dmTask');
+    const startEl = document.getElementById('dmStart');
+    const errEl = document.getElementById('dmErr');
+    if (taskEl) taskEl.focus();
+    function submitDelegate() {
+      const task = taskEl && taskEl.value.trim();
+      if (!task) { if (taskEl) taskEl.focus(); return; }
       const kind = kindEl ? kindEl.value : 'managed';
       const url = kind === 'managed' ? '/api/agents/managed/start' : '/api/agents/pty/start';
       const body = kind === 'managed' ? { task: task } : { agent: kind, task: task };
+      if (errEl) errEl.textContent = '';
+      if (startEl) { startEl.disabled = true; startEl.textContent = 'Starting…'; }
       fetch(url, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify(body),
       }).then(function (r) {
-        if (!r.ok) { return r.text().then(function (t) { openModal('agent', '<pre>' + escapeHtml(t) + '</pre>'); }); }
-        if (inp) inp.value = '';
+        if (!r.ok) {
+          return r.text().then(function (t) {
+            if (errEl) errEl.textContent = t || ('failed (' + r.status + ')');
+            if (startEl) { startEl.disabled = false; startEl.textContent = 'Start agent →'; }
+          });
+        }
+        closeModal();
         if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
-      }).catch(function () {});
+      }).catch(function () {
+        if (errEl) errEl.textContent = 'network error';
+        if (startEl) { startEl.disabled = false; startEl.textContent = 'Start agent →'; }
+      });
+    }
+    if (startEl) startEl.addEventListener('click', submitDelegate);
+    if (taskEl) taskEl.addEventListener('keydown', function (e) {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') { e.preventDefault(); submitDelegate(); }
     });
   }
+  const sbDelegateBtn = document.getElementById('sbDelegateBtn');
+  if (sbDelegateBtn) sbDelegateBtn.addEventListener('click', openDelegateModal);
 
   async function refreshIdentity() {
     try {

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -366,40 +366,42 @@ export const MAIN_CSS = `  :root {
     background: rgba(0,0,0,0.25);
     color: var(--fg);
   }
-  /* "Delegate a task" composer at the top of the agents card. */
-  .delegate {
-    display: flex;
-    gap: 6px;
+  /* "Delegate a task" → a single full-width button that opens a modal. */
+  .delegate-btn {
+    width: 100%;
     margin: 2px 0 8px;
-  }
-  .delegate input {
-    flex: 1;
-    font-size: 11px;
-    padding: 4px 8px;
-    border-radius: 7px;
-    border: 1px solid var(--border);
-    background: rgba(0,0,0,0.25);
-    color: var(--fg);
-  }
-  .delegate select {
-    font-size: 10.5px;
-    padding: 3px 4px;
-    border-radius: 7px;
-    border: 1px solid var(--border);
-    background: rgba(0,0,0,0.25);
-    color: var(--fg-2);
-    cursor: pointer;
-  }
-  .delegate button {
-    font-size: 11px;
-    padding: 4px 10px;
-    border-radius: 7px;
+    font-size: 11.5px;
+    padding: 6px 10px;
+    border-radius: 8px;
     border: 1px solid var(--claude, #ff8c42);
-    background: rgba(255,140,66,0.16);
+    background: rgba(255,140,66,0.14);
     color: var(--claude, #ff8c42);
     cursor: pointer;
+    transition: background 0.12s ease;
   }
-  .delegate button:hover { background: rgba(255,140,66,0.28); }
+  .delegate-btn:hover { background: rgba(255,140,66,0.26); }
+  /* Delegate dialog (rendered in the shared modal). */
+  .delegate-modal { display: flex; flex-direction: column; gap: 8px; }
+  .delegate-modal .dm-label {
+    font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+    color: var(--fg-2); margin-top: 4px;
+  }
+  .delegate-modal .dm-kind,
+  .delegate-modal .dm-task {
+    width: 100%; box-sizing: border-box;
+    font-size: 13px; padding: 8px 10px; border-radius: 8px;
+    border: 1px solid var(--border); background: rgba(0,0,0,0.25); color: var(--fg);
+  }
+  .delegate-modal .dm-task { resize: vertical; min-height: 88px; font-family: inherit; }
+  .delegate-modal .dm-actions { display: flex; justify-content: flex-end; margin-top: 4px; }
+  .delegate-modal .dm-start {
+    font-size: 13px; padding: 8px 16px; border-radius: 8px;
+    border: 1px solid var(--brand, #6ad4ff); background: rgba(106,212,255,0.16);
+    color: var(--brand, #6ad4ff); cursor: pointer;
+  }
+  .delegate-modal .dm-start:hover { background: rgba(106,212,255,0.28); }
+  .delegate-modal .dm-start:disabled { opacity: 0.5; cursor: default; }
+  .delegate-modal .dm-err { color: var(--err-color, #ff5577); font-size: 12px; white-space: pre-wrap; }
   .session-empty {
     color: var(--fg-faint);
     font-size: 11.5px;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -16,12 +16,12 @@ import { MAIN_HTML } from "./lisa-html.js";
  * change the GUI markup/CSS/JS, recompute them:
  *   node --import tsx -e 'import("./src/web/lisa-html.ts").then(async m=>{const {createHash}=await import("node:crypto");console.log(m.MAIN_HTML.length, createHash("sha256").update(m.MAIN_HTML).digest("hex"))})'
  *
- * Last updated: first-run safety net (lisaBanner + global error/rejection
- * guards + retrying startupGate) so the boot never dead-ends silently.
+ * Last updated: delegate-a-task moved from a cramped sidebar form to a single
+ * button that opens a roomy modal (agent picker + task textarea).
  */
-const EXPECTED_LENGTH = 93016;
+const EXPECTED_LENGTH = 95181;
 const EXPECTED_SHA256 =
-  "eb15c942d0260b6da7c3ea4e212a3e8d603dc9c70bf83b0e6018fe217a9cb594";
+  "057b3c90dfd99d1a2bec6ce1233f547e466265a7abd4271e9ff1ac66f947a655";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -80,15 +80,9 @@ ${MAIN_CSS}
         <div class="left">agents</div>
         <div class="count">▶︎ <span id="sbClaudeCount">0</span></div>
       </div>
-      <form id="sbDelegate" class="delegate" autocomplete="off">
-        <select id="sbDelegateKind" title="Agent type — managed (LISA-run) or a real CLI under a PTY (spike)">
-          <option value="managed">managed</option>
-          <option value="claude">claude</option>
-          <option value="codex">codex</option>
-        </select>
-        <input id="sbDelegateTask" type="text" placeholder="delegate a task…" />
-        <button type="submit" title="Start an agent">▶</button>
-      </form>
+      <button id="sbDelegateBtn" class="delegate-btn" type="button" title="Start an agent">
+        ＋ delegate a task
+      </button>
       <div id="sbClaudeRows">
         <div class="session-empty">(idle)</div>
       </div>


### PR DESCRIPTION
## What
The "delegate a task" composer was crammed into the 280px agents card — a kind dropdown, a tiny text input, and a ▶ button all fighting for space (see report). Replaced with a single full-width **＋ delegate a task** button that opens the shared modal:
- roomy **agent picker** (managed — LISA-run / claude / codex — real CLI under a PTY),
- multi-line **task textarea** (⌘/Ctrl+Enter to start),
- inline **errors** (e.g. the PTY-disabled 503 hint) instead of a separate popup.

## Verification
824 tests pass (1 skip), typecheck + build clean; snapshot recomputed (93016 → 95181); `MAIN_HTML` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)