### PR TITLE
feat(clients): delegate-a-task on the menu bar + iOS

### DIFF
--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -120,6 +120,11 @@ final class LisaClient {
     func managedApprove(_ id: String, allow: Bool) async throws { try await fire("/api/agents/managed/\(id)/approve", json: ["allow": allow]) }
 
     // ── control: PTY agents ──
+    /// Spawn a fresh real CLI under a PTY (agent = "claude" | "codex"). Returns
+    /// the HTTP code (503 ⇒ the PTY spike is off on the Mac: LISA_PTY_AGENTS=1).
+    func ptyStart(agent: String, task: String) async throws -> Int {
+        try await fire("/api/agents/pty/start", json: ["agent": agent, "task": task])
+    }
     func ptySend(_ id: String, _ text: String) async throws { try await fire("/api/agents/pty/\(id)/send", json: ["text": text]) }
     func ptyCancel(_ id: String) async throws { try await fire("/api/agents/pty/\(id)/cancel") }
     func ptyOutput(_ id: String) async throws -> String {

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -111,6 +111,7 @@ struct RosterView: View {
     @StateObject private var model = RosterModel()
     @Environment(\.scenePhase) private var scenePhase
     @State private var path: [AgentSession] = []
+    @State private var showDelegate = false
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -134,10 +135,18 @@ struct RosterView: View {
             .navigationDestination(for: AgentSession.self) { SessionDetailView(session: $0) }
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
+                    Button { showDelegate = true } label: { Image(systemName: "plus") }
+                        .disabled(!app.config.isConfigured)
+                        .accessibilityLabel("Delegate a task")
+                }
+                ToolbarItem(placement: .topBarTrailing) {
                     NavigationLink { DispatchLedgerView() } label: {
                         Image(systemName: "list.bullet.rectangle")
                     }
                 }
+            }
+            .sheet(isPresented: $showDelegate) {
+                DelegateSheet(client: app.client) { Task { await model.load(app.client) } }
             }
             .refreshable { await model.load(app.client) }
             .task(id: app.config) {
@@ -215,6 +224,77 @@ struct Pill: View {
             .background(color.opacity(0.15))
             .foregroundStyle(color)
             .clipShape(Capsule())
+    }
+}
+
+/// Start a new agent: managed (Lisa runs it) or a real claude/codex CLI under a
+/// PTY. Mirrors the Mac GUI's "delegate a task" modal.
+struct DelegateSheet: View {
+    let client: LisaClient
+    var onStarted: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var kind = "managed"
+    @State private var task = ""
+    @State private var status = ""
+    @State private var busy = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section("Agent") {
+                    Picker("Agent", selection: $kind) {
+                        Text("managed — Lisa runs it").tag("managed")
+                        Text("claude — real CLI (PTY)").tag("claude")
+                        Text("codex — real CLI (PTY)").tag("codex")
+                    }
+                    .pickerStyle(.menu)
+                }
+                Section("Task") {
+                    TextField("Describe the task…", text: $task, axis: .vertical)
+                        .lineLimit(3...8)
+                }
+                if !status.isEmpty {
+                    Section { Text(status).font(.caption).foregroundStyle(.red) }
+                }
+            }
+            .navigationTitle("Delegate a task")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Start") { start() }
+                        .disabled(busy || task.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+
+    private func start() {
+        let t = task.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty else { return }
+        busy = true
+        status = ""
+        Task { @MainActor in
+            do {
+                if kind == "managed" {
+                    try await client.managedStart(task: t)
+                } else {
+                    let code = try await client.ptyStart(agent: kind, task: t)
+                    if !(200..<300).contains(code) {
+                        busy = false
+                        status = code == 503
+                            ? "PTY agents are disabled on the Mac (set LISA_PTY_AGENTS=1)."
+                            : "Couldn't start (HTTP \(code))."
+                        return
+                    }
+                }
+                onStarted()
+                dismiss()
+            } catch {
+                busy = false
+                status = (error as? LocalizedError)?.errorDescription ?? "\(error)"
+            }
+        }
     }
 }
 

--- a/packaging/mac-client/Sources/Lisa/MenuBarController.swift
+++ b/packaging/mac-client/Sources/Lisa/MenuBarController.swift
@@ -511,11 +511,23 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     }
 
     private func buttonsView(inner: CGFloat) -> NSView {
+        let col = NSStackView()
+        col.orientation = .vertical
+        col.alignment = .leading
+        col.spacing = 8
+        col.translatesAutoresizingMaskIntoConstraints = false
+
+        // Full-width "delegate a task" — opens a small dialog to start an agent.
+        let delegate = NSButton(title: "＋ Delegate a task", target: self, action: #selector(delegateTask))
+        delegate.bezelStyle = .rounded
+        delegate.translatesAutoresizingMaskIntoConstraints = false
+        delegate.widthAnchor.constraint(equalToConstant: inner).isActive = true
+        col.addArrangedSubview(delegate)
+
         let row = NSStackView()
         row.orientation = .horizontal
         row.distribution = .fillEqually
         row.spacing = 10
-        row.translatesAutoresizingMaskIntoConstraints = false
         let open = NSButton(title: "Open chat", target: self, action: #selector(openWindow))
         open.bezelStyle = .rounded
         open.keyEquivalent = "\r"   // default (accent-tinted) button
@@ -524,7 +536,10 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
         row.addArrangedSubview(open)
         row.addArrangedSubview(refresh)
         row.widthAnchor.constraint(equalToConstant: inner).isActive = true
-        return row
+        col.addArrangedSubview(row)
+
+        col.widthAnchor.constraint(equalToConstant: inner).isActive = true
+        return col
     }
 
     private func wrappedLabel(_ s: String, size: CGFloat, color: NSColor, width: CGFloat) -> NSTextField {
@@ -570,12 +585,79 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     @objc private func refreshFromPopover() {
         Task { @MainActor in
             await refreshOnce()
-            // Rebuild popover view with fresh data + resize to fit it.
-            if let p = popover, p.isShown {
-                let vc = makePopoverContent()
-                p.contentViewController = vc
-                p.contentSize = vc.view.fittingSize
-            }
+            rebuildPopoverIfShown()
+        }
+    }
+
+    private func rebuildPopoverIfShown() {
+        if let p = popover, p.isShown {
+            let vc = makePopoverContent()
+            p.contentViewController = vc
+            p.contentSize = vc.view.fittingSize
+        }
+    }
+
+    // MARK: - Delegate a task
+
+    /// Small modal: pick an agent (managed / claude / codex) + type a task, then
+    /// POST it to the backend. (Loopback ⇒ no token needed.)
+    @objc private func delegateTask() {
+        popover?.close()
+
+        let width: CGFloat = 320
+        let kind = NSPopUpButton(frame: NSRect(x: 0, y: 62, width: width, height: 26), pullsDown: false)
+        kind.addItems(withTitles: ["managed — Lisa runs it", "claude — real CLI (PTY)", "codex — real CLI (PTY)"])
+        let field = NSTextField(frame: NSRect(x: 0, y: 0, width: width, height: 52))
+        field.placeholderString = "Describe the task…"
+        field.cell?.wraps = true
+        field.cell?.isScrollable = false
+        let accessory = NSView(frame: NSRect(x: 0, y: 0, width: width, height: 96))
+        accessory.addSubview(kind)
+        accessory.addSubview(field)
+
+        let alert = NSAlert()
+        alert.messageText = "Delegate a task"
+        alert.informativeText = "Pick an agent and describe what it should do."
+        alert.accessoryView = accessory
+        alert.addButton(withTitle: "Start")
+        alert.addButton(withTitle: "Cancel")
+        alert.window.initialFirstResponder = field
+
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        let task = field.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !task.isEmpty else { return }
+        let agent = ["managed", "claude", "codex"][max(0, min(2, kind.indexOfSelectedItem))]
+        Task { @MainActor in await startAgent(agent: agent, task: task) }
+    }
+
+    private func startAgent(agent: String, task: String) async {
+        let isManaged = (agent == "managed")
+        let path = isManaged ? "/api/agents/managed/start" : "/api/agents/pty/start"
+        let body: [String: Any] = isManaged ? ["task": task] : ["agent": agent, "task": task]
+        let result = await Self.post(url: URL(string: "http://localhost:5757\(path)")!, json: body)
+        if !result.ok {
+            let a = NSAlert()
+            a.messageText = "Couldn't start the agent"
+            a.informativeText = result.message ?? "Request failed."
+            a.runModal()
+        }
+        await refreshOnce()
+        rebuildPopoverIfShown()
+    }
+
+    private static func post(url: URL, json: [String: Any]) async -> (ok: Bool, message: String?) {
+        var req = URLRequest(url: url, timeoutInterval: 8)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "content-type")
+        req.httpBody = try? JSONSerialization.data(withJSONObject: json)
+        do {
+            let (data, resp) = try await URLSession.shared.data(for: req)
+            let code = (resp as? HTTPURLResponse)?.statusCode ?? 0
+            if (200..<300).contains(code) { return (true, nil) }
+            let msg = String(data: data, encoding: .utf8)
+            return (false, (msg?.isEmpty == false) ? msg : "HTTP \(code)")
+        } catch {
+            return (false, error.localizedDescription)
         }
     }
 


### PR DESCRIPTION
## What
"Delegate a task" existed only in the web GUI. Added it to the two **native** client surfaces that showed the roster but couldn't start an agent.

**Menu bar (AppKit):** a **＋ Delegate a task** button in the popover → `NSAlert` with a kind popup (managed / claude / codex) + task field → `POST /api/agents/{managed,pty}/start` (loopback, no token). New `post()` helper; failures (e.g. the PTY-disabled 503) surface in an alert. Folded the repeated popover-rebuild into `rebuildPopoverIfShown()`.

**iOS (SwiftUI, Lisa Pocket):** a **+** toolbar button on the roster opens a `DelegateSheet` (Picker + multiline task field + Start). managed → `managedStart`; claude/codex → new `LisaClient.ptyStart(agent:task:)` (surfaces the 503 hint inline).

## Verification
- mac-client `swift build` — clean.
- iOS `xcodebuild -sdk iphonesimulator … build` — **BUILD SUCCEEDED**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)