### PR TITLE
feat(mail): M2 — daily digest schedule + push + web GUI card/modal

### DIFF
--- a/src/cli/mail.ts
+++ b/src/cli/mail.ts
@@ -13,6 +13,7 @@ import { addAccount, loadAccounts, removeAccount, setAccountEnabled } from "../m
 import { sweepAll } from "../mail/service.js";
 import { latestDigest } from "../mail/store.js";
 import { formatDigestText } from "../mail/digest.js";
+import { inferHost } from "../mail/hosts.js";
 
 function parseFlags(args: string[]): Record<string, string> {
   const out: Record<string, string> = {};
@@ -29,26 +30,6 @@ function parseFlags(args: string[]): Record<string, string> {
     }
   }
   return out;
-}
-
-/** Infer the IMAP host from the email domain (common providers). */
-export function inferHost(email: string): string | undefined {
-  const domain = (email.split("@")[1] ?? "").toLowerCase();
-  const map: Record<string, string> = {
-    "qq.com": "imap.qq.com",
-    "163.com": "imap.163.com",
-    "126.com": "imap.126.com",
-    "gmail.com": "imap.gmail.com",
-    "googlemail.com": "imap.gmail.com",
-    "outlook.com": "outlook.office365.com",
-    "hotmail.com": "outlook.office365.com",
-    "live.com": "outlook.office365.com",
-    "icloud.com": "imap.mail.me.com",
-    "me.com": "imap.mail.me.com",
-    "yahoo.com": "imap.mail.yahoo.com",
-  };
-  if (map[domain]) return map[domain];
-  return domain ? `imap.${domain}` : undefined;
 }
 
 function ask(question: string): Promise<string> {

--- a/src/mail/hosts.ts
+++ b/src/mail/hosts.ts
@@ -1,0 +1,18 @@
+/** Infer the IMAP host from an email domain (common providers). Pure. */
+export function inferHost(email: string): string | undefined {
+  const domain = (email.split("@")[1] ?? "").toLowerCase();
+  const map: Record<string, string> = {
+    "qq.com": "imap.qq.com",
+    "163.com": "imap.163.com",
+    "126.com": "imap.126.com",
+    "gmail.com": "imap.gmail.com",
+    "googlemail.com": "imap.gmail.com",
+    "outlook.com": "outlook.office365.com",
+    "hotmail.com": "outlook.office365.com",
+    "live.com": "outlook.office365.com",
+    "icloud.com": "imap.mail.me.com",
+    "me.com": "imap.mail.me.com",
+    "yahoo.com": "imap.mail.yahoo.com",
+  };
+  return map[domain] ?? (domain ? `imap.${domain}` : undefined);
+}

--- a/src/mail/scheduler.test.ts
+++ b/src/mail/scheduler.test.ts
@@ -1,0 +1,26 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { isDigestDue, digestHour, DEFAULT_DIGEST_HOUR } from "./scheduler.js";
+
+test("isDigestDue: not due if already produced today", () => {
+  const now = new Date(2026, 5, 25, 9, 0); // local Jun 25 2026, 09:00
+  assert.equal(isDigestDue("2026-06-25", now, 8), false);
+});
+
+test("isDigestDue: due once past the target hour on a new day", () => {
+  const now = new Date(2026, 5, 25, 9, 0);
+  assert.equal(isDigestDue("2026-06-24", now, 8), true);
+  assert.equal(isDigestDue(null, now, 8), true);
+});
+
+test("isDigestDue: not due before the target hour", () => {
+  const now = new Date(2026, 5, 25, 7, 30);
+  assert.equal(isDigestDue("2026-06-24", now, 8), false);
+});
+
+test("digestHour: env override within range, else default", () => {
+  assert.equal(digestHour({ LISA_MAIL_DIGEST_HOUR: "6" } as NodeJS.ProcessEnv), 6);
+  assert.equal(digestHour({} as NodeJS.ProcessEnv), DEFAULT_DIGEST_HOUR);
+  assert.equal(digestHour({ LISA_MAIL_DIGEST_HOUR: "99" } as NodeJS.ProcessEnv), DEFAULT_DIGEST_HOUR);
+  assert.equal(digestHour({ LISA_MAIL_DIGEST_HOUR: "nope" } as NodeJS.ProcessEnv), DEFAULT_DIGEST_HOUR);
+});

--- a/src/mail/scheduler.ts
+++ b/src/mail/scheduler.ts
@@ -1,0 +1,22 @@
+/**
+ * Daily-digest scheduling — pure decision logic. The server polls this on a
+ * timer; the actual sweep + push happens in server.ts.
+ */
+import { localDate } from "./service.js";
+
+export const DEFAULT_DIGEST_HOUR = 8;
+
+/** Target local hour (0-23) for the daily digest; LISA_MAIL_DIGEST_HOUR overrides. */
+export function digestHour(env: NodeJS.ProcessEnv = process.env): number {
+  const h = Number(env.LISA_MAIL_DIGEST_HOUR);
+  return Number.isInteger(h) && h >= 0 && h <= 23 ? h : DEFAULT_DIGEST_HOUR;
+}
+
+/**
+ * Is a daily digest due? True when we haven't produced one for the local day yet
+ * AND it's at/after the target hour. Pure.
+ */
+export function isDigestDue(lastDigestDate: string | null, now: Date, targetHour: number): boolean {
+  if (lastDigestDate === localDate(now.getTime())) return false;
+  return now.getHours() >= targetHour;
+}

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -453,6 +453,8 @@ function connectEvents() {
       // "sidebar live wiring" block). Generalized from claude_session_update
       // so codex / opencode / git / … sessions update the sidebar too.
       if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
+    } else if (ev.type === 'mail_digest_update' || ev.type === 'mail_accounts_update') {
+      if (typeof window.refreshMail === 'function') window.refreshMail();
     }
   });
   es.onerror = () => {
@@ -1379,13 +1381,114 @@ if ('serviceWorker' in navigator) {
     }
   }
 
+  // ── Mail card: connect a mailbox + show the daily classified digest ──
+  function renderMail(accounts, digest) {
+    const body = document.getElementById('sbMailBody');
+    const count = document.getElementById('sbMailCount');
+    const connectBtn = document.getElementById('sbMailConnectBtn');
+    if (!body) return;
+    while (body.firstChild) body.removeChild(body.firstChild);
+    const hasAccounts = accounts && accounts.length > 0;
+    if (connectBtn) connectBtn.textContent = hasAccounts ? '＋ add mailbox' : '＋ connect mailbox';
+    if (!hasAccounts) {
+      const empty = document.createElement('div');
+      empty.className = 'session-empty';
+      empty.textContent = '(not connected)';
+      body.appendChild(empty);
+      if (count) count.textContent = '';
+      return;
+    }
+    const sum = document.createElement('div');
+    sum.className = 'mail-summary';
+    sum.textContent = digest && digest.summary ? digest.summary : 'No digest yet — sweep to build one.';
+    body.appendChild(sum);
+    const needs = digest && digest.needsYou ? digest.needsYou : [];
+    if (count) count.textContent = needs.length ? ('✦ ' + needs.length) : '';
+    for (const i of needs.slice(0, 5)) {
+      const row = document.createElement('div');
+      row.className = 'mail-row';
+      const bang = document.createElement('span');
+      bang.className = 'mail-bang' + (i.importance >= 3 ? ' urgent' : '');
+      bang.textContent = i.importance >= 3 ? '‼' : '!';
+      const subj = document.createElement('span');
+      subj.className = 'mail-subj';
+      subj.textContent = i.subject || '(no subject)';
+      subj.title = (i.from || '') + ' — ' + (i.reason || '');
+      row.appendChild(bang);
+      row.appendChild(subj);
+      body.appendChild(row);
+    }
+    const sweep = document.createElement('button');
+    sweep.className = 'mail-sweep';
+    sweep.type = 'button';
+    sweep.textContent = 'sweep now';
+    sweep.addEventListener('click', function () {
+      sweep.disabled = true; sweep.textContent = 'sweeping…';
+      fetch('/api/mail/sweep', { method: 'POST' }).then(function () {
+        if (window.refreshMail) window.refreshMail();
+      }).catch(function () {}).then(function () { sweep.disabled = false; sweep.textContent = 'sweep now'; });
+    });
+    body.appendChild(sweep);
+  }
+
+  window.refreshMail = async function () {
+    try {
+      const a = await fetch('/api/mail/accounts').then(function (r) { return r.ok ? r.json() : null; });
+      const d = await fetch('/api/mail/digest').then(function (r) { return r.ok ? r.json() : null; });
+      renderMail(a ? a.accounts : [], d ? d.digest : null);
+    } catch (e) {}
+  };
+
+  function openMailModal() {
+    openModal('Connect a mailbox',
+      '<div class="delegate-modal">' +
+        '<label class="dm-label">Email</label>' +
+        '<input id="mmEmail" class="dm-kind" type="email" placeholder="you@qq.com" autocomplete="off" />' +
+        '<label class="dm-label">App-password / authorization code</label>' +
+        '<input id="mmPass" class="dm-kind" type="password" placeholder="not your login password" autocomplete="off" />' +
+        '<label class="dm-label">IMAP host (optional — auto-detected)</label>' +
+        '<input id="mmHost" class="dm-kind" type="text" placeholder="imap.qq.com" autocomplete="off" />' +
+        '<div class="dm-actions"><button id="mmStart" class="dm-start" type="button">Connect →</button></div>' +
+        '<div id="mmErr" class="dm-err"></div>' +
+        '<div class="dm-note">Read-only. Stored locally (0600). Most providers need an app-password, not your login password.</div>' +
+      '</div>');
+    const emailEl = document.getElementById('mmEmail');
+    const passEl = document.getElementById('mmPass');
+    const hostEl = document.getElementById('mmHost');
+    const startEl = document.getElementById('mmStart');
+    const errEl = document.getElementById('mmErr');
+    if (emailEl) emailEl.focus();
+    function submitMail() {
+      const email = emailEl && emailEl.value.trim();
+      const pass = passEl && passEl.value;
+      if (!email || !pass) { if (errEl) errEl.textContent = 'email + app-password required'; return; }
+      const body = { email: email, password: pass };
+      if (hostEl && hostEl.value.trim()) body.host = hostEl.value.trim();
+      if (errEl) errEl.textContent = '';
+      if (startEl) { startEl.disabled = true; startEl.textContent = 'Connecting…'; }
+      fetch('/api/mail/connect', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+        .then(function (r) {
+          if (!r.ok) { return r.text().then(function (t) { if (errEl) errEl.textContent = t || ('failed (' + r.status + ')'); if (startEl) { startEl.disabled = false; startEl.textContent = 'Connect →'; } }); }
+          closeModal();
+          if (window.refreshMail) window.refreshMail();
+        })
+        .catch(function () { if (errEl) errEl.textContent = 'network error'; if (startEl) { startEl.disabled = false; startEl.textContent = 'Connect →'; } });
+    }
+    if (startEl) startEl.addEventListener('click', submitMail);
+    if (passEl) passEl.addEventListener('keydown', function (e) { if (e.key === 'Enter') { e.preventDefault(); submitMail(); } });
+  }
+  var sbMailConnectBtn = document.getElementById('sbMailConnectBtn');
+  if (sbMailConnectBtn) sbMailConnectBtn.addEventListener('click', openMailModal);
+
   // Bootstrap + periodic resync. SSE handles the fast-path updates;
   // these timers are belt-and-braces in case the stream silently dies.
   refreshPing();
   window.refreshClaudeSessions();
+  window.refreshMail();
   refreshIdentity();
   refreshSessionsBadge();
   setInterval(refreshPing, 30_000);
   setInterval(window.refreshClaudeSessions, 60_000);
+  setInterval(window.refreshMail, 5 * 60_000);
   setInterval(refreshSessionsBadge, 5 * 60_000);
 })();`;

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -243,6 +243,11 @@ export const MAIN_CSS = `  :root {
     border-color: rgba(255, 208, 102, 0.22);
     background: linear-gradient(180deg, rgba(255, 208, 102, 0.07), rgba(255, 208, 102, 0.02));
   }
+  .card.tint-mail {
+    border-color: rgba(106, 212, 255, 0.20);
+    background: linear-gradient(180deg, rgba(106, 212, 255, 0.06), rgba(106, 212, 255, 0.02));
+  }
+  .card.tint-mail .h .left { color: var(--brand, #6ad4ff); }
   .card .h {
     display: flex;
     justify-content: space-between;
@@ -402,6 +407,19 @@ export const MAIN_CSS = `  :root {
   .delegate-modal .dm-start:hover { background: rgba(106,212,255,0.28); }
   .delegate-modal .dm-start:disabled { opacity: 0.5; cursor: default; }
   .delegate-modal .dm-err { color: var(--err-color, #ff5577); font-size: 12px; white-space: pre-wrap; }
+  .delegate-modal .dm-note { font-size: 11px; color: var(--fg-faint); line-height: 1.4; margin-top: 2px; }
+  /* Mail card body */
+  #sbMailBody { margin: 2px 0 6px; }
+  .mail-summary { font-size: 11.5px; color: var(--fg-2); line-height: 1.45; margin-bottom: 6px; }
+  .mail-row { display: flex; gap: 6px; align-items: baseline; padding: 1px 0; }
+  .mail-bang { color: var(--brand, #6ad4ff); font-weight: 700; font-size: 11px; flex: none; }
+  .mail-bang.urgent { color: var(--err-color, #ff5577); }
+  .mail-subj { font-size: 11.5px; color: var(--fg); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .mail-sweep {
+    margin-top: 6px; font-size: 10.5px; background: none; border: none;
+    color: var(--brand, #6ad4ff); cursor: pointer; padding: 2px 0;
+  }
+  .mail-sweep:hover { text-decoration: underline; }
   .session-empty {
     color: var(--fg-faint);
     font-size: 11.5px;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -16,12 +16,12 @@ import { MAIN_HTML } from "./lisa-html.js";
  * change the GUI markup/CSS/JS, recompute them:
  *   node --import tsx -e 'import("./src/web/lisa-html.ts").then(async m=>{const {createHash}=await import("node:crypto");console.log(m.MAIN_HTML.length, createHash("sha256").update(m.MAIN_HTML).digest("hex"))})'
  *
- * Last updated: delegate-a-task moved from a cramped sidebar form to a single
- * button that opens a roomy modal (agent picker + task textarea).
+ * Last updated: Mail card (connect-mailbox modal + daily classified digest +
+ * needs-you list + sweep-now) added to the sidebar.
  */
-const EXPECTED_LENGTH = 95181;
+const EXPECTED_LENGTH = 102331;
 const EXPECTED_SHA256 =
-  "057b3c90dfd99d1a2bec6ce1233f547e466265a7abd4271e9ff1ac66f947a655";
+  "c14af5253ba023e34df61639ac35eaa449c1b70339d5c4ad1dcd944acd00a2d7";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -88,6 +88,20 @@ ${MAIN_CSS}
       </div>
     </div>
 
+    <!-- Mail digest (connect a mailbox → daily classified digest) -->
+    <div class="card tint-mail" id="sbMailCard">
+      <div class="h">
+        <div class="left">mail</div>
+        <div class="count" id="sbMailCount"></div>
+      </div>
+      <div id="sbMailBody">
+        <div class="session-empty">(not connected)</div>
+      </div>
+      <button id="sbMailConnectBtn" class="delegate-btn" type="button" title="Connect a mailbox">
+        ＋ connect mailbox
+      </button>
+    </div>
+
     <!-- Last reflection (collapsed pointer to the most recent ★) -->
     <div class="card tint-idle" id="sbReflection" style="display:none;">
       <div class="h">

--- a/src/web/push.test.ts
+++ b/src/web/push.test.ts
@@ -48,8 +48,8 @@ const withPending = (p: string) =>
   sess({ activity: { turnCount: 1, lastTools: [], filesTouched: [], pendingPermission: p } });
 
 describe("push prefs", () => {
-  test("defaults: done/error/permission/idle on, advisor off", () => {
-    assert.deepEqual(defaultPushPrefs(), { done: true, error: true, permission: true, idle: true, advisor: false });
+  test("defaults: done/error/permission/idle/mail on, advisor off", () => {
+    assert.deepEqual(defaultPushPrefs(), { done: true, error: true, permission: true, idle: true, advisor: false, mail: true });
   });
   test("normalize coerces non-bool / missing / null to defaults", () => {
     assert.deepEqual(normalizePushPrefs({ advisor: true }), { ...defaultPushPrefs(), advisor: true });

--- a/src/web/push.ts
+++ b/src/web/push.ts
@@ -28,15 +28,24 @@ export interface PushPrefs {
   permission: boolean;
   idle: boolean;
   advisor: boolean;
+  /** Daily mail digest + important-mail alerts. */
+  mail: boolean;
 }
 export function defaultPushPrefs(): PushPrefs {
-  return { done: true, error: true, permission: true, idle: true, advisor: false };
+  return { done: true, error: true, permission: true, idle: true, advisor: false, mail: true };
 }
 export function normalizePushPrefs(p: Partial<PushPrefs> | null | undefined): PushPrefs {
   const base = defaultPushPrefs();
   if (!p || typeof p !== "object") return base;
   const pick = (k: keyof PushPrefs): boolean => (typeof p[k] === "boolean" ? (p[k] as boolean) : base[k]);
-  return { done: pick("done"), error: pick("error"), permission: pick("permission"), idle: pick("idle"), advisor: pick("advisor") };
+  return {
+    done: pick("done"),
+    error: pick("error"),
+    permission: pick("permission"),
+    idle: pick("idle"),
+    advisor: pick("advisor"),
+    mail: pick("mail"),
+  };
 }
 
 export interface PushSubscription {
@@ -464,6 +473,22 @@ export class PushBridge {
     this.fire(
       { pref: "idle", title: "Lisa — while you were away", body: text.slice(0, 200), priority: "default", tag: "idle" },
       `idle#${this.now()}`,
+    );
+  }
+
+  /** Daily mail digest push (default priority). */
+  onMailDigest(text: string, click?: string): void {
+    this.fire(
+      { pref: "mail", title: "📬 Mail digest", body: text.slice(0, 240), priority: "default", tag: "mail-digest", click },
+      `mail-digest#${this.now()}`,
+    );
+  }
+
+  /** Important-mail alert (high priority); `tag` dedups per message. */
+  onMailImportant(ev: { title: string; body: string; click?: string; tag: string }): void {
+    this.fire(
+      { pref: "mail", title: ev.title, body: ev.body.slice(0, 240), priority: "high", tag: ev.tag, click: ev.click },
+      `mail#${ev.tag}`,
     );
   }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,6 +39,13 @@ import { signalAgentTool } from "../tools/signal_agent.js";
 import { managedRegistry } from "../agents/managed.js";
 import { ptyRegistry, ptyEnabled, normalizeAgentKind } from "../agents/pty.js";
 import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
+import { sweepAll } from "../mail/service.js";
+import { latestDigest } from "../mail/store.js";
+import { formatDigestText } from "../mail/digest.js";
+import { isDigestDue, digestHour } from "../mail/scheduler.js";
+import { loadAccounts, addAccount, removeAccount, setAccountEnabled } from "../mail/accounts.js";
+import { inferHost } from "../mail/hosts.js";
+import type { DailyDigest } from "../mail/types.js";
 import { listRecentDispatches, isAlive, toDispatchView, readDispatchOutput } from "../integrations/dispatch-ledger.js";
 import { loadControlPolicy, saveControlPolicy, type ControlPolicy } from "../control/policy.js";
 import { mintDevice, verifyDeviceToken, touchDevice, listDevices, revokeDevice } from "./devices.js";
@@ -328,6 +335,44 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     })();
   }, ADVISE_INTERVAL_MS);
   if (adviseTimer.unref) adviseTimer.unref();
+
+  // ── Mail digest (daily) ─────────────────────────────────────────────
+  // Once past the target hour, if not already done today, sweep all mailboxes,
+  // build + push the classified digest. Inert unless `mail` consent is granted
+  // and at least one account is connected.
+  let mailSweepRunning = false;
+  const afterMailDigest = (digest: DailyDigest): void => {
+    broadcast({
+      type: "mail_digest_update",
+      date: digest.date,
+      total: digest.total,
+      needsYou: digest.needsYou.length,
+      at: new Date().toISOString(),
+    });
+    pushBridge.onMailDigest(formatDigestText(digest));
+  };
+  const runMailDigest = async (force: boolean): Promise<DailyDigest | null> => {
+    if (mailSweepRunning || !isGranted("mail")) return null;
+    if (loadAccounts().filter((a) => a.enabled).length === 0) return null;
+    if (!force && !isDigestDue(latestDigest()?.date ?? null, new Date(), digestHour())) return null;
+    mailSweepRunning = true;
+    try {
+      const { digest } = await sweepAll();
+      afterMailDigest(digest);
+      console.error(`[mail] digest ${digest.date}: ${digest.total} mail · ${digest.needsYou.length} need-you`);
+      return digest;
+    } catch (err) {
+      console.error(`[mail] digest sweep failed: ${(err as Error).message}`);
+      return null;
+    } finally {
+      mailSweepRunning = false;
+    }
+  };
+  const mailTimer = setInterval(() => void runMailDigest(false), 30 * 60_000);
+  if (mailTimer.unref) mailTimer.unref();
+  // Catch a restart that happens after the target hour (don't wait 30m).
+  const mailKick = setTimeout(() => void runMailDigest(false), 20_000);
+  if (mailKick.unref) mailKick.unref();
 
   // ── Screen advisor (opt-in): periodic screen-grounded next-step ─────
   // When enabled, every N minutes capture a full-screen shot, ask the model
@@ -923,6 +968,79 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       const sub = typeof payload.id === "string" ? setPushPrefs(payload.id, payload.prefs ?? {}) : null;
       res.writeHead(sub ? 200 : 404, { "content-type": "application/json" });
       res.end(JSON.stringify(sub ? { ok: true, subscription: sub } : { ok: false }));
+      return;
+    }
+
+    // ── Mail module (read-only): accounts, connect, sweep, digest ───────
+    if (req.method === "GET" && url === "/api/mail/accounts") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ accounts: loadAccounts(), consent: isGranted("mail") }));
+      return;
+    }
+    if (req.method === "GET" && url === "/api/mail/digest") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ digest: latestDigest() }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/mail/connect") {
+      let mBody = "";
+      for await (const chunk of req) mBody += chunk.toString("utf8");
+      let p: { email?: unknown; host?: unknown; port?: unknown; password?: unknown; label?: unknown };
+      try { p = JSON.parse(mBody || "{}"); } catch {
+        res.writeHead(400, { "content-type": "text/plain" }); res.end("bad json"); return;
+      }
+      const email = typeof p.email === "string" ? p.email.trim() : "";
+      const password = typeof p.password === "string" ? p.password : "";
+      if (!email.includes("@") || !password) {
+        res.writeHead(400, { "content-type": "text/plain" }); res.end("email + password required"); return;
+      }
+      const host = typeof p.host === "string" && p.host ? p.host : inferHost(email);
+      if (!host) {
+        res.writeHead(400, { "content-type": "text/plain" }); res.end("couldn't infer IMAP host — pass host"); return;
+      }
+      const account = addAccount(
+        {
+          provider: "imap",
+          email,
+          host,
+          port: typeof p.port === "number" ? p.port : 993,
+          label: typeof p.label === "string" ? p.label : undefined,
+        },
+        { password },
+      );
+      grant("mail"); // connecting a mailbox is the consent act
+      broadcast({ type: "mail_accounts_update", at: new Date().toISOString() });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, account }));
+      return;
+    }
+    if (req.method === "POST" && url.startsWith("/api/mail/accounts/")) {
+      const rest = url.slice("/api/mail/accounts/".length);
+      const slash = rest.indexOf("/");
+      const id = decodeURIComponent(slash >= 0 ? rest.slice(0, slash) : rest);
+      const action = slash >= 0 ? rest.slice(slash + 1) : "";
+      let ok = false;
+      if (action === "remove") ok = removeAccount(id);
+      else if (action === "enable") ok = setAccountEnabled(id, true);
+      else if (action === "disable") ok = setAccountEnabled(id, false);
+      else {
+        res.writeHead(400, { "content-type": "text/plain" }); res.end("action must be remove|enable|disable"); return;
+      }
+      if (ok) broadcast({ type: "mail_accounts_update", at: new Date().toISOString() });
+      res.writeHead(ok ? 200 : 404, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/mail/sweep") {
+      if (!isGranted("mail")) {
+        res.writeHead(409, { "content-type": "text/plain" });
+        res.end("mail consent not granted");
+        return;
+      }
+      const swept = await sweepAll();
+      if (!swept.blocked) afterMailDigest(swept.digest);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: !swept.blocked, digest: swept.digest, newItems: swept.newItems.length }));
       return;
     }
 


### PR DESCRIPTION
## What
Turns the M1 pipeline into a live surface (req #2: *daily classified digest, pushed*).

- **Schedule** — `scheduler.ts` (pure `isDigestDue` + `digestHour`); server checks every 30 min and, once past the target hour (`LISA_MAIL_DIGEST_HOUR`, default 8) and not yet done today, sweeps → builds → pushes. Inert unless `mail` consent + an account; a 20 s post-start kick covers restarts.
- **Push** — `PushPrefs.mail`; `PushBridge.onMailDigest` (daily) + `onMailImportant` (high-prio, used by M3).
- **Endpoints** (auth-gated) — `GET /api/mail/accounts`, `GET /api/mail/digest`, `POST /api/mail/connect` (adds account **+ grants `mail` consent**), `POST /api/mail/accounts/<id>/{remove,enable,disable}`, `POST /api/mail/sweep`; each mutation broadcasts an SSE.
- **GUI** — a **MAIL** sidebar card: connect-mailbox **modal** (email + app-password + optional host), digest summary + needs-you list + **sweep now**; live via `mail_*` SSE. `hosts.ts` shares `inferHost`.

## Verification
**847 tests / 1 skip**; typecheck + build clean. Live smoke: `/api/mail/accounts` → `{accounts:[],consent:false}`; sweep-without-consent → **409**; GUI serves the card.

Next: M3 (important-mail alerts + proactive chat), M4 (Gmail OAuth + iOS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)