### PR TITLE
feat(mail): M3 — important-mail alerts + proactive chat

### DIFF
--- a/src/mail/alerts.test.ts
+++ b/src/mail/alerts.test.ts
@@ -1,0 +1,52 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { pickImportant, formatAlert, alertLevel, pollMinutes, DEFAULT_ALERT_LEVEL, DEFAULT_POLL_MINUTES } from "./alerts.js";
+import type { MailItem } from "./types.js";
+
+function item(o: Partial<MailItem> = {}): MailItem {
+  return {
+    uid: "1",
+    accountId: "acc",
+    from: "Jane Doe <jane@x.com>",
+    fromAddress: "jane@x.com",
+    subject: "hello",
+    date: 100,
+    snippet: "hi",
+    category: "personal",
+    importance: 3,
+    reason: "awaiting your reply",
+    signals: [],
+    classifiedAt: 1,
+    ...o,
+  };
+}
+
+test("pickImportant filters by threshold and sorts importance then date", () => {
+  const items = [
+    item({ uid: "a", importance: 1 }),
+    item({ uid: "b", importance: 2, date: 100 }),
+    item({ uid: "c", importance: 3, date: 50 }),
+    item({ uid: "d", importance: 2, date: 200 }),
+  ];
+  assert.deepEqual(pickImportant(items, 3).map((i) => i.uid), ["c"]);
+  assert.deepEqual(pickImportant(items, 2).map((i) => i.uid), ["c", "d", "b"]);
+});
+
+test("formatAlert builds push title/body/tag + a proactive chat line", () => {
+  const a = formatAlert(item({ uid: "9", accountId: "qq", subject: "Sign the lease", importance: 3 }));
+  assert.equal(a.title, "📬 Important mail");
+  assert.match(a.body, /Jane Doe: Sign the lease/);
+  assert.equal(a.tag, "qq:9");
+  assert.match(a.chat, /Important mail from Jane Doe/);
+  assert.match(a.chat, /Sign the lease/);
+  assert.match(a.chat, /awaiting your reply/);
+});
+
+test("alertLevel + pollMinutes read env with safe defaults", () => {
+  assert.equal(alertLevel({ LISA_MAIL_ALERT_LEVEL: "2" } as NodeJS.ProcessEnv), 2);
+  assert.equal(alertLevel({} as NodeJS.ProcessEnv), DEFAULT_ALERT_LEVEL);
+  assert.equal(alertLevel({ LISA_MAIL_ALERT_LEVEL: "5" } as NodeJS.ProcessEnv), DEFAULT_ALERT_LEVEL);
+  assert.equal(pollMinutes({} as NodeJS.ProcessEnv), DEFAULT_POLL_MINUTES);
+  assert.equal(pollMinutes({ LISA_MAIL_POLL_MINUTES: "0" } as NodeJS.ProcessEnv), 0);
+  assert.equal(pollMinutes({ LISA_MAIL_POLL_MINUTES: "15" } as NodeJS.ProcessEnv), 15);
+});

--- a/src/mail/alerts.ts
+++ b/src/mail/alerts.ts
@@ -1,0 +1,62 @@
+/**
+ * Important-mail alerting — pure decision + formatting. The server's intraday
+ * poll feeds freshly-classified items here; what survives becomes a high-priority
+ * push + a proactive chat message.
+ */
+import type { MailItem } from "./types.js";
+
+export const DEFAULT_ALERT_LEVEL = 3;
+export const DEFAULT_POLL_MINUTES = 30;
+/** Cap alerts per poll so a burst of important mail can't spam the user. */
+export const MAX_ALERTS_PER_POLL = 3;
+
+/** Importance threshold for a proactive alert (2 or 3); LISA_MAIL_ALERT_LEVEL. */
+export function alertLevel(env: NodeJS.ProcessEnv = process.env): number {
+  const n = Number(env.LISA_MAIL_ALERT_LEVEL);
+  return n === 2 || n === 3 ? n : DEFAULT_ALERT_LEVEL;
+}
+
+/** Minutes between intraday important-mail polls; 0 disables. LISA_MAIL_POLL_MINUTES. */
+export function pollMinutes(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.LISA_MAIL_POLL_MINUTES;
+  if (raw === undefined) return DEFAULT_POLL_MINUTES;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 ? n : DEFAULT_POLL_MINUTES;
+}
+
+/** Items at/above the threshold, most-important + newest first. Pure. */
+export function pickImportant(items: MailItem[], threshold: number): MailItem[] {
+  return items
+    .filter((i) => i.importance >= threshold)
+    .sort((a, b) => b.importance - a.importance || b.date - a.date);
+}
+
+function who(from: string): string {
+  const m = from.match(/^\s*"?([^"<]+?)"?\s*</);
+  return (m?.[1] ?? from).trim().slice(0, 40);
+}
+
+export interface MailAlert {
+  /** Push title. */
+  title: string;
+  /** Push body. */
+  body: string;
+  /** Dedup tag (account:uid). */
+  tag: string;
+  /** Proactive chat message text. */
+  chat: string;
+}
+
+/** Format one important item into a push + chat alert. Pure. */
+export function formatAlert(i: MailItem): MailAlert {
+  const sender = who(i.from);
+  const subject = i.subject.slice(0, 100) || "(no subject)";
+  return {
+    title: i.importance >= 3 ? "📬 Important mail" : "📬 Mail",
+    body: `${sender}: ${subject.slice(0, 80)}`,
+    tag: `${i.accountId}:${i.uid}`,
+    chat:
+      `📬 ${i.importance >= 3 ? "Important" : "Notable"} mail from ${sender}: ` +
+      `“${subject}”${i.reason ? ` — ${i.reason}` : ""}`,
+  };
+}

--- a/src/mail/service.test.ts
+++ b/src/mail/service.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { sweepAll, type ConnectorFactory } from "./service.js";
+import { sweepAll, pollNewMail, type ConnectorFactory } from "./service.js";
 import { addAccount } from "./accounts.js";
 import { latestDigest } from "./store.js";
 import { grant } from "../consent/store.js";
@@ -107,6 +107,27 @@ test("a second sweep marks nothing new (seen-uid dedup)", async () => {
     const second = await sweepAll({ connectorFactory: fakeConnector(raws), provider: fakeProvider(json) });
     assert.equal(second.items.length, 1); // still classified for the digest
     assert.equal(second.newItems.length, 0); // but nothing NEW
+  });
+});
+
+test("pollNewMail returns only freshly-classified items and is empty on re-poll", async () => {
+  await withHome(async () => {
+    grant("mail");
+    addAccount({ provider: "imap", email: "me@qq.com", host: "imap.qq.com" }, { password: "pw" });
+    const raws = [raw("1", { subject: "Pay invoice" })];
+    const json = '[{"uid":"1","category":"finance","importance":3,"reason":"due"}]';
+    const first = await pollNewMail({ connectorFactory: fakeConnector(raws), provider: fakeProvider(json) });
+    assert.equal(first.length, 1);
+    assert.equal(first[0].importance, 3);
+    const second = await pollNewMail({ connectorFactory: fakeConnector(raws), provider: fakeProvider(json) });
+    assert.equal(second.length, 0); // already seen ⇒ no re-alert
+  });
+});
+
+test("pollNewMail returns nothing without consent", async () => {
+  await withHome(async () => {
+    const res = await pollNewMail({ connectorFactory: fakeConnector([raw("1")]), provider: fakeProvider("[]") });
+    assert.equal(res.length, 0);
   });
 });
 

--- a/src/mail/service.ts
+++ b/src/mail/service.ts
@@ -112,3 +112,41 @@ export async function sweepAll(opts: SweepOpts = {}): Promise<SweepResult> {
   saveDigest(digest);
   return { items: allItems, digest, newItems: allNew };
 }
+
+/**
+ * Lightweight intraday poll: fetch, classify ONLY the unseen messages, mark seen.
+ * Returns just the freshly-classified items (for important-mail alerts). Does NOT
+ * rebuild/save the digest — that stays a daily artifact (or a manual sweep).
+ */
+export async function pollNewMail(opts: SweepOpts = {}): Promise<MailItem[]> {
+  const now = opts.now ?? Date.now;
+  const sinceMs = opts.sinceMs ?? now() - 24 * 60 * 60 * 1000;
+  const limit = opts.limit ?? 200;
+  const factory = opts.connectorFactory ?? defaultConnector;
+  if (!isGranted("mail")) return [];
+
+  const out: MailItem[] = [];
+  for (const account of loadAccounts().filter((a) => a.enabled)) {
+    const secret = getSecret(account.id);
+    if (!secret) continue;
+    let connector: MailConnector | null = null;
+    try {
+      connector = factory(account, secret);
+      const raws = (await connector.listSince({ sinceMs, limit })).map((r) => ({ ...r, accountId: account.id }));
+      const seen = loadSeen(account.id);
+      const fresh = raws.filter((r) => !seen.has(r.uid));
+      if (fresh.length) {
+        out.push(
+          ...(await classifyMail(fresh, { provider: opts.provider, model: opts.model, now, signal: opts.signal })),
+        );
+      }
+      markSeen(account.id, raws.map((r) => r.uid));
+      markSwept(account.id, now());
+    } catch {
+      // skip a failing account
+    } finally {
+      if (connector) await connector.close().catch(() => {});
+    }
+  }
+  return out;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -39,7 +39,8 @@ import { signalAgentTool } from "../tools/signal_agent.js";
 import { managedRegistry } from "../agents/managed.js";
 import { ptyRegistry, ptyEnabled, normalizeAgentKind } from "../agents/pty.js";
 import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
-import { sweepAll } from "../mail/service.js";
+import { sweepAll, pollNewMail } from "../mail/service.js";
+import { pickImportant, formatAlert, alertLevel, pollMinutes } from "../mail/alerts.js";
 import { latestDigest } from "../mail/store.js";
 import { formatDigestText } from "../mail/digest.js";
 import { isDigestDue, digestHour } from "../mail/scheduler.js";
@@ -359,6 +360,11 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     try {
       const { digest } = await sweepAll();
       afterMailDigest(digest);
+      // Post the digest into the chat too (the "here's your mail" moment), in
+      // addition to the push — but only on the scheduled daily run, not manual.
+      if (!force && digest.total > 0) {
+        broadcast({ type: "idle_message", text: formatDigestText(digest), at: new Date().toISOString(), source: "mail" });
+      }
       console.error(`[mail] digest ${digest.date}: ${digest.total} mail · ${digest.needsYou.length} need-you`);
       return digest;
     } catch (err) {
@@ -373,6 +379,38 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   // Catch a restart that happens after the target hour (don't wait 30m).
   const mailKick = setTimeout(() => void runMailDigest(false), 20_000);
   if (mailKick.unref) mailKick.unref();
+
+  // ── Important-mail alerts (intraday) ────────────────────────────────
+  // Every LISA_MAIL_POLL_MINUTES (default 30; 0 disables), incrementally read
+  // NEW mail; for items at/above the alert level, fire a high-priority push +
+  // a proactive chat message. Inert without consent + an account.
+  const mailPollMin = pollMinutes();
+  if (mailPollMin > 0) {
+    let mailPollRunning = false;
+    const mailPoll = setInterval(() => {
+      void (async () => {
+        if (mailPollRunning || !isGranted("mail")) return;
+        if (loadAccounts().filter((a) => a.enabled).length === 0) return;
+        mailPollRunning = true;
+        try {
+          const important = pickImportant(await pollNewMail(), alertLevel());
+          if (important.length === 0) return;
+          for (const item of important.slice(0, 3)) {
+            const alert = formatAlert(item);
+            pushBridge.onMailImportant({ title: alert.title, body: alert.body, tag: alert.tag });
+            broadcast({ type: "idle_message", text: alert.chat, at: new Date().toISOString(), source: "mail" });
+          }
+          broadcast({ type: "mail_digest_update", at: new Date().toISOString() });
+          console.error(`[mail] ${important.length} important new mail (alerted ${Math.min(3, important.length)})`);
+        } catch (err) {
+          console.error(`[mail] poll failed: ${(err as Error).message}`);
+        } finally {
+          mailPollRunning = false;
+        }
+      })();
+    }, mailPollMin * 60_000);
+    if (mailPoll.unref) mailPoll.unref();
+  }
 
   // ── Screen advisor (opt-in): periodic screen-grounded next-step ─────
   // When enabled, every N minutes capture a full-screen shot, ask the model


### PR DESCRIPTION
## What
Req #3: *especially-important mail → proactively message + push the user.*

- **alerts.ts** (pure) — `pickImportant` (≥ threshold, importance/date sorted), `formatAlert` (push title/body/tag + a proactive chat line), `alertLevel` (`LISA_MAIL_ALERT_LEVEL`, default 3), `pollMinutes` (`LISA_MAIL_POLL_MINUTES`, default 30; 0 disables).
- **service.pollNewMail** — lightweight intraday poll: classifies **only unseen** messages (no LLM when nothing new), marks them seen, returns the fresh items. No digest rebuild.
- **server** — a poll timer every `pollMinutes`; items at/above the alert level → a **high-priority push** (`onMailImportant`) **+ a proactive chat message** (`idle_message` source `mail`), capped at 3/poll. The scheduled daily digest now **also posts into the chat** (not just push). Inert without consent + an account.

Dedup is structural — an item is "new" only in the first sweep/poll that sees it (seen-uids), so it alerts at most once.

## Verification
**28 mail tests** (pure picks/format/config + `pollNewMail` fresh-then-empty + consent-gated). **852 total / 1 skip**; typecheck + build clean.

Next: M4 (Gmail OAuth connector + iOS Mail surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)