### PR TITLE
feat(mail): M4 — Gmail OAuth connector + iOS mail surface

### DIFF
--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -87,6 +87,10 @@ final class LisaClient {
         return try await decode("/api/dispatch/status?id=\(enc)", as: DispatchStatus.self)
     }
     func islandPing() async throws -> IslandPing { try await decode("/api/island/ping", as: IslandPing.self) }
+
+    // ── read: mail (read-only digest) ──
+    func mailDigest() async throws -> MailDigest? { try await decode("/api/mail/digest", as: MailDigestResponse.self).digest }
+    func mailAccounts() async throws -> MailAccountsResponse { try await decode("/api/mail/accounts", as: MailAccountsResponse.self) }
     func controlPolicy() async throws -> ControlPolicy { try await decode("/api/control/policy", as: ControlPolicy.self) }
 
     // ── read: inspection ──

--- a/packaging/ios-companion/Sources/Models.swift
+++ b/packaging/ios-companion/Sources/Models.swift
@@ -129,7 +129,35 @@ struct PushPrefs: Codable, Equatable {
     var permission: Bool = true
     var idle: Bool = true
     var advisor: Bool = false
+    var mail: Bool = true
 }
+
+// ── Mail (read-only digest + accounts) ──
+struct MailItemDTO: Codable, Identifiable, Hashable {
+    var uid: String
+    var accountId: String
+    var from: String
+    var subject: String
+    var importance: Int
+    var reason: String
+    var category: String
+    var id: String { accountId + ":" + uid }
+}
+struct MailDigest: Codable {
+    var date: String
+    var total: Int
+    var unread: Int
+    var summary: String
+    var needsYou: [MailItemDTO]
+}
+struct MailDigestResponse: Codable { var digest: MailDigest? }
+struct MailAccountDTO: Codable, Identifiable, Hashable {
+    var id: String
+    var email: String
+    var provider: String
+    var enabled: Bool
+}
+struct MailAccountsResponse: Codable { var accounts: [MailAccountDTO]; var consent: Bool }
 
 // ── read-only inspection (/api/soul, /api/memory, /api/skills, /api/tools) ──
 

--- a/packaging/ios-companion/Sources/ReveView.swift
+++ b/packaging/ios-companion/Sources/ReveView.swift
@@ -14,6 +14,8 @@ struct ReveView: View {
     @State private var window = 120          // minutes
     @State private var error: String?
     @State private var loading = false
+    @State private var mailDigest: MailDigest?
+    @State private var mailAccounts = 0
 
     private let windows: [(String, Int)] = [("2h", 120), ("8h", 480), ("24h", 1440)]
 
@@ -32,6 +34,23 @@ struct ReveView: View {
                             if let desire = p.current_desire, !desire.isEmpty {
                                 Section("Current desire") {
                                     Label(desire, systemImage: "scope").font(.callout)
+                                }
+                            }
+                        }
+
+                        if mailAccounts > 0, let m = mailDigest {
+                            Section("📬 Mail · \(m.date)") {
+                                Text(m.summary).font(.callout)
+                                ForEach(m.needsYou.prefix(5)) { i in
+                                    HStack(alignment: .top, spacing: 6) {
+                                        Text(i.importance >= 3 ? "‼" : "!")
+                                            .font(.caption.bold())
+                                            .foregroundStyle(i.importance >= 3 ? .red : .orange)
+                                        VStack(alignment: .leading, spacing: 1) {
+                                            Text(i.subject.isEmpty ? "(no subject)" : i.subject).font(.callout).lineLimit(1)
+                                            Text(i.reason).font(.caption2).foregroundStyle(.secondary).lineLimit(1)
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -82,9 +101,13 @@ struct ReveView: View {
         async let pingResult = app.client.islandPing()
         async let recapResult = app.client.recap(sinceMinutes: window)
         async let advisorResult = app.client.advisorLatest()
+        async let mailDigestResult = app.client.mailDigest()
+        async let mailAccountsResult = app.client.mailAccounts()
         ping = try? await pingResult
         recap = (try? await recapResult)?.text ?? ""
         suggestions = (try? await advisorResult)?.suggestions ?? []
+        mailDigest = try? await mailDigestResult
+        mailAccounts = (try? await mailAccountsResult)?.accounts.count ?? 0
         error = nil
     }
 

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -56,6 +56,7 @@ struct SettingsView: View {
                     Toggle("Agent error", isOn: $prefs.error)
                     Toggle("Needs permission", isOn: $prefs.permission)
                     Toggle("Reve notes", isOn: $prefs.idle)
+                    Toggle("Mail digest + alerts", isOn: $prefs.mail)
                     Button("Register push") {
                         Task { @MainActor in
                             do {

--- a/src/cli/mail.ts
+++ b/src/cli/mail.ts
@@ -8,12 +8,17 @@
  *   lisa mail list             # accounts + consent state
  */
 import { createInterface } from "node:readline";
+import { createServer } from "node:http";
+import { spawn } from "node:child_process";
+import crypto from "node:crypto";
 import { grant, isGranted } from "../consent/store.js";
 import { addAccount, loadAccounts, removeAccount, setAccountEnabled } from "../mail/accounts.js";
 import { sweepAll } from "../mail/service.js";
 import { latestDigest } from "../mail/store.js";
 import { formatDigestText } from "../mail/digest.js";
 import { inferHost } from "../mail/hosts.js";
+import { buildAuthUrl, exchangeCode } from "../mail/google-oauth.js";
+import { gmailProfileEmail } from "../mail/connectors/gmail.js";
 
 function parseFlags(args: string[]): Record<string, string> {
   const out: Record<string, string> = {};
@@ -51,6 +56,69 @@ function printAccounts(): void {
   }
 }
 
+/** Gmail OAuth via the loopback "installed app" flow. */
+async function connectGmail(flags: Record<string, string>): Promise<number> {
+  const clientId = flags["client-id"] ?? process.env.LISA_GOOGLE_CLIENT_ID ?? "";
+  const clientSecret = flags["client-secret"] ?? process.env.LISA_GOOGLE_CLIENT_SECRET ?? "";
+  if (!clientId || !clientSecret) {
+    console.error("Gmail OAuth needs a Google OAuth client id + secret.");
+    console.error("One-time setup: in a Google Cloud project, enable the Gmail API and create an");
+    console.error("OAuth client of type \"Desktop app\", then:");
+    console.error("  lisa mail connect --provider gmail --client-id <id> --client-secret <secret>");
+    console.error("  (or set LISA_GOOGLE_CLIENT_ID / LISA_GOOGLE_CLIENT_SECRET)");
+    return 1;
+  }
+  const state = crypto.randomBytes(8).toString("hex");
+  let redirectUri = "";
+  console.log("Authorizing Gmail (read-only)…");
+  let code: string;
+  try {
+    code = await new Promise<string>((resolve, reject) => {
+      const server = createServer((req, res) => {
+        const u = new URL(req.url ?? "/", "http://127.0.0.1");
+        if (u.pathname !== "/oauth2callback") { res.writeHead(404); res.end(); return; }
+        const c = u.searchParams.get("code");
+        const s = u.searchParams.get("state");
+        res.writeHead(200, { "content-type": "text/html" });
+        res.end("<html><body style='font-family:sans-serif;padding:2rem'>Lisa: Gmail connected. You can close this tab.</body></html>");
+        server.close();
+        if (s !== state) reject(new Error("OAuth state mismatch"));
+        else if (!c) reject(new Error("no authorization code"));
+        else resolve(c);
+      });
+      server.on("error", reject);
+      server.listen(0, "127.0.0.1", () => {
+        const addr = server.address();
+        const port = typeof addr === "object" && addr ? addr.port : 0;
+        redirectUri = `http://127.0.0.1:${port}/oauth2callback`;
+        const url = buildAuthUrl({ clientId, redirectUri, state });
+        console.log("Opening your browser to approve read-only Gmail access.");
+        console.log("If it doesn't open, paste this URL:\n  " + url + "\n");
+        try { spawn("open", [url], { stdio: "ignore", detached: true }).unref(); } catch { /* print-only */ }
+      });
+      setTimeout(() => { try { server.close(); } catch { /* noop */ } reject(new Error("timed out waiting for authorization")); }, 300_000);
+    });
+  } catch (err) {
+    console.error("✗ " + (err as Error).message);
+    return 1;
+  }
+  try {
+    const tokens = await exchangeCode({ code, clientId, clientSecret, redirectUri });
+    const email = await gmailProfileEmail(tokens.accessToken);
+    const account = addAccount(
+      { provider: "gmail", email: email || "gmail", label: flags.label },
+      { refreshToken: tokens.refreshToken, accessToken: tokens.accessToken, expiry: tokens.expiry, clientId, clientSecret },
+    );
+    grant("mail");
+    console.log(`\n✓ connected ${email} (${account.id}, gmail). Mail consent granted.`);
+    console.log("  Run `lisa mail sweep` to read + classify now.");
+    return 0;
+  } catch (err) {
+    console.error("✗ token exchange failed: " + (err as Error).message);
+    return 1;
+  }
+}
+
 export async function runMailCommand(subargs: string[]): Promise<number> {
   const sub = subargs[0] ?? "list";
   const flags = parseFlags(subargs.slice(1));
@@ -58,6 +126,10 @@ export async function runMailCommand(subargs: string[]): Promise<number> {
   if (sub === "list" || sub === "status") {
     printAccounts();
     return 0;
+  }
+
+  if (sub === "connect" && flags.provider === "gmail") {
+    return connectGmail(flags);
   }
 
   if (sub === "connect") {

--- a/src/mail/connectors/gmail.test.ts
+++ b/src/mail/connectors/gmail.test.ts
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { GmailConnector, gmailMessageToRaw, type HttpFetch } from "./gmail.js";
+import type { MailAccount, MailSecret } from "../types.js";
+
+function ok(payload: object): { ok: boolean; status: number; text(): Promise<string> } {
+  return { ok: true, status: 200, text: async () => JSON.stringify(payload) };
+}
+function msg(id: string, subject: string, internalDate: string) {
+  return {
+    id,
+    snippet: `snip ${id}`,
+    internalDate,
+    payload: { headers: [{ name: "From", value: "Jane <jane@x.com>" }, { name: "Subject", value: subject }] },
+  };
+}
+function gmailFake(opts: { onToken?: () => void } = {}): HttpFetch {
+  return async (url) => {
+    if (url.includes("oauth2.googleapis.com/token")) { opts.onToken?.(); return ok({ access_token: "new-at", expires_in: 3600 }); }
+    if (url.includes("/messages?")) return ok({ messages: [{ id: "m1" }, { id: "m2" }] });
+    if (url.includes("/messages/m1")) return ok(msg("m1", "Older", "1000"));
+    if (url.includes("/messages/m2")) return ok(msg("m2", "Newer", "2000"));
+    if (url.includes("/profile")) return ok({ emailAddress: "me@gmail.com" });
+    return { ok: false, status: 404, text: async () => "nope" };
+  };
+}
+
+const account: MailAccount = { id: "g1", provider: "gmail", email: "me@gmail.com", addedAt: 0, enabled: true };
+
+test("gmailMessageToRaw maps headers, snippet, internalDate", () => {
+  const r = gmailMessageToRaw(msg("x", "Hi", "1234"), "acc");
+  assert.equal(r.uid, "x");
+  assert.equal(r.subject, "Hi");
+  assert.equal(r.date, 1234);
+  assert.equal(r.fromAddress, "jane@x.com");
+  assert.match(r.snippet, /snip x/);
+});
+
+test("listSince uses a valid token (no refresh) and returns newest-first", async () => {
+  const secret: MailSecret = { refreshToken: "rt", clientId: "id", clientSecret: "s", accessToken: "valid", expiry: 9_999_999_999_999 };
+  let tokenHit = false;
+  const conn = new GmailConnector(account, secret, { fetchImpl: gmailFake({ onToken: () => (tokenHit = true) }), now: () => 1000 });
+  const raws = await conn.listSince({ sinceMs: 0, limit: 10 });
+  assert.equal(tokenHit, false); // token still valid ⇒ no refresh
+  assert.equal(raws.length, 2);
+  assert.equal(raws[0].uid, "m2"); // internalDate 2000 newer than 1000
+  assert.equal(raws[0].subject, "Newer");
+});
+
+test("listSince refreshes an expired token and reports it", async () => {
+  const secret: MailSecret = { refreshToken: "rt", clientId: "id", clientSecret: "s", accessToken: "old", expiry: 500 };
+  let tokenHit = false;
+  let refreshed = false;
+  const conn = new GmailConnector(account, secret, {
+    fetchImpl: gmailFake({ onToken: () => (tokenHit = true) }),
+    onTokenRefresh: () => (refreshed = true),
+    now: () => 1000, // > expiry 500 ⇒ refresh
+  });
+  const raws = await conn.listSince({ sinceMs: 0, limit: 10 });
+  assert.equal(tokenHit, true);
+  assert.equal(refreshed, true);
+  assert.equal(raws.length, 2);
+});
+
+test("unauthorized account (no tokens) throws", async () => {
+  const conn = new GmailConnector(account, { clientId: "id" }, { fetchImpl: gmailFake() });
+  await assert.rejects(() => conn.listSince({ sinceMs: 0, limit: 10 }), /not authorized/);
+});

--- a/src/mail/connectors/gmail.ts
+++ b/src/mail/connectors/gmail.ts
@@ -1,0 +1,124 @@
+/**
+ * Gmail connector — Gmail REST API (read-only) over the OAuth access token,
+ * refreshing it when expired. format=metadata fetches headers + Gmail's native
+ * `snippet` only (never the full body) — same privacy contract as IMAP.
+ */
+import { tokenExpired, refreshAccessToken, type FetchLike, type GoogleTokens } from "../google-oauth.js";
+import type { MailAccount, MailConnector, MailSecret, RawMail } from "../types.js";
+
+const GMAIL_API = "https://gmail.googleapis.com/gmail/v1/users/me";
+
+/** Minimal fetch (optional body so GETs omit it). */
+export type HttpFetch = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body?: string },
+) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+
+interface GmailMessage {
+  id?: string;
+  snippet?: string;
+  internalDate?: string;
+  payload?: { headers?: { name?: string; value?: string }[] };
+}
+
+function header(msg: GmailMessage, name: string): string {
+  const h = msg.payload?.headers?.find((x) => (x.name ?? "").toLowerCase() === name.toLowerCase());
+  return h?.value ?? "";
+}
+
+/** Map a Gmail API message resource → RawMail. Pure. */
+export function gmailMessageToRaw(msg: GmailMessage, accountId: string): RawMail {
+  const fromRaw = header(msg, "From");
+  const m = fromRaw.match(/<([^>]+)>/);
+  const address = (m?.[1] ?? fromRaw).trim();
+  return {
+    uid: msg.id ?? "",
+    accountId,
+    from: fromRaw || address,
+    fromAddress: address,
+    subject: header(msg, "Subject"),
+    date: msg.internalDate ? Number(msg.internalDate) : Date.now(),
+    snippet: (msg.snippet ?? "").replace(/\s+/g, " ").trim().slice(0, 400),
+    flags: [],
+    mailbox: "INBOX",
+  };
+}
+
+export interface GmailDeps {
+  fetchImpl?: HttpFetch;
+  /** Persist refreshed tokens (the service wires this to setSecret). */
+  onTokenRefresh?: (t: GoogleTokens) => void;
+  now?: () => number;
+}
+
+export class GmailConnector implements MailConnector {
+  private readonly account: MailAccount;
+  private secret: MailSecret;
+  private readonly http: HttpFetch;
+  private readonly onTokenRefresh?: (t: GoogleTokens) => void;
+  private readonly now: () => number;
+
+  constructor(account: MailAccount, secret: MailSecret, deps: GmailDeps = {}) {
+    this.account = account;
+    this.secret = secret;
+    this.http = deps.fetchImpl ?? (fetch as unknown as HttpFetch);
+    this.onTokenRefresh = deps.onTokenRefresh;
+    this.now = deps.now ?? Date.now;
+  }
+
+  private async accessToken(): Promise<string> {
+    const { refreshToken, clientId, clientSecret, accessToken, expiry } = this.secret;
+    if (!refreshToken || !clientId || !clientSecret) {
+      throw new Error(`gmail account ${this.account.id} is not authorized (no OAuth tokens)`);
+    }
+    if (accessToken && expiry && !tokenExpired(expiry, this.now())) return accessToken;
+    const t = await refreshAccessToken(
+      { refreshToken, clientId, clientSecret },
+      this.http as unknown as FetchLike,
+      this.now(),
+    );
+    this.secret = { ...this.secret, accessToken: t.accessToken, expiry: t.expiry, refreshToken: t.refreshToken };
+    this.onTokenRefresh?.(t);
+    return t.accessToken;
+  }
+
+  private async api<T>(url: string, token: string): Promise<T> {
+    const res = await this.http(url, { method: "GET", headers: { authorization: `Bearer ${token}` } });
+    const text = await res.text();
+    if (!res.ok) throw new Error(`gmail api ${res.status}: ${text.slice(0, 200)}`);
+    return JSON.parse(text) as T;
+  }
+
+  async listSince(opts: { sinceMs: number; limit: number }): Promise<RawMail[]> {
+    const token = await this.accessToken();
+    const d = new Date(opts.sinceMs);
+    const q = `after:${d.getFullYear()}/${d.getMonth() + 1}/${d.getDate()} in:inbox`;
+    const list = await this.api<{ messages?: { id?: string }[] }>(
+      `${GMAIL_API}/messages?maxResults=${opts.limit}&q=${encodeURIComponent(q)}`,
+      token,
+    );
+    const ids = (list.messages ?? []).map((m) => m.id).filter((x): x is string => !!x);
+    const out: RawMail[] = [];
+    for (const id of ids) {
+      const msg = await this.api<GmailMessage>(
+        `${GMAIL_API}/messages/${id}?format=metadata&metadataHeaders=From&metadataHeaders=Subject&metadataHeaders=Date`,
+        token,
+      );
+      out.push(gmailMessageToRaw(msg, this.account.id));
+    }
+    out.sort((a, b) => b.date - a.date);
+    return out;
+  }
+
+  async close(): Promise<void> {
+    /* stateless (HTTP) */
+  }
+}
+
+/** Fetch the authorized account's email address (users/me/profile). */
+export async function gmailProfileEmail(token: string, fetchImpl: HttpFetch = fetch as unknown as HttpFetch): Promise<string> {
+  const res = await fetchImpl(`${GMAIL_API}/profile`, { method: "GET", headers: { authorization: `Bearer ${token}` } });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`gmail profile ${res.status}`);
+  return String((JSON.parse(text) as { emailAddress?: string }).emailAddress ?? "");
+}

--- a/src/mail/google-oauth.test.ts
+++ b/src/mail/google-oauth.test.ts
@@ -1,0 +1,54 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildAuthUrl, tokenExpired, exchangeCode, refreshAccessToken, GMAIL_SCOPE, type FetchLike } from "./google-oauth.js";
+
+function jsonFetch(payload: object, ok = true, status = 200): FetchLike {
+  return async () => ({ ok, status, text: async () => JSON.stringify(payload) });
+}
+
+test("buildAuthUrl carries scope, offline access, redirect + state", () => {
+  const url = buildAuthUrl({ clientId: "cid", redirectUri: "http://127.0.0.1:9/cb", state: "xyz" });
+  assert.match(url, /accounts\.google\.com/);
+  assert.ok(url.includes("client_id=cid"));
+  assert.ok(url.includes("access_type=offline"));
+  assert.ok(url.includes("state=xyz"));
+  assert.ok(url.includes(encodeURIComponent(GMAIL_SCOPE)));
+  assert.ok(url.includes(encodeURIComponent("http://127.0.0.1:9/cb")));
+});
+
+test("tokenExpired honors a 60s skew", () => {
+  // effective expiry = expiry - 60s
+  assert.equal(tokenExpired(100_000, 10_000), false); // 10s ≪ 40s effective expiry
+  assert.equal(tokenExpired(100_000, 39_000), false); // just before the skew window
+  assert.equal(tokenExpired(100_000, 50_000), true); // inside the 60s skew ⇒ refresh
+  assert.equal(tokenExpired(100_000, 100_000), true); // at/after expiry
+});
+
+test("exchangeCode parses tokens + computes absolute expiry", async () => {
+  const t = await exchangeCode(
+    { code: "c", clientId: "id", clientSecret: "s", redirectUri: "r" },
+    jsonFetch({ access_token: "at", refresh_token: "rt", expires_in: 3600 }),
+    1_000,
+  );
+  assert.equal(t.accessToken, "at");
+  assert.equal(t.refreshToken, "rt");
+  assert.equal(t.expiry, 1_000 + 3600_000);
+});
+
+test("refreshAccessToken reuses the existing refresh token when none returned", async () => {
+  const t = await refreshAccessToken(
+    { refreshToken: "old-rt", clientId: "id", clientSecret: "s" },
+    jsonFetch({ access_token: "at2", expires_in: 1800 }),
+    2_000,
+  );
+  assert.equal(t.accessToken, "at2");
+  assert.equal(t.refreshToken, "old-rt");
+  assert.equal(t.expiry, 2_000 + 1800_000);
+});
+
+test("token endpoint error throws", async () => {
+  await assert.rejects(
+    () => exchangeCode({ code: "c", clientId: "i", clientSecret: "s", redirectUri: "r" }, jsonFetch({ error: "bad" }, false, 400)),
+    /google token endpoint 400/,
+  );
+});

--- a/src/mail/google-oauth.ts
+++ b/src/mail/google-oauth.ts
@@ -1,0 +1,106 @@
+/**
+ * Google OAuth2 for Gmail (read-only) — no SDK, just fetch + the documented
+ * token endpoints. Used by the loopback "installed app" flow (CLI) and by the
+ * Gmail connector's token refresh.
+ *
+ * Setup the user does once: create an OAuth client (type "Desktop app") in a
+ * Google Cloud project, enable the Gmail API, and provide the client id/secret
+ * (LISA_GOOGLE_CLIENT_ID / _SECRET, or --client-id/--client-secret). Tokens are
+ * stored per-account in the 0600 secrets file; only the gmail.readonly scope is
+ * requested.
+ */
+export const GMAIL_SCOPE = "https://www.googleapis.com/auth/gmail.readonly";
+const AUTH_BASE = "https://accounts.google.com/o/oauth2/v2/auth";
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+export interface GoogleTokens {
+  accessToken: string;
+  /** Present on the initial exchange (access_type=offline); absent on refresh. */
+  refreshToken?: string;
+  /** Absolute expiry, epoch ms. */
+  expiry: number;
+}
+
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string },
+) => Promise<{ ok: boolean; status: number; text(): Promise<string> }>;
+
+/** Build the consent URL. Pure. */
+export function buildAuthUrl(o: { clientId: string; redirectUri: string; state: string }): string {
+  const q = new URLSearchParams({
+    client_id: o.clientId,
+    redirect_uri: o.redirectUri,
+    response_type: "code",
+    scope: GMAIL_SCOPE,
+    access_type: "offline",
+    prompt: "consent", // force a refresh_token even on re-auth
+    state: o.state,
+  });
+  return `${AUTH_BASE}?${q.toString()}`;
+}
+
+/** True if the access token is expired (60s skew). Pure. */
+export function tokenExpired(expiry: number, now: number): boolean {
+  return now >= expiry - 60_000;
+}
+
+function parseTokens(json: Record<string, unknown>, now: number): GoogleTokens {
+  const accessToken = String(json.access_token ?? "");
+  if (!accessToken) throw new Error("no access_token in token response");
+  const ttl = typeof json.expires_in === "number" ? json.expires_in : 3600;
+  return {
+    accessToken,
+    refreshToken: typeof json.refresh_token === "string" ? json.refresh_token : undefined,
+    expiry: now + ttl * 1000,
+  };
+}
+
+async function postToken(body: URLSearchParams, fetchImpl: FetchLike, now: number): Promise<GoogleTokens> {
+  const res = await fetchImpl(TOKEN_URL, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+    body: body.toString(),
+  });
+  const text = await res.text();
+  if (!res.ok) throw new Error(`google token endpoint ${res.status}: ${text.slice(0, 200)}`);
+  return parseTokens(JSON.parse(text) as Record<string, unknown>, now);
+}
+
+/** Exchange an auth code for tokens. */
+export async function exchangeCode(
+  o: { code: string; clientId: string; clientSecret: string; redirectUri: string },
+  fetchImpl: FetchLike = fetch as unknown as FetchLike,
+  now: number = Date.now(),
+): Promise<GoogleTokens> {
+  return postToken(
+    new URLSearchParams({
+      code: o.code,
+      client_id: o.clientId,
+      client_secret: o.clientSecret,
+      redirect_uri: o.redirectUri,
+      grant_type: "authorization_code",
+    }),
+    fetchImpl,
+    now,
+  );
+}
+
+/** Refresh an access token (refresh_token is reused, not returned). */
+export async function refreshAccessToken(
+  o: { refreshToken: string; clientId: string; clientSecret: string },
+  fetchImpl: FetchLike = fetch as unknown as FetchLike,
+  now: number = Date.now(),
+): Promise<GoogleTokens> {
+  const t = await postToken(
+    new URLSearchParams({
+      refresh_token: o.refreshToken,
+      client_id: o.clientId,
+      client_secret: o.clientSecret,
+      grant_type: "refresh_token",
+    }),
+    fetchImpl,
+    now,
+  );
+  return { ...t, refreshToken: t.refreshToken ?? o.refreshToken };
+}

--- a/src/mail/service.ts
+++ b/src/mail/service.ts
@@ -7,11 +7,12 @@
  * unit-testable without a real mailbox or a live model.
  */
 import { isGranted } from "../consent/store.js";
-import { loadAccounts, getSecret, markSwept } from "./accounts.js";
+import { loadAccounts, getSecret, markSwept, setSecret } from "./accounts.js";
 import { classifyMail } from "./classify.js";
 import { buildDigest } from "./digest.js";
 import { saveDigest, loadSeen, markSeen } from "./store.js";
 import { ImapConnector } from "./connectors/imap.js";
+import { GmailConnector } from "./connectors/gmail.js";
 import type { Provider } from "../providers/types.js";
 import type { DailyDigest, MailAccount, MailConnector, MailItem, MailSecret } from "./types.js";
 
@@ -19,7 +20,10 @@ export type ConnectorFactory = (account: MailAccount, secret: MailSecret) => Mai
 
 function defaultConnector(account: MailAccount, secret: MailSecret): MailConnector {
   if (account.provider === "imap") return new ImapConnector(account, secret);
-  if (account.provider === "gmail") throw new Error("gmail connector not available yet (M4)");
+  if (account.provider === "gmail") {
+    // Persist refreshed access tokens back to the 0600 secrets file.
+    return new GmailConnector(account, secret, { onTokenRefresh: (t) => setSecret(account.id, t) });
+  }
   throw new Error(`unknown mail provider: ${account.provider}`);
 }
 


### PR DESCRIPTION
## What
Completes req #1 (**Gmail via proper OAuth**, not an app-password) and adds a phone surface.

**Gmail** (no new deps — raw `fetch` + a loopback callback):
- `google-oauth.ts` — `buildAuthUrl` / `exchangeCode` / `refreshAccessToken` / `tokenExpired` (scope `gmail.readonly`, offline access).
- `connectors/gmail.ts` — `GmailConnector` over the Gmail REST API: `format=metadata` fetches headers + Gmail's native **`snippet` only** (never the body); auto-refreshes the access token (persisted to the 0600 secrets file).
- `service` wires `provider:"gmail"` → `GmailConnector`. CLI `lisa mail connect --provider gmail` runs the **loopback OAuth flow** (local callback + opens the browser). Needs a Google "Desktop app" client (`LISA_GOOGLE_CLIENT_ID/_SECRET`).

**iOS (Lisa Pocket):**
- `LisaClient.mailDigest()/mailAccounts()`; models gain `MailDigest`/`MailItemDTO` + `PushPrefs.mail`.
- **ReveView** shows a "📬 Mail" section (summary + needs-you) when a mailbox is connected; **Settings** gets a "Mail digest + alerts" toggle.

## Verification
**37 mail tests** (oauth url/expiry/exchange/refresh + gmail map/list/refresh/unauthorized via injected fetch). **861 TS / 1 skip**; typecheck + build clean; iOS `xcodebuild -sdk iphonesimulator` **BUILD SUCCEEDED**.

This completes the mail module (M1–M4): connect IMAP/Gmail/QQ → daily classified digest (push + chat) → important-mail proactive alerts, across CLI / web / Mac / iOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)