### PR TITLE
feat(ui): agent operations console — clients + web redesign

### DIFF
--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -28,6 +28,10 @@ struct RootView: View {
             SettingsView()
                 .tabItem { Label("Settings", systemImage: "gearshape") }.tag(4)
         }
+        .tint(Theme.accent)                                  // cyan active tab + links + controls
+        .preferredColorScheme(.dark)                         // force the console dark look
+        .toolbarBackground(Theme.panel, for: .tabBar)
+        .toolbarBackground(.visible, for: .tabBar)
         .onOpenURL { app.handleDeepLink($0) }
         .overlay { if app.locked { LockView() } }
         .onChange(of: scenePhase) { _, phase in

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -149,4 +149,37 @@ final class AppState: ObservableObject {
             locked = false
         }
     }
+
+    // ── proactive mode (autonomy on/off), mirrored from /api/autonomy/state ──
+    /// Whether Lisa self-drives (idle + heartbeat) when you're away.
+    @Published var proactiveEnabled = true
+    /// Disables the toggle mid-flight so a double-tap can't race.
+    @Published var proactiveBusy = false
+    /// False when the Mac is too old to expose /api/autonomy/state (404) — the
+    /// toggle then renders disabled rather than lying about a state it can't set.
+    @Published var proactiveAvailable = true
+
+    func loadProactive() async {
+        do {
+            proactiveEnabled = try await client.autonomyState()
+            proactiveAvailable = true
+        } catch LisaError.http(404) {
+            proactiveAvailable = false
+        } catch {
+            // transient (offline / timeout) — keep the last-known state, don't flip the UI
+        }
+    }
+
+    /// Optimistic flip with rollback on failure (mirrors how fire() actions behave).
+    func setProactive(_ on: Bool) {
+        guard !proactiveBusy else { return }
+        let previous = proactiveEnabled
+        proactiveEnabled = on
+        proactiveBusy = true
+        Task { @MainActor in
+            defer { proactiveBusy = false }
+            do { try await client.setAutonomyState(on) }
+            catch { proactiveEnabled = previous }
+        }
+    }
 }

--- a/packaging/ios-companion/Sources/ChatView.swift
+++ b/packaging/ios-companion/Sources/ChatView.swift
@@ -65,6 +65,7 @@ struct ChatView: View {
                     Text(model.transcript.isEmpty ? "Say hi to Lisa." : model.transcript)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
+                        .foregroundStyle(Theme.text)
                         .padding()
                 }
                 Divider()
@@ -82,6 +83,7 @@ struct ChatView: View {
                 }
                 .padding()
             }
+            .background(Theme.bgDeep.ignoresSafeArea())
             .navigationTitle("Chat")
             .task(id: app.config) { model.startMood(app.client) }
             .onDisappear { model.stopMood() }
@@ -149,13 +151,13 @@ struct MoodChip: View {
     }
     private var color: Color {
         switch mood.lowercased() {
-        case "happy", "content", "joyful", "playful": return .green
-        case "curious", "intrigued", "awe", "wonder": return .blue
-        case "proud": return .yellow
-        case "weary", "tired": return .gray
-        case "frustrated", "annoyed": return .red
+        case "happy", "content", "joyful", "playful": return Theme.green
+        case "curious", "intrigued", "awe", "wonder": return Theme.accent
+        case "proud": return Theme.gold
+        case "weary", "tired": return Theme.idle
+        case "frustrated", "annoyed": return Theme.danger
         case "affectionate", "warm": return .pink
-        default: return .secondary
+        default: return Theme.secondary
         }
     }
 }

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -89,6 +89,10 @@ final class LisaClient {
     func islandPing() async throws -> IslandPing { try await decode("/api/island/ping", as: IslandPing.self) }
     func controlPolicy() async throws -> ControlPolicy { try await decode("/api/control/policy", as: ControlPolicy.self) }
 
+    // ── proactive mode (autonomy on/off) ──
+    func autonomyState() async throws -> Bool { try await decode("/api/autonomy/state", as: AutonomyState.self).enabled }
+    func setAutonomyState(_ enabled: Bool) async throws { try await fire("/api/autonomy/state", json: ["enabled": enabled]) }
+
     // ── read: inspection ──
     func soul() async throws -> SoulResponse { try await decode("/api/soul", as: SoulResponse.self) }
     func memory() async throws -> MemoryResponse { try await decode("/api/memory", as: MemoryResponse.self) }

--- a/packaging/ios-companion/Sources/Models.swift
+++ b/packaging/ios-companion/Sources/Models.swift
@@ -123,6 +123,11 @@ struct ControlPolicy: Codable, Equatable {
     var remoteAdoptExternal: Bool
 }
 
+/// /api/autonomy/state — the "Proactive mode" master switch (idle + heartbeat).
+struct AutonomyState: Codable, Equatable {
+    var enabled: Bool
+}
+
 struct PushPrefs: Codable, Equatable {
     var done: Bool = true
     var error: Bool = true

--- a/packaging/ios-companion/Sources/ReveView.swift
+++ b/packaging/ios-companion/Sources/ReveView.swift
@@ -68,6 +68,7 @@ struct ReveView: View {
                     }
                 }
             }
+            .consoleBackground()
             .navigationTitle("Reve")
             .refreshable { await load() }
             .task(id: ReveLoadKey(window: window, configured: app.config.isConfigured)) { await load() }

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -96,13 +96,13 @@ func sortRows(_ rows: [AgentSession]) -> [AgentSession] {
 }
 
 func stateColor(_ s: AgentSession) -> Color {
-    if s.activity?.pendingPermission != nil { return .orange }
+    if s.activity?.pendingPermission != nil { return Theme.waiting }
     switch s.state {
-    case "working": return .blue
-    case "waiting": return .yellow
-    case "error": return .red
-    case "done": return .green
-    default: return .gray
+    case "working": return Theme.working
+    case "waiting": return Theme.waiting
+    case "error": return Theme.danger
+    case "done": return Theme.done
+    default: return Theme.idle
     }
 }
 
@@ -115,22 +115,31 @@ struct RosterView: View {
 
     var body: some View {
         NavigationStack(path: $path) {
-            Group {
-                if !app.config.isConfigured {
-                    ContentUnavailableView("Not paired", systemImage: "wifi.slash",
-                                           description: Text("Add your Mac in Settings."))
-                } else if let err = model.error, model.sessions.isEmpty {
-                    ContentUnavailableView("Can't reach Lisa", systemImage: "exclamationmark.triangle",
-                                           description: Text(err))
-                } else if model.sessions.isEmpty {
-                    ContentUnavailableView("No agents", systemImage: "moon.zzz",
-                                           description: Text("Nothing running right now."))
-                } else {
-                    List(model.sessions) { session in
-                        NavigationLink(value: session) { RosterRow(session: session) }
+            VStack(spacing: 0) {
+                if app.config.isConfigured {
+                    ProactiveBanner()
+                    StatStrip(counts: rosterCounts(model.sessions))
+                }
+                Group {
+                    if !app.config.isConfigured {
+                        ContentUnavailableView("Not paired", systemImage: "wifi.slash",
+                                               description: Text("Add your Mac in Settings."))
+                    } else if let err = model.error, model.sessions.isEmpty {
+                        ContentUnavailableView("Can't reach Lisa", systemImage: "exclamationmark.triangle",
+                                               description: Text(err))
+                    } else if model.sessions.isEmpty {
+                        ContentUnavailableView("No agents", systemImage: "moon.zzz",
+                                               description: Text("Nothing running right now."))
+                    } else {
+                        List(model.sessions) { session in
+                            NavigationLink(value: session) { RosterRow(session: session) }
+                                .listRowBackground(Theme.card)
+                        }
+                        .consoleBackground()
                     }
                 }
             }
+            .background(Theme.bgDeep.ignoresSafeArea())
             .navigationTitle("Dispatch")
             .navigationDestination(for: AgentSession.self) { SessionDetailView(session: $0) }
             .toolbar {
@@ -151,6 +160,7 @@ struct RosterView: View {
             .refreshable { await model.load(app.client) }
             .task(id: app.config) {
                 await model.load(app.client)
+                await app.loadProactive()
                 resolvePending()
                 model.startStream(app.client)
             }
@@ -159,7 +169,7 @@ struct RosterView: View {
                 // full resync and reconnect so the roster is correct + live again.
                 // Skip while the Face ID lock is up — don't fetch behind the gate.
                 guard phase == .active, app.config.isConfigured, !app.locked else { return }
-                Task { await model.load(app.client); model.startStream(app.client) }
+                Task { await model.load(app.client); await app.loadProactive(); model.startStream(app.client) }
             }
             // Deep-link (push Click / widget): open the requested session once it's
             // in the roster — handle either arrival order (link before/after load).
@@ -183,22 +193,22 @@ struct RosterRow: View {
     let session: AgentSession
     var body: some View {
         HStack(spacing: 10) {
-            Circle().fill(stateColor(session)).frame(width: 10, height: 10)
+            StatusDot(color: stateColor(session))
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
-                    Text(session.project).font(.headline).lineLimit(1)
-                    Text(session.agent).font(.caption2).foregroundStyle(.secondary)
+                    Text(session.project).font(.headline).foregroundStyle(Theme.text).lineLimit(1)
+                    Text(session.agent).font(.caption2).foregroundStyle(Theme.secondary)
                     if let c = session.controllable {
-                        Pill(text: c, color: .blue)
+                        ThemePill(text: c, color: Theme.accent)
                     } else if session.resumable == true {
-                        Pill(text: "resumable", color: .orange)
+                        ThemePill(text: "resumable", color: Theme.waiting)
                     }
                 }
-                Text(subtitle).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                Text(subtitle).font(.caption).foregroundStyle(Theme.secondary).lineLimit(1)
             }
             Spacer()
             if session.activity?.pendingPermission != nil {
-                Image(systemName: "exclamationmark.shield.fill").foregroundStyle(.orange)
+                Image(systemName: "exclamationmark.shield.fill").foregroundStyle(Theme.waiting)
             }
         }
         .padding(.vertical, 2)
@@ -224,6 +234,45 @@ struct Pill: View {
             .background(color.opacity(0.15))
             .foregroundStyle(color)
             .clipShape(Capsule())
+    }
+}
+
+/// Green "Proactive mode" banner at the top of Dispatch — echoes the web app's
+/// proactive panel. The toggle controls real autonomy via /api/autonomy/state.
+struct ProactiveBanner: View {
+    @EnvironmentObject var app: AppState
+    var body: some View {
+        HStack(spacing: 12) {
+            StatusDot(color: app.proactiveEnabled ? Theme.green : Theme.idle, size: 11)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Proactive").font(.subheadline.weight(.medium)).foregroundStyle(Theme.text)
+                Text(app.proactiveEnabled ? "Lisa acts on her own when idle" : "Lisa waits for you")
+                    .font(.caption).foregroundStyle(Theme.secondary)
+            }
+            Spacer()
+            Toggle("", isOn: Binding(get: { app.proactiveEnabled }, set: { app.setProactive($0) }))
+                .labelsHidden()
+                .tint(Theme.green)
+                .disabled(app.proactiveBusy || !app.proactiveAvailable)
+        }
+        .padding(14)
+        .background(Theme.green.opacity(0.10), in: RoundedRectangle(cornerRadius: Theme.cardRadius))
+        .overlay(RoundedRectangle(cornerRadius: Theme.cardRadius).strokeBorder(Theme.green.opacity(0.35), lineWidth: Theme.hairline))
+        .padding(.horizontal).padding(.top, 8).padding(.bottom, 4)
+    }
+}
+
+/// Agents · Working · Needs-you stat strip — counts derived from the already-loaded
+/// roster via the pure `rosterCounts` helper (no extra network call).
+struct StatStrip: View {
+    let counts: AgentSnapshot
+    var body: some View {
+        HStack(spacing: 10) {
+            StatCell(value: counts.total, label: "Agents", tint: Theme.accent)
+            StatCell(value: counts.working, label: "Working", tint: Theme.green)
+            StatCell(value: counts.waiting, label: "Needs you", tint: Theme.waiting)
+        }
+        .padding(.horizontal).padding(.bottom, 8)
     }
 }
 

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -224,19 +224,6 @@ struct RosterRow: View {
     }
 }
 
-struct Pill: View {
-    let text: String
-    let color: Color
-    var body: some View {
-        Text(text)
-            .font(.caption2)
-            .padding(.horizontal, 6).padding(.vertical, 1)
-            .background(color.opacity(0.15))
-            .foregroundStyle(color)
-            .clipShape(Capsule())
-    }
-}
-
 /// Green "Proactive mode" banner at the top of Dispatch — echoes the web app's
 /// proactive panel. The toggle controls real autonomy via /api/autonomy/state.
 struct ProactiveBanner: View {

--- a/packaging/ios-companion/Sources/SenseView.swift
+++ b/packaging/ios-companion/Sources/SenseView.swift
@@ -64,6 +64,7 @@ struct SenseView: View {
                     }
                 }
             }
+            .consoleBackground()
             .navigationTitle("Sense")
             .refreshable { await load() }
             .task(id: app.config) { await load() }

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -88,6 +88,18 @@ struct SettingsView: View {
                     Text("Change these on the Mac (localhost only).").font(.caption).foregroundStyle(.secondary)
                 }
 
+                Section("Autonomy") {
+                    Toggle("Proactive mode", isOn: Binding(
+                        get: { app.proactiveEnabled },
+                        set: { app.setProactive($0) }))
+                        .tint(Theme.green)
+                        .disabled(app.proactiveBusy || !app.proactiveAvailable)
+                    Text(app.proactiveAvailable
+                         ? "When on, Lisa reflects and pursues her desires while you're away (idle + heartbeat). Off means she only acts when you talk to her."
+                         : "This Mac doesn't expose autonomy control yet — update Lisa to toggle it from here.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
                 Section {
                     NavigationLink { DevicesView() } label: { Label("Paired devices", systemImage: "iphone.gen3") }
                 }
@@ -115,9 +127,10 @@ struct SettingsView: View {
                     Section { Text(status).font(.caption).foregroundStyle(.secondary) }
                 }
             }
+            .consoleBackground()
             .navigationTitle("Settings")
             .onAppear(perform: syncFromConfig)
-            .task { policy = try? await app.client.controlPolicy() }
+            .task { policy = try? await app.client.controlPolicy(); await app.loadProactive() }
             .sheet(isPresented: $showScanner) {
                 QRScanSheet(onScanned: handleScan, onError: { status = $0 })
             }

--- a/packaging/ios-companion/Sources/Theme.swift
+++ b/packaging/ios-companion/Sources/Theme.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+/// Agent-console palette — mirrors the web shell tokens (src/web/lisa-css.ts):
+/// cyan accent, gold Lisa identity, green "proactive / live", dark card UI.
+/// Defined once so views reference `Theme.*` instead of ad-hoc semantic colors.
+enum Theme {
+    // Surfaces
+    static let bgDeep = Color(hex: 0x0A0E22)   // app background
+    static let panel  = Color(hex: 0x0F1430)   // tab/nav bars, grouped lists
+    static let card   = Color(hex: 0x161C3C)   // rows, cards, banners
+    static let border = Color.white.opacity(0.08)
+
+    // Text
+    static let text      = Color(hex: 0xE8EAFF)
+    static let secondary = Color(hex: 0x9AA3C8)
+    static let tertiary  = Color(hex: 0x6B7299)
+
+    // Identity / accents
+    static let accent = Color(hex: 0x6AD4FF)   // cyan — nav / active / links
+    static let gold   = Color(hex: 0xFFD066)   // Lisa identity
+    static let green  = Color(hex: 0x3DDC97)   // proactive / live / done
+
+    // Status pips (mirror the web .pip / .ac-status colors)
+    static let working = Color(hex: 0x5B9DFF)
+    static let waiting = Color(hex: 0xFFB84D)
+    static let danger  = Color(hex: 0xFF5D73)
+    static let done    = green
+    static let idle    = Color(hex: 0x6B7299)
+
+    static let cardRadius: CGFloat = 12
+    static let hairline: CGFloat = 0.5
+}
+
+extension Color {
+    /// 0xRRGGBB initializer so tokens read as the hex in the design spec.
+    init(hex: UInt32) {
+        self.init(.sRGB,
+                  red:   Double((hex >> 16) & 0xFF) / 255,
+                  green: Double((hex >> 8) & 0xFF) / 255,
+                  blue:  Double(hex & 0xFF) / 255,
+                  opacity: 1)
+    }
+}
+
+// ── reusable console components ──────────────────────────────────────
+
+/// Rounded console card: card fill + hairline border + padding.
+struct ConsoleCard: ViewModifier {
+    var padding: CGFloat = 14
+    func body(content: Content) -> some View {
+        content
+            .padding(padding)
+            .background(Theme.card, in: RoundedRectangle(cornerRadius: Theme.cardRadius))
+            .overlay(RoundedRectangle(cornerRadius: Theme.cardRadius).strokeBorder(Theme.border, lineWidth: Theme.hairline))
+    }
+}
+
+extension View {
+    func consoleCard(padding: CGFloat = 14) -> some View { modifier(ConsoleCard(padding: padding)) }
+
+    /// Dark console canvas for a List / Form / ScrollView screen — clears the
+    /// default grouped background and drops the deep app background behind it.
+    func consoleBackground() -> some View {
+        self.scrollContentBackground(.hidden).background(Theme.bgDeep.ignoresSafeArea())
+    }
+}
+
+/// Status pip — replaces the hand-rolled `Circle().fill(stateColor(...))` dots.
+struct StatusDot: View {
+    let color: Color
+    var size: CGFloat = 10
+    var body: some View {
+        Circle().fill(color).frame(width: size, height: size)
+    }
+}
+
+/// Themed capsule pill — same call shape as the old `Pill` (text + color).
+struct ThemePill: View {
+    let text: String
+    var color: Color = Theme.accent
+    var body: some View {
+        Text(text)
+            .font(.caption2.weight(.medium))
+            .padding(.horizontal, 7).padding(.vertical, 2)
+            .background(color.opacity(0.16), in: Capsule())
+            .foregroundStyle(color)
+            .overlay(Capsule().strokeBorder(color.opacity(0.3), lineWidth: Theme.hairline))
+    }
+}
+
+/// One stat cell in the Dispatch stat strip (count above, label below).
+struct StatCell: View {
+    let value: Int
+    let label: String
+    var tint: Color = Theme.accent
+    var body: some View {
+        VStack(spacing: 2) {
+            Text("\(value)").font(.title3.weight(.medium)).foregroundStyle(tint)
+            Text(label).font(.caption2).foregroundStyle(Theme.tertiary)
+        }
+        .frame(maxWidth: .infinity)
+        .consoleCard(padding: 10)
+    }
+}

--- a/src/autonomy/state.test.ts
+++ b/src/autonomy/state.test.ts
@@ -1,0 +1,46 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-autonomy-"));
+process.env.LISA_HOME = TMP;
+const FILE = path.join(TMP, "autonomy", "state.json");
+
+const { loadAutonomyState, getAutonomyEnabled, setAutonomyEnabled, normalizeAutonomyState } =
+  await import("./state.js");
+
+beforeEach(() => {
+  fs.rmSync(FILE, { force: true });
+});
+
+describe("autonomy state", () => {
+  test("defaults to enabled when no file exists (preserves always-on behavior)", () => {
+    assert.equal(getAutonomyEnabled(), true);
+    assert.deepEqual(loadAutonomyState(), { enabled: true });
+  });
+
+  test("set → load round-trips and persists to autonomy/state.json", () => {
+    setAutonomyEnabled(false);
+    assert.equal(getAutonomyEnabled(), false);
+    assert.deepEqual(loadAutonomyState(), { enabled: false });
+    assert.equal(JSON.parse(fs.readFileSync(FILE, "utf8")).enabled, false);
+
+    setAutonomyEnabled(true);
+    assert.equal(getAutonomyEnabled(), true);
+  });
+
+  test("normalize coerces missing / ill-typed to the default (enabled)", () => {
+    assert.deepEqual(normalizeAutonomyState(null), { enabled: true });
+    assert.deepEqual(normalizeAutonomyState({}), { enabled: true });
+    assert.deepEqual(normalizeAutonomyState({ enabled: "no" as unknown as boolean }), { enabled: true });
+    assert.deepEqual(normalizeAutonomyState({ enabled: false }), { enabled: false });
+  });
+
+  test("tolerates a corrupt file → falls back to default", () => {
+    fs.mkdirSync(path.dirname(FILE), { recursive: true });
+    fs.writeFileSync(FILE, "{not json");
+    assert.deepEqual(loadAutonomyState(), { enabled: true });
+  });
+});

--- a/src/autonomy/state.ts
+++ b/src/autonomy/state.ts
@@ -1,0 +1,63 @@
+/**
+ * Autonomy on/off — the "Proactive mode" master switch.
+ *
+ * When disabled, LISA's unattended self-driven runs (idle reflection and the
+ * heartbeat) no-op: she only acts in response to direct user input. The web
+ * GUI and the iOS companion surface this as the "Proactive" toggle via
+ * GET/POST /api/autonomy/state.
+ *
+ * Persisted to ~/.lisa/autonomy/state.json (alongside the run ledger
+ * runs.jsonl). Default enabled = true, preserving the historical always-on
+ * autonomy behavior. Shape + tolerance mirror control/policy.ts.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { LISA_HOME } from "../paths.js";
+
+export interface AutonomyState {
+  /** Whether unattended self-driven runs (idle + heartbeat) are allowed. */
+  enabled: boolean;
+}
+
+export function defaultAutonomyState(): AutonomyState {
+  return { enabled: true };
+}
+
+/** Coerce an arbitrary object into a valid AutonomyState (default for missing/ill-typed). Pure. */
+export function normalizeAutonomyState(s: Partial<AutonomyState> | null | undefined): AutonomyState {
+  const base = defaultAutonomyState();
+  if (!s || typeof s !== "object") return base;
+  return { enabled: typeof s.enabled === "boolean" ? s.enabled : base.enabled };
+}
+
+/** Resolved lazily so tests can point LISA_HOME at a tmp dir. */
+function statePath(): string {
+  return path.join(LISA_HOME, "autonomy", "state.json");
+}
+
+/** Read the state, merged over defaults; tolerant of a missing/corrupt file. */
+export function loadAutonomyState(): AutonomyState {
+  try {
+    const raw = fs.readFileSync(statePath(), "utf8");
+    return normalizeAutonomyState(JSON.parse(raw) as Partial<AutonomyState>);
+  } catch {
+    return defaultAutonomyState();
+  }
+}
+
+export function saveAutonomyState(s: Partial<AutonomyState>): AutonomyState {
+  const next = normalizeAutonomyState(s);
+  const file = statePath();
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(file, JSON.stringify(next, null, 2));
+  return next;
+}
+
+/** Convenience for the autonomy runners: is unattended self-driving allowed right now? */
+export function getAutonomyEnabled(): boolean {
+  return loadAutonomyState().enabled;
+}
+
+export function setAutonomyEnabled(enabled: boolean): AutonomyState {
+  return saveAutonomyState({ enabled });
+}

--- a/src/heartbeat/runner.ts
+++ b/src/heartbeat/runner.ts
@@ -12,6 +12,7 @@ import {
 } from "../soul/store.js";
 import { withSoulCaller } from "../soul/git.js";
 import { withFileLock } from "../soul/lock.js";
+import { getAutonomyEnabled } from "../autonomy/state.js";
 import { autonomousSubset } from "../tools/registry.js";
 import { runSubagent } from "../subagent.js";
 import { recordAutonomyRun, type AutonomyKind } from "../autonomy/runs.js";
@@ -52,6 +53,13 @@ export async function runHeartbeatOnce(opts: {
   model: string;
   taskFilter?: string;
 }): Promise<HeartbeatRunResult[]> {
+  // Proactive-mode master switch (web/iOS "Proactive" toggle → ~/.lisa/autonomy/
+  // state.json). When autonomy is off, the heartbeat no-ops entirely — no
+  // scheduled dispatches, desires, or chores run unattended until it's back on.
+  if (!getAutonomyEnabled()) {
+    console.error("[heartbeat] proactive mode is off — skipping this tick");
+    return [];
+  }
   // Run-level lock: if launchd/cron fires a new heartbeat while the previous
   // one is still running (long desires + short interval), skip rather than
   // double-run and race on soul state. timeoutMs:0 → fail fast, don't wait.

--- a/src/idle/runner.ts
+++ b/src/idle/runner.ts
@@ -4,6 +4,7 @@ import { withFileLock } from "../soul/lock.js";
 import { autonomousSubset } from "../tools/registry.js";
 import { runSubagent } from "../subagent.js";
 import { recordAutonomyRun, type AutonomyOutcome } from "../autonomy/runs.js";
+import { getAutonomyEnabled } from "../autonomy/state.js";
 import type { ToolDefinition } from "../types.js";
 
 const IDLE_RUN_LOCK = path.join(LISA_HOME, "idle.lock");
@@ -95,6 +96,12 @@ export async function runIdleOnce(opts: {
   model: string;
   idleMs: number;
 }): Promise<IdleRunResult> {
+  // Proactive-mode master switch (web/iOS "Proactive" toggle → ~/.lisa/autonomy/
+  // state.json). When autonomy is off, idle reflection no-ops: Lisa only acts on
+  // direct user input. The watcher keeps ticking, so flipping it back on resumes.
+  if (!getAutonomyEnabled()) {
+    return { text: "", silent: true, iterations: 0, inputTokens: 0, outputTokens: 0 };
+  }
   const idleMin = Math.round(opts.idleMs / 60_000);
   // Cross-process run-lock (mirrors heartbeat's RUN_LOCK): a web-server idle
   // tick and a REPL idle tick — or two web servers — must not reflect

--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -34,6 +34,7 @@ export const ISLAND_HTML = `<!doctype html>
     --accent-warm: #ffd066;
     --accent-dream: #b487ff;
     --accent-claude: #ff8c42;
+    --accent-proactive: #3ddc97;
     --border: rgba(255, 255, 255, 0.08);
     /* 1px top inner highlight that reads as a glass bevel */
     --hairline: rgba(255, 255, 255, 0.12);

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1350,6 +1350,8 @@ if ('serviceWorker' in navigator) {
   }
   const sbDelegateBtn = document.getElementById('sbDelegateBtn');
   if (sbDelegateBtn) sbDelegateBtn.addEventListener('click', openDelegateModal);
+  // Exposed so the console Dashboard / Control views reuse the same dialog.
+  window.lisaOpenDelegate = openDelegateModal;
 
   async function refreshIdentity() {
     try {
@@ -1388,4 +1390,382 @@ if ('serviceWorker' in navigator) {
   setInterval(refreshPing, 30_000);
   setInterval(window.refreshClaudeSessions, 60_000);
   setInterval(refreshSessionsBadge, 5 * 60_000);
+})();
+
+// ════════════════════════════════════════════════════════════════════
+// Console view-switcher — adds Dashboard / Control / Reve / Sense /
+// Memory views beside the default Chat. Purely additive: the chat
+// pipeline and every existing id stay untouched. Each non-chat view is
+// built lazily from the real endpoints on first activation, and the live
+// agent stream (refreshClaudeSessions) is wrapped to re-render the active
+// console view. No backticks / no template placeholders in this block.
+// ════════════════════════════════════════════════════════════════════
+(function setupConsole() {
+  var navList = document.getElementById('navList');
+  if (!navList) return;
+  var views = {
+    chat: document.getElementById('viewChat'),
+    dashboard: document.getElementById('viewDashboard'),
+    control: document.getElementById('viewControl'),
+    reve: document.getElementById('viewReve'),
+    sense: document.getElementById('viewSense'),
+    memory: document.getElementById('viewMemory'),
+  };
+  var loaded = {};
+  var active = 'chat';
+  var proactiveOn = true;
+
+  function esc(s) { return (typeof escapeHtml === 'function') ? escapeHtml(s) : String(s == null ? '' : s); }
+  function getJSON(u) { return fetch(u).then(function (r) { return r.ok ? r.json() : null; }).catch(function () { return null; }); }
+
+  function statusClass(state) {
+    if (state === 'working') return 'working';
+    if (state === 'waiting') return 'waiting';
+    if (state === 'error') return 'error';
+    if (state === 'done' || state === 'idle') return 'done';
+    return '';
+  }
+  function statusLabel(state) {
+    if (state === 'working') return 'Working';
+    if (state === 'waiting') return 'Waiting';
+    if (state === 'error') return 'Error';
+    if (state === 'done') return 'Done';
+    if (state === 'idle') return 'Idle';
+    return 'Unknown';
+  }
+  // Compact activity line (local copy of the sidebar helper — kept decoupled).
+  function actLine(s) {
+    var a = s && s.activity;
+    if (!a || typeof a !== 'object') return '';
+    if (a.pendingPermission) return 'wants to run ' + a.pendingPermission;
+    var bits = [];
+    if (a.lastError) bits.push(a.lastError);
+    if (typeof a.turnCount === 'number' && a.turnCount > 0) bits.push('turn ' + a.turnCount);
+    if (a.tokens && (a.tokens.input || a.tokens.output)) {
+      var tot = (a.tokens.input || 0) + (a.tokens.output || 0);
+      bits.push(tot >= 1000 ? Math.round(tot / 1000) + 'k tok' : tot + ' tok');
+    }
+    var tool = a.lastTools && a.lastTools.length ? a.lastTools[a.lastTools.length - 1] : '';
+    var file = a.filesTouched && a.filesTouched.length ? (String(a.filesTouched[a.filesTouched.length - 1]).split('/').pop() || '') : '';
+    if (tool && file) bits.push(tool + ' ' + file);
+    else if (tool) bits.push(tool);
+    else if (file) bits.push(file);
+    return bits.join(' · ');
+  }
+  function updateAgentCount(n) {
+    var c = document.getElementById('navAgentCount');
+    if (c) c.textContent = String(n);
+  }
+
+  // ── view switching ──────────────────────────────────────────────
+  function loadView(name) {
+    if (loaded[name]) return;
+    loaded[name] = true;
+    if (name === 'dashboard') loadDashboard();
+    else if (name === 'control') loadControl();
+    else if (name === 'reve') loadReve();
+    else if (name === 'sense') loadSense();
+    else if (name === 'memory') loadMemory();
+  }
+  function showView(name) {
+    if (!views[name]) name = 'chat';
+    active = name;
+    for (var k in views) { if (views[k]) views[k].classList.toggle('active', k === name); }
+    var items = navList.querySelectorAll('.nav-item');
+    for (var i = 0; i < items.length; i++) {
+      items[i].classList.toggle('active', items[i].getAttribute('data-view') === name);
+    }
+    if (name !== 'chat') loadView(name);
+    else { try { document.getElementById('input').focus(); } catch (e) {} }
+    try { history.replaceState(null, '', name === 'chat' ? location.pathname + location.search : '#' + name); } catch (e) {}
+  }
+  navList.addEventListener('click', function (e) {
+    var btn = e.target && e.target.closest ? e.target.closest('.nav-item') : null;
+    if (btn && btn.getAttribute('data-view')) showView(btn.getAttribute('data-view'));
+  });
+  window.lisaShowView = showView;
+
+  // ── proactive toggle ────────────────────────────────────────────
+  var ptEl = document.getElementById('proactiveToggle');
+  function setProactiveUI(on) {
+    proactiveOn = !!on;
+    if (ptEl) { ptEl.classList.toggle('on', proactiveOn); ptEl.setAttribute('aria-checked', proactiveOn ? 'true' : 'false'); }
+    var pp = document.getElementById('ppPanel');
+    if (pp) {
+      pp.classList.toggle('off', !proactiveOn);
+      var st = document.getElementById('ppState');
+      if (st) st.textContent = proactiveOn ? 'On · watching' : 'Paused';
+      var sd = document.getElementById('ppDesc');
+      if (sd) sd.textContent = proactiveOn ? 'Lisa watches your agents, tasks and signals for blockers and next steps.' : 'Resting — she will only act when you talk to her.';
+    }
+  }
+  function syncProactive() {
+    getJSON('/api/autonomy/state').then(function (s) { if (s && typeof s.enabled === 'boolean') setProactiveUI(s.enabled); });
+  }
+  function toggleProactive() {
+    var on = !proactiveOn;
+    setProactiveUI(on);
+    fetch('/api/autonomy/state', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ enabled: on }) })
+      .then(function (r) { return r && r.ok ? r.json() : null; })
+      .then(function (j) { if (j && typeof j.enabled === 'boolean') setProactiveUI(j.enabled); else setProactiveUI(!on); })
+      .catch(function () { setProactiveUI(!on); });
+  }
+  if (ptEl) {
+    ptEl.addEventListener('click', toggleProactive);
+    ptEl.addEventListener('keydown', function (e) { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleProactive(); } });
+  }
+  syncProactive();
+
+  // ── Dashboard ───────────────────────────────────────────────────
+  function agentCardHTML(s) {
+    var cls = statusClass(s.state);
+    var act = actLine(s);
+    return '<div class="ac">' +
+      '<div class="ac-top"><span>' + esc(s.agent || 'agent') + '</span><span class="ac-status ' + cls + '">' + esc(statusLabel(s.state)) + '</span></div>' +
+      '<div class="ac-title">' + esc(s.project || s.agent || 'agent') + '</div>' +
+      '<div class="ac-desc">' + (act ? esc(act) : 'no recent activity') + '</div>' +
+      '</div>';
+  }
+  function taskCardHTML(d) {
+    return '<div class="ac">' +
+      '<div class="ac-top"><span>' + esc(d.agent || 'dispatch') + '</span><span class="ac-status ' + (d.alive ? 'working' : 'done') + '">' + (d.alive ? 'Running' : 'Done') + '</span></div>' +
+      '<div class="ac-title">' + esc(String(d.task || 'task').slice(0, 80)) + '</div>' +
+      '<div class="ac-meta">' + esc(d.cwd ? String(d.cwd).split('/').pop() : 'dispatch') + '</div>' +
+      '</div>';
+  }
+  function loadDashboard() {
+    views.dashboard.innerHTML =
+      '<div class="view-head"><div><h2>Dashboard</h2><div class="vh-sub">Operations at a glance</div></div>' +
+      '<button class="view-act" id="dashDelegate">+ Delegate a task</button></div>' +
+      '<div class="view-scroll" id="dashScroll"><div class="view-empty">loading…</div></div>';
+    var del = document.getElementById('dashDelegate');
+    if (del) del.addEventListener('click', function () { if (typeof window.lisaOpenDelegate === 'function') window.lisaOpenDelegate(); });
+    renderDashboard();
+  }
+  function renderDashboard() {
+    var scroll = document.getElementById('dashScroll');
+    if (!scroll) return;
+    Promise.all([
+      getJSON('/api/agents/sessions'), getJSON('/api/dispatch/list'),
+      getJSON('/api/sense/recent'), getJSON('/api/island/ping'),
+    ]).then(function (res) {
+      var sessions = (res[0] && res[0].sessions) || [];
+      var dispatches = (res[1] && res[1].dispatches) || [];
+      var events = (res[2] && res[2].events) || [];
+      var ping = res[3] || {};
+      updateAgentCount(sessions.length);
+      var aliveTasks = dispatches.filter(function (d) { return d.alive; }).length;
+      var waiting = sessions.filter(function (s) { return s.state === 'waiting'; }).length;
+      var errored = sessions.filter(function (s) { return s.state === 'error'; }).length;
+      var desire = ping.current_desire || '';
+      var html = '';
+      html += '<div class="stat-bar">' +
+        '<div class="stat"><div class="n">' + sessions.length + '</div><div class="k">Agents</div></div>' +
+        '<div class="stat"><div class="n">' + aliveTasks + '</div><div class="k">Tasks</div></div>' +
+        '<div class="stat"><div class="n">' + dispatches.length + '</div><div class="k">Dispatched</div></div>' +
+        '<div class="stat"><div class="n">' + events.length + '</div><div class="k">Signals</div></div></div>';
+      html += '<div class="proactive-panel' + (proactiveOn ? '' : ' off') + '" id="ppPanel"><div class="pp-head"><span class="pp-dot"></span>' +
+        '<div><div class="pp-title">Proactive mode <b id="ppState">' + (proactiveOn ? 'On · watching' : 'Paused') + '</b></div>' +
+        '<div class="pp-desc" id="ppDesc">' + (proactiveOn ? 'Lisa watches your agents, tasks and signals for blockers and next steps.' : 'Resting — she will only act when you talk to her.') + '</div></div></div>' +
+        '<div class="pp-tags"><span class="pp-tag">' + sessions.length + ' agents</span><span class="pp-tag">' + aliveTasks + ' tasks</span>' +
+        (waiting ? '<span class="pp-tag warn">' + waiting + ' waiting</span>' : '') +
+        (errored ? '<span class="pp-tag warn">' + errored + ' errored</span>' : '') +
+        '<span class="pp-tag">owner-routed</span><span class="pp-tag">quiet on waits</span></div></div>';
+      html += '<div class="view-sec-label">Focus · currently pursuing</div>';
+      if (desire) {
+        html += '<div class="focus-card"><div class="fc-top"><div>' +
+          '<div class="fc-title">' + esc(desire) + '</div>' +
+          '<div class="fc-desc">A self-driven desire Lisa is pursuing on her own time.</div></div>' +
+          '<span class="fc-pill">Active</span></div>' +
+          '<div class="fc-meta"><span>self-driven</span><span>' + sessions.length + ' agents live</span></div></div>';
+      } else {
+        html += '<div class="focus-card"><div class="fc-desc">Nothing actively pursued right now.</div></div>';
+      }
+      html += '<div class="view-sec-label">Agents &amp; tasks</div>';
+      var cards = sessions.map(agentCardHTML).concat(dispatches.slice(0, 6).map(taskCardHTML));
+      html += cards.length ? '<div class="card-scroll">' + cards.join('') + '</div>'
+                           : '<div class="view-empty">No active agents or tasks. Delegate one to get started.</div>';
+      scroll.innerHTML = html;
+    });
+  }
+
+  // ── Control ─────────────────────────────────────────────────────
+  function controlRowHTML(s) {
+    var act = actLine(s);
+    var fam = s.controllable === 'pty' ? 'pty' : (s.controllable === 'managed' ? 'managed' : '');
+    var pend = s.activity && s.activity.pendingPermission;
+    var id = esc(s.sessionId);
+    var ctrl = '';
+    if (fam && pend) {
+      ctrl += '<button class="mc approve" data-fam="' + fam + '" data-id="' + id + '" data-act="approve">approve</button>';
+      ctrl += '<button class="mc deny" data-fam="' + fam + '" data-id="' + id + '" data-act="deny">deny</button>';
+    }
+    if (fam) ctrl += '<button class="mc cancel" data-fam="' + fam + '" data-id="' + id + '" data-act="cancel">cancel</button>';
+    if (fam === 'pty') ctrl += '<button class="mc" data-id="' + id + '" data-act="output">output</button>';
+    var badge = (s.agent && s.agent !== 'claude-code') ? '<span class="agent-badge">' + esc(s.agent) + '</span>' : '';
+    return '<div class="session-row">' +
+      '<div class="pip ' + (s.state || 'unknown') + '"></div>' +
+      '<div class="name">' + badge + esc(s.project || s.agent || 'agent') + '</div>' +
+      '<div class="when">' + (s.controllable ? esc(s.controllable) : esc(statusLabel(s.state))) + '</div>' +
+      (act ? '<div class="session-act">' + esc(act) + '</div>' : '') +
+      (ctrl ? '<div class="session-ctrl">' + ctrl + '</div>' : '') +
+      '</div>';
+  }
+  function controlAction(fam, id, action) {
+    return fetch('/api/agents/' + fam + '/' + encodeURIComponent(id) + '/' + action, { method: 'POST' })
+      .then(function (r) { if (!r.ok) return r.text().then(function (t) { throw new Error(String(r.status) + (t ? ' ' + t : '')); }); });
+  }
+  function ctrlPtyOutput(id) {
+    getJSON('/api/agents/pty/' + encodeURIComponent(id) + '/output').then(function (d) {
+      if (typeof openModal === 'function') openModal('agent output', '<pre>' + esc(d && d.output ? d.output : '(no output yet)') + '</pre>');
+    });
+  }
+  function loadControl() {
+    views.control.innerHTML =
+      '<div class="view-head"><div><h2>Control</h2><div class="vh-sub">Live agents &amp; control plane</div></div>' +
+      '<button class="view-act" id="ctrlDelegate">+ Delegate a task</button></div>' +
+      '<div class="view-scroll" id="ctrlScroll"><div class="view-empty">loading…</div></div>';
+    var del = document.getElementById('ctrlDelegate');
+    if (del) del.addEventListener('click', function () { if (typeof window.lisaOpenDelegate === 'function') window.lisaOpenDelegate(); });
+    renderControl();
+  }
+  function renderControl() {
+    var scroll = document.getElementById('ctrlScroll');
+    if (!scroll) return;
+    Promise.all([getJSON('/api/agents/sessions'), getJSON('/api/control/policy')]).then(function (res) {
+      var sessions = (res[0] && res[0].sessions) || [];
+      var policy = res[1] || {};
+      updateAgentCount(sessions.length);
+      var html = '<div class="pp-tags" style="margin-bottom:14px">' +
+        '<span class="pp-tag">remote control: ' + (policy.remoteControl ? 'on' : 'off') + '</span>' +
+        '<span class="pp-tag">adopt external: ' + (policy.remoteAdoptExternal ? 'on' : 'off') + '</span></div>';
+      if (!sessions.length) { scroll.innerHTML = html + '<div class="view-empty">No agents running. Delegate a task to start one.</div>'; return; }
+      sessions.forEach(function (s) { html += controlRowHTML(s); });
+      scroll.innerHTML = html;
+      var btns = scroll.querySelectorAll('[data-act]');
+      for (var i = 0; i < btns.length; i++) {
+        btns[i].addEventListener('click', function () {
+          var act = this.getAttribute('data-act');
+          var fam = this.getAttribute('data-fam');
+          var id = this.getAttribute('data-id');
+          if (act === 'output') { ctrlPtyOutput(id); return; }
+          controlAction(fam, id, act).then(function () { renderControl(); }).catch(function (err) {
+            scroll.insertAdjacentHTML('afterbegin', '<div class="view-empty" style="color:var(--err-color)">' + esc(err.message) + '</div>');
+          });
+        });
+      }
+    });
+  }
+
+  // ── Reve ────────────────────────────────────────────────────────
+  function loadReve() {
+    views.reve.innerHTML =
+      '<div class="view-head"><div><h2>Rêve</h2><div class="vh-sub">Reflections from her own time</div></div>' +
+      '<select class="v-sel" id="reveWindow"><option value="120">last 2h</option><option value="480">last 8h</option><option value="1440">last 24h</option></select></div>' +
+      '<div class="view-scroll" id="reveScroll"><div class="view-empty">loading…</div></div>';
+    var sel = document.getElementById('reveWindow');
+    if (sel) sel.addEventListener('change', function () { renderReve(sel.value); });
+    renderReve('120');
+  }
+  function renderReve(mins) {
+    var scroll = document.getElementById('reveScroll');
+    if (!scroll) return;
+    Promise.all([getJSON('/api/island/ping'), getJSON('/api/agents/recap?sinceMinutes=' + encodeURIComponent(mins))]).then(function (res) {
+      var ping = res[0] || {}; var recap = res[1] || {};
+      var html = '';
+      if (ping.last_idle_message_text) html += '<div class="v-card"><h3>While you were away</h3><div style="font-size:13px;color:var(--fg);line-height:1.55">' + esc(ping.last_idle_message_text) + '</div></div>';
+      if (ping.current_desire) html += '<div class="v-card"><h3>Currently pursuing</h3><div style="font-size:13px;color:var(--fg)">' + esc(ping.current_desire) + '</div></div>';
+      html += '<div class="v-card"><h3>Recap</h3><pre class="v-pre">' + esc(recap.text || 'No activity in this window.') + '</pre></div>';
+      scroll.innerHTML = html;
+    });
+  }
+
+  // ── Sense ───────────────────────────────────────────────────────
+  function loadSense() {
+    views.sense.innerHTML =
+      '<div class="view-head"><div><h2>Sense</h2><div class="vh-sub">Ambient signals Lisa may see</div></div></div>' +
+      '<div class="view-scroll" id="senseScroll"><div class="view-empty">loading…</div></div>';
+    renderSense();
+  }
+  function renderSense() {
+    var scroll = document.getElementById('senseScroll');
+    if (!scroll) return;
+    Promise.all([getJSON('/api/consent'), getJSON('/api/sense/recent')]).then(function (res) {
+      var grants = (res[0] && res[0].grants) || [];
+      var events = (res[1] && res[1].events) || [];
+      var html = '<div class="view-sec-label">Consent</div><div class="v-card">';
+      if (!grants.length) html += '<div class="view-empty" style="padding:6px 0">No signals configured.</div>';
+      grants.forEach(function (g) {
+        html += '<div class="v-row"><div class="v-main"><div class="v-name">' + esc(g.signal) + '</div>' +
+          (g.description ? '<div class="v-sub">' + esc(g.description) + '</div>' : '') + '</div>' +
+          '<button class="v-toggle' + (g.granted ? ' on' : '') + '" data-signal="' + esc(g.signal) + '" data-on="' + (g.granted ? '1' : '0') + '">' + (g.granted ? 'on' : 'off') + '</button></div>';
+      });
+      html += '</div><div class="view-sec-label">Recently sensed</div><div class="v-card">';
+      if (!events.length) html += '<div class="view-empty" style="padding:6px 0">Nothing captured.</div>';
+      events.slice(0, 30).forEach(function (e) {
+        html += '<div class="v-row"><div class="v-main"><div class="v-name" style="font-weight:400">' + esc(e.summary || '') + '</div>' +
+          '<div class="v-sub">' + esc([e.signal, e.kind, e.app].filter(Boolean).join(' · ')) + '</div></div></div>';
+      });
+      html += '</div>';
+      scroll.innerHTML = html;
+      var tgs = scroll.querySelectorAll('.v-toggle');
+      for (var i = 0; i < tgs.length; i++) {
+        tgs[i].addEventListener('click', function () {
+          var sig = this.getAttribute('data-signal');
+          var on = this.getAttribute('data-on') === '1';
+          fetch(on ? '/api/consent/revoke' : '/api/consent/grant', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ signal: sig }) })
+            .then(function () { renderSense(); }).catch(function () {});
+        });
+      }
+    });
+  }
+
+  // ── Memory (launchers for the existing modal panels) ────────────
+  function memBtn(key, ico, title, sub) {
+    return '<button class="mem-btn" data-mem="' + key + '"><span class="mem-ico">' + ico + '</span>' + title + '<span class="mem-sub">' + sub + '</span></button>';
+  }
+  function loadMemory() {
+    views.memory.innerHTML =
+      '<div class="view-head"><div><h2>Memory</h2><div class="vh-sub">Soul · skills · memory · tools</div></div></div>' +
+      '<div class="view-scroll">' +
+      memBtn('soul', '★', 'Soul', 'identity · values · emotions') +
+      memBtn('skills', '✦', 'Skills', 'saved workflows') +
+      memBtn('memory', '▤', 'Memory', 'USER.md · MEMORY.md') +
+      memBtn('tools', '⚒', 'Tools', 'capabilities') +
+      memBtn('plans', '◆', 'Coding plans', 'subscription CLIs') +
+      '</div>';
+    var mbs = views.memory.querySelectorAll('.mem-btn');
+    for (var i = 0; i < mbs.length; i++) {
+      mbs[i].addEventListener('click', function () {
+        var w = this.getAttribute('data-mem');
+        if (w === 'soul' && typeof showSoul === 'function') showSoul();
+        else if (w === 'skills' && typeof showSkills === 'function') showSkills();
+        else if (w === 'memory' && typeof showMemory === 'function') showMemory();
+        else if (w === 'tools' && typeof showTools === 'function') showTools();
+        else if (w === 'plans' && typeof showPlans === 'function') showPlans();
+      });
+    }
+  }
+
+  // ── live refresh: wrap the agent-session refresh so the active console
+  //    view + the Control nav count update on SSE agent_session_update.
+  var origRefresh = window.refreshClaudeSessions;
+  window.refreshClaudeSessions = function () {
+    var r = origRefresh ? origRefresh.apply(this, arguments) : undefined;
+    Promise.resolve(r).then(function () {
+      if (active === 'dashboard') renderDashboard();
+      else if (active === 'control') renderControl();
+      else getJSON('/api/agents/sessions').then(function (d) { updateAgentCount((d && d.sessions) ? d.sessions.length : 0); });
+    });
+    return r;
+  };
+  getJSON('/api/agents/sessions').then(function (d) { updateAgentCount((d && d.sessions) ? d.sessions.length : 0); });
+
+  // ── init: honor a deep-link hash, else default to chat ──────────
+  var initial = (location.hash || '').replace('#', '');
+  showView(views[initial] ? initial : 'chat');
+  window.addEventListener('hashchange', function () {
+    var h = (location.hash || '').replace('#', '');
+    if (views[h] && h !== active) showView(h);
+  });
 })();`;

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1388,7 +1388,10 @@ if ('serviceWorker' in navigator) {
   refreshIdentity();
   refreshSessionsBadge();
   setInterval(refreshPing, 30_000);
-  setInterval(window.refreshClaudeSessions, 60_000);
+  // Resolve refreshClaudeSessions at call time (arrow), not now: setupConsole
+  // later wraps window.refreshClaudeSessions to re-render the active console
+  // view + nav count, and the wrapper must win on this 60s tick too.
+  setInterval(() => window.refreshClaudeSessions(), 60_000);
   setInterval(refreshSessionsBadge, 5 * 60_000);
 })();
 

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -738,7 +738,6 @@ export const MAIN_CSS = `  :root {
     padding: 2px 9px;
   }
   .pp-tag.warn { color: var(--warm); }
-  .pp-tag.you { color: var(--accent); }
 
   /* "Focus" big card (current desire / objective analog) */
   .focus-card {

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -17,6 +17,10 @@ export const MAIN_CSS = `  :root {
     --accent: #6ad4ff;
     --accent-soft: rgba(106, 212, 255, 0.13);
     --accent-glow: rgba(106, 212, 255, 0.27);
+    /* Proactive / autonomy "live" accent (green) — the console's watching state. */
+    --proactive: #3ddc97;
+    --proactive-soft: rgba(61, 220, 151, 0.13);
+    --proactive-glow: rgba(61, 220, 151, 0.30);
     --warm: #ffd066;
     --dream: #b487ff;
     --claude: #ff8c42;
@@ -491,16 +495,386 @@ export const MAIN_CSS = `  :root {
     flex-shrink: 0;
   }
 
+  /* ── Workspace pill (top of sidebar) ───────────────────────── */
+  .ws-pill {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 11px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 11px;
+  }
+  .ws-pill .ws-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--proactive);
+    box-shadow: 0 0 6px var(--proactive-glow);
+    flex-shrink: 0;
+  }
+  .ws-pill .ws-name {
+    font-size: 12px;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--fg-2);
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  }
+  .ws-pill .ws-ico { margin-left: auto; color: var(--fg-faint); font-size: 13px; }
+
+  /* ── Primary nav (vertical list in the sidebar) ────────────── */
+  .nav-list { display: flex; flex-direction: column; gap: 2px; }
+  .nav-item {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    width: 100%;
+    padding: 8px 11px;
+    border: 0;
+    border-radius: 9px;
+    background: transparent;
+    color: var(--fg-2);
+    font-family: inherit;
+    font-size: 12.5px;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    text-align: left;
+    cursor: pointer;
+    transition: background 120ms ease, color 120ms ease;
+  }
+  .nav-item .nav-ico { width: 18px; font-size: 15px; text-align: center; flex-shrink: 0; opacity: 0.9; }
+  .nav-item:hover { background: var(--bg-card); color: var(--fg); }
+  .nav-item.active { background: var(--accent-soft); color: var(--accent); }
+  .nav-item.active::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    width: 3px;
+    height: 18px;
+    border-radius: 0 3px 3px 0;
+    background: var(--accent);
+  }
+  .nav-item .nav-tag {
+    margin-left: auto;
+    font-size: 9.5px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: var(--fg);
+    background: var(--bg-3);
+    border-radius: 999px;
+    padding: 1px 7px;
+    min-width: 18px;
+    text-align: center;
+  }
+  .nav-item.active .nav-tag { background: var(--accent); color: #06141b; }
+
+  /* ── Proactive toggle (sidebar footer area) ────────────────── */
+  .proactive-toggle {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 9px 11px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 11px;
+    cursor: pointer;
+    user-select: none;
+    transition: border-color 140ms ease, background 140ms ease;
+  }
+  .proactive-toggle .pt-label {
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+    transition: color 140ms ease;
+  }
+  .proactive-toggle .pt-track {
+    margin-left: auto;
+    width: 34px;
+    height: 18px;
+    border-radius: 999px;
+    background: var(--bg-3);
+    border: 1px solid var(--border-new);
+    position: relative;
+    flex-shrink: 0;
+    transition: background 140ms ease, border-color 140ms ease;
+  }
+  .proactive-toggle .pt-knob {
+    position: absolute;
+    top: 1px;
+    left: 1px;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--fg-3);
+    transition: transform 140ms ease, background 140ms ease;
+  }
+  .proactive-toggle.on { border-color: var(--proactive-glow); background: var(--proactive-soft); }
+  .proactive-toggle.on .pt-label { color: var(--proactive); }
+  .proactive-toggle.on .pt-track { background: var(--proactive-soft); border-color: var(--proactive-glow); }
+  .proactive-toggle.on .pt-knob { transform: translateX(16px); background: var(--proactive); }
+
   /* ── Main pane ─────────────────────────────────────────────── */
+  /* The main pane is a view stack: each .view fills the pane and only the
+     active one is shown. Chat is the default; it keeps its original
+     log / attachPreview / form 3-row grid (moved onto #viewChat). */
   .main {
     grid-area: main;
-    display: grid;
-    grid-template-rows: 1fr auto auto;
+    position: relative;
     overflow: hidden;
     background:
       radial-gradient(ellipse at 50% -30%, rgba(106, 212, 255, 0.06) 0%, transparent 60%),
       linear-gradient(180deg, transparent, rgba(106, 212, 255, 0.015));
   }
+  .view { display: none; }
+  .view.active {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    flex-direction: column;
+  }
+  #viewChat.view.active {
+    display: grid;
+    grid-template-rows: 1fr auto auto;
+  }
+
+  /* ── Console views (dashboard / control / reve / sense / memory) ── */
+  .view-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 16px 24px;
+    border-bottom: 1px solid var(--border-new);
+  }
+  .view-head h2 { margin: 0; font-size: 16px; font-weight: 700; letter-spacing: 0.02em; color: var(--fg); }
+  .view-head .vh-sub { margin: 2px 0 0; font-size: 11.5px; color: var(--fg-3); }
+  .view-act {
+    flex-shrink: 0;
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 600;
+    color: #06140d;
+    background: var(--accent);
+    border: 0;
+    border-radius: 9px;
+    padding: 8px 13px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    transition: filter 120ms ease, transform 120ms ease;
+  }
+  .view-act:hover { filter: brightness(1.08); }
+  .view-act:active { transform: translateY(1px); }
+  .view-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 18px 24px 26px; }
+  .view-empty { color: var(--fg-faint); font-size: 12.5px; font-style: italic; padding: 18px 4px; }
+  .view-sec-label {
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.10em;
+    color: var(--fg-3);
+    margin: 4px 0 8px;
+  }
+
+  /* Stat bar */
+  .stat-bar { display: flex; gap: 10px; flex-wrap: wrap; margin-bottom: 16px; }
+  .stat {
+    flex: 1;
+    min-width: 92px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 12px;
+    padding: 11px 13px;
+  }
+  .stat .n { font-size: 21px; font-weight: 700; color: var(--fg); font-variant-numeric: tabular-nums; line-height: 1.1; }
+  .stat .k {
+    margin-top: 3px;
+    font-size: 10px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-3);
+  }
+
+  /* Green "proactive — watching" panel */
+  .proactive-panel {
+    border: 1px solid var(--proactive-glow);
+    background: linear-gradient(180deg, var(--proactive-soft), transparent);
+    border-radius: 14px;
+    padding: 13px 15px;
+    margin-bottom: 16px;
+  }
+  .proactive-panel .pp-head { display: flex; align-items: center; gap: 10px; }
+  .proactive-panel .pp-dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: var(--proactive);
+    box-shadow: 0 0 8px var(--proactive-glow);
+    flex-shrink: 0;
+  }
+  .proactive-panel.off .pp-dot { background: var(--fg-faint); box-shadow: none; }
+  .proactive-panel .pp-title { font-size: 13px; font-weight: 700; color: var(--fg); }
+  .proactive-panel .pp-title b { color: var(--proactive); font-weight: 700; }
+  .proactive-panel.off .pp-title b { color: var(--fg-3); }
+  .proactive-panel .pp-desc { margin: 2px 0 0; font-size: 11.5px; color: var(--fg-2); }
+  /* .pp-tags / .pp-tag are reused outside the panel (Control policy chips),
+     so they are not scoped to .proactive-panel. */
+  .pp-tags { display: flex; flex-wrap: wrap; gap: 6px; }
+  .proactive-panel .pp-tags { margin-top: 10px; }
+  .pp-tag {
+    font-size: 10.5px;
+    color: var(--fg-3);
+    background: rgba(255, 255, 255, 0.05);
+    border: 1px solid var(--border-new);
+    border-radius: 999px;
+    padding: 2px 9px;
+  }
+  .pp-tag.warn { color: var(--warm); }
+  .pp-tag.you { color: var(--accent); }
+
+  /* "Focus" big card (current desire / objective analog) */
+  .focus-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 14px;
+    padding: 15px;
+    margin-bottom: 18px;
+  }
+  .focus-card .fc-top { display: flex; align-items: flex-start; gap: 10px; }
+  .focus-card .fc-title { font-size: 14.5px; font-weight: 700; color: var(--fg); }
+  .focus-card .fc-desc { margin: 4px 0 0; font-size: 12px; color: var(--fg-2); line-height: 1.5; }
+  .focus-card .fc-pill {
+    margin-left: auto;
+    flex-shrink: 0;
+    font-size: 10.5px;
+    color: var(--proactive);
+    border: 1px solid var(--proactive-glow);
+    border-radius: 999px;
+    padding: 2px 10px;
+  }
+  .focus-card .fc-meta { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 11px; font-size: 11px; color: var(--fg-3); }
+
+  /* Horizontally-scrolling agent / task cards */
+  .card-scroll {
+    display: flex;
+    gap: 12px;
+    overflow-x: auto;
+    padding-bottom: 6px;
+    margin-bottom: 18px;
+    scroll-snap-type: x proximity;
+  }
+  .ac {
+    flex: 0 0 232px;
+    scroll-snap-align: start;
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 13px;
+    padding: 13px;
+  }
+  .ac .ac-top { display: flex; align-items: center; gap: 6px; font-size: 10.5px; color: var(--fg-3); margin-bottom: 8px; }
+  .ac .ac-status { margin-left: auto; font-weight: 700; text-transform: uppercase; letter-spacing: 0.04em; }
+  .ac .ac-status.working { color: var(--accent); }
+  .ac .ac-status.waiting { color: var(--warm); }
+  .ac .ac-status.error   { color: var(--err-color); }
+  .ac .ac-status.done    { color: var(--proactive); }
+  .ac .ac-title { font-size: 13px; font-weight: 600; color: var(--fg); margin-bottom: 3px; word-break: break-word; }
+  .ac .ac-desc { font-size: 11.5px; color: var(--fg-2); line-height: 1.45; }
+  .ac .ac-meta {
+    margin-top: 9px;
+    padding-top: 7px;
+    border-top: 1px solid var(--border-new);
+    font-size: 10px;
+    color: var(--fg-3);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+
+  /* Simple list rows / cards used by Reve / Sense / Memory */
+  .v-card {
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 12px;
+    padding: 12px 14px;
+    margin-bottom: 10px;
+  }
+  .v-card h3 {
+    margin: 0 0 6px;
+    font-size: 11px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--fg-3);
+  }
+  .v-pre {
+    margin: 0;
+    white-space: pre-wrap;
+    word-break: break-word;
+    font-size: 12px;
+    line-height: 1.55;
+    color: var(--fg-2);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  }
+  .v-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 11px 0;
+    border-top: 1px solid var(--border-new);
+  }
+  .v-row:first-child { border-top: 0; }
+  .v-row .v-main { min-width: 0; flex: 1; }
+  .v-row .v-name { font-size: 12.5px; font-weight: 600; color: var(--fg); }
+  .v-row .v-sub { font-size: 11px; color: var(--fg-3); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .v-toggle {
+    font-family: inherit;
+    font-size: 11px;
+    font-weight: 600;
+    cursor: pointer;
+    border-radius: 7px;
+    padding: 4px 10px;
+    border: 1px solid var(--border-new);
+    background: var(--bg-3);
+    color: var(--fg-3);
+    flex-shrink: 0;
+  }
+  .v-toggle.on { color: var(--proactive); border-color: var(--proactive-glow); background: var(--proactive-soft); }
+  .v-sel {
+    font-family: inherit;
+    font-size: 12px;
+    color: var(--fg);
+    background: var(--bg-3);
+    border: 1px solid var(--border-new);
+    border-radius: 8px;
+    padding: 5px 8px;
+  }
+  .mem-btn {
+    width: 100%;
+    text-align: left;
+    font-family: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--fg);
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 11px;
+    padding: 13px 15px;
+    margin-bottom: 9px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    transition: background 120ms ease, border-color 120ms ease;
+  }
+  .mem-btn:hover { background: var(--bg-card-strong); border-color: var(--border-strong); }
+  .mem-btn .mem-ico { font-size: 16px; width: 20px; text-align: center; }
+  .mem-btn .mem-sub { margin-left: auto; font-size: 11px; color: var(--fg-3); font-weight: 400; }
 
   #log {
     overflow-y: auto;
@@ -787,7 +1161,8 @@ export const MAIN_CSS = `  :root {
     }
     .frame {
       grid-template-columns: 1fr;
-      grid-template-rows: auto 1fr auto;
+      /* titlebar · sidebar (capped, scrolls) · main view-stack (fills rest) */
+      grid-template-rows: auto auto 1fr;
     }
     .sidebar {
       max-height: 38vh;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -19,11 +19,13 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Last updated: "agent console" redesign — left-rail nav (Chat / Dashboard /
  * Control / Reve / Sense / Memory) switching a main view-stack, a workspace
  * pill, and a Proactive autonomy toggle, all added additively beside the
- * untouched chat pipeline.
+ * untouched chat pipeline. Then: review cleanups — 60s refresh tick resolves
+ * the wrapped refreshClaudeSessions at call time, dropped an unused .pp-tag.you
+ * rule.
  */
-const EXPECTED_LENGTH = 130493;
+const EXPECTED_LENGTH = 130688;
 const EXPECTED_SHA256 =
-  "c8c263615b33e7a3f0f73560254bbad5a35a23141ad3f5e04c3b44eac5507666";
+  "a106d2de2b3c160f61b05944118159205b916f4e532438819ffeca9bb116781c";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -16,12 +16,14 @@ import { MAIN_HTML } from "./lisa-html.js";
  * change the GUI markup/CSS/JS, recompute them:
  *   node --import tsx -e 'import("./src/web/lisa-html.ts").then(async m=>{const {createHash}=await import("node:crypto");console.log(m.MAIN_HTML.length, createHash("sha256").update(m.MAIN_HTML).digest("hex"))})'
  *
- * Last updated: delegate-a-task moved from a cramped sidebar form to a single
- * button that opens a roomy modal (agent picker + task textarea).
+ * Last updated: "agent console" redesign — left-rail nav (Chat / Dashboard /
+ * Control / Reve / Sense / Memory) switching a main view-stack, a workspace
+ * pill, and a Proactive autonomy toggle, all added additively beside the
+ * untouched chat pipeline.
  */
-const EXPECTED_LENGTH = 95181;
+const EXPECTED_LENGTH = 130493;
 const EXPECTED_SHA256 =
-  "057b3c90dfd99d1a2bec6ce1233f547e466265a7abd4271e9ff1ac66f947a655";
+  "c8c263615b33e7a3f0f73560254bbad5a35a23141ad3f5e04c3b44eac5507666";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -56,6 +56,13 @@ ${MAIN_CSS}
   <!-- ╔════════════════ Sidebar ════════════════╗ -->
   <aside class="sidebar">
 
+    <!-- LISA workspace -->
+    <div class="ws-pill">
+      <span class="ws-dot"></span>
+      <span class="ws-name">LISA workspace</span>
+      <span class="ws-ico">⌄</span>
+    </div>
+
     <!-- Identity card -->
     <div class="identity">
       <div class="avatar-wrap">
@@ -67,6 +74,16 @@ ${MAIN_CSS}
         <div class="mood" id="mascotTag">neutral</div>
       </div>
     </div>
+
+    <!-- Primary navigation (view switcher — wired in setupConsole) -->
+    <nav class="nav-list" id="navList">
+      <button class="nav-item active" type="button" data-view="chat"><span class="nav-ico">◍</span>Chat</button>
+      <button class="nav-item" type="button" data-view="dashboard"><span class="nav-ico">▦</span>Dashboard</button>
+      <button class="nav-item" type="button" data-view="control"><span class="nav-ico">⌘</span>Control<span class="nav-tag" id="navAgentCount">0</span></button>
+      <button class="nav-item" type="button" data-view="reve"><span class="nav-ico">☾</span>Rêve</button>
+      <button class="nav-item" type="button" data-view="sense"><span class="nav-ico">◉</span>Sense</button>
+      <button class="nav-item" type="button" data-view="memory"><span class="nav-ico">✦</span>Memory</button>
+    </nav>
 
     <!-- Currently wanting -->
     <div class="sb-section">
@@ -105,6 +122,12 @@ ${MAIN_CSS}
       <button class="badge" type="button" data-panel="plans"><img src="/assets/icon-tool.png" alt="">PLANS</button>
     </div>
 
+    <!-- Proactive autonomy toggle (master switch — wired in setupConsole) -->
+    <div class="proactive-toggle" id="proactiveToggle" role="switch" aria-checked="false" tabindex="0" title="Let Lisa watch and act on her own when you're away">
+      <span class="pt-label">Proactive</span>
+      <span class="pt-track"><span class="pt-knob"></span></span>
+    </div>
+
     <!-- Footer: current session id -->
     <div class="sb-footer">
       <span class="session-id" id="sessionId">—</span>
@@ -114,6 +137,9 @@ ${MAIN_CSS}
 
   <!-- ╔════════════════ Main pane ════════════════╗ -->
   <div class="main">
+
+    <!-- Chat view (default home) — log + attachments + composer -->
+    <div class="view active" id="viewChat">
 
     <!-- Chat log (messages, tool blocks, idle blocks injected here) -->
     <div id="log"></div>
@@ -135,6 +161,14 @@ ${MAIN_CSS}
         SEND →
       </button>
     </form>
+    </div><!-- /#viewChat -->
+
+    <!-- Console views (populated lazily by setupConsole in lisa-client.ts) -->
+    <section class="view" id="viewDashboard"></section>
+    <section class="view" id="viewControl"></section>
+    <section class="view" id="viewReve"></section>
+    <section class="view" id="viewSense"></section>
+    <section class="view" id="viewMemory"></section>
   </div>
 </div>
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -41,6 +41,7 @@ import { ptyRegistry, ptyEnabled, normalizeAgentKind } from "../agents/pty.js";
 import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
 import { listRecentDispatches, isAlive, toDispatchView, readDispatchOutput } from "../integrations/dispatch-ledger.js";
 import { loadControlPolicy, saveControlPolicy, type ControlPolicy } from "../control/policy.js";
+import { loadAutonomyState, saveAutonomyState, type AutonomyState } from "../autonomy/state.js";
 import { mintDevice, verifyDeviceToken, touchDevice, listDevices, revokeDevice } from "./devices.js";
 import { PushBridge, listPush, registerPush, unregisterPush, setPushPrefs, registerLiveActivity, unregisterLiveActivity, type PushPrefs } from "./push.js";
 import { SenseService } from "../sense/service.js";
@@ -949,6 +950,34 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         const saved = saveControlPolicy({ ...loadControlPolicy(), ...payload });
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: true, ...saved }));
+      } catch (err) {
+        res.writeHead(500, { "content-type": "text/plain" });
+        res.end((err as Error).message);
+      }
+      return;
+    }
+
+    // Autonomy on/off — the "Proactive mode" master switch surfaced in the web
+    // GUI + iOS as the Proactive toggle. GET reports it (any authed caller);
+    // POST sets it. Unlike the control policy (loopback-only), this is allowed
+    // from any authed device — letting Lisa rest is low-risk, and pausing her
+    // from the phone is a primary use case. The token gate (above) still applies.
+    if (req.method === "GET" && url === "/api/autonomy/state") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(loadAutonomyState()));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/autonomy/state") {
+      let asBody = "";
+      for await (const chunk of req) asBody += chunk.toString("utf8");
+      let payload: Partial<AutonomyState>;
+      try { payload = JSON.parse(asBody || "{}"); } catch {
+        res.writeHead(400, { "content-type": "text/plain" }); res.end("bad json"); return;
+      }
+      try {
+        const saved = saveAutonomyState({ ...loadAutonomyState(), ...payload });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(saved));
       } catch (err) {
         res.writeHead(500, { "content-type": "text/plain" });
         res.end((err as Error).message);


### PR DESCRIPTION
## What

Redesigns the LISA **client and web interface** into an "agent operations console" (per a reference layout), mapped onto LISA's **real data** — no fictional OKR backend. **Chat stays the default home**; Dashboard / Control / Rêve / Sense / Memory are new nav destinations.

## Surfaces

- **Backend** — the one missing primitive: a real proactive/autonomy master switch. New `~/.lisa/autonomy/state.json` + `GET/POST /api/autonomy/state` (token-gated, so the phone can flip it); the `idle` and `heartbeat` runners no-op when it's off.
- **Web / Mac** (the Mac app is a WKWebView wrapper, so it inherits this) — left rail (workspace pill · identity · nav list · live agents card · PROACTIVE toggle) + a main view-stack. The chat/SSE/birth/cfg ids are byte-intact; everything is **additive**. Five new views pull live data; the byte-exact `MAIN_HTML` snapshot is regenerated.
- **iOS** — shared `Theme.swift`, global dark + cyan tint, restyled 5 tabs, a green Proactive banner + stat strip on Dispatch, and a mirrored toggle in Settings.
- **Island** — green accent token only (backtick-safe).

## Mapping (reference → LISA)

| Reference | LISA |
|---|---|
| Departments | live agent sessions |
| OKR stat bar | Agents · Tasks · Signals |
| Objectives card | Lisa's current desire / focus |
| Key Results cards | agent & dispatch-task cards |
| PROACTIVE toggle | autonomy (idle + heartbeat) |

## Verification

- `npm run typecheck` ✅ · **828 tests, 0 failures** (snapshot regenerated, inline-JS syntax guards green).
- Web run + screenshots: chat is default & unchanged, all views render real data, and the proactive toggle round-trips to the server (persists `enabled` to `~/.lisa/autonomy/state.json`).
- iOS: `swiftc -parse` clean on all files; full compile is CI/Xcode (no Xcode in this environment).

## Notes

- Nav is a **vertical list inside the sidebar** (matches the approved mockup / reference) rather than a separate icon rail, so the `.frame` grid is unchanged — lower risk.
- The Control view ships approve/deny/cancel + PTY output; per-row "send" was left out to avoid guessing its request shape.
- A self-contained click-through mockup exists locally at `mockups/lisa-console.html` (not committed — fake data + a throwaway preview server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
