### PR TITLE
feat(web): ＋ composer menu (attach+camera) + top icon function bar (功能区)

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -115,7 +115,7 @@ let capturing = false;
 window.lisaCaptureAndAttach = async function (mode) {
   if (capturing) return false;
   capturing = true;
-  const btn = document.getElementById('captureBtn');
+  const btn = document.getElementById('plusBtn');
   if (btn) btn.classList.add('flash');
   try {
     const res = await fetch('/api/vision/capture', {
@@ -171,10 +171,26 @@ fileInput.addEventListener('change', async () => {
 // listener that forwards the click synchronously (preserving the
 // user-gesture context) and logs to console so we can verify in the
 // inspector if it ever silently no-ops again.
-// 📷 capture button → interactive crosshair screenshot into the composer.
-const captureBtnEl = document.getElementById('captureBtn');
-if (captureBtnEl) {
-  captureBtnEl.addEventListener('click', () => { void window.lisaCaptureAndAttach('interactive'); });
+// ── ＋ composer menu: merges 📎 attach + 📷 screenshot into one button ──
+const plusBtnEl = document.getElementById('plusBtn');
+const plusMenuEl = document.getElementById('plusMenu');
+function closePlusMenu() { if (plusMenuEl) plusMenuEl.classList.remove('open'); }
+if (plusBtnEl && plusMenuEl) {
+  plusBtnEl.addEventListener('click', (e) => { e.stopPropagation(); plusMenuEl.classList.toggle('open'); });
+  document.addEventListener('click', (e) => {
+    if (plusMenuEl.classList.contains('open') && !plusMenuEl.contains(e.target) && e.target !== plusBtnEl) closePlusMenu();
+  });
+}
+const pmAttachEl = document.getElementById('pmAttach');
+if (pmAttachEl) {
+  pmAttachEl.addEventListener('click', () => {
+    closePlusMenu();
+    try { fileInput.click(); } catch (err) { console.error('[attach] fileInput.click failed:', err); }
+  });
+}
+const pmShotEl = document.getElementById('pmShot');
+if (pmShotEl) {
+  pmShotEl.addEventListener('click', () => { closePlusMenu(); void window.lisaCaptureAndAttach('interactive'); });
 }
 
 // ── Audio recording → transcribe → Lisa summarizes ─────────────────
@@ -309,21 +325,7 @@ if (recordBtnEl) {
   });
 }
 
-const attachBtnEl = document.getElementById('attachBtn');
-if (attachBtnEl) {
-  attachBtnEl.addEventListener('click', (ev) => {
-    // Don't preventDefault — that cancels the implicit label-forward
-    // and removes the redundant gesture path. Letting both fire is
-    // fine because <input type=file>.click() fires the picker only
-    // once per user gesture.
-    console.log('[attach] click forwarded to fileInput');
-    try {
-      fileInput.click();
-    } catch (err) {
-      console.error('[attach] fileInput.click failed:', err);
-    }
-  });
-}
+// (📎 attach is now an item in the ＋ composer menu — see pmAttach above.)
 
 // Paste-to-attach: when the user has copied an image (screenshot,
 // image from a webpage, etc.) and presses ⌘V, pull the image off the
@@ -870,7 +872,8 @@ async function showSoul() {
   modalBody.innerHTML = html;
 }
 
-document.querySelectorAll('.badge').forEach(b => {
+// Panel openers — the top function bar (.fbtn) + any legacy .badge share this.
+document.querySelectorAll('[data-panel]').forEach(b => {
   b.addEventListener('click', () => {
     const which = b.dataset.panel;
     if (which === 'soul') showSoul();
@@ -880,6 +883,28 @@ document.querySelectorAll('.badge').forEach(b => {
     else if (which === 'plans') showPlans();
   });
 });
+
+// Find in conversation — toggle a filter box that hides non-matching log rows.
+const fnSearchBtn = document.getElementById('fnSearchBtn');
+const fnFind = document.getElementById('fnFind');
+function filterLog(q) {
+  const logEl = document.getElementById('log');
+  if (!logEl) return;
+  for (const child of logEl.children) {
+    child.style.display = !q || (child.textContent || '').toLowerCase().includes(q) ? '' : 'none';
+  }
+}
+if (fnSearchBtn && fnFind) {
+  fnSearchBtn.addEventListener('click', () => {
+    const show = fnFind.style.display === 'none';
+    fnFind.style.display = show ? '' : 'none';
+    if (show) { fnFind.focus(); } else { fnFind.value = ''; filterLog(''); }
+  });
+  fnFind.addEventListener('input', () => filterLog(fnFind.value.trim().toLowerCase()));
+  fnFind.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape') { fnFind.value = ''; filterLog(''); fnFind.style.display = 'none'; }
+  });
+}
 
 let currentLisaSpan = null;
 let pendingTools = new Map();

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -513,7 +513,7 @@ export const MAIN_CSS = `  :root {
   .main {
     grid-area: main;
     display: grid;
-    grid-template-rows: 1fr auto auto;
+    grid-template-rows: auto 1fr auto auto;
     overflow: hidden;
     background:
       radial-gradient(ellipse at 50% -30%, rgba(106, 212, 255, 0.06) 0%, transparent 60%),
@@ -705,12 +705,12 @@ export const MAIN_CSS = `  :root {
     -webkit-backdrop-filter: blur(30px);
     border-top: 1px solid var(--border-new);
     display: grid;
-    grid-template-columns: 36px 36px 36px 1fr 96px;
+    grid-template-columns: 36px 36px 1fr 96px;
     gap: 10px;
     align-items: end;
   }
 
-  #attachBtn, #captureBtn, #recordBtn {
+  #plusBtn, #recordBtn {
     align-self: stretch;
     display: flex;
     align-items: center;
@@ -725,8 +725,56 @@ export const MAIN_CSS = `  :root {
     min-height: 44px;
     padding: 0;
   }
-  #attachBtn:hover, #captureBtn:hover, #recordBtn:hover { background: var(--bg-card); color: var(--fg); }
-  #captureBtn.flash { background: var(--accent); color: var(--bg-deep); }
+  #plusBtn { font-size: 22px; font-weight: 400; }
+  #plusBtn:hover, #recordBtn:hover { background: var(--bg-card); color: var(--fg); }
+  #plusBtn.flash { background: var(--accent); color: var(--bg-deep); }
+
+  /* ＋ composer menu (merged attach + screenshot) */
+  .plus-wrap { position: relative; align-self: stretch; display: flex; }
+  .plus-menu {
+    display: none;
+    position: absolute;
+    left: 0;
+    bottom: calc(100% + 8px);
+    min-width: 168px;
+    background: var(--bg-deep, #0c1024);
+    border: 1px solid var(--border-new, rgba(255,255,255,.1));
+    border-radius: 11px;
+    padding: 5px;
+    box-shadow: 0 14px 34px rgba(0,0,0,.5);
+    z-index: 30;
+  }
+  .plus-menu.open { display: block; }
+  .plus-menu button {
+    display: flex; align-items: center; gap: 9px; width: 100%;
+    background: transparent; border: 0; color: var(--fg); font-size: 13px;
+    padding: 9px 10px; border-radius: 8px; cursor: pointer; text-align: left;
+  }
+  .plus-menu button:hover { background: var(--bg-card); }
+  .plus-menu .g { width: 18px; text-align: center; }
+
+  /* Top icon function bar (功能区) */
+  .fnbar {
+    display: flex; align-items: center; gap: 4px;
+    padding: 6px 14px;
+    border-bottom: 1px solid var(--border-new, rgba(255,255,255,.08));
+    background: rgba(255,255,255,.02);
+  }
+  .fbtn {
+    width: 32px; height: 32px; flex: none;
+    display: flex; align-items: center; justify-content: center;
+    background: transparent; border: 1px solid transparent; border-radius: 8px;
+    color: var(--fg-2); font-size: 15px; cursor: pointer;
+    transition: background 120ms ease;
+  }
+  .fbtn:hover { background: var(--bg-card, rgba(255,255,255,.06)); }
+  .fbtn img { width: 17px; height: 17px; object-fit: contain; image-rendering: pixelated; }
+  .fbar-spacer { flex: 1; }
+  .fn-find {
+    height: 28px; width: 150px; font-size: 12px; padding: 0 9px;
+    border-radius: 8px; border: 1px solid var(--border-strong, rgba(255,255,255,.14));
+    background: rgba(0,0,0,.3); color: var(--fg);
+  }
   /* Pulsing red while recording. */
   #recordBtn.recording {
     background: var(--err-color);
@@ -813,7 +861,7 @@ export const MAIN_CSS = `  :root {
       gap: 14px;
     }
     #form {
-      grid-template-columns: 36px 36px 36px 1fr 84px;
+      grid-template-columns: 36px 36px 1fr 84px;
       padding: 10px 14px 14px;
     }
     #input { font-size: 16px; /* prevents iOS Safari auto-zoom */ }

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -16,12 +16,12 @@ import { MAIN_HTML } from "./lisa-html.js";
  * change the GUI markup/CSS/JS, recompute them:
  *   node --import tsx -e 'import("./src/web/lisa-html.ts").then(async m=>{const {createHash}=await import("node:crypto");console.log(m.MAIN_HTML.length, createHash("sha256").update(m.MAIN_HTML).digest("hex"))})'
  *
- * Last updated: Mail card (connect-mailbox modal + daily classified digest +
- * needs-you list + sweep-now) added to the sidebar.
+ * Last updated: composer ＋ menu (merged attach+screenshot) + top icon function
+ * bar (功能区: soul/skills/memory/tools/plans + find); bottom badges removed.
  */
-const EXPECTED_LENGTH = 102331;
+const EXPECTED_LENGTH = 106010;
 const EXPECTED_SHA256 =
-  "c14af5253ba023e34df61639ac35eaa449c1b70339d5c4ad1dcd944acd00a2d7";
+  "a087cdfe5f63ab981cf68e31fecb0042878231e3113f553c061329c34d0c3365";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -110,14 +110,7 @@ ${MAIN_CSS}
       <p style="margin:0; font-size:11.5px; color:var(--fg-2); line-height:1.5;" id="sbReflectionBody"></p>
     </div>
 
-    <!-- SOUL / SKILLS / MEMORY / TOOLS row -->
-    <div class="badges">
-      <button class="badge" type="button" data-panel="soul"><img src="/assets/icon-soul.png" alt="">SOUL</button>
-      <button class="badge" type="button" data-panel="skills"><img src="/assets/icon-skill.png" alt="">SKILLS</button>
-      <button class="badge" type="button" data-panel="memory"><img src="/assets/icon-memory.png" alt="">MEMORY</button>
-      <button class="badge" type="button" data-panel="tools"><img src="/assets/icon-tool.png" alt="">TOOLS</button>
-      <button class="badge" type="button" data-panel="plans"><img src="/assets/icon-tool.png" alt="">PLANS</button>
-    </div>
+    <!-- (SOUL/SKILLS/MEMORY/TOOLS/PLANS moved to the top icon function bar) -->
 
     <!-- Footer: current session id -->
     <div class="sb-footer">
@@ -129,6 +122,18 @@ ${MAIN_CSS}
   <!-- ╔════════════════ Main pane ════════════════╗ -->
   <div class="main">
 
+    <!-- Top icon function bar (功能区): panels + find -->
+    <div class="fnbar" id="fnbar">
+      <button class="fbtn" type="button" data-panel="soul" title="Soul"><img src="/assets/icon-soul.png" alt="Soul"></button>
+      <button class="fbtn" type="button" data-panel="skills" title="Skills"><img src="/assets/icon-skill.png" alt="Skills"></button>
+      <button class="fbtn" type="button" data-panel="memory" title="Memory"><img src="/assets/icon-memory.png" alt="Memory"></button>
+      <button class="fbtn" type="button" data-panel="tools" title="Tools"><img src="/assets/icon-tool.png" alt="Tools"></button>
+      <button class="fbtn" type="button" data-panel="plans" title="Coding plans"><img src="/assets/icon-tool.png" alt="Plans"></button>
+      <span class="fbar-spacer"></span>
+      <input id="fnFind" class="fn-find" type="text" placeholder="find in chat…" autocomplete="off" style="display:none">
+      <button class="fbtn" type="button" id="fnSearchBtn" title="Find in conversation">⌕</button>
+    </div>
+
     <!-- Chat log (messages, tool blocks, idle blocks injected here) -->
     <div id="log"></div>
 
@@ -137,11 +142,14 @@ ${MAIN_CSS}
 
     <!-- Composer -->
     <form id="form">
-      <label id="attachBtn" title="Attach file (or paste images directly into the textarea)">
-        <input type="file" id="fileInput" accept="image/*,.pdf,.txt,.md,.csv,.json" multiple>
-        📎
-      </label>
-      <button type="button" id="captureBtn" title="Screenshot for Lisa (⌃⌥S anywhere)">📷</button>
+      <input type="file" id="fileInput" accept="image/*,.pdf,.txt,.md,.csv,.json" multiple>
+      <div class="plus-wrap">
+        <button type="button" id="plusBtn" title="Attach or screenshot">＋</button>
+        <div class="plus-menu" id="plusMenu">
+          <button type="button" id="pmAttach"><span class="g">📎</span> Attach file</button>
+          <button type="button" id="pmShot"><span class="g">📷</span> Screenshot</button>
+        </div>
+      </div>
       <button type="button" id="recordBtn" title="Dictate — speak and Lisa drops polished text in the box (hold to record a summary)">🎙</button>
       <textarea id="input" placeholder="Talk to Lisa…  (Enter to send · Shift+Enter for newline)" autofocus></textarea>
       <button type="submit" id="sendBtn">


### PR DESCRIPTION
## What
The two requested chat-UI changes ([mockup](reference/mockups/lisa-sidebar-mode.html)):

1. **＋ composer button** — 📎 attach + 📷 screenshot merge into one **＋** that opens a popover (Attach file · Screenshot). 🎙 stays separate, so the composer is **＋ · 🎙 · input · SEND** (5-col → 4-col grid; survives narrow widths). The file-input is reused (kept off-screen for WKWebView); the capture handler moves under "Screenshot"; ＋ flashes during capture.
2. **Top icon function bar (功能区)** — a thin row atop the chat pane: **soul · skills · memory · tools · plans** + a **find-in-conversation** box. SOUL/SKILLS/MEMORY/TOOLS/PLANS move here from the bottom sidebar badges (removed). The panel handler now binds `[data-panel]`; find filters `#log` rows client-side.

## Verification
**861 tests / 1 skip**; typecheck + build clean; snapshot updated. Live smoke: served HTML has `fnbar` + 6 `fbtn`s + ＋ menu (`pmAttach`/`pmShot`); `captureBtn`/`attachBtn`/`badges` gone; `fileInput` retained.

Next (PR B): the compact/sidebar responsive mode + Settings toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)