### PR TITLE
feat(web): compact / sidebar mode toggle (dock as a narrow panel)

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -906,6 +906,28 @@ if (fnSearchBtn && fnFind) {
   });
 }
 
+// Compact / sidebar mode — force the narrow stacked layout at any width, persisted.
+const compactToggleEl = document.getElementById('compactToggle');
+if (compactToggleEl) {
+  let compactOn = false;
+  try { compactOn = localStorage.getItem('lisaCompact') === '1'; } catch (e) {}
+  const applyCompact = () => {
+    document.body.classList.toggle('force-compact', compactOn);
+    compactToggleEl.classList.toggle('on', compactOn);
+    compactToggleEl.setAttribute('aria-checked', compactOn ? 'true' : 'false');
+  };
+  applyCompact();
+  const toggleCompact = () => {
+    compactOn = !compactOn;
+    try { localStorage.setItem('lisaCompact', compactOn ? '1' : '0'); } catch (e) {}
+    applyCompact();
+  };
+  compactToggleEl.addEventListener('click', toggleCompact);
+  compactToggleEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); toggleCompact(); }
+  });
+}
+
 let currentLisaSpan = null;
 let pendingTools = new Map();
 let thinkingEl = null;

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -1241,6 +1241,20 @@ export const MAIN_CSS = `  :root {
     #input { font-size: 16px; /* prevents iOS Safari auto-zoom */ }
   }
 
+  /* ── Forced compact / "sidebar mode" ─────────────────────────────
+     Same stacked layout as the narrow breakpoint, but toggled on at ANY
+     width (persisted client-side) so Lisa can be docked as a skinny panel. */
+  body.force-compact .frame {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto auto 1fr;
+  }
+  body.force-compact .sidebar {
+    max-height: 38vh;
+    padding: 14px 14px 12px;
+    gap: 14px;
+  }
+  body.force-compact #form { grid-template-columns: 36px 36px 1fr 84px; }
+
   /* ===================================================================
      Modal panel (skills / memory / tools / soul) — unchanged from the
      legacy pixel-art shell. Uses the legacy CSS vars declared above.

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -26,9 +26,9 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: composer ＋ menu (merged attach+screenshot) + a top icon function bar
  * (功能区: soul/skills/tools/plans + find) in #viewChat; bottom badges removed.
  */
-const EXPECTED_LENGTH = 141400;
+const EXPECTED_LENGTH = 143278;
 const EXPECTED_SHA256 =
-  "26e94cfe385fdd7b75f98751d490aec9de209965af409fdd6f29798af7c5e0e8";
+  "c7061e2586e4de82f1ff774f9cef2ce6dac4ed07f762842201da1f096aa2dd7b";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -135,6 +135,13 @@ ${MAIN_CSS}
       <span class="pt-track"><span class="pt-knob"></span></span>
     </div>
 
+    <!-- Compact / sidebar-mode toggle (client-side; forces the narrow stacked
+         layout at any width so Lisa can dock as a skinny panel) -->
+    <div class="proactive-toggle" id="compactToggle" role="switch" aria-checked="false" tabindex="0" title="Compact / sidebar mode — dock Lisa as a narrow panel (also auto on a small window)">
+      <span class="pt-label">Compact</span>
+      <span class="pt-track"><span class="pt-knob"></span></span>
+    </div>
+
     <!-- Footer: current session id -->
     <div class="sb-footer">
       <span class="session-id" id="sessionId">—</span>


### PR DESCRIPTION
Adds a Compact toggle (beside Proactive) that forces the console's narrow stacked layout at any width, persisted in localStorage — dock Lisa as a skinny panel. body.force-compact mirrors the existing @media(max-width:720px) rules. 865 tests / 1 skip; typecheck + build clean; snapshot 141400 to 143278.

🤖 Generated with [Claude Code](https://claude.com/claude-code)