### PR TITLE
fix(web,mac): line-style 功能区 icons + connect WKWebView voice mic

### DIFF
--- a/packaging/mac-client/Resources/Entitlements.plist
+++ b/packaging/mac-client/Resources/Entitlements.plist
@@ -21,5 +21,9 @@
     <true/>
     <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
     <true/>
+    <!-- audio-input: the hardened runtime requires this to use the microphone
+         (🎙 voice dictation in the embedded WKWebView). -->
+    <key>com.apple.security.device.audio-input</key>
+    <true/>
 </dict>
 </plist>

--- a/packaging/mac-client/Resources/Info.plist
+++ b/packaging/mac-client/Resources/Info.plist
@@ -28,6 +28,10 @@
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>
     <true/>
+    <!-- Microphone — for 🎙 voice dictation in the chat composer (getUserMedia
+         in the embedded WKWebView). Audio is transcribed via the local server. -->
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Lisa uses the microphone for voice dictation — speak and Lisa turns it into text.</string>
     <!-- ATS exception: we only ever talk to localhost. -->
     <key>NSAppTransportSecurity</key>
     <dict>

--- a/packaging/mac-client/Sources/Lisa/WebContent.swift
+++ b/packaging/mac-client/Sources/Lisa/WebContent.swift
@@ -338,6 +338,22 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WK
         return nil
     }
 
+    // Grant the web UI's getUserMedia request (🎙 voice dictation). Without this
+    // delegate, WKWebView denies capture by default and the page sees no
+    // mediaDevices ("recording not supported"). We only ever load our own
+    // localhost UI; the OS TCC prompt (NSMicrophoneUsageDescription) still gates
+    // actual access, and the audio-input entitlement is declared for the
+    // hardened runtime.
+    func webView(
+        _ webView: WKWebView,
+        requestMediaCapturePermissionFor origin: WKSecurityOrigin,
+        initiatedByFrame frame: WKFrameInfo,
+        type: WKMediaCaptureType,
+        decisionHandler: @escaping (WKPermissionDecision) -> Void
+    ) {
+        decisionHandler(.grant)
+    }
+
     /// WKWebView on macOS does NOT provide a default file picker for
     /// `<input type="file">` clicks — without this delegate method,
     /// clicking the paperclip in the chat composer is a silent no-op.

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -1128,20 +1128,20 @@ export const MAIN_CSS = `  :root {
 
   /* Top icon function bar (功能区) inside #viewChat */
   .fnbar {
-    display: flex; align-items: center; gap: 4px;
-    padding: 6px 14px;
+    display: flex; align-items: center; gap: 6px;
+    padding: 7px 16px;
     border-bottom: 1px solid var(--border-new, rgba(255,255,255,.08));
     background: rgba(255,255,255,.02);
   }
   .fbtn {
-    width: 32px; height: 32px; flex: none;
+    width: 34px; height: 34px; flex: none;
     display: flex; align-items: center; justify-content: center;
-    background: transparent; border: 1px solid transparent; border-radius: 8px;
-    color: var(--fg-2); font-size: 15px; cursor: pointer;
-    transition: background 120ms ease;
+    background: transparent; border: 1px solid transparent; border-radius: 9px;
+    color: var(--fg-2); cursor: pointer;
+    transition: background 120ms ease, color 120ms ease;
   }
-  .fbtn:hover { background: var(--bg-card, rgba(255,255,255,.06)); }
-  .fbtn img { width: 17px; height: 17px; object-fit: contain; image-rendering: pixelated; }
+  .fbtn:hover { background: var(--bg-card, rgba(255,255,255,.06)); color: var(--fg); }
+  .fbtn svg { width: 19px; height: 19px; display: block; }
   .fbar-spacer { flex: 1; }
   .fn-find {
     height: 28px; width: 150px; font-size: 12px; padding: 0 9px;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -26,9 +26,9 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: composer ＋ menu (merged attach+screenshot) + a top icon function bar
  * (功能区: soul/skills/tools/plans + find) in #viewChat; bottom badges removed.
  */
-const EXPECTED_LENGTH = 143278;
+const EXPECTED_LENGTH = 144313;
 const EXPECTED_SHA256 =
-  "c7061e2586e4de82f1ff774f9cef2ce6dac4ed07f762842201da1f096aa2dd7b";
+  "e462cd93950f1e1f9528381bc70e3b739fe617a34cd4b45e643dcdef33b909eb";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -157,13 +157,13 @@ ${MAIN_CSS}
 
     <!-- Top icon function bar (功能区): quick panels + find -->
     <div class="fnbar" id="fnbar">
-      <button class="fbtn" type="button" data-panel="soul" title="Soul"><img src="/assets/icon-soul.png" alt="Soul"></button>
-      <button class="fbtn" type="button" data-panel="skills" title="Skills"><img src="/assets/icon-skill.png" alt="Skills"></button>
-      <button class="fbtn" type="button" data-panel="tools" title="Tools"><img src="/assets/icon-tool.png" alt="Tools"></button>
-      <button class="fbtn" type="button" data-panel="plans" title="Coding plans"><img src="/assets/icon-tool.png" alt="Plans"></button>
+      <button class="fbtn" type="button" data-panel="soul" title="Soul" aria-label="Soul"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l2.2 6.6L21 12l-6.8 2.4L12 21l-2.2-6.6L3 12l6.8-2.4z"/></svg></button>
+      <button class="fbtn" type="button" data-panel="skills" title="Skills" aria-label="Skills"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 4 14h7l-1 8 10-12h-7z"/></svg></button>
+      <button class="fbtn" type="button" data-panel="tools" title="Tools" aria-label="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></button>
+      <button class="fbtn" type="button" data-panel="plans" title="Coding plans" aria-label="Coding plans"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><line x1="6" y1="3" x2="6" y2="15"/><circle cx="18" cy="6" r="3"/><circle cx="6" cy="18" r="3"/><path d="M18 9a9 9 0 0 1-9 9"/></svg></button>
       <span class="fbar-spacer"></span>
       <input id="fnFind" class="fn-find" type="text" placeholder="find in chat…" autocomplete="off" style="display:none">
-      <button class="fbtn" type="button" id="fnSearchBtn" title="Find in conversation">⌕</button>
+      <button class="fbtn" type="button" id="fnSearchBtn" title="Find in conversation" aria-label="Find"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
     </div>
 
     <!-- Chat log (messages, tool blocks, idle blocks injected here) -->


### PR DESCRIPTION
Two fixes from the live client (screenshot).

## 1. Header icons → line-style SVG
The 功能区 used tiny pixel-art PNGs (ugly + small). Swapped for inline **line-style SVG** icons — soul=sparkle, skills=bolt, tools=wrench, plans=git-branch, find=search — 19px, `currentColor` stroke (inherits theme + hover). Bigger, crisper, consistent.

## 2. Voice dictation — "recording not supported" → connected
It failed in the Mac app because **WKWebView denies media capture by default** (`navigator.mediaDevices` absent). Connected it:
- `WebContent.swift`: implement `requestMediaCapturePermissionFor` → `.grant`.
- `Info.plist`: `NSMicrophoneUsageDescription` (TCC prompt).
- `Entitlements.plist`: `com.apple.security.device.audio-input` (hardened runtime).

Then `getUserMedia` → `MediaRecorder` → `POST /api/voice/transcribe` (Whisper; needs `OPENAI_API_KEY` for the actual transcript). **Needs a Mac-app rebuild** to take effect.

## Verification
865 tests / 1 skip; typecheck + build clean; `swift build` clean; snapshot 143278 → 144313.

🤖 Generated with [Claude Code](https://claude.com/claude-code)