### PR TITLE
fix(web): compact/sidebar mode broke the layout (missing grid-template-areas)

### DIFF
--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -1228,6 +1228,10 @@ export const MAIN_CSS = `  :root {
       grid-template-columns: 1fr;
       /* titlebar · sidebar (capped, scrolls) · main view-stack (fills rest) */
       grid-template-rows: auto auto 1fr;
+      grid-template-areas:
+        "titlebar"
+        "sidebar"
+        "main";
     }
     .sidebar {
       max-height: 38vh;
@@ -1247,6 +1251,10 @@ export const MAIN_CSS = `  :root {
   body.force-compact .frame {
     grid-template-columns: 1fr;
     grid-template-rows: auto auto 1fr;
+    grid-template-areas:
+      "titlebar"
+      "sidebar"
+      "main";
   }
   body.force-compact .sidebar {
     max-height: 38vh;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -26,9 +26,9 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: composer ＋ menu (merged attach+screenshot) + a top icon function bar
  * (功能区: soul/skills/tools/plans + find) in #viewChat; bottom badges removed.
  */
-const EXPECTED_LENGTH = 144313;
+const EXPECTED_LENGTH = 144465;
 const EXPECTED_SHA256 =
-  "e462cd93950f1e1f9528381bc70e3b739fe617a34cd4b45e643dcdef33b909eb";
+  "50106ac69deb60c674e4a1ce35ac106e0233f63b09490db3ebd39b4cb617bff1";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);


### PR DESCRIPTION
## Bug
Toggling **Compact** collapsed the app to just the left rail over an empty void, and looked stuck (screenshot).

## Root cause
`body.force-compact .frame` (and the narrow `@media` breakpoint) switched the shell grid to **1 column + 3 rows** but never overrode `grid-template-areas`, which still declared the 2-column `"titlebar titlebar" / "sidebar main"`. With one column, the `main` (chat) area couldn't be placed → it vanished.

## Fix
Add the stacked areas to **both** rules:
```
"titlebar"
"sidebar"   /* capped 38vh, scrolls */
"main"      /* chat view fills below */
```
Compact now lays out correctly and the toggle restores cleanly.

## Verification
865 tests / 1 skip; typecheck + build clean; snapshot 144313 → 144465. CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)