### PR TITLE
feat(web): floating-panel sidebar (Claude-Code style) + wider + drop workspace pill

### DIFF
--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -71,7 +71,7 @@ export const MAIN_CSS = `  :root {
     height: 100vh;
     width: 100vw;
     display: grid;
-    grid-template-columns: 280px 1fr;
+    grid-template-columns: 300px 1fr;
     grid-template-rows: 36px 1fr;
     grid-template-areas:
       "titlebar titlebar"
@@ -120,15 +120,18 @@ export const MAIN_CSS = `  :root {
     letter-spacing: 0;
   }
 
-  /* ── Sidebar ───────────────────────────────────────────────── */
+  /* ── Sidebar (floating panel — Claude-Code-style detached card) ──── */
   .sidebar {
     grid-area: sidebar;
-    background: rgba(7, 9, 26, 0.4);
+    margin: 8px 6px 10px 10px;
+    background: linear-gradient(180deg, rgba(18, 23, 48, 0.62), rgba(10, 13, 33, 0.6));
     backdrop-filter: blur(30px);
     -webkit-backdrop-filter: blur(30px);
-    border-right: 1px solid var(--border-new);
+    border: 1px solid var(--border-new);
+    border-radius: 16px;
+    box-shadow: 0 18px 44px rgba(0, 0, 0, 0.5);
     overflow-y: auto;
-    padding: 20px 16px 16px;
+    padding: 18px 14px 14px;
     display: flex;
     flex-direction: column;
     gap: 18px;
@@ -512,35 +515,6 @@ export const MAIN_CSS = `  :root {
     font-variant-numeric: tabular-nums;
     flex-shrink: 0;
   }
-
-  /* ── Workspace pill (top of sidebar) ───────────────────────── */
-  .ws-pill {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 11px;
-    background: var(--bg-card);
-    border: 1px solid var(--border-new);
-    border-radius: 11px;
-  }
-  .ws-pill .ws-dot {
-    width: 8px;
-    height: 8px;
-    border-radius: 50%;
-    background: var(--proactive);
-    box-shadow: 0 0 6px var(--proactive-glow);
-    flex-shrink: 0;
-  }
-  .ws-pill .ws-name {
-    font-size: 12px;
-    font-weight: 700;
-    letter-spacing: 0.04em;
-    color: var(--fg-2);
-    overflow: hidden;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-  }
-  .ws-pill .ws-ico { margin-left: auto; color: var(--fg-faint); font-size: 13px; }
 
   /* ── Primary nav (vertical list in the sidebar) ────────────── */
   .nav-list { display: flex; flex-direction: column; gap: 2px; }

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -25,10 +25,12 @@ import { MAIN_HTML } from "./lisa-html.js";
  * and an unused .pp-tag.you rule was dropped.
  * Then: composer ＋ menu (merged attach+screenshot) + a top icon function bar
  * (功能区: soul/skills/tools/plans + find) in #viewChat; bottom badges removed.
+ * Then: removed the "LISA workspace" pill (markup + .ws-pill CSS) from the top
+ * of the sidebar — redundant chrome; the identity card is now the first block.
  */
-const EXPECTED_LENGTH = 144465;
+const EXPECTED_LENGTH = 143704;
 const EXPECTED_SHA256 =
-  "50106ac69deb60c674e4a1ce35ac106e0233f63b09490db3ebd39b4cb617bff1";
+  "9fbd62a96ed2ee95efeaa28dbb92a7b5167935110d142537f5226bd6f59b091b";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -56,13 +56,6 @@ ${MAIN_CSS}
   <!-- ╔════════════════ Sidebar ════════════════╗ -->
   <aside class="sidebar">
 
-    <!-- LISA workspace -->
-    <div class="ws-pill">
-      <span class="ws-dot"></span>
-      <span class="ws-name">LISA workspace</span>
-      <span class="ws-ico">⌄</span>
-    </div>
-
     <!-- Identity card -->
     <div class="identity">
       <div class="avatar-wrap">


### PR DESCRIPTION
Floating-card sidebar (inset margins, 16px radius, shadow, full border) like Claude Code's launcher; width 280→300px (~+5% usable); drops the redundant LISA workspace pill. CSS/markup only. 865 tests, snapshot 144465→143704.

🤖 Generated with [Claude Code](https://claude.com/claude-code)