### PR TITLE
chore(ios): align App Store submission with Telloria (privacy manifest + docs)

### DIFF
--- a/packaging/ios-companion/RELEASE.md
+++ b/packaging/ios-companion/RELEASE.md
@@ -12,6 +12,18 @@ workflow runs the same thing in CI — modeled on the secret-gated pattern of
 App identity: bundle id **`ai.meetlisa.pocket`** (+ the widget extension
 `ai.meetlisa.pocket.widgets`), team **`9LH9NBX7P4`**.
 
+**Reused from Telloria** (same Apple Developer account, **wangharp@gmail.com**):
+the Apple **team `9LH9NBX7P4`** and the **App Store Connect API key** are
+account-level, so the very key that uploads Telloria uploads Lisa Pocket too —
+no new credentials. The **privacy manifest** ([`Sources/PrivacyInfo.xcprivacy`](Sources/PrivacyInfo.xcprivacy))
+mirrors Telloria's required-reason API set (UserDefaults / file-timestamp /
+boot-time / disk-space). It differs only on data collection: Telloria declares
+email / user-id / purchase / analytics because it collects them; Lisa Pocket is
+a thin client to **your own** backend and collects nothing to a Lisa server, so
+its collected-data + tracking are empty. **iOS only** — there is no Android
+target (Lisa Pocket is native SwiftUI, not the Expo app Telloria ships to both
+stores).
+
 ## One-time setup (Apple account actions — only you can do these)
 
 1. **Register the app in App Store Connect.** App Store Connect → Apps → ➕ →
@@ -61,6 +73,27 @@ Add these repo secrets (Settings → Secrets and variables → Actions):
 
 Then push a tag `pocket-vX.Y.Z` (or run the workflow manually). With the secrets
 absent the workflow is a no-op, so the repo stays green for others.
+
+## From TestFlight to App Store (public release)
+
+TestFlight (above) gets the build to Apple. Going **public on the App Store**
+adds these App Store Connect console steps (account actions — only you):
+
+1. **App Privacy** (App → App Privacy) — answer **"Data Not Collected"** to match
+   the privacy manifest (Lisa Pocket is a thin client to your own backend; nothing
+   reaches a Lisa-operated server). No tracking.
+2. **Reviewability — the make-or-break item.** A reviewer has no Mac running
+   `lisa serve`, so a pairing-only build looks non-functional (Guideline 2.1).
+   Ship the **LISA Cloud M0 demo** (see [docs/PLAN_CLOUD_v1.0.md](../../docs/PLAN_CLOUD_v1.0.md)):
+   a hosted instance + a seeded **demo account**, and put its credentials in
+   App Review → **App Review Information → Sign-in required → demo user/pass**,
+   with a note explaining the Mac-pairing vs cloud modes.
+3. **Encryption / export compliance** — answered by `ITSAppUsesNonExemptEncryption=false`
+   in `project.yml` (standard HTTPS only), so no per-build prompt.
+4. **Metadata** — name "Lisa Pocket", subtitle, description, keywords, **support URL**
+   + **privacy-policy URL** (required; host on meetlisa.ai), category, **age rating**,
+   and **screenshots** (6.7"/6.5" iPhone at minimum; iPad if `supportsTablet`).
+5. **Submit for Review** (the build from TestFlight → "Add Build" on the app version).
 
 ## Honest limits
 

--- a/packaging/ios-companion/Sources/PrivacyInfo.xcprivacy
+++ b/packaging/ios-companion/Sources/PrivacyInfo.xcprivacy
@@ -3,13 +3,20 @@
 <!--
   Privacy manifest for Lisa Pocket (required by Apple since May 2024).
 
-  Lisa Pocket is a thin client to the user's OWN Lisa backend (their Mac, or
-  later their private LISA Cloud instance). It does not track users and does not
-  ship data to a third-party analytics/ads service, so NSPrivacyTracking is false
-  and NSPrivacyCollectedDataTypes is empty. The only required-reason API is
-  UserDefaults, used for the app's own settings + the App Group snapshot the
-  home-screen widget reads (reason CA92.1 — access to info from the app itself /
-  its app group).
+  Required-reason API set mirrors Telloria's proven manifest
+  (telloria-web/apps/mobile/plugins/withPrivacyManifest.js): UserDefaults,
+  file-timestamp, system-boot-time, disk-space — the APIs Foundation / URLSession
+  pull in. Reason codes: CA92.1 (UserDefaults, app-internal state + the App Group
+  snapshot the widget reads), C617.1 (file timestamps, app-owned files), 35F9.1
+  (boot time, session age), 85F4.1 (disk space, cache management).
+
+  DIFFERS from Telloria on data collection: Telloria collects email / user-id /
+  purchase / analytics / crash data to its own backend, so it declares them.
+  Lisa Pocket is a THIN CLIENT to the user's OWN Lisa backend (their Mac, or
+  later their own LISA Cloud instance, BYO key) — nothing is collected to a
+  Lisa-operated server and there is no tracking. So NSPrivacyTracking is false,
+  NSPrivacyTrackingDomains is empty, and NSPrivacyCollectedDataTypes is empty.
+  (Revisit if/when a Lisa-operated multi-tenant cloud ships.)
 -->
 <plist version="1.0">
 <dict>
@@ -25,9 +32,25 @@
             <key>NSPrivacyAccessedAPIType</key>
             <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
             <key>NSPrivacyAccessedAPITypeReasons</key>
-            <array>
-                <string>CA92.1</string>
-            </array>
+            <array><string>CA92.1</string></array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryFileTimestamp</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array><string>C617.1</string></array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array><string>35F9.1</string></array>
+        </dict>
+        <dict>
+            <key>NSPrivacyAccessedAPIType</key>
+            <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+            <key>NSPrivacyAccessedAPITypeReasons</key>
+            <array><string>85F4.1</string></array>
         </dict>
     </array>
 </dict>


### PR DESCRIPTION
Reference Telloria's submission + reuse the permission files (same Apple account wangharp@gmail.com, iOS-only):

- **PrivacyInfo.xcprivacy** mirrors Telloria's required-reason API set (UserDefaults / file-timestamp / boot-time / disk-space). Differs only on data collection — Telloria collects email/user-id/purchase/analytics; Lisa Pocket is a thin client to your own backend and collects nothing to a Lisa server, so collected-data + tracking are empty.
- **RELEASE.md** documents the reuse: team `9LH9NBX7P4` + the ASC API key are account-level (the key that ships Telloria ships Lisa Pocket too); iOS-only (no Android target); + the App-Store steps (App Privacy answers, reviewer demo account via the cloud M0).

`testflight.sh` already mirrors EAS submit (xcodebuild archive + ASC API key). No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)