### PR TITLE
feat(cloud): C1 — cloud edition auth gate + /api/edition (no loopback trust)

### DIFF
--- a/src/web/auth.test.ts
+++ b/src/web/auth.test.ts
@@ -55,4 +55,14 @@ describe("isRequestAuthorized — the RCE gate (red-team)", () => {
   test("a LAN request with the correct token is allowed", () => {
     assert.equal(isRequestAuthorized("192.168.1.20", TOKEN, TOKEN), true);
   });
+
+  // Cloud edition: loopback is NOT a free pass — the container must not trust
+  // its own/proxy loopback, so trustLoopback=false forces a token everywhere.
+  test("trustLoopback=false (cloud) makes loopback require the token", () => {
+    assert.equal(isRequestAuthorized("127.0.0.1", TOKEN, null, false), false);
+    assert.equal(isRequestAuthorized("::1", TOKEN, "wrong", false), false);
+    assert.equal(isRequestAuthorized("127.0.0.1", TOKEN, TOKEN, false), true);
+    // default (Mac edition) still trusts loopback
+    assert.equal(isRequestAuthorized("127.0.0.1", TOKEN, null), true);
+  });
 });

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -67,6 +67,7 @@ import {
 } from "../screen_advisor/engine.js";
 import os from "node:os";
 import { LISA_HOME } from "../paths.js";
+import { isCloud, editionInfo } from "../edition.js";
 import type { ToolDefinition, StoredMessage } from "../types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -115,8 +116,9 @@ export function isRequestAuthorized(
   remoteAddr: string,
   webToken: string | null,
   presented: string | null,
+  trustLoopback = true,
 ): boolean {
-  if (isLoopbackAddress(remoteAddr)) return true;
+  if (trustLoopback && isLoopbackAddress(remoteAddr)) return true;
   return !!webToken && !!presented && timingSafeEqualStr(presented, webToken);
 }
 
@@ -559,10 +561,14 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     // full-tool agent and /api/vision/capture grabs the screen, so an
     // unauthenticated non-loopback request is a remote-code-execution hole.
     const remoteAddr = req.socket.remoteAddress ?? "";
-    if (!isLoopbackAddress(remoteAddr)) {
+    // In the hosted cloud edition there is no trusted local user — the gate runs
+    // for EVERY request and loopback is not a free pass (the container must never
+    // trust its own/proxy loopback). Mac edition: loopback = the local owner.
+    const cloud = isCloud();
+    if (cloud || !isLoopbackAddress(remoteAddr)) {
       const presented = webToken ? presentedToken(req, url) : null;
       // Authorized by the global LISA_WEB_TOKEN OR a non-revoked per-device token.
-      let authed = isRequestAuthorized(remoteAddr, webToken, presented);
+      let authed = isRequestAuthorized(remoteAddr, webToken, presented, !cloud);
       if (!authed && presented) {
         const device = verifyDeviceToken(presented);
         if (device) {
@@ -611,6 +617,14 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     if (req.method === "GET" && (url === "/" || url.startsWith("/?"))) {
       res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
       res.end(MAIN_HTML);
+      return;
+    }
+
+    // Edition + capability descriptor — the client hides Mac-only surfaces
+    // (PTY/adopt, local dispatch, Sense, agent control) in the cloud edition.
+    if (req.method === "GET" && url === "/api/edition") {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(editionInfo()));
       return;
     }
 


### PR DESCRIPTION
In `LISA_EDITION=cloud` the server must not trust loopback as the local owner. `isRequestAuthorized` gains `trustLoopback` (default true ⇒ Mac unchanged); the handler passes `!isCloud()` and runs the gate for every request in cloud → token always required. `GET /api/edition` serves the capability descriptor so clients hide Mac-only surfaces.

Verified: 883 tests (red-team gate + new cloud-gate test); live smoke (cloud + token): loopback no-token → 401, wrong → 401, correct → 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)