### PR TITLE
feat(cloud): M0 deploy scaffolding (entrypoint + deploy.sh + Dockerfile)

### DIFF
--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -2,10 +2,10 @@
 # See docs/PLAN_CLOUD_v1.0.md (C1). Build context = repo root:
 #   gcloud run deploy lisa-cloud --source . --project oratis-491316 --region us-central1
 #
-# DRAFT (M0): not yet wired to the cloud auth gate (C3 — Firebase token). Until
-# then the container REQUIRES LISA_WEB_TOKEN (a shared secret for the seeded demo
-# account) since it binds a non-loopback address. node-pty (Mac-only PTY) is an
-# optionalDependency and is expected to be skipped here.
+# M0: the cloud auth gate is live (LISA_EDITION=cloud ⇒ no loopback trust), so the
+# container REQUIRES LISA_WEB_TOKEN (the shared demo secret). entrypoint.sh seeds
+# a demo soul on first boot (needs ANTHROPIC_API_KEY). node-pty (Mac-only PTY) is
+# an optionalDependency and is expected to be skipped here.
 FROM node:22-slim AS build
 WORKDIR /app
 COPY package.json package-lock.json ./
@@ -20,11 +20,15 @@ ENV LISA_EDITION=cloud
 # Cloud Run injects $PORT (default 8080). Auth is the cloud token/identity gate
 # (NOT loopback) — the ingress LB fronts this, so binding 0.0.0.0 is intended.
 ENV PORT=8080
+# Soul + sessions live here (mount a volume / use --min-instances=1 to persist).
+ENV LISA_HOME=/data
 COPY --from=build /app/node_modules ./node_modules
 COPY --from=build /app/dist ./dist
 COPY --from=build /app/package.json ./package.json
 # The build symlinks dist/web/assets → ../../src/web/assets; ship the real assets
 # so the link resolves at runtime.
 COPY --from=build /app/src/web/assets ./src/web/assets
+COPY deploy/entrypoint.sh ./deploy/entrypoint.sh
+RUN chmod +x ./deploy/entrypoint.sh && mkdir -p /data
 EXPOSE 8080
-CMD ["sh", "-c", "node dist/cli.js serve --web --port ${PORT:-8080} --host 0.0.0.0"]
+CMD ["./deploy/entrypoint.sh"]

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Deploy LISA Cloud (M0 reviewer demo) to Cloud Run — mirrors website/deploy/deploy.sh.
+#
+# Build context = the repo ROOT (the server needs all of src/). The cloud
+# Dockerfile lives at deploy/Dockerfile; since `gcloud run deploy --source` only
+# picks up a Dockerfile at the context root, we stage it there for the build and
+# clean it up after. A trimmed .gcloudignore keeps the upload small.
+#
+# You provide (secrets — never commit these):
+#   LISA_WEB_TOKEN      the demo password; hand it to App Review as the sign-in
+#   ANTHROPIC_API_KEY   funds the demo LLM — RATE-LIMIT this key (demo-only)
+# Overrides: PROJECT (default oratis-491316), REGION (us-central1), SERVICE (lisa-cloud)
+#
+# Usage:
+#   LISA_WEB_TOKEN=… ANTHROPIC_API_KEY=… deploy/deploy.sh
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/.." && pwd)"
+PROJECT="${PROJECT:-oratis-491316}"; REGION="${REGION:-us-central1}"; SERVICE="${SERVICE:-lisa-cloud}"
+: "${LISA_WEB_TOKEN:?set LISA_WEB_TOKEN (the demo password)}"
+: "${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY (funds the demo LLM — rate-limit it)}"
+
+cd "$ROOT"
+cp deploy/Dockerfile ./Dockerfile
+cat > .gcloudignore <<'IGN'
+.git
+node_modules
+dist
+packaging
+website
+docs
+reference
+build
+IGN
+cleanup() { rm -f ./Dockerfile ./.gcloudignore; }
+trap cleanup EXIT
+
+echo "→ deploying $SERVICE to $PROJECT/$REGION (min-instances=1, allow-unauthenticated; the app's own token gate is the auth)"
+gcloud run deploy "$SERVICE" \
+  --source . --project "$PROJECT" --region "$REGION" --quiet \
+  --allow-unauthenticated --min-instances 1 --max-instances 2 \
+  --memory 1Gi --cpu 1 --timeout 300 \
+  --set-env-vars "LISA_EDITION=cloud,LISA_WEB_TOKEN=$LISA_WEB_TOKEN,ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY"
+
+URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT" --region "$REGION" --format='value(status.url)' 2>/dev/null || true)"
+echo "✓ deployed${URL:+: $URL}"
+[ -n "$URL" ] && echo "  Reviewer demo URL (opens authed, pins the cookie):  $URL/?token=$LISA_WEB_TOKEN"

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+# LISA Cloud container entrypoint (LISA_EDITION=cloud).
+#
+# 1. Seed a demo soul on first boot so a reviewer (or any first visitor) isn't
+#    stuck at the birth ritual — idempotent: skips if already born.
+# 2. Start the web server bound to all interfaces ($PORT, default 8080). Auth is
+#    the cloud token gate (LISA_WEB_TOKEN required), NOT loopback.
+#
+# State lives under $LISA_HOME (default /data). On Cloud Run the container FS is
+# ephemeral, so run with --min-instances=1 to keep the demo warm + stateful;
+# otherwise each cold start re-births a fresh demo soul.
+set -e
+
+export LISA_HOME="${LISA_HOME:-/data}"
+mkdir -p "$LISA_HOME"
+
+# Born? isBorn() resolves true once the soul seed exists under $LISA_HOME.
+if node -e "import('./dist/soul/store.js').then(m=>m.isBorn()).then(b=>process.exit(b?0:1)).catch(e=>{console.error(e);process.exit(1)})"; then
+  echo "[cloud] soul already present — skipping birth"
+elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
+  echo "[cloud] birthing the demo soul…"
+  node dist/cli.js birth || echo "[cloud] birth failed — the app will show the birth ritual to the first visitor"
+else
+  echo "[cloud] no ANTHROPIC_API_KEY — skipping birth (set it to seed a demo soul)"
+fi
+
+exec node dist/cli.js serve --web --port "${PORT:-8080}" --host 0.0.0.0

--- a/docs/PLAN_CLOUD_v1.0.md
+++ b/docs/PLAN_CLOUD_v1.0.md
@@ -246,6 +246,42 @@ hides Mac-only surfaces (Control tab's PTY/adopt, Sense capture toggles).
 - **C5 — harden + demo**: Cloud Armor, budgets, the App-Review demo account, the
   privacy policy page.
 
+## M0 deploy runbook (C1 — reviewer demo) ✅ scaffolded
+
+The C1 code is merged (`src/edition.ts` edition flag, the cloud auth gate that
+drops loopback trust, `GET /api/edition`). The container + deploy glue lives in
+`deploy/`:
+
+| File | Role |
+| --- | --- |
+| `deploy/Dockerfile` | multi-stage `node:22-slim`; builds `dist/`, ships assets, `ENV LISA_EDITION=cloud LISA_HOME=/data`, runs `entrypoint.sh`. |
+| `deploy/entrypoint.sh` | first-boot: seed a demo soul (`lisa birth`, idempotent via `hasSeed()`) if `ANTHROPIC_API_KEY` is set, then `lisa serve --web --host 0.0.0.0`. |
+| `deploy/deploy.sh` | `gcloud run deploy lisa-cloud --source .` to `oratis-491316/us-central1`, `--min-instances 1` (keep the demo warm + stateful on the ephemeral Cloud Run FS), secrets via env. |
+
+**State caveat.** Cloud Run's container FS is ephemeral. `--min-instances 1`
+keeps one warm instance so the seeded soul/sessions survive between requests; a
+cold start (or scale-to-2) re-births a fresh demo soul. That's acceptable for an
+M0 *reviewer demo* but **not** for real users — C2 (`CloudHome` on GCS) is the
+prerequisite before anyone but a reviewer touches it.
+
+**Auth.** Cloud Run IAM is `--allow-unauthenticated` (the reviewer needs to reach
+the URL), and the *app's own* `LISA_WEB_TOKEN` gate is the real auth — in cloud
+edition loopback is no longer trusted, so every request needs the token. Hand the
+reviewer `https://<service-url>/?token=<LISA_WEB_TOKEN>` (opens authed, pins a
+cookie). The token + a rate-limited `ANTHROPIC_API_KEY` are the only secrets.
+
+**Run it (you, with your secrets — this is real prod GCP + spends money):**
+
+```sh
+LISA_WEB_TOKEN='<demo-password>' \
+ANTHROPIC_API_KEY='<rate-limited-demo-key>' \
+deploy/deploy.sh
+```
+
+Overrides: `PROJECT` (default `oratis-491316`), `REGION` (`us-central1`),
+`SERVICE` (`lisa-cloud`). For production-grade secret handling, swap the
+`--set-env-vars` for Secret Manager (`--set-secrets`) before M1.
+
 ## Open questions for review
 
 1. **API key model** — bring-your-own (v1, simplest) vs LISA-billed managed tier


### PR DESCRIPTION
Completes the **C1 reviewer-demo** deploy path, on top of the already-merged edition flag (#152) and cloud auth gate (#155).

## What's here (`deploy/`)
| File | Role |
| --- | --- |
| `entrypoint.sh` | first-boot seeds a demo soul (`lisa birth`, idempotent via `isBorn()`, needs `ANTHROPIC_API_KEY`) under `$LISA_HOME`, then `lisa serve --web --host 0.0.0.0`. |
| `Dockerfile` | `ENV LISA_HOME=/data`, copies + runs `entrypoint.sh`, `mkdir /data`. |
| `deploy.sh` | `gcloud run deploy lisa-cloud --source .` → `oratis-491316/us-central1`, `--min-instances 1`, `--allow-unauthenticated`, secrets via env. Mirrors `website/deploy/deploy.sh`. |
| `docs/PLAN_CLOUD_v1.0.md` | M0 runbook: files, state caveat, auth model, the gated command. |

## Auth & state
- **Auth** — Cloud Run IAM is `--allow-unauthenticated` so the reviewer can reach the URL; the *app's own* `LISA_WEB_TOKEN` gate is the real auth (cloud edition drops loopback trust, so every request needs the token). Reviewer gets `https://<url>/?token=<TOKEN>`.
- **State** — Cloud Run's FS is ephemeral; `--min-instances 1` keeps one warm instance so the seeded soul survives. Fine for an M0 *reviewer demo*; **C2 (`CloudHome` on GCS) is required before any real user**.

## Verification
- `isBorn()` predicate tested against a built `dist/` (fresh `LISA_HOME` → not-born → births; idempotent on a born home).
- `lisa birth` confirmed non-interactive (LLM-autonomous, no stdin) and `ANTHROPIC_API_KEY`-gated; `serve --web` + `LISA_HOME` env honored.

## Not auto-deployed
`deploy/deploy.sh` is **operator-run only** — real prod GCP (`oratis-491316`), spends money, needs the operator's `LISA_WEB_TOKEN` + a rate-limited `ANTHROPIC_API_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)