### PR TITLE
feat(cloud): provider-aware key gates + GLM-powered M0 demo

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -7,17 +7,41 @@
 # clean it up after. A trimmed .gcloudignore keeps the upload small.
 #
 # You provide (secrets — never commit these):
-#   LISA_WEB_TOKEN      the demo password; hand it to App Review as the sign-in
-#   ANTHROPIC_API_KEY   funds the demo LLM — RATE-LIMIT this key (demo-only)
-# Overrides: PROJECT (default oratis-491316), REGION (us-central1), SERVICE (lisa-cloud)
+#   LISA_WEB_TOKEN     the demo password; hand it to App Review as the sign-in
+#   + exactly one LLM provider key, which also selects the model:
+#       ZHIPU_API_KEY    → GLM (set LISA_MODEL=glm-4.6; defaulted if unset)
+#       ANTHROPIC_API_KEY→ Claude (LISA_MODEL defaults to claude-sonnet-4-6)
+#       OPENAI_API_KEY   → GPT (set LISA_MODEL=gpt-4o)
+#   RATE-LIMIT whichever key you use — it funds the public demo.
+# Overrides: PROJECT (default oratis-491316), REGION (us-central1),
+#   SERVICE (lisa-cloud), LISA_MODEL.
 #
-# Usage:
-#   LISA_WEB_TOKEN=… ANTHROPIC_API_KEY=… deploy/deploy.sh
+# Usage (GLM):
+#   LISA_WEB_TOKEN=… ZHIPU_API_KEY=… deploy/deploy.sh
 set -euo pipefail
 HERE="$(cd "$(dirname "$0")" && pwd)"; ROOT="$(cd "$HERE/.." && pwd)"
 PROJECT="${PROJECT:-oratis-491316}"; REGION="${REGION:-us-central1}"; SERVICE="${SERVICE:-lisa-cloud}"
 : "${LISA_WEB_TOKEN:?set LISA_WEB_TOKEN (the demo password)}"
-: "${ANTHROPIC_API_KEY:?set ANTHROPIC_API_KEY (funds the demo LLM — rate-limit it)}"
+
+# Require at least one LLM key (the demo soul is born by an LLM).
+if [ -z "${ANTHROPIC_API_KEY:-}${ZHIPU_API_KEY:-}${OPENAI_API_KEY:-}" ]; then
+  echo "✗ set one LLM provider key: ZHIPU_API_KEY (GLM), ANTHROPIC_API_KEY (Claude), or OPENAI_API_KEY (GPT)" >&2
+  exit 1
+fi
+# Default the model from the key in use so the GLM path "just works".
+if [ -z "${LISA_MODEL:-}" ]; then
+  if   [ -n "${ZHIPU_API_KEY:-}" ];     then LISA_MODEL="glm-4.6"
+  elif [ -n "${OPENAI_API_KEY:-}" ];    then LISA_MODEL="gpt-4o"
+  fi   # else: leave unset → Anthropic default (claude-sonnet-4-6)
+fi
+
+# Build the env list with a custom '##' delimiter (gcloud's ^d^ syntax) so secret
+# values may safely contain commas.
+ENVS="^##^LISA_EDITION=cloud##LISA_WEB_TOKEN=${LISA_WEB_TOKEN}"
+[ -n "${LISA_MODEL:-}" ]        && ENVS="${ENVS}##LISA_MODEL=${LISA_MODEL}"
+[ -n "${ANTHROPIC_API_KEY:-}" ] && ENVS="${ENVS}##ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}"
+[ -n "${ZHIPU_API_KEY:-}" ]     && ENVS="${ENVS}##ZHIPU_API_KEY=${ZHIPU_API_KEY}"
+[ -n "${OPENAI_API_KEY:-}" ]    && ENVS="${ENVS}##OPENAI_API_KEY=${OPENAI_API_KEY}"
 
 cd "$ROOT"
 cp deploy/Dockerfile ./Dockerfile
@@ -34,12 +58,12 @@ IGN
 cleanup() { rm -f ./Dockerfile ./.gcloudignore; }
 trap cleanup EXIT
 
-echo "→ deploying $SERVICE to $PROJECT/$REGION (min-instances=1, allow-unauthenticated; the app's own token gate is the auth)"
+echo "→ deploying $SERVICE to $PROJECT/$REGION (model ${LISA_MODEL:-claude-default}, min-instances=1, allow-unauthenticated; the app's token gate is the auth)"
 gcloud run deploy "$SERVICE" \
   --source . --project "$PROJECT" --region "$REGION" --quiet \
   --allow-unauthenticated --min-instances 1 --max-instances 2 \
   --memory 1Gi --cpu 1 --timeout 300 \
-  --set-env-vars "LISA_EDITION=cloud,LISA_WEB_TOKEN=$LISA_WEB_TOKEN,ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY"
+  --set-env-vars "$ENVS"
 
 URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT" --region "$REGION" --format='value(status.url)' 2>/dev/null || true)"
 echo "✓ deployed${URL:+: $URL}"

--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -17,11 +17,12 @@ mkdir -p "$LISA_HOME"
 # Born? isBorn() resolves true once the soul seed exists under $LISA_HOME.
 if node -e "import('./dist/soul/store.js').then(m=>m.isBorn()).then(b=>process.exit(b?0:1)).catch(e=>{console.error(e);process.exit(1)})"; then
   echo "[cloud] soul already present — skipping birth"
-elif [ -n "${ANTHROPIC_API_KEY:-}" ]; then
-  echo "[cloud] birthing the demo soul…"
-  node dist/cli.js birth || echo "[cloud] birth failed — the app will show the birth ritual to the first visitor"
 else
-  echo "[cloud] no ANTHROPIC_API_KEY — skipping birth (set it to seed a demo soul)"
+  echo "[cloud] birthing the demo soul (model ${LISA_MODEL:-default})…"
+  # `lisa birth` validates that a provider key for the model is configured (any of
+  # ANTHROPIC_API_KEY / ZHIPU_API_KEY / OPENAI_API_KEY / … per the model). If none
+  # is set it exits non-zero and the first web visitor gets the birth ritual.
+  node dist/cli.js birth || echo "[cloud] birth skipped/failed — first visitor will see the birth ritual"
 fi
 
 exec node dist/cli.js serve --web --port "${PORT:-8080}" --host 0.0.0.0

--- a/docs/PLAN_CLOUD_v1.0.md
+++ b/docs/PLAN_CLOUD_v1.0.md
@@ -255,8 +255,8 @@ drops loopback trust, `GET /api/edition`). The container + deploy glue lives in
 | File | Role |
 | --- | --- |
 | `deploy/Dockerfile` | multi-stage `node:22-slim`; builds `dist/`, ships assets, `ENV LISA_EDITION=cloud LISA_HOME=/data`, runs `entrypoint.sh`. |
-| `deploy/entrypoint.sh` | first-boot: seed a demo soul (`lisa birth`, idempotent via `hasSeed()`) if `ANTHROPIC_API_KEY` is set, then `lisa serve --web --host 0.0.0.0`. |
-| `deploy/deploy.sh` | `gcloud run deploy lisa-cloud --source .` to `oratis-491316/us-central1`, `--min-instances 1` (keep the demo warm + stateful on the ephemeral Cloud Run FS), secrets via env. |
+| `deploy/entrypoint.sh` | first-boot: seed a demo soul (`lisa birth`, idempotent via `isBorn()`) using whichever provider key is set, then `lisa serve --web --host 0.0.0.0`. |
+| `deploy/deploy.sh` | `gcloud run deploy lisa-cloud --source .` to `oratis-491316/us-central1`, `--min-instances 1` (keep the demo warm + stateful on the ephemeral Cloud Run FS), secrets via env (comma-safe `^##^` delimiter). |
 
 **State caveat.** Cloud Run's container FS is ephemeral. `--min-instances 1`
 keeps one warm instance so the seeded soul/sessions survive between requests; a
@@ -268,19 +268,26 @@ prerequisite before anyone but a reviewer touches it.
 the URL), and the *app's own* `LISA_WEB_TOKEN` gate is the real auth — in cloud
 edition loopback is no longer trusted, so every request needs the token. Hand the
 reviewer `https://<service-url>/?token=<LISA_WEB_TOKEN>` (opens authed, pins a
-cookie). The token + a rate-limited `ANTHROPIC_API_KEY` are the only secrets.
+cookie). The two secrets are `LISA_WEB_TOKEN` + one rate-limited LLM key.
+
+**Provider/model.** The birth + run gates are provider-aware
+(`hasCredentialsForModel`), so any one of these funds the demo and picks the
+model: `ZHIPU_API_KEY` → GLM (`LISA_MODEL=glm-4.6`, defaulted), `ANTHROPIC_API_KEY`
+→ Claude, `OPENAI_API_KEY` → GPT. **The M0 demo runs on GLM** (`glm-4.6`,
+bigmodel.cn OpenAI-compatible endpoint, LISA's built-in Zhipu preset).
 
 **Run it (you, with your secrets — this is real prod GCP + spends money):**
 
 ```sh
+# GLM (the M0 demo):
 LISA_WEB_TOKEN='<demo-password>' \
-ANTHROPIC_API_KEY='<rate-limited-demo-key>' \
+ZHIPU_API_KEY='<rate-limited-glm-key>' \
 deploy/deploy.sh
 ```
 
 Overrides: `PROJECT` (default `oratis-491316`), `REGION` (`us-central1`),
-`SERVICE` (`lisa-cloud`). For production-grade secret handling, swap the
-`--set-env-vars` for Secret Manager (`--set-secrets`) before M1.
+`SERVICE` (`lisa-cloud`), `LISA_MODEL`. For production-grade secret handling,
+swap the `--set-env-vars` for Secret Manager (`--set-secrets`) before M1.
 
 ## Open questions for review
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,7 +22,7 @@ import { LISA_HOME } from "./paths.js";
 import { loadAllPlugins, PLUGINS_ROOT } from "./plugins/loader.js";
 import type { HookSpec } from "./plugins/types.js";
 import { buildSystemPromptSnapshot, getPromptFingerprint } from "./prompt.js";
-import { providerForModel, resolveDefaultModel } from "./providers/registry.js";
+import { providerForModel, resolveDefaultModel, hasCredentialsForModel } from "./providers/registry.js";
 import { reflectOnSession } from "./reflect.js";
 import { runRepl } from "./cli/repl.js";
 import { listSessionsOnDisk, loadSessionMessages } from "./sessions/list.js";
@@ -364,8 +364,11 @@ async function main(): Promise<void> {
 
   // ── soul-only subcommands (don't need agent loop) ─────────────────────
   if (args.subcommand === "birth") {
-    if (!process.env.ANTHROPIC_API_KEY) {
-      console.error("Birth ritual needs ANTHROPIC_API_KEY (an LLM dreams Lisa into existence).");
+    if (!hasCredentialsForModel(args.model)) {
+      console.error(
+        `Birth ritual needs an LLM API key for ${args.model} (an LLM dreams Lisa into existence). ` +
+          `Set the provider key — e.g. ANTHROPIC_API_KEY, or ZHIPU_API_KEY for a glm-* model.`,
+      );
       process.exit(1);
     }
     await runBirthCeremony(args.model);
@@ -540,21 +543,14 @@ async function main(): Promise<void> {
   // Exception: `serve --web` defers the key check to the browser UI, which
   // shows a popup that writes the key to ~/.lisa/config.env on save.
   const isWebServe = args.subcommand === "serve" && args.serveWeb;
-  const provider = providerForModel(args.model);
-  if (!isWebServe) {
-    if (provider.name === "anthropic" && !process.env.ANTHROPIC_API_KEY) {
-      console.error(
-        `Lisa needs ANTHROPIC_API_KEY. Set it in your shell or in ${CONFIG_ENV_PATH}:\n\n  ANTHROPIC_API_KEY=sk-ant-...\n\nGet a key at https://console.anthropic.com/.`,
-      );
-      process.exit(1);
-    }
-    if (provider.name === "openai" && !process.env.OPENAI_API_KEY) {
-      console.error(
-        `Lisa needs OPENAI_API_KEY for the OpenAI provider. Set it in your shell or in ${CONFIG_ENV_PATH}.`,
-      );
-      process.exit(1);
-    }
+  if (!isWebServe && !hasCredentialsForModel(args.model)) {
+    console.error(
+      `Lisa needs an API key for ${args.model}. Set the provider key in your shell or in ${CONFIG_ENV_PATH} ` +
+        `— e.g. ANTHROPIC_API_KEY (https://console.anthropic.com/), OPENAI_API_KEY, or a preset key like ZHIPU_API_KEY for glm-*.`,
+    );
+    process.exit(1);
   }
+  const provider = providerForModel(args.model);
 
   // ── auto-birth on first launch ──────────────────────────────────────
   // Skipped for `serve --web` — the browser UI runs the birth ritual itself

--- a/src/providers/registry.test.ts
+++ b/src/providers/registry.test.ts
@@ -1,6 +1,11 @@
 import { test, describe, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { detectProvider, resolveAnthropicAuth, OPENAI_COMPAT_PRESETS } from "./registry.js";
+import {
+  detectProvider,
+  resolveAnthropicAuth,
+  hasCredentialsForModel,
+  OPENAI_COMPAT_PRESETS,
+} from "./registry.js";
 
 // detectProvider reads a few env vars as fallbacks. Snapshot + restore them
 // so tests are hermetic regardless of the dev's shell.
@@ -107,6 +112,34 @@ describe("resolveAnthropicAuth — Bearer gateway vs x-api-key", () => {
   });
   test("neither set → apiKey undefined", () => {
     assert.deepEqual(resolveAnthropicAuth({}), { apiKey: undefined });
+  });
+});
+
+describe("hasCredentialsForModel — the CLI key-gate matches the real provider key", () => {
+  test("glm-* needs ZHIPU_API_KEY (its preset), NOT OPENAI_API_KEY", () => {
+    assert.equal(hasCredentialsForModel("glm-4.6", { ZHIPU_API_KEY: "z" }), true);
+    // the bug we fixed: an OpenAI key must NOT satisfy a glm-* model
+    assert.equal(hasCredentialsForModel("glm-4.6", { OPENAI_API_KEY: "sk" }), false);
+    assert.equal(hasCredentialsForModel("glm-4.6", {}), false);
+  });
+
+  test("claude-* accepts ANTHROPIC_API_KEY or ANTHROPIC_AUTH_TOKEN", () => {
+    assert.equal(hasCredentialsForModel("claude-sonnet-4-6", { ANTHROPIC_API_KEY: "sk-ant" }), true);
+    assert.equal(hasCredentialsForModel("claude-sonnet-4-6", { ANTHROPIC_AUTH_TOKEN: "tok" }), true);
+    assert.equal(hasCredentialsForModel("claude-sonnet-4-6", { ANTHROPIC_AUTH_TOKEN: "  " }), false);
+    assert.equal(hasCredentialsForModel("claude-sonnet-4-6", {}), false);
+  });
+
+  test("other presets read their own key env (deepseek, qwen)", () => {
+    assert.equal(hasCredentialsForModel("deepseek-chat", { DEEPSEEK_API_KEY: "d" }), true);
+    assert.equal(hasCredentialsForModel("qwen-max", { DASHSCOPE_API_KEY: "q" }), true);
+    assert.equal(hasCredentialsForModel("deepseek-chat", { ZHIPU_API_KEY: "z" }), false);
+  });
+
+  test("vanilla openai + gemini", () => {
+    assert.equal(hasCredentialsForModel("gpt-4o", { OPENAI_API_KEY: "sk" }), true);
+    assert.equal(hasCredentialsForModel("gemini-2.5-flash", { GOOGLE_API_KEY: "g" }), true);
+    assert.equal(hasCredentialsForModel("gemini-2.5-flash", { GEMINI_API_KEY: "g" }), true);
   });
 });
 

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -171,6 +171,35 @@ export function resolveAnthropicAuth(
   return { apiKey: env.ANTHROPIC_API_KEY };
 }
 
+/**
+ * Does `env` carry credentials for the provider that MODEL routes to? Mirrors
+ * resolveProvider's auth resolution exactly, so the CLI key-gate matches the key
+ * the provider will actually read — e.g. a `glm-*` model needs ZHIPU_API_KEY (its
+ * preset), not OPENAI_API_KEY. Used by the birth + run gates. Pure.
+ *
+ * (detectProvider consults process.env for the LISA_BASE_URL / LISA_PROVIDER
+ * routing rules; the per-key lookups below read the passed `env`.)
+ */
+export function hasCredentialsForModel(
+  model: string,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const provider = detectProvider(model);
+  if (provider === "anthropic") {
+    return !!(env.ANTHROPIC_AUTH_TOKEN?.trim() || env.ANTHROPIC_API_KEY);
+  }
+  if (provider === "gemini") {
+    return !!(env.GEMINI_API_KEY ?? env.GOOGLE_API_KEY);
+  }
+  // openai / openai-compatible — same precedence as resolveProvider.
+  const preset = findPreset(model);
+  if (preset) return !!env[preset.apiKeyEnv];
+  if (env.LISA_BASE_URL) {
+    return !!(env.LISA_API_KEY ?? env.TAKO_KEY ?? env.OPENAI_API_KEY);
+  }
+  return !!env.OPENAI_API_KEY;
+}
+
 export function makeProvider(name: ProviderName): Provider {
   switch (name) {
     case "anthropic":


### PR DESCRIPTION
Wires the LISA Cloud M0 demo to run on **GLM** (`glm-4.6`), and fixes the gate bug that blocked any non-Anthropic provider.

## The bug
`lisa birth` hardcoded `ANTHROPIC_API_KEY` ([cli.ts:367](src/cli.ts)) and the run-gate demanded `OPENAI_API_KEY` for any OpenAI-class provider — but a `glm-*` model's key lives in `ZHIPU_API_KEY` (via the built-in Zhipu preset). So GLM could never pass the gate even though `providerForModel` routes it fine.

## The fix
New preset-aware `hasCredentialsForModel(model, env?)` in the registry, mirroring `resolveProvider`'s auth resolution exactly (anthropic ⇒ key/auth-token, gemini ⇒ GEMINI/GOOGLE, **preset ⇒ its `apiKeyEnv`**, `LISA_BASE_URL` catch-all, else OPENAI). Both gates use it now. +4 unit tests.

## GLM deploy wiring
- `entrypoint.sh` — births with whatever provider key is set (not ANTHROPIC-only).
- `deploy.sh` — accepts `ZHIPU_API_KEY` (defaults `LISA_MODEL=glm-4.6`) / `ANTHROPIC_API_KEY` / `OPENAI_API_KEY`; comma-safe `^##^` env delimiter.
- doc runbook updated: GLM is the M0 demo provider.

## Verified
- GLM round-trips through LISA's own provider: `providerForModel("glm-4.6").runTurn(...)` → `"OK"`, 13/23 tokens, `stop=end_turn`.
- `887 tests pass` (4 new), typecheck + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)