### PR TITLE
chore(cloud): exclude .claude + logs from Cloud Run source upload

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -47,6 +47,7 @@ cd "$ROOT"
 cp deploy/Dockerfile ./Dockerfile
 cat > .gcloudignore <<'IGN'
 .git
+.claude
 node_modules
 dist
 packaging
@@ -54,6 +55,8 @@ website
 docs
 reference
 build
+*.log
+.DS_Store
 IGN
 cleanup() { rm -f ./Dockerfile ./.gcloudignore; }
 trap cleanup EXIT


### PR DESCRIPTION
`gcloud run deploy --source .` uploads the working tree; `.claude/worktrees/` holds full repo copies that must not reach Cloud Build. Adds `.claude`, `*.log`, `.DS_Store` to the generated `.gcloudignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)