### PR TITLE
docs(cloud): mark M0 reviewer demo DEPLOYED (live on GLM)

### DIFF
--- a/docs/PLAN_CLOUD_v1.0.md
+++ b/docs/PLAN_CLOUD_v1.0.md
@@ -1,8 +1,14 @@
 # PLAN — LISA Cloud (GCP) v1.0
 
-**Status: DESIGN, for review. Nothing built yet.** Project pinned to
-`oratis-491316` (reuse). Includes a 正反方 debate (below) whose verdict is a
-**Conditional GO — build M0 (reviewer demo) only, defer public multi-tenant**.
+**Status: M0 DEPLOYED — reviewer demo, live on GLM.** Project `oratis-491316`.
+C1 (edition flag + cloud auth gate + `/api/edition`) and M0 (Cloud Run service
+`lisa-cloud`, us-central1, a GLM-`glm-4.6`-birthed demo soul) are live and
+verified (401/401/200 auth gate, cloud edition, end-to-end chat). The live URL +
+demo token are NOT committed — they live in the Cloud Run env. Includes a 正反方
+debate (below) whose verdict is a **Conditional GO — M0 (reviewer demo) only,
+defer public multi-tenant**. Still in force: **C2 (`CloudHome` GCS persistence)
+is required before any real (non-reviewer) user**, since the demo soul is held in
+a single warm instance and resets on cold start.
 
 ## Why
 


### PR DESCRIPTION
C1 + M0 are live on Cloud Run (`oratis-491316/us-central1`, service `lisa-cloud`), demo soul birthed by **GLM `glm-4.6`**, verified (auth 401/401/200, cloud edition, end-to-end chat). Live URL + demo token stay in the Cloud Run env, not the repo. C2 (CloudHome GCS persistence) still required before any real user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)