### PR TITLE
feat(ios): connect to an HTTPS cloud URL (App Store reviewability)

### DIFF
--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -32,7 +32,8 @@ final class AppState: ObservableObject {
         let d = UserDefaults.standard
         let host = d.string(forKey: "lisa.host") ?? ""
         let storedPort = d.integer(forKey: "lisa.port")
-        let cfg = ServerConfig(host: host, port: storedPort == 0 ? 5757 : storedPort, token: TokenStore.load())
+        let scheme = d.string(forKey: "lisa.scheme") ?? "http"
+        let cfg = ServerConfig(host: host, port: storedPort == 0 ? 5757 : storedPort, token: TokenStore.load(), scheme: scheme)
         self.config = cfg
         self.client = LisaClient(config: cfg)
         let lockOn = d.bool(forKey: "lisa.biometricLock")
@@ -76,28 +77,40 @@ final class AppState: ObservableObject {
         }
     }
 
-    func update(host: String, port: Int, token: String?) {
-        let cfg = ServerConfig(host: host, port: port, token: token)
+    func update(host: String, port: Int, token: String?, scheme: String = "http") {
+        let cfg = ServerConfig(host: host, port: port, token: token, scheme: scheme)
         config = cfg
         client = LisaClient(config: cfg)
         let d = UserDefaults.standard
         d.set(host, forKey: "lisa.host")
         d.set(port, forKey: "lisa.port")
+        d.set(scheme, forKey: "lisa.scheme")
         if let token, !token.isEmpty { TokenStore.save(token) } else { TokenStore.delete() }
     }
 
-    /// Parse a pairing string: `lisa-pair://v1?host=&port=&token=` or `http://host:port/?token=`.
+    /// Apply a pairing string (from QR / paste). Returns false if unparseable.
     func applyPairing(_ raw: String) -> Bool {
+        guard let cfg = AppState.parsePairing(raw) else { return false }
+        update(host: cfg.host, port: cfg.port, token: cfg.token, scheme: cfg.scheme)
+        return true
+    }
+
+    /// Pure parse of a pairing string into a ServerConfig (no side effects) — so it's
+    /// testable off the main actor. Accepts `lisa-pair://v1?host=&port=&token=&scheme=`,
+    /// `http://host:port/?token=` (LAN Mac), or `https://host/?token=` (cloud). A
+    /// literal http(s):// URL carries its own scheme; the lisa-pair:// form may pass
+    /// `?scheme=`. Port defaults to 443 for https, else 5757. Requires host + token.
+    nonisolated static func parsePairing(_ raw: String) -> ServerConfig? {
         let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard let comps = URLComponents(string: trimmed) else { return false }
+        guard let comps = URLComponents(string: trimmed) else { return nil }
         let items = comps.queryItems ?? []
         func q(_ key: String) -> String? { items.first { $0.name == key }?.value }
-        let host = q("host") ?? comps.host
-        let token = q("token")
-        let port = Int(q("port") ?? "") ?? comps.port ?? 5757
-        guard let host, !host.isEmpty, let token, !token.isEmpty else { return false }
-        update(host: host, port: port, token: token)
-        return true
+        guard let host = q("host") ?? comps.host, !host.isEmpty,
+              let token = q("token"), !token.isEmpty else { return nil }
+        let urlScheme = (comps.scheme == "http" || comps.scheme == "https") ? comps.scheme : nil
+        let scheme = q("scheme") ?? urlScheme ?? "http"
+        let port = Int(q("port") ?? "") ?? comps.port ?? (scheme == "https" ? 443 : 5757)
+        return ServerConfig(host: host, port: port, token: token, scheme: scheme)
     }
 
     /// Route a `lisapocket://` deep-link (from a push Click or the home Widget).

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -1,12 +1,18 @@
 import Foundation
 
 struct ServerConfig: Equatable {
-    var host: String          // "192.168.3.162" or "mac.tailnet.ts.net"
+    var host: String          // "192.168.3.162", "mac.tailnet.ts.net", or "lisa-cloud-xxx.run.app"
     var port: Int
     var token: String?        // device or global token (nil only for loopback, unused from a phone)
+    var scheme: String = "http"  // "http" for a LAN Mac; "https" for a cloud URL
 
     var isConfigured: Bool { !host.isEmpty && port > 0 }
-    var baseURL: URL? { URL(string: "http://\(host):\(port)") }
+    /// Base URL. Drop the port when it's the scheme's default (so a cloud URL is
+    /// `https://host`, not `https://host:443`).
+    var baseURL: URL? {
+        let standardPort = (scheme == "https" && port == 443) || (scheme == "http" && port == 80)
+        return URL(string: standardPort ? "\(scheme)://\(host)" : "\(scheme)://\(host):\(port)")
+    }
 }
 
 enum LisaError: LocalizedError {

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -35,9 +35,10 @@ struct SettingsView: View {
                     } label: {
                         Label("Scan QR code", systemImage: "qrcode.viewfinder")
                     }
-                    TextField("lisa-pair://… or http://host:port/?token=", text: $pairText)
+                    TextField("LAN http://host:port/?token= or cloud https://…/?token=", text: $pairText)
                         .autocorrectionDisabled()
                         .textInputAutocapitalization(.never)
+                        .keyboardType(.URL)
                     Button("Apply pairing") {
                         if app.applyPairing(pairText) {
                             syncFromConfig()
@@ -47,6 +48,8 @@ struct SettingsView: View {
                         }
                     }
                     .disabled(pairText.isEmpty)
+                    Text("Paste your Mac's pairing URL, or a LISA Cloud URL (https://…run.app/?token=…) to use the hosted demo without a Mac.")
+                        .font(.caption).foregroundStyle(.secondary)
                 }
 
                 Section("Push (ntfy)") {

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -68,6 +68,30 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertEqual(AppState.parseDeepLink(URL(string: "https://example.com")!), .ignore)
     }
 
+    // ── parsePairing: LAN http, cloud https, lisa-pair:// ──
+    func testParsePairingCloudHTTPS() {
+        let cfg = AppState.parsePairing("https://lisa-cloud-xxx.run.app/?token=abc")
+        XCTAssertEqual(cfg, ServerConfig(host: "lisa-cloud-xxx.run.app", port: 443, token: "abc", scheme: "https"))
+        // baseURL drops the default :443 → a clean cloud URL.
+        XCTAssertEqual(cfg?.baseURL?.absoluteString, "https://lisa-cloud-xxx.run.app")
+    }
+    func testParsePairingLANHTTP() {
+        let cfg = AppState.parsePairing("http://192.168.3.162:5757/?token=abc")
+        XCTAssertEqual(cfg, ServerConfig(host: "192.168.3.162", port: 5757, token: "abc", scheme: "http"))
+        XCTAssertEqual(cfg?.baseURL?.absoluteString, "http://192.168.3.162:5757")
+    }
+    func testParsePairingLisaPairWithScheme() {
+        let cfg = AppState.parsePairing("lisa-pair://v1?host=lisa-cloud.run.app&port=443&token=abc&scheme=https")
+        XCTAssertEqual(cfg, ServerConfig(host: "lisa-cloud.run.app", port: 443, token: "abc", scheme: "https"))
+    }
+    func testParsePairingLisaPairDefaultsToLAN() {
+        let cfg = AppState.parsePairing("lisa-pair://v1?host=mac.local&token=abc")
+        XCTAssertEqual(cfg, ServerConfig(host: "mac.local", port: 5757, token: "abc", scheme: "http"))
+    }
+    func testParsePairingRejectsMissingToken() {
+        XCTAssertNil(AppState.parsePairing("https://lisa-cloud.run.app/"))
+    }
+
     // ── AgentSession.lastMtime tolerates both shapes (regression for the SSE bug) ──
     func testDecodesNumericLastMtimeFromSSE() throws {
         // agent_session_update broadcasts raw epoch-ms; must not throw.


### PR DESCRIPTION
Lets the iOS app point at the **LISA Cloud** demo (HTTPS) instead of only a LAN Mac (`http://host:port`) — the concrete unlock for App Store review (reviewers have no Mac to pair).

## Problem
`ServerConfig.baseURL` was `URL(string: "http://\(host):\(port)")` — scheme hardcoded. Any cloud `https://…run.app` URL got downgraded to `http://…:5757`.

## Change (backward-compatible)
- `ServerConfig` gains `scheme` (default `"http"` → existing LAN pairings unchanged); `baseURL` uses it and drops the default port (cloud → `https://host`).
- `applyPairing` → pure `static parsePairing` (mirrors `parseDeepLink`): reads scheme from a literal `http(s)://` URL or the lisa-pair `?scheme=`; port defaults 443 (https) / 5757 (http); requires host + token.
- `AppState` persists `lisa.scheme`; `update(…, scheme:)` defaults to `"http"`.
- SettingsView: pairing field accepts `https://…/?token=`, with a caption pointing at the hosted demo + a URL keyboard.

Reviewer flow: paste the cloud URL+token (from App Review notes) → app works, no Mac.

## Verification
- `build.sh` → **BUILD SUCCEEDED** (app + test targets compile).
- `parsePairing` logic verified against real `URLComponents` (5 cases: cloud https, LAN http, lisa-pair w/ scheme, lisa-pair default LAN, reject-no-token).
- +5 `LisaPocketTests` (execute in CI — the simulator test-runner can't launch in this headless env, same PTY limitation as elsewhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)