### PR TITLE
feat(cloud): durable soul via GCS volume at /data (basic C2)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -13,8 +13,12 @@
 #       ANTHROPIC_API_KEY→ Claude (LISA_MODEL defaults to claude-sonnet-4-6)
 #       OPENAI_API_KEY   → GPT (set LISA_MODEL=gpt-4o)
 #   RATE-LIMIT whichever key you use — it funds the public demo.
+# Persistence (C2): a GCS bucket is mounted at /data (= $LISA_HOME) so the soul +
+# sessions survive restarts/redeploys (Cloud Run's own FS is ephemeral). The
+# bucket + the runtime service account's access are ensured idempotently here.
+#
 # Overrides: PROJECT (default oratis-491316), REGION (us-central1),
-#   SERVICE (lisa-cloud), LISA_MODEL.
+#   SERVICE (lisa-cloud), LISA_MODEL, LISA_BUCKET (default <project>-lisa-cloud-data).
 #
 # Usage (GLM):
 #   LISA_WEB_TOKEN=… ZHIPU_API_KEY=… deploy/deploy.sh
@@ -43,6 +47,16 @@ ENVS="^##^LISA_EDITION=cloud##LISA_WEB_TOKEN=${LISA_WEB_TOKEN}"
 [ -n "${ZHIPU_API_KEY:-}" ]     && ENVS="${ENVS}##ZHIPU_API_KEY=${ZHIPU_API_KEY}"
 [ -n "${OPENAI_API_KEY:-}" ]    && ENVS="${ENVS}##OPENAI_API_KEY=${OPENAI_API_KEY}"
 
+# ── durable home (C2): a GCS bucket mounted at /data keeps the soul across restarts ──
+BUCKET="${LISA_BUCKET:-${PROJECT}-lisa-cloud-data}"
+echo "→ ensuring durable bucket gs://$BUCKET (+ Cloud Run SA access)"
+gcloud storage buckets describe "gs://$BUCKET" --project "$PROJECT" >/dev/null 2>&1 \
+  || gcloud storage buckets create "gs://$BUCKET" --project "$PROJECT" --location "$REGION" --uniform-bucket-level-access
+# The default Cloud Run runtime identity is the compute service account; grant it object access.
+SA="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')-compute@developer.gserviceaccount.com"
+gcloud storage buckets add-iam-policy-binding "gs://$BUCKET" --project "$PROJECT" \
+  --member "serviceAccount:$SA" --role roles/storage.objectAdmin >/dev/null
+
 cd "$ROOT"
 cp deploy/Dockerfile ./Dockerfile
 cat > .gcloudignore <<'IGN'
@@ -61,10 +75,13 @@ IGN
 cleanup() { rm -f ./Dockerfile ./.gcloudignore; }
 trap cleanup EXIT
 
-echo "→ deploying $SERVICE to $PROJECT/$REGION (model ${LISA_MODEL:-claude-default}, min-instances=1, allow-unauthenticated; the app's token gate is the auth)"
+echo "→ deploying $SERVICE to $PROJECT/$REGION (model ${LISA_MODEL:-claude-default}, /data←gs://$BUCKET, min=max=1 single-writer, allow-unauthenticated; the app's token gate is the auth)"
 gcloud run deploy "$SERVICE" \
   --source . --project "$PROJECT" --region "$REGION" --quiet \
-  --allow-unauthenticated --min-instances 1 --max-instances 2 \
+  --allow-unauthenticated --min-instances 1 --max-instances 1 \
+  --execution-environment gen2 \
+  --add-volume "name=soul,type=cloud-storage,bucket=$BUCKET" \
+  --add-volume-mount "volume=soul,mount-path=/data" \
   --memory 1Gi --cpu 1 --timeout 300 \
   --set-env-vars "$ENVS"
 

--- a/docs/PLAN_CLOUD_v1.0.md
+++ b/docs/PLAN_CLOUD_v1.0.md
@@ -1,14 +1,16 @@
 # PLAN — LISA Cloud (GCP) v1.0
 
-**Status: M0 DEPLOYED — reviewer demo, live on GLM.** Project `oratis-491316`.
-C1 (edition flag + cloud auth gate + `/api/edition`) and M0 (Cloud Run service
-`lisa-cloud`, us-central1, a GLM-`glm-4.6`-birthed demo soul) are live and
-verified (401/401/200 auth gate, cloud edition, end-to-end chat). The live URL +
-demo token are NOT committed — they live in the Cloud Run env. Includes a 正反方
-debate (below) whose verdict is a **Conditional GO — M0 (reviewer demo) only,
-defer public multi-tenant**. Still in force: **C2 (`CloudHome` GCS persistence)
-is required before any real (non-reviewer) user**, since the demo soul is held in
-a single warm instance and resets on cold start.
+**Status: M0 DEPLOYED + DURABLE — reviewer demo, live on GLM.** Project
+`oratis-491316`. C1 (edition flag + cloud auth gate + `/api/edition`) and M0
+(Cloud Run `lisa-cloud`, us-central1, a GLM-`glm-4.6` demo soul) are live and
+verified (401/401/200 auth gate, cloud edition, end-to-end chat). **Persistence
+is done (basic C2):** a GCS bucket (`<project>-lisa-cloud-data`) is mounted at
+`/data`, single-writer (`min=max=1`); a forced restart confirmed the soul is
+detected and re-birth is skipped. The live URL + demo token are NOT committed —
+they live in the Cloud Run env. Includes a 正反方 debate (below) whose verdict is a
+**Conditional GO — M0 (reviewer demo) only, defer public multi-tenant**. Remaining
+before real (non-reviewer) users: **per-user isolation** — today it's a single
+shared soul/bucket; multi-tenant needs a per-`uid` home + auth (full C2/C3).
 
 ## Why
 
@@ -262,13 +264,15 @@ drops loopback trust, `GET /api/edition`). The container + deploy glue lives in
 | --- | --- |
 | `deploy/Dockerfile` | multi-stage `node:22-slim`; builds `dist/`, ships assets, `ENV LISA_EDITION=cloud LISA_HOME=/data`, runs `entrypoint.sh`. |
 | `deploy/entrypoint.sh` | first-boot: seed a demo soul (`lisa birth`, idempotent via `isBorn()`) using whichever provider key is set, then `lisa serve --web --host 0.0.0.0`. |
-| `deploy/deploy.sh` | `gcloud run deploy lisa-cloud --source .` to `oratis-491316/us-central1`, `--min-instances 1` (keep the demo warm + stateful on the ephemeral Cloud Run FS), secrets via env (comma-safe `^##^` delimiter). |
+| `deploy/deploy.sh` | ensures a GCS bucket + the Cloud Run SA's access, then `gcloud run deploy lisa-cloud --source .` to `oratis-491316/us-central1` with the bucket mounted at `/data` (gen2), `min=max=1` (single writer), secrets via env (comma-safe `^##^` delimiter). |
 
-**State caveat.** Cloud Run's container FS is ephemeral. `--min-instances 1`
-keeps one warm instance so the seeded soul/sessions survive between requests; a
-cold start (or scale-to-2) re-births a fresh demo soul. That's acceptable for an
-M0 *reviewer demo* but **not** for real users — C2 (`CloudHome` on GCS) is the
-prerequisite before anyone but a reviewer touches it.
+**State (basic C2 done).** Cloud Run's own FS is ephemeral, so `/data` (=`$LISA_HOME`)
+is a **GCS bucket mounted via the gen2 cloud-storage volume** — the soul +
+sessions are durable across restarts/redeploys (verified: a forced new revision
+logged `soul already present — skipping birth`). `min=max=1` keeps a single warm
+writer (two instances mounting one bucket could race the soul files). **Still
+single-tenant**: one shared soul/bucket — per-`uid` isolation + auth is the
+remaining work before real (non-reviewer) users.
 
 **Auth.** Cloud Run IAM is `--allow-unauthenticated` (the reviewer needs to reach
 the URL), and the *app's own* `LISA_WEB_TOKEN` gate is the real auth — in cloud


### PR DESCRIPTION
The M0 demo soul reset on every Cloud Run cold start (ephemeral FS). Mount a **GCS bucket at `/data`** so it persists.

## Change (`deploy/deploy.sh`)
- Idempotently ensures `gs://<project>-lisa-cloud-data` exists + grants the Cloud Run runtime SA `roles/storage.objectAdmin`.
- Deploys with `--execution-environment gen2 --add-volume name=soul,type=cloud-storage,bucket=… --add-volume-mount volume=soul,mount-path=/data`.
- Tightened to `min=max=1` — a single warm writer (two instances mounting one bucket could race the soul's atomic-write/rename).
- Docs: status → **DEPLOYED + DURABLE**; runbook reflects the mount.

## Verified live
- Soul birthed **into the bucket** (`gs://…/soul/seed.json`, `name.md`, `emotions.json`, `desires/`, …).
- **Forced a fresh revision** (`lisa-cloud-00003`) → boot log: `soul already present — skipping birth` ✅ (no re-birth).
- Auth gate 401/200 + end-to-end chat still pass on the persisted soul.

## Remaining (not this PR)
Per-`uid` isolation + auth — today it's a single shared soul/bucket (fine for a reviewer demo; needed before real multi-tenant users).

🤖 Generated with [Claude Code](https://claude.com/claude-code)