### PR TITLE
feat(identity): one-identity-two-data-planes plan + iOS connection mode (I1)

### DIFF
--- a/docs/PLAN_IDENTITY_v1.0.md
+++ b/docs/PLAN_IDENTITY_v1.0.md
@@ -1,0 +1,145 @@
+# PLAN — Identity & connection model: "one identity, two data planes" (v1.0)
+
+**Status: DESIGN, for review.** Resolves three questions raised about how the
+iOS app connects and whether a cloud user system is warranted. Builds on the
+shipped pieces: per-device tokens ([devices.ts](../src/web/devices.ts)),
+scheme-aware iOS config (#161), the cloud edition flag
+([edition.ts](../src/edition.ts)), and the durable cloud M0
+([PLAN_CLOUD_v1.0.md](PLAN_CLOUD_v1.0.md)).
+
+## The thesis: decouple *who you are* from *where your LISA lives*
+
+LISA has two legitimate deployment shapes, and they must not be conflated:
+
+- **Your Mac** = the full-power, local-first, private edition (spawns/steers your
+  local `claude`/`codex`, Sense, dispatch). Data lives in `~/.lisa`.
+- **LISA Cloud** = the no-Mac on-ramp (chat + companion + cloud agents). Data
+  lives per-user in the cloud.
+
+The mistake would be to put a cloud account *in front of the local connection* —
+that adds a third party to "your AI on your machine" without removing the need to
+reach the Mac. The right model:
+
+```
+                 Identity (who you are)
+                         │
+          ┌──────────────┴───────────────┐
+   Data plane A: your Mac          Data plane B: LISA Cloud
+   token / Tailscale, E2E          per-uid home, hosted
+   data NEVER leaves the Mac       data in your cloud account
+   = full power                    = on-ramp, no Mac needed
+```
+
+One identity; the **user chooses the data plane**. This maps directly onto the
+`LISA_EDITION` flag we already ship.
+
+## Where we are today (recap)
+
+- **iOS ↔ Mac**: phone is a thin client that talks **directly** to the Mac's
+  `lisa serve --web` over LAN IP or a **Tailscale** tailnet name. Pairing
+  (`lisa pair`) mints a **per-device token** (only its SHA-256 hash is stored in
+  `~/.lisa/devices.json`; revocable per device) and shows a `lisa-pair://` QR.
+  Auth = loopback-trusted, else a valid device token / `LISA_WEB_TOKEN`. **No
+  cloud, no accounts.** This is correct for the local edition — keep it.
+- **iOS ↔ Cloud**: since #161 the app can point at an HTTPS cloud URL; the M0 demo
+  uses a single shared `LISA_WEB_TOKEN` and a **single shared soul** (not yet
+  per-user).
+
+## Decision 1 — Cloud needs a real user system (C3). ✅ Yes.
+
+For the *cloud* data plane, accounts are not optional — a hosted multi-tenant
+LISA must authenticate users and isolate their souls.
+
+- **Login: Sign in with Apple.** Simplest, native on iOS, and Apple *requires* it
+  once you offer any third-party login — so starting here avoids rework. (Add
+  email/Google later only if needed.)
+- **Token verification**: the iOS app obtains an Apple identity token (JWT); the
+  server verifies it (RS256 against Apple's JWKS; validate `iss`/`aud`/`exp`) →
+  a stable `uid` (Apple's `sub`). Two implementation choices:
+  - **A. Firebase Auth** — handles Apple/Google verification + a user directory +
+    revocation out of the box; matches the cloud plan's C3. Adds a GCP dependency.
+  - **B. Custom verifier** — a small `src/cloud/identity.ts` that fetches Apple's
+    JWKS and verifies the JWT (via `jose`), no extra service. Leaner, but we own
+    session issuance + a user record store.
+  - **Recommendation: B (custom verifier)** for v1 — fewer moving parts, no vendor
+    lock, and the verification is ~80 lines + tests. Graduate to Firebase only if
+    we add multiple providers / need its directory.
+- **Session**: after verifying the Apple token once, issue a LISA session cookie
+  (HMAC-signed, `uid`-scoped, expiring) so every later request is cheap. This
+  replaces the shared `LISA_WEB_TOKEN` in cloud edition (the shared token stays
+  the *reviewer-demo* fallback behind a flag).
+
+### The hard part — per-uid isolation (the multi-tenant core)
+
+Today `LISA_HOME` is **process-global** ([paths.ts](../src/paths.ts) computes it
+once), so the whole codebase reads one soul. Multi-tenant requires a **per-request
+home context**:
+
+1. **Home seam**: introduce `homeFor(uid)` → `${LISA_HOME}/users/<uid>` and thread
+   a request-scoped home through the soul/session stores (today they import the
+   global). This is the largest refactor in the plan — every `store.ts` call gains
+   a home/uid context. Do it behind the cloud edition so the Mac edition is
+   untouched (it keeps the single global home).
+2. **Per-uid GCS**: the C2 bucket already mounts at `/data`; per-uid just uses the
+   `/data/users/<uid>` subtree — no new infra, only the seam.
+3. **Birth-on-first-login**: a new user's first authenticated request births
+   *their* soul under their home (the entrypoint's one-shot birth becomes
+   per-user, lazy).
+
+This is genuinely multi-PR work; it is the gate before *any* real cloud user
+beyond a reviewer. Until it lands, cloud stays single-shared-soul (M0).
+
+## Decision 2 — Local reachability: Tailscale now, relay later (maybe never).
+
+The local data plane's only real friction is *reachability* (same Wi-Fi, or set
+up Tailscale). Options:
+
+- **Tailscale (recommend now)**: already solves private NAT traversal with E2E
+  encryption and **zero data in any cloud** — exactly the local-first property we
+  want. Action: make it a first-class, documented, near-one-tap path (the Mac
+  app's pairing screen detects/links Tailscale; `lisa pair --host <tailnet>` is
+  already supported).
+- **A custom cloud relay (defer)**: a LISA-run rendezvous so the phone reaches the
+  Mac with no user network setup. To keep the thesis it must be a *blind* E2E
+  tunnel (the relay never sees plaintext) — which is ~rebuilding Tailscale.
+  **Not worth it pre-PMF.** Revisit only if Tailscale friction provably blocks
+  adoption.
+
+**Verdict**: no relay in v1. Lean into Tailscale + smooth the pairing UX.
+
+## Decision 3 — iOS surfaces the choice: a "connection mode".
+
+A first-class **`ConnectionMode` = { My Mac, LISA Cloud }** in the app:
+
+- **My Mac** — the existing pairing (QR / `lisa-pair://` / manual host+port+token),
+  over LAN/Tailscale. Data stays on the Mac.
+- **LISA Cloud** — Sign in with Apple (interim: paste a cloud URL+token). Hosted.
+
+The mode is the stable UX primitive; Sign in with Apple just fills the cloud
+mode's auth in I2. Settings shows only the fields relevant to the chosen mode.
+
+## Phasing
+
+| Phase | What | Needs |
+| --- | --- | --- |
+| **I1 (now)** | iOS `ConnectionMode` scaffold (My Mac / Cloud) — forward-compatible UX | — |
+| **I2** | Cloud **Sign in with Apple**: `src/cloud/identity.ts` verifier + session cookie + iOS Sign-in button | Apple: enable "Sign in with Apple" capability + a Services ID/key (you) |
+| **I3** | **Per-uid home** refactor + per-uid GCS subtree + lazy per-user birth (the multi-tenant core) | the home-seam refactor |
+| **I4** | Account lifecycle (sign-out, deletion per App Store 5.1.1(v)), abuse limits; revisit relay | — |
+| **(local)** | Make Tailscale a one-tap pairing path in the Mac app | — |
+
+## Security / privacy invariants (must hold)
+
+- The **local data plane never sends user data to any LISA-run cloud** — token/
+  Tailscale only; the cloud account (if signed in) is identity, not a data pipe.
+- Cloud souls are **isolated per uid**; no cross-tenant read (a test gates this).
+- Account **deletion removes the cloud home** (Apple requirement + privacy).
+- Reviewer-demo shared token survives only behind an explicit flag, off for real
+  users once I2/I3 land.
+
+## What this turn ships
+
+- This doc.
+- **I1**: the iOS connection-mode scaffold (below). I2/I3 are sequenced; I2 is
+  blocked on you enabling "Sign in with Apple" for `ai.meetlisa.pocket` in the
+  Apple Developer portal.

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -14,10 +14,21 @@ enum DeepLinkRoute: Equatable {
     case session(agent: String, id: String)  // lisapocket://session?agent=&id=
 }
 
+/// Which data plane the app talks to — your own Mac, or hosted LISA Cloud.
+/// One identity, two data planes (see docs/PLAN_IDENTITY_v1.0.md).
+enum ConnectionMode: String, CaseIterable, Identifiable {
+    case myMac, cloud
+    var id: String { rawValue }
+    var label: String { self == .myMac ? "My Mac" : "LISA Cloud" }
+}
+
 @MainActor
 final class AppState: ObservableObject {
     @Published var config: ServerConfig
     @Published private(set) var client: LisaClient
+    /// User's chosen data plane (My Mac vs LISA Cloud). Persisted; UX-only for now —
+    /// the transport is the same scheme-aware ServerConfig either way.
+    @Published var connectionMode: ConnectionMode
     /// Drives the TabView selection (0=Dispatch … 4=Settings) — deep-links set it.
     @Published var selectedTab = 0
     /// Set by a `lisapocket://session?…` deep-link; RosterView consumes + clears it.
@@ -36,6 +47,7 @@ final class AppState: ObservableObject {
         let cfg = ServerConfig(host: host, port: storedPort == 0 ? 5757 : storedPort, token: TokenStore.load(), scheme: scheme)
         self.config = cfg
         self.client = LisaClient(config: cfg)
+        self.connectionMode = ConnectionMode(rawValue: d.string(forKey: "lisa.mode") ?? "") ?? .myMac
         let lockOn = d.bool(forKey: "lisa.biometricLock")
         self.biometricLockEnabled = lockOn
         self.locked = lockOn && cfg.token != nil  // require unlock at launch when armed
@@ -75,6 +87,11 @@ final class AppState: ObservableObject {
         } catch {
             pushStatus = (error as? LocalizedError)?.errorDescription ?? "\(error)"
         }
+    }
+
+    func setConnectionMode(_ m: ConnectionMode) {
+        connectionMode = m
+        UserDefaults.standard.set(m.rawValue, forKey: "lisa.mode")
     }
 
     func update(host: String, port: Int, token: String?, scheme: String = "http") {

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -17,9 +17,9 @@ enum DeepLinkRoute: Equatable {
 /// Which data plane the app talks to — your own Mac, or hosted LISA Cloud.
 /// One identity, two data planes (see docs/PLAN_IDENTITY_v1.0.md).
 enum ConnectionMode: String, CaseIterable, Identifiable {
-    case myMac, cloud
+    case mac, cloud
     var id: String { rawValue }
-    var label: String { self == .myMac ? "My Mac" : "LISA Cloud" }
+    var label: String { self == .mac ? "My Mac" : "LISA Cloud" }
 }
 
 @MainActor
@@ -47,7 +47,7 @@ final class AppState: ObservableObject {
         let cfg = ServerConfig(host: host, port: storedPort == 0 ? 5757 : storedPort, token: TokenStore.load(), scheme: scheme)
         self.config = cfg
         self.client = LisaClient(config: cfg)
-        self.connectionMode = ConnectionMode(rawValue: d.string(forKey: "lisa.mode") ?? "") ?? .myMac
+        self.connectionMode = ConnectionMode(rawValue: d.string(forKey: "lisa.mode") ?? "") ?? .mac
         let lockOn = d.bool(forKey: "lisa.biometricLock")
         self.biometricLockEnabled = lockOn
         self.locked = lockOn && cfg.token != nil  // require unlock at launch when armed

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -16,40 +16,77 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             Form {
-                Section("Connection") {
-                    TextField("Host (IP or tailnet name)", text: $host)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                    TextField("Port", text: $portText)
-                        .keyboardType(.numberPad)
-                    SecureField("Device token", text: $token)
-                    Button("Save") {
-                        app.update(host: host, port: Int(portText) ?? 5757, token: token.isEmpty ? nil : token)
-                        status = "Saved."
+                Section {
+                    Picker("Connect to", selection: Binding(
+                        get: { app.connectionMode },
+                        set: { app.setConnectionMode($0) })) {
+                        ForEach(ConnectionMode.allCases) { m in Text(m.label).tag(m) }
                     }
+                    .pickerStyle(.segmented)
+                } footer: {
+                    Text(app.connectionMode == .myMac
+                         ? "Talk to your own Mac running Lisa — your data stays on your Mac."
+                         : "Use hosted LISA Cloud — no Mac needed.")
                 }
 
-                Section("Pair from QR / URL") {
-                    Button {
-                        showScanner = true
-                    } label: {
-                        Label("Scan QR code", systemImage: "qrcode.viewfinder")
-                    }
-                    TextField("LAN http://host:port/?token= or cloud https://…/?token=", text: $pairText)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
-                        .keyboardType(.URL)
-                    Button("Apply pairing") {
-                        if app.applyPairing(pairText) {
-                            syncFromConfig()
-                            status = "Paired."
-                        } else {
-                            status = "Couldn't parse that pairing string."
+                if app.connectionMode == .myMac {
+                    Section("Connection") {
+                        TextField("Host (IP or tailnet name)", text: $host)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                        TextField("Port", text: $portText)
+                            .keyboardType(.numberPad)
+                        SecureField("Device token", text: $token)
+                        Button("Save") {
+                            app.update(host: host, port: Int(portText) ?? 5757, token: token.isEmpty ? nil : token)
+                            status = "Saved."
                         }
                     }
-                    .disabled(pairText.isEmpty)
-                    Text("Paste your Mac's pairing URL, or a LISA Cloud URL (https://…run.app/?token=…) to use the hosted demo without a Mac.")
-                        .font(.caption).foregroundStyle(.secondary)
+
+                    Section("Pair from QR / URL") {
+                        Button {
+                            showScanner = true
+                        } label: {
+                            Label("Scan QR code", systemImage: "qrcode.viewfinder")
+                        }
+                        TextField("lisa-pair://… or http://host:port/?token=", text: $pairText)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .keyboardType(.URL)
+                        Button("Apply pairing") {
+                            if app.applyPairing(pairText) {
+                                syncFromConfig()
+                                status = "Paired."
+                            } else {
+                                status = "Couldn't parse that pairing string."
+                            }
+                        }
+                        .disabled(pairText.isEmpty)
+                        Text("Run `lisa pair` on your Mac and scan the QR — over the same Wi-Fi (LAN) or a Tailscale tailnet name.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
+                } else {
+                    Section("LISA Cloud") {
+                        TextField("https://…run.app/?token=", text: $pairText)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .keyboardType(.URL)
+                        Button("Connect") {
+                            if app.applyPairing(pairText) {
+                                syncFromConfig()
+                                status = "Connected to LISA Cloud."
+                            } else {
+                                status = "Couldn't parse that cloud URL."
+                            }
+                        }
+                        .disabled(pairText.isEmpty)
+                        Button {} label: {
+                            Label("Sign in with Apple (coming soon)", systemImage: "person.crop.circle")
+                        }
+                        .disabled(true)
+                        Text("Paste your LISA Cloud URL + token. Sign in with Apple is coming.")
+                            .font(.caption).foregroundStyle(.secondary)
+                    }
                 }
 
                 Section("Push (ntfy)") {

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -24,12 +24,12 @@ struct SettingsView: View {
                     }
                     .pickerStyle(.segmented)
                 } footer: {
-                    Text(app.connectionMode == .myMac
+                    Text(app.connectionMode == .mac
                          ? "Talk to your own Mac running Lisa — your data stays on your Mac."
                          : "Use hosted LISA Cloud — no Mac needed.")
                 }
 
-                if app.connectionMode == .myMac {
+                if app.connectionMode == .mac {
                     Section("Connection") {
                         TextField("Host (IP or tailnet name)", text: $host)
                             .autocorrectionDisabled()

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -92,6 +92,14 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertNil(AppState.parsePairing("https://lisa-cloud.run.app/"))
     }
 
+    // ── ConnectionMode persists by rawValue (the "lisa.mode" UserDefaults key) ──
+    func testConnectionModeRawValues() {
+        XCTAssertEqual(ConnectionMode(rawValue: "myMac"), .myMac)
+        XCTAssertEqual(ConnectionMode(rawValue: "cloud"), .cloud)
+        XCTAssertNil(ConnectionMode(rawValue: "bogus"))
+        XCTAssertEqual(ConnectionMode.allCases.count, 2)
+    }
+
     // ── AgentSession.lastMtime tolerates both shapes (regression for the SSE bug) ──
     func testDecodesNumericLastMtimeFromSSE() throws {
         // agent_session_update broadcasts raw epoch-ms; must not throw.

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -94,7 +94,7 @@ final class LisaPocketTests: XCTestCase {
 
     // ── ConnectionMode persists by rawValue (the "lisa.mode" UserDefaults key) ──
     func testConnectionModeRawValues() {
-        XCTAssertEqual(ConnectionMode(rawValue: "myMac"), .myMac)
+        XCTAssertEqual(ConnectionMode(rawValue: "mac"), .mac)
         XCTAssertEqual(ConnectionMode(rawValue: "cloud"), .cloud)
         XCTAssertNil(ConnectionMode(rawValue: "bogus"))
         XCTAssertEqual(ConnectionMode.allCases.count, 2)


### PR DESCRIPTION
Answers "how does iOS↔Mac connect, and is a cloud user system more reasonable?" with a design doc + the first safe slice.

## docs/PLAN_IDENTITY_v1.0.md — "one identity, two data planes"
Decouple *who you are* (account) from *where your LISA lives* (your Mac vs cloud).
- **Cloud needs a real user system (C3)** — Sign in with Apple; server verifies the Apple JWT → uid (recommend a small custom verifier over Firebase for v1); **per-uid home isolation** is the big refactor (today `LISA_HOME` is process-global).
- **Local reachability** — Tailscale now (private NAT traversal, no data in cloud); **defer a relay** (it'd be ~rebuilding Tailscale).
- **iOS** surfaces the choice as a `ConnectionMode`.

## Ships now — I1: iOS ConnectionMode (My Mac / LISA Cloud)
- Segmented picker gates the relevant Settings fields; **My Mac** = existing pairing (LAN/Tailscale), **LISA Cloud** = paste cloud URL+token (Sign in with Apple placeholder for I2).
- Persists to `lisa.mode`; transport is the same scheme-aware `ServerConfig`. +1 unit test. `build.sh` **BUILD SUCCEEDED**.

## Sequenced (not here)
- **I2** Sign in with Apple — blocked on enabling that capability for `ai.meetlisa.pocket` in the Apple Developer portal.
- **I3** per-uid home refactor + per-uid GCS (multi-tenant core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)