### PR TITLE
feat(website): privacy policy page (en + zh-CN)

### DIFF
--- a/website/src/layouts/Base.astro
+++ b/website/src/layouts/Base.astro
@@ -87,6 +87,7 @@ const promptHost = lang === "zh-CN" ? "lisa@meetlisa" : "lisa@meetlisa";
           ? "lisa · MIT 开源 · 主权属于用户的本地 AI · 运行于 ~/.lisa"
           : "lisa · MIT open source · sovereign AI on your machine · lives in ~/.lisa"}
       </span>
+      <a class="footer-link" href={lang === "zh-CN" ? "/zh-CN/privacy" : "/privacy"}>{lang === "zh-CN" ? "隐私" : "privacy"}</a>
     </footer>
 
     <style is:global>
@@ -259,6 +260,8 @@ const promptHost = lang === "zh-CN" ? "lisa@meetlisa" : "lisa@meetlisa";
         background: rgba(10,13,43,0.9);
       }
       .footer-text { font-family: 'Press Start 2P', monospace; font-size: 9px; color: var(--text-dim); }
+      .footer-link { font-family: 'Press Start 2P', monospace; font-size: 9px; color: var(--text-dim); margin-left: 14px; }
+      .footer-link:hover { color: var(--amber); }
       .dotgreen { width: 9px; height: 9px; background: var(--green);
         box-shadow: 0 0 8px var(--green); display: inline-block; }
       @media (prefers-reduced-motion: no-preference) {

--- a/website/src/pages/privacy.astro
+++ b/website/src/pages/privacy.astro
@@ -1,0 +1,76 @@
+---
+import Base from "../layouts/Base.astro";
+---
+<Base title="Privacy" lang="en" description="Lisa's privacy policy — a local-first AI that collects nothing to our servers.">
+  <h1>Privacy Policy</h1>
+  <p><em>Last updated: 2026-06-26</em></p>
+
+  <p>
+    Lisa is <strong>local-first</strong>. The apps — <strong>Lisa</strong> (macOS)
+    and <strong>Lisa Pocket</strong> (iOS) — are clients to a Lisa backend that
+    <em>you</em> run or choose. We do not operate a server that receives your
+    personal data in normal use, and we do not sell, rent, or share any data.
+  </p>
+
+  <h2>What we collect</h2>
+  <p>
+    <strong>Nothing — to us.</strong> Lisa Pocket and Lisa collect no analytics,
+    no advertising identifiers, and contain no third-party tracking SDKs. There is
+    no Lisa-operated account system in the default (local) mode.
+  </p>
+
+  <h2>What stays on your device</h2>
+  <ul>
+    <li>
+      <strong>Connection settings</strong> — the address of your backend and a
+      device token are stored on your device (the iOS Keychain / app preferences)
+      so the app can reconnect. They are never sent to us.
+    </li>
+    <li>
+      <strong>Your conversations and Lisa's memory ("soul")</strong> live on the
+      backend you connect to — your own Mac (under <code>~/.lisa</code>) or a Lisa
+      Cloud instance you use. The app is a window onto that backend.
+    </li>
+  </ul>
+
+  <h2>Your backend &amp; LLM providers</h2>
+  <p>
+    When you chat, your messages are processed by the large-language-model
+    provider configured on <em>your</em> backend (e.g. Anthropic, Zhipu/GLM,
+    OpenAI, Google), using <em>your</em> API key. That processing is governed by
+    that provider's privacy policy. We do not intercept or relay it.
+  </p>
+
+  <h2>Lisa Cloud (optional / demo)</h2>
+  <p>
+    If you connect to a hosted <strong>Lisa Cloud</strong> instance instead of
+    your own Mac, your messages are processed by that instance to provide the
+    service (and passed to its configured LLM provider). The public review/demo
+    instance is <strong>shared and rate-limited</strong> — please don't put
+    sensitive information into it.
+  </p>
+
+  <h2>Notifications</h2>
+  <p>
+    If you enable push notifications, a push token (Apple APNs, or an ntfy topic
+    you choose) is used <em>only</em> to deliver the alerts you opt into, routed
+    through the backend you paired with. It is not used for tracking.
+  </p>
+
+  <h2>Children</h2>
+  <p>Lisa is not directed at children under 13 and does not knowingly collect their data.</p>
+
+  <h2>Changes</h2>
+  <p>
+    We may update this policy as the apps evolve; material changes will be noted
+    here with a new date. The source is public:
+    <a href="https://github.com/oratis/LISA">github.com/oratis/LISA</a>.
+  </p>
+
+  <h2>Contact</h2>
+  <p>
+    Questions about privacy? Open an issue at
+    <a href="https://github.com/oratis/LISA/issues">github.com/oratis/LISA/issues</a>
+    or email <a href="mailto:wangharp@gmail.com">wangharp@gmail.com</a>.
+  </p>
+</Base>

--- a/website/src/pages/zh-CN/privacy.astro
+++ b/website/src/pages/zh-CN/privacy.astro
@@ -1,0 +1,69 @@
+---
+import Base from "../../layouts/Base.astro";
+---
+<Base title="隐私" lang="zh-CN" description="Lisa 隐私政策——本地优先,不向我们的服务器收集任何数据。">
+  <h1>隐私政策</h1>
+  <p><em>最后更新:2026-06-26</em></p>
+
+  <p>
+    Lisa 是<strong>本地优先</strong>的。两个客户端——<strong>Lisa</strong>(macOS)
+    和 <strong>Lisa Pocket</strong>(iOS)——连接的是<em>你自己</em>运行或选择的
+    Lisa 后端。在正常使用下,我们不运营任何接收你个人数据的服务器,也不会出售、
+    出租或分享任何数据。
+  </p>
+
+  <h2>我们收集什么</h2>
+  <p>
+    <strong>对我们而言,什么都不收集。</strong>Lisa Pocket 与 Lisa 不含任何分析统计、
+    广告标识或第三方追踪 SDK。默认(本地)模式下不存在由 Lisa 运营的账户体系。
+  </p>
+
+  <h2>留在你设备上的数据</h2>
+  <ul>
+    <li>
+      <strong>连接设置</strong>——你后端的地址和一个设备令牌存放在你的设备上
+      (iOS 钥匙串 / 应用偏好),用于重新连接,绝不会发送给我们。
+    </li>
+    <li>
+      <strong>你的对话与 Lisa 的记忆("灵魂")</strong>存放在你连接的后端上——
+      你自己的 Mac(位于 <code>~/.lisa</code>)或你使用的 Lisa Cloud 实例。
+      应用只是通向该后端的一扇窗。
+    </li>
+  </ul>
+
+  <h2>你的后端与大模型提供商</h2>
+  <p>
+    当你聊天时,消息由配置在<em>你</em>后端上的大语言模型提供商
+    (如 Anthropic、智谱/GLM、OpenAI、Google)用<em>你</em>的 API key 处理,
+    受该提供商的隐私政策约束。我们不拦截、不中转。
+  </p>
+
+  <h2>Lisa Cloud(可选 / 演示)</h2>
+  <p>
+    如果你连接的是托管的 <strong>Lisa Cloud</strong> 实例而非自己的 Mac,你的消息
+    会由该实例处理以提供服务(并交给其配置的大模型提供商)。公开的审核/演示实例
+    是<strong>共享且限流</strong>的——请勿在其中输入敏感信息。
+  </p>
+
+  <h2>通知</h2>
+  <p>
+    若你启用推送通知,推送令牌(Apple APNs,或你自选的 ntfy 主题)
+    <em>仅</em>用于投递你主动开启的提醒,经由你配对的后端路由,不用于追踪。
+  </p>
+
+  <h2>儿童</h2>
+  <p>Lisa 并非面向 13 岁以下儿童,也不会有意收集他们的数据。</p>
+
+  <h2>变更</h2>
+  <p>
+    随着应用演进,我们可能更新本政策;重大变更会在此注明新日期。源代码公开:
+    <a href="https://github.com/oratis/LISA">github.com/oratis/LISA</a>。
+  </p>
+
+  <h2>联系</h2>
+  <p>
+    隐私相关问题?在
+    <a href="https://github.com/oratis/LISA/issues">github.com/oratis/LISA/issues</a>
+    提 issue,或邮件 <a href="mailto:wangharp@gmail.com">wangharp@gmail.com</a>。
+  </p>
+</Base>


### PR DESCRIPTION
Adds the **privacy-policy URL Apple requires** for the iOS submission: `/privacy` + `/zh-CN/privacy`, linked from the footer.

Matches App Privacy = **Data Not Collected**: Lisa is local-first; no analytics/tracking/third-party SDKs; the apps are clients to a backend the user runs/chooses; chats go to the user's own LLM provider; the hosted demo is shared + rate-limited. `astro build` → 10 pages OK.

After merge, deploy the site (`PROJECT=… website/deploy/deploy.sh`) so https://meetlisa.ai/privacy is live, then use that URL in App Store Connect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)