### PR TITLE
fix(website): relative redirects — no-slash routes were broken behind Cloud Run

### DIFF
--- a/website/nginx.conf
+++ b/website/nginx.conf
@@ -4,6 +4,12 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Behind Cloud Run's proxy nginx doesn't know the external host/scheme, so an
+    # absolute trailing-slash redirect (from try_files $uri/) 301s to a broken
+    # http://<internal-host>:8080/… URL. Emit RELATIVE redirects so the browser
+    # keeps https://meetlisa.ai — fixes every no-slash route (/privacy, /install, …).
+    absolute_redirect off;
+
     # Astro emits <route>/index.html — resolve dirs, then .html, then 404 page.
     location / {
         try_files $uri $uri/ $uri.html =404;


### PR DESCRIPTION
Every no-slash URL (`/privacy`, `/install`, all nav links) 301-redirected to a broken `http://lisa-web-…:8080/…/` (protocol downgrade + internal host) because nginx behind Cloud Run's proxy emits absolute redirects. `absolute_redirect off` → relative redirects that keep `https://meetlisa.ai`. Caught while wiring the App Store privacy-policy URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)