### PR TITLE
feat(ios): first-run onboarding — install LISA on your Mac & pair (M1)

### DIFF
--- a/docs/PLAN_IOS_ONBOARDING_v1.0.md
+++ b/docs/PLAN_IOS_ONBOARDING_v1.0.md
@@ -33,14 +33,27 @@ default-bind tweak (decision ②).
 ## Decisions (locked)
 
 1. **Ship the My Mac / LISA Cloud fork now** (flow step 1). The Mac path is fully
-   functional; the Cloud card routes to the `edition.ts` sign-in if ready, else a
-   "Coming soon" state. A single `ConnectionMode` threads through later steps and
-   drives `parsePairing`'s `http` (Mac) vs `https` (cloud) scheme.
+   functional. **The Cloud card is active in M1** — it routes to manual paste of an
+   `https://…?token=` cloud URL (the same `parsePairing` path), so a user with a
+   LISA Cloud endpoint can connect today; only *Sign in with Apple* is deferred
+   (shown disabled, "coming soon", wired in M4). A single `ConnectionMode` threads
+   through later steps and drives `parsePairing`'s `http` (Mac) vs `https` (cloud)
+   scheme.
 2. **The menu-bar Mac app binds LAN-reachable by default** (`--host 0.0.0.0`).
    This removes the #1 failure (forgetting the flag) for app users and lets the
    flow's "Start LISA" step branch by install method. LAN-reachable is still
    **token-gated** — someone on your Wi-Fi can attempt to connect but can't
    without the paired device token; the flow says so on-screen.
+   - *Why always-on, not "bind 0.0.0.0 only once a device is paired":* pairing is
+     loopback-only (the QR is minted on the Mac), so gate-on-first-pair is feasible
+     and is strictly more least-privilege — but it costs a backend restart at the
+     exact moment the user is mid-pair, the most failure-sensitive step. Always-on
+     keeps the port open behind the token gate; the residual exposure (a future
+     auth regression / DoS / "this Mac runs LISA" fingerprinting) is the accepted
+     trade for a restart-free pair. Revisit if we ever bind without a token.
+   - *Firewall:* the first `0.0.0.0` bind can trip the macOS Application Firewall
+     "allow incoming connections" prompt for the `node` process; if denied, pairing
+     fails. The onboarding "Can't reach your Mac" help calls this out.
 3. **Skip allowed + "Finish setup" banner.** `needsOnboarding = !isConfigured &&
    !skipped`. Skipping drops into the app's existing empty states plus a
    persistent top banner that re-enters the flow; Settings also gets a

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -278,7 +278,7 @@ struct OnboardingFlow: View {
             case .unreachable, .ok:
                 return ("wifi.exclamationmark",
                         "Can't reach your Mac",
-                        "• Is this iPhone on the same Wi-Fi as your Mac?\n• For a terminal install, did you start it with `--host 0.0.0.0`?\n• A Tailscale tailnet name works too.")
+                        "• Is this iPhone on the same Wi-Fi as your Mac?\n• For a terminal install, did you start it with `--host 0.0.0.0`?\n• If macOS asked to allow incoming connections, choose Allow.\n• A Tailscale tailnet name works too.")
             }
         }()
         VStack(spacing: 14) {


### PR DESCRIPTION
**Note:** the M1 onboarding feature itself already reached `main` via #168 (the bundle-id PR was stacked on this branch and carried these files in). To avoid re-merging identical code as an add/add conflict, this branch was rebuilt on top of `main` and now contains **only the follow-up polish** that wasn't in #168:

1. **Plan ↔ impl reconcile** — `PLAN_IOS_ONBOARDING_v1.0.md` decision ① said the LISA Cloud card was a disabled "Coming soon" state; the shipped `OnboardingFlow` actually makes it *active* (manual `https://…?token=` paste via `parsePairing`), with only Sign in with Apple deferred to M4. Doc now matches code. Also records *why* decision ② binds `0.0.0.0` always rather than gating on first-pair (pairing is loopback-only, so gate-on-pair is feasible + more least-privilege, but costs a backend restart mid-pair).
2. **UX** — the "Can't reach your Mac" help now mentions the macOS Application Firewall "allow incoming connections" prompt, the silent-failure mode of the default `0.0.0.0` bind (companion to #169).

## Verification
- `packaging/ios-companion/build.sh` → **BUILD SUCCEEDED** (iPhone 17 Pro sim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)