### PR TITLE
feat(ios): onboarding M2 — outcome-specific recovery + haptics

### DIFF
--- a/docs/PLAN_IOS_ONBOARDING_v1.0.md
+++ b/docs/PLAN_IOS_ONBOARDING_v1.0.md
@@ -1,0 +1,133 @@
+# PLAN — iOS Onboarding: "Get LISA on your Mac & pair" (v1.0)
+
+**Status: design locked; M1 building.** iOS-only UX layer over existing pairing
+primitives — the Mac-local path needs **zero new backend protocol**. Builds on the
+merged `ConnectionMode` + scheme-aware `parsePairing` (#161, #163 — the iOS half of
+*one identity, two data planes*, `docs/PLAN_IDENTITY_v1.0.md`) and extends
+`docs/IOS_COMPANION_PLAN.md` §5.3 (the QR-pairing spec).
+
+## Why / the gap
+
+Lisa Pocket is a **companion to a Mac running LISA** (local-first). Today, first
+launch drops a brand-new user straight into the `TabView`, where every tab is a
+dead-end `ContentUnavailableView("Not paired")`. The user is left to *discover*
+that they need a Mac, install LISA, start it **reachably**, run `lisa pair`, and
+scan — with no guidance. That's a cliff, and the most common failure (the phone
+can't reach the Mac because `lisa serve` binds loopback by default) is invisible.
+
+**This feature** is a first-run guided flow that carries a new user from "app
+installed, nothing configured" → "paired and in the app", holding their hand
+through the Mac install, the reachability gotcha, and the QR scan.
+
+**Key fact:** every primitive already exists —
+- `lisa pair` (`src/cli/pair.ts`) → POSTs loopback-only `/api/pair/start`, which
+  `mintDevice`s a per-device token (returned once), builds
+  `lisa-pair://v1?host=&port=&token=&name=`, and renders a **terminal QR**.
+- iOS `AppState.parsePairing` already accepts that URL **and** literal
+  `http(s)://host:port/?token=` (port defaults 5757 / 443).
+- `QRScannerView` already scans + degrades honestly (no camera → `onError`).
+
+So this is a **pure iOS-side UX layer**; the only Mac-side code change is a
+default-bind tweak (decision ②).
+
+## Decisions (locked)
+
+1. **Ship the My Mac / LISA Cloud fork now** (flow step 1). The Mac path is fully
+   functional; the Cloud card routes to the `edition.ts` sign-in if ready, else a
+   "Coming soon" state. A single `ConnectionMode` threads through later steps and
+   drives `parsePairing`'s `http` (Mac) vs `https` (cloud) scheme.
+2. **The menu-bar Mac app binds LAN-reachable by default** (`--host 0.0.0.0`).
+   This removes the #1 failure (forgetting the flag) for app users and lets the
+   flow's "Start LISA" step branch by install method. LAN-reachable is still
+   **token-gated** — someone on your Wi-Fi can attempt to connect but can't
+   without the paired device token; the flow says so on-screen.
+3. **Skip allowed + "Finish setup" banner.** `needsOnboarding = !isConfigured &&
+   !skipped`. Skipping drops into the app's existing empty states plus a
+   persistent top banner that re-enters the flow; Settings also gets a
+   "Set up / re-pair" row. Never hard-blocked.
+
+## The flow (happy path = 3 copies + 1 scan)
+
+Presented as a `.fullScreenCover` over `RootView` whenever `needsOnboarding`.
+
+| # | Screen | Content | Primary CTA | Escape hatch |
+|---|--------|---------|-------------|--------------|
+| 0 | **Welcome** | Lisa portrait. "Meet Lisa. She lives on your Mac — this is your window to her." | Get started | *I already have LISA running →* (→ step 4) |
+| 1 | **Where Lisa lives** | Two cards: **My Mac** (recommended · private · local) / **LISA Cloud** (no Mac needed) | pick a card | — |
+| 2 | **Install on your Mac** | Segmented **Homebrew / npm / Mac app**, each a tap-to-copy command (`brew install oratis/tap/lisa`, `npm i -g @oratis/lisa`) or a download link | It's installed → | Help link |
+| 3 | **Start LISA** | Branches by install method: **Mac app** → "Open LISA from your menu bar — already reachable"; **CLI** → copy `lisa serve --web --host 0.0.0.0` + "stay on the same Wi-Fi" | It's running → | — |
+| 4 | **Show the pairing QR** | Copy `lisa pair` + "it prints a QR on your Mac" | Scan the QR | *Paste link / enter manually* |
+| 5 | **Scan** | Full-screen `QRScannerView` framing the Mac's QR | (auto on scan) | Paste `lisa-pair://` · manual host/port/token |
+| 6 | **Connecting → Connected** | Verify reachability + token, then "Connected to Lisa ✓" | Enter | (on failure → targeted help) |
+
+After success the user lands on **Chat** (warmer than Dispatch).
+
+## Connection-mode fork
+
+`enum ConnectionMode { case mac, cloud }`, chosen at step 1, threaded through:
+- **mac** → install/serve/pair steps above; scheme `http`, default port 5757.
+- **cloud** → sign-in (Firebase / Sign in with Apple per `PLAN_CLOUD`) → server
+  hands back an `https://…?token=` config; scheme `https`, default port 443.
+  Until the cloud edition lands, the card shows "Coming soon" and is disabled.
+
+## Pairing mechanism — 100% reuse
+
+- Scan/paste → `AppState.applyPairing(raw)` → `parsePairing` writes config +
+  `TokenStore`, sets `isConfigured`.
+- **Verify before declaring success:** ping a cheap endpoint (island ping /
+  `/api/edition`) so a bad token or unreachable host surfaces *now*, not on the
+  first dead tab.
+- No change to `devices.ts` / `/api/pair/start` / `lisa pair`.
+
+## Error handling (every step recovers, never traps)
+
+| Failure | Detection | Recovery shown |
+|---|---|---|
+| Phone can't reach Mac | verify times out / refused | "Same Wi-Fi? Did you run `--host 0.0.0.0`?" + Retry + manual entry + Tailscale tip (mirrors `pair.ts`'s printed hint) |
+| Token rejected (401) | verify → 401 | "This link expired or was revoked — run `lisa pair` again." → rescan |
+| Camera denied / Simulator | `QRScannerView.onError` | auto-fall back to Paste / Manual |
+| Not a LISA code | `parsePairing` → nil | "That's not a LISA pairing code." → retry |
+| Mac too old | `/api/edition` / version probe absent | soft warning, continue |
+| "Not now" | user skips | empty app + persistent "Finish setup" banner |
+
+## State & integration
+
+- **Trigger:** `RootView` gains `.fullScreenCover(isPresented: app.needsOnboarding)`;
+  dismiss on success/skip.
+- **AppState additions:** `OnboardingStep` enum / presentation flag,
+  `verifyConnection() async`, persisted `completedOrSkippedOnboarding`
+  (UserDefaults). Everything else reuses `update / applyPairing / config`.
+- **Re-entry:** Settings "Set up / re-pair" row re-presents the flow (also for
+  switching Macs or to Cloud).
+- **New SwiftUI files** (`Sources/Onboarding/`): `OnboardingFlow.swift` (host +
+  step machine), `OnboardingScaffold.swift` (shared: progress dots, title/body,
+  tap-to-copy command block, primary CTA + secondary link), per-step views, and
+  `OnboardingScan.swift` (wraps the existing `QRScannerView`). All styled via
+  `Theme.swift` (cyan accent, dark). One test target for the step logic +
+  `parsePairing` round-trip (already pure/testable).
+
+## Mac-side change (decision ②)
+
+The menu-bar app (`packaging/mac-client`) starts `lisa serve` bound to
+`0.0.0.0` by default (today it relies on the CLI default of loopback). Still
+token-gated. The CLI keeps its loopback default; the flow / `lisa pair` instruct
+`--host 0.0.0.0` for CLI users.
+
+## Phasing (each shippable)
+
+1. **M1** — Mac-local happy path (steps 0,1-mac,2-6) + fork UI (Cloud stubbed) +
+   paste/manual fallbacks + skip-with-banner. Pure iOS + the one-line menu-bar
+   default-bind change.
+2. **M2** — targeted error screens, "I already have it" shortcut, Settings
+   re-entry, copy haptics.
+3. **M3** — Mac-side GUI QR ("Pair iPhone…" menu item / window) so non-CLI users
+   skip the terminal.
+4. **M4** — wire the LISA Cloud fork to the cloud-edition sign-in.
+
+## Open questions (non-blocking)
+
+- After success, land on **Chat** (warm) vs **Dispatch** (utility)? (Proposed: Chat.)
+- Install screen: show all three methods, or detect/recommend one? (Proposed: show
+  all, default-highlight Homebrew.)
+- Do we surface a short link (e.g. `meetlisa.ai/start`) on the install screen so
+  the user can open the Mac instructions on the Mac itself?

--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -34,6 +34,15 @@ struct RootView: View {
         .toolbarBackground(.visible, for: .tabBar)
         .onOpenURL { app.handleDeepLink($0) }
         .overlay { if app.locked { LockView() } }
+        .fullScreenCover(isPresented: $app.showOnboarding) {
+            OnboardingFlow().environmentObject(app)
+        }
+        .safeAreaInset(edge: .top) {
+            // Persistent nudge after a skip, while still unpaired — taps re-enter the flow.
+            if app.needsSetup && !app.showOnboarding {
+                SetupBanner { app.presentOnboarding() }
+            }
+        }
         .onChange(of: scenePhase) { _, phase in
             if phase == .background { app.lockIfEnabled() }  // re-arm when leaving foreground
         }

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -38,6 +38,8 @@ final class AppState: ObservableObject {
     @Published var locked: Bool
     /// Last APNs registration outcome, shown in Settings.
     @Published var pushStatus = ""
+    /// Drives the first-run onboarding cover (docs/PLAN_IOS_ONBOARDING_v1.0.md).
+    @Published var showOnboarding = false
 
     init() {
         let d = UserDefaults.standard
@@ -51,6 +53,8 @@ final class AppState: ObservableObject {
         let lockOn = d.bool(forKey: "lisa.biometricLock")
         self.biometricLockEnabled = lockOn
         self.locked = lockOn && cfg.token != nil  // require unlock at launch when armed
+        // Guided setup auto-opens for a brand-new (unpaired, never-onboarded) install.
+        self.showOnboarding = !cfg.isConfigured && !d.bool(forKey: "lisa.onboarded")
         // The AppDelegate posts the APNs device token here once it arrives.
         NotificationCenter.default.addObserver(forName: .apnsToken, object: nil, queue: .main) { [weak self] note in
             let hex = note.object as? String
@@ -128,6 +132,46 @@ final class AppState: ObservableObject {
         let scheme = q("scheme") ?? urlScheme ?? "http"
         let port = Int(q("port") ?? "") ?? comps.port ?? (scheme == "https" ? 443 : 5757)
         return ServerConfig(host: host, port: port, token: token, scheme: scheme)
+    }
+
+    // ── first-run onboarding (docs/PLAN_IOS_ONBOARDING_v1.0.md) ──
+    /// Sticky once the user finishes or skips, so the cover doesn't reappear every
+    /// launch (UserDefaults "lisa.onboarded").
+    private var onboarded: Bool {
+        get { UserDefaults.standard.bool(forKey: "lisa.onboarded") }
+        set { UserDefaults.standard.set(newValue, forKey: "lisa.onboarded") }
+    }
+
+    /// Still unpaired — drives the persistent "Finish setup" banner.
+    var needsSetup: Bool { !config.isConfigured }
+
+    /// Re-enter the flow (from the banner or Settings).
+    func presentOnboarding() { showOnboarding = true }
+
+    /// Close the flow. `paired` true means a verified connection — land on Chat
+    /// (warmer than Dispatch). Either way mark onboarded so it won't auto-reappear.
+    func finishOnboarding(paired: Bool) {
+        onboarded = true
+        showOnboarding = false
+        if paired { selectedTab = 1 }
+    }
+
+    /// Probe the saved config before declaring success, so a bad token / unreachable
+    /// Mac surfaces during onboarding rather than on the first dead tab. Uses the
+    /// cheap authed island ping: 401/403 ⇒ token rejected, a connection error ⇒
+    /// unreachable, 404 ⇒ reachable + token accepted (just an older Mac).
+    func verifyConnection() async -> VerifyOutcome {
+        guard config.isConfigured else { return .unreachable }
+        do {
+            _ = try await client.islandPing()
+            return .ok
+        } catch LisaError.http(let code) {
+            if code == 401 || code == 403 { return .unauthorized }
+            if code == 404 { return .ok }
+            return .serverError(code)
+        } catch {
+            return .unreachable
+        }
     }
 
     /// Route a `lisapocket://` deep-link (from a push Click or the home Widget).

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -255,12 +255,27 @@ struct OnboardingFlow: View {
     @ViewBuilder private var footer: some View {
         if outcome == .ok {
             OnboardingPrimaryButton(title: "Enter") { app.finishOnboarding(paired: true) }
-        } else if !verifying, outcome != nil {
+        } else if !verifying, let outcome {
+            // Outcome-specific recovery: a rejected token re-scans, an unreachable
+            // Mac retries (see VerifyOutcome.recovery).
+            let actions = outcome.recovery
             VStack(spacing: 8) {
-                OnboardingPrimaryButton(title: "Try again") { Task { await verify() } }
-                OnboardingSecondaryButton(title: "Enter manually") { openManual(.mac) }
+                if let primary = actions.first {
+                    OnboardingPrimaryButton(title: primary.label) { perform(primary) }
+                }
+                ForEach(Array(actions.dropFirst()), id: \.self) { action in
+                    OnboardingSecondaryButton(title: action.label) { perform(action) }
+                }
                 OnboardingSecondaryButton(title: "Back") { go(.pair) }
             }
+        }
+    }
+
+    private func perform(_ action: RecoveryAction) {
+        switch action {
+        case .retry:  Task { await verify() }
+        case .rescan: scanNote = nil; go(.scan)
+        case .manual: openManual(.mac)
         }
     }
 
@@ -293,8 +308,10 @@ struct OnboardingFlow: View {
     @MainActor private func verify() async {
         verifying = true
         outcome = nil
-        outcome = await app.verifyConnection()
+        let result = await app.verifyConnection()
+        outcome = result
         verifying = false
+        if result == .ok { Haptics.success() } else { Haptics.warning() }
     }
 }
 

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -1,0 +1,375 @@
+import SwiftUI
+
+/// First-run guided flow: carries a brand-new user from "app installed, nothing
+/// configured" → "paired and in the app" (docs/PLAN_IOS_ONBOARDING_v1.0.md, M1).
+/// Presented as a `.fullScreenCover` over RootView when `app.showOnboarding`.
+///
+/// Pure UX over existing primitives — `applyPairing` / `parsePairing` / `update`
+/// / `QRScannerView` / `verifyConnection`. No new backend protocol.
+struct OnboardingFlow: View {
+    @EnvironmentObject var app: AppState
+
+    @State private var step: OnboardingStep = .welcome
+    @State private var method: InstallMethod = .homebrew
+    @State private var showManual = false
+    @State private var manualMode: ConnectionMode = .mac
+    @State private var scanNote: String?
+    @State private var verifying = false
+    @State private var outcome: VerifyOutcome?
+
+    var body: some View {
+        ZStack {
+            Theme.bgDeep.ignoresSafeArea()
+            content
+        }
+        .preferredColorScheme(.dark)
+        .tint(Theme.accent)
+        .sheet(isPresented: $showManual) {
+            OnboardingManualEntry(mode: manualMode) {
+                showManual = false
+                go(.connect)
+            }
+            .environmentObject(app)
+        }
+    }
+
+    @ViewBuilder private var content: some View {
+        switch step {
+        case .welcome: welcomeScreen
+        case .mode:    modeScreen
+        case .install: installScreen
+        case .start:   startScreen
+        case .pair:    pairScreen
+        case .scan:    scanScreen
+        case .connect: connectScreen
+        }
+    }
+
+    // ── navigation ──────────────────────────────────────────────
+    private func go(_ s: OnboardingStep) { withAnimation(.easeInOut(duration: 0.2)) { step = s } }
+    private func skip() { app.finishOnboarding(paired: false) }
+    private func openManual(_ m: ConnectionMode) { manualMode = m; showManual = true }
+
+    // ── 0 · Welcome ─────────────────────────────────────────────
+    private var welcomeScreen: some View {
+        VStack(spacing: 0) {
+            OnboardingTopBar(step: nil, onSkip: skip)
+            Spacer()
+            VStack(spacing: 22) {
+                Image(systemName: "macbook.and.iphone")
+                    .font(.system(size: 72, weight: .light))
+                    .foregroundStyle(Theme.accent)
+                VStack(spacing: 10) {
+                    Text("Meet Lisa")
+                        .font(.largeTitle.weight(.bold)).foregroundStyle(Theme.text)
+                    Text("She lives on your Mac. This is your window to her — chat, check on her agents, and stay in the loop from anywhere.")
+                        .font(.body).foregroundStyle(Theme.secondary)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 32)
+                }
+            }
+            Spacer()
+            VStack(spacing: 8) {
+                OnboardingPrimaryButton(title: "Get started") { go(.mode) }
+                OnboardingSecondaryButton(title: "I already have LISA running") { go(.pair) }
+            }
+            .padding(.bottom, 24)
+        }
+    }
+
+    // ── 1 · Where Lisa lives (mode fork) ────────────────────────
+    private var modeScreen: some View {
+        VStack(spacing: 0) {
+            OnboardingTopBar(step: nil, onSkip: skip)
+            ScrollView {
+                VStack(spacing: 18) {
+                    OnboardingTitle(title: "Where does Lisa live?",
+                                    subtitle: "Lisa runs on a Mac. Connect to your own, or use hosted LISA Cloud.")
+                    OnboardingChoiceCard(systemImage: "desktopcomputer",
+                                         title: "My Mac", subtitle: "Private and local — your data never leaves your Mac.",
+                                         badge: "Recommended", selected: app.connectionMode == .mac) {
+                        app.setConnectionMode(.mac); go(.install)
+                    }
+                    OnboardingChoiceCard(systemImage: "cloud",
+                                         title: "LISA Cloud", subtitle: "No Mac needed. Paste a cloud URL + token for now.",
+                                         selected: app.connectionMode == .cloud) {
+                        app.setConnectionMode(.cloud); openManual(.cloud)
+                    }
+                }
+                .padding(.vertical, 24)
+            }
+        }
+    }
+
+    // ── 2 · Install on your Mac ─────────────────────────────────
+    private var installScreen: some View {
+        VStack(spacing: 0) {
+            OnboardingTopBar(step: .install, onSkip: skip)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    OnboardingTitle(title: "Install LISA on your Mac",
+                                    subtitle: "Pick whichever you prefer — you only do this once.")
+                    Picker("Install method", selection: $method) {
+                        ForEach(InstallMethod.allCases) { m in Text(m.label).tag(m) }
+                    }
+                    .pickerStyle(.segmented)
+                    .padding(.horizontal, 24)
+
+                    if let cmd = method.installCommand {
+                        CopyCommandRow(command: cmd)
+                        Text("Paste it into Terminal on your Mac and press return.")
+                            .font(.caption).foregroundStyle(Theme.tertiary).padding(.horizontal, 24)
+                    } else if let url = method.downloadURL {
+                        Link(destination: url) {
+                            HStack(spacing: 8) {
+                                Image(systemName: "arrow.down.circle.fill")
+                                Text("Download Lisa-Suite.dmg")
+                            }
+                            .font(.headline).foregroundStyle(Theme.accent)
+                            .frame(maxWidth: .infinity).padding(.vertical, 14)
+                            .background(Theme.card, in: RoundedRectangle(cornerRadius: Theme.cardRadius))
+                            .overlay(RoundedRectangle(cornerRadius: Theme.cardRadius).strokeBorder(Theme.border, lineWidth: Theme.hairline))
+                        }
+                        .padding(.horizontal, 24)
+                        Text("Open the .dmg and drag Lisa to Applications.")
+                            .font(.caption).foregroundStyle(Theme.tertiary).padding(.horizontal, 24)
+                    }
+                }
+                .padding(.vertical, 24)
+            }
+            VStack { OnboardingPrimaryButton(title: "It's installed →") { go(.start) } }
+                .padding(.bottom, 24)
+        }
+    }
+
+    // ── 3 · Start LISA (reachably) ──────────────────────────────
+    private var startScreen: some View {
+        VStack(spacing: 0) {
+            OnboardingTopBar(step: .start, onSkip: skip)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    OnboardingTitle(title: "Start Lisa", subtitle: method.startHint)
+                    if let serve = method.serveCommand {
+                        CopyCommandRow(command: serve)
+                        Label("Keep this iPhone on the same Wi-Fi as your Mac.",
+                              systemImage: "wifi")
+                            .font(.caption).foregroundStyle(Theme.tertiary).padding(.horizontal, 24)
+                    } else {
+                        Label("Keep this iPhone on the same Wi-Fi as your Mac.",
+                              systemImage: "wifi")
+                            .font(.subheadline).foregroundStyle(Theme.secondary).padding(.horizontal, 24)
+                    }
+                }
+                .padding(.vertical, 24)
+            }
+            VStack { OnboardingPrimaryButton(title: "It's running →") { go(.pair) } }
+                .padding(.bottom, 24)
+        }
+    }
+
+    // ── 4 · Show the pairing QR ─────────────────────────────────
+    private var pairScreen: some View {
+        VStack(spacing: 0) {
+            OnboardingTopBar(step: .pair, onSkip: skip)
+            ScrollView {
+                VStack(alignment: .leading, spacing: 18) {
+                    OnboardingTitle(title: "Pair this iPhone",
+                                    subtitle: "On your Mac, run this — it prints a QR code in the terminal.")
+                    CopyCommandRow(command: pairCommand)
+                    Text("Only someone with this code can connect — and only over your Wi-Fi or tailnet.")
+                        .font(.caption).foregroundStyle(Theme.tertiary).padding(.horizontal, 24)
+                }
+                .padding(.vertical, 24)
+            }
+            VStack(spacing: 8) {
+                OnboardingPrimaryButton(title: "Scan the QR") { go(.scan) }
+                OnboardingSecondaryButton(title: "Paste link / enter manually") { openManual(.mac) }
+            }
+            .padding(.bottom, 24)
+        }
+    }
+
+    // ── 5 · Scan ────────────────────────────────────────────────
+    private var scanScreen: some View {
+        ZStack {
+            QRScannerView(
+                onScan: { value in
+                    if app.applyPairing(value) { go(.connect) }
+                    else { scanNote = "That QR isn't a LISA pairing code."; openManual(.mac) }
+                },
+                onError: { reason in scanNote = reason; openManual(.mac) }
+            )
+            .ignoresSafeArea()
+            VStack {
+                OnboardingTopBar(step: .scan, onSkip: skip)
+                Spacer()
+                VStack(spacing: 12) {
+                    if let scanNote {
+                        Text(scanNote).font(.caption).foregroundStyle(.white)
+                            .padding(8).background(.ultraThinMaterial, in: Capsule())
+                    } else {
+                        Text("Point at the QR code Lisa shows on your Mac.")
+                            .font(.subheadline).foregroundStyle(.white)
+                            .padding(10).background(.ultraThinMaterial, in: Capsule())
+                    }
+                    Button("Paste link / enter manually") { openManual(.mac) }
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 16).padding(.vertical, 10)
+                        .background(.ultraThinMaterial, in: Capsule())
+                }
+                .padding(.bottom, 32)
+            }
+        }
+    }
+
+    // ── 6 · Connecting → Connected ──────────────────────────────
+    private var connectScreen: some View {
+        VStack(spacing: 0) {
+            OnboardingTopBar(step: .connect, onSkip: skip)
+            Spacer()
+            Group {
+                if verifying {
+                    VStack(spacing: 16) {
+                        ProgressView().tint(Theme.accent).scaleEffect(1.4)
+                        Text("Connecting to Lisa…").font(.headline).foregroundStyle(Theme.text)
+                    }
+                } else if outcome == .ok {
+                    VStack(spacing: 16) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .font(.system(size: 64)).foregroundStyle(Theme.green)
+                        Text("Connected to Lisa").font(.title2.weight(.bold)).foregroundStyle(Theme.text)
+                        Text("You're all set.").font(.body).foregroundStyle(Theme.secondary)
+                    }
+                } else if let outcome {
+                    failureView(outcome)
+                }
+            }
+            Spacer()
+            footer
+                .padding(.bottom, 24)
+        }
+        .task { await verify() }
+    }
+
+    @ViewBuilder private var footer: some View {
+        if outcome == .ok {
+            OnboardingPrimaryButton(title: "Enter") { app.finishOnboarding(paired: true) }
+        } else if !verifying, outcome != nil {
+            VStack(spacing: 8) {
+                OnboardingPrimaryButton(title: "Try again") { Task { await verify() } }
+                OnboardingSecondaryButton(title: "Enter manually") { openManual(.mac) }
+                OnboardingSecondaryButton(title: "Back") { go(.pair) }
+            }
+        }
+    }
+
+    @ViewBuilder private func failureView(_ o: VerifyOutcome) -> some View {
+        let (icon, title, desc): (String, String, String) = {
+            switch o {
+            case .unauthorized:
+                return ("lock.trianglebadge.exclamationmark",
+                        "Pairing was rejected",
+                        "That code may have expired or been revoked. Run `lisa pair` on your Mac again for a fresh QR, then re-scan.")
+            case .serverError(let code):
+                return ("exclamationmark.triangle",
+                        "Your Mac returned an error",
+                        "LISA answered with HTTP \(code). Make sure it's up to date, then try again.")
+            case .unreachable, .ok:
+                return ("wifi.exclamationmark",
+                        "Can't reach your Mac",
+                        "• Is this iPhone on the same Wi-Fi as your Mac?\n• For a terminal install, did you start it with `--host 0.0.0.0`?\n• A Tailscale tailnet name works too.")
+            }
+        }()
+        VStack(spacing: 14) {
+            Image(systemName: icon).font(.system(size: 52)).foregroundStyle(Theme.waiting)
+            Text(title).font(.title3.weight(.bold)).foregroundStyle(Theme.text)
+            Text(desc).font(.subheadline).foregroundStyle(Theme.secondary)
+                .multilineTextAlignment(.center).padding(.horizontal, 28)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    @MainActor private func verify() async {
+        verifying = true
+        outcome = nil
+        outcome = await app.verifyConnection()
+        verifying = false
+    }
+}
+
+/// Paste / manual-entry fallback for both data planes. Mac: a `lisa-pair://` or
+/// `http://host:port/?token=` link, or host/port/token fields. Cloud: an
+/// `https://…run.app/?token=` URL (Sign in with Apple is coming later).
+struct OnboardingManualEntry: View {
+    @EnvironmentObject var app: AppState
+    let mode: ConnectionMode
+    let onPaired: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var pasteText = ""
+    @State private var host = ""
+    @State private var portText = "5757"
+    @State private var token = ""
+    @State private var error: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    TextField(mode == .cloud ? "https://…run.app/?token=" : "lisa-pair://… or http://host:port/?token=",
+                              text: $pasteText)
+                        .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
+                    Button(mode == .cloud ? "Connect" : "Apply") { apply(pasteText) }
+                        .disabled(pasteText.isEmpty)
+                } header: {
+                    Text(mode == .cloud ? "Cloud URL" : "Paste pairing link")
+                } footer: {
+                    Text(mode == .cloud
+                         ? "Paste your LISA Cloud URL with its token."
+                         : "Run `lisa pair` on your Mac and copy the link it prints.")
+                }
+
+                if mode == .mac {
+                    Section("Or enter manually") {
+                        TextField("Host (IP or tailnet name)", text: $host)
+                            .autocorrectionDisabled().textInputAutocapitalization(.never)
+                        TextField("Port", text: $portText).keyboardType(.numberPad)
+                        SecureField("Device token", text: $token)
+                        Button("Connect") {
+                            app.update(host: host.trimmingCharacters(in: .whitespaces),
+                                       port: Int(portText) ?? 5757,
+                                       token: token.isEmpty ? nil : token, scheme: "http")
+                            if app.config.isConfigured { finish() } else { error = "Enter a host and token." }
+                        }
+                        .disabled(host.isEmpty || token.isEmpty)
+                    }
+                }
+
+                if mode == .cloud {
+                    Section {
+                        Button {} label: { Label("Sign in with Apple (coming soon)", systemImage: "person.crop.circle") }
+                            .disabled(true)
+                    }
+                }
+
+                if let error {
+                    Section { Text(error).font(.caption).foregroundStyle(Theme.danger) }
+                }
+            }
+            .consoleBackground()
+            .navigationTitle(mode == .cloud ? "Connect to LISA Cloud" : "Enter pairing details")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
+            }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private func apply(_ raw: String) {
+        if app.applyPairing(raw) { finish() }
+        else { error = mode == .cloud ? "Couldn't read that cloud URL." : "Couldn't read that pairing link." }
+    }
+    private func finish() { dismiss(); onPaired() }
+}

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+// Pure, testable model for the first-run onboarding flow
+// (docs/PLAN_IOS_ONBOARDING_v1.0.md). No SwiftUI / no side effects here, so the
+// copy strings + step logic are unit-testable off the main actor.
+
+/// Steps of the Mac-local wizard. The raw Int drives the progress dots; `.welcome`
+/// and `.mode` sit before the dotted sequence. The LISA Cloud branch reuses
+/// `.connect` directly after a paste, skipping install/start/pair/scan.
+enum OnboardingStep: Int, CaseIterable {
+    case welcome, mode, install, start, pair, scan, connect
+
+    /// The dotted sub-sequence (install → connect) — welcome/mode are pre-flow.
+    static let dotted: [OnboardingStep] = [.install, .start, .pair, .scan, .connect]
+}
+
+/// How the user installs LISA on their Mac (the "install" step). Commands are the
+/// real ones from the repo README — keep them in sync.
+enum InstallMethod: String, CaseIterable, Identifiable {
+    case homebrew, npm, app
+    var id: String { rawValue }
+
+    var label: String {
+        switch self {
+        case .homebrew: return "Homebrew"
+        case .npm:      return "npm"
+        case .app:      return "Mac app"
+        }
+    }
+
+    /// The one-line install command to copy, or nil for the download-a-.app path.
+    var installCommand: String? {
+        switch self {
+        case .homebrew: return "brew install oratis/tap/lisa"
+        case .npm:      return "npm install -g @oratis/lisa"
+        case .app:      return nil
+        }
+    }
+
+    /// Download page for the notarized Mac app (.dmg), nil for the CLI methods.
+    var downloadURL: URL? {
+        self == .app ? URL(string: "https://github.com/oratis/LISA/releases/latest") : nil
+    }
+
+    /// Whether this is a command-line install (vs the menu-bar .app).
+    var isCLI: Bool { self != .app }
+
+    /// What the user runs to start LISA *LAN-reachable* (the "start" step). CLI
+    /// installs print a copy-able command (the `--host 0.0.0.0` is the #1 gotcha);
+    /// the menu-bar app is launched from the menu bar, so there's nothing to type.
+    var serveCommand: String? {
+        isCLI ? "lisa serve --web --host 0.0.0.0" : nil
+    }
+
+    /// One-line "start" instruction shown with (or instead of) the command.
+    var startHint: String {
+        isCLI
+            ? "In a terminal on your Mac, start LISA so this iPhone can reach it over Wi-Fi:"
+            : "Open LISA from your Mac's menu bar — look for the Lisa icon."
+    }
+}
+
+/// The command that prints the pairing QR on the Mac (the "pair" step).
+let pairCommand = "lisa pair"
+
+/// Outcome of probing the saved config before declaring the pairing a success.
+/// Lets the connect screen show targeted help instead of a generic failure.
+enum VerifyOutcome: Equatable {
+    case ok            // reachable + token accepted
+    case unreachable   // can't reach the host (wrong Wi-Fi, loopback bind, offline)
+    case unauthorized  // reached a server but the token was rejected (expired/revoked)
+    case serverError(Int)
+}

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
@@ -71,3 +71,30 @@ enum VerifyOutcome: Equatable {
     case unauthorized  // reached a server but the token was rejected (expired/revoked)
     case serverError(Int)
 }
+
+/// A recovery action offered on a failed connect (drives the connect screen's
+/// buttons). Kept pure so the outcome→action mapping is unit-testable.
+enum RecoveryAction: Hashable {
+    case retry, rescan, manual
+
+    var label: String {
+        switch self {
+        case .retry:  return "Try again"
+        case .rescan: return "Scan a fresh code"
+        case .manual: return "Enter manually"
+        }
+    }
+}
+
+extension VerifyOutcome {
+    /// Recovery actions for a failed connect, most-useful first. A rejected token
+    /// can't be retried — re-scan a fresh code (run `lisa pair` again); an
+    /// unreachable / erroring Mac is worth a retry.
+    var recovery: [RecoveryAction] {
+        switch self {
+        case .ok:                        return []
+        case .unauthorized:              return [.rescan, .manual]
+        case .unreachable, .serverError: return [.retry, .manual]
+        }
+    }
+}

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
@@ -1,0 +1,204 @@
+import SwiftUI
+import UIKit
+
+// Shared chrome for the onboarding screens (docs/PLAN_IOS_ONBOARDING_v1.0.md).
+// Small composable pieces rather than one big generic scaffold, so each screen
+// reads top-to-bottom and compiles cleanly.
+
+/// Progress dots for the dotted sub-sequence (install → connect). Hidden for the
+/// pre-flow steps (welcome / mode) and the cloud branch by passing `step: nil`.
+struct OnboardingDots: View {
+    let step: OnboardingStep?
+    var body: some View {
+        HStack(spacing: 7) {
+            ForEach(OnboardingStep.dotted, id: \.rawValue) { s in
+                Capsule()
+                    .fill(isActive(s) ? Theme.accent : Theme.border)
+                    .frame(width: isCurrent(s) ? 18 : 7, height: 7)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: step)
+    }
+    private func isCurrent(_ s: OnboardingStep) -> Bool { s == step }
+    private func isActive(_ s: OnboardingStep) -> Bool {
+        guard let step else { return false }
+        return s.rawValue <= step.rawValue
+    }
+}
+
+/// Top bar: progress dots (optional) on the left, a "Not now" skip on the right.
+struct OnboardingTopBar: View {
+    var step: OnboardingStep?
+    var onSkip: (() -> Void)?
+    var body: some View {
+        HStack {
+            if step != nil { OnboardingDots(step: step) }
+            Spacer()
+            if let onSkip {
+                Button("Not now", action: onSkip)
+                    .font(.subheadline)
+                    .foregroundStyle(Theme.tertiary)
+            }
+        }
+        .frame(height: 28)
+        .padding(.horizontal, 24)
+        .padding(.top, 8)
+    }
+}
+
+/// Big title + optional subtitle block.
+struct OnboardingTitle: View {
+    let title: String
+    var subtitle: String? = nil
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(title)
+                .font(.title.weight(.bold))
+                .foregroundStyle(Theme.text)
+                .fixedSize(horizontal: false, vertical: true)
+            if let subtitle {
+                Text(subtitle)
+                    .font(.body)
+                    .foregroundStyle(Theme.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24)
+    }
+}
+
+/// A monospaced terminal command in a card with a tap-to-copy button. Shows a
+/// transient "Copied" state + a success haptic.
+struct CopyCommandRow: View {
+    let command: String
+    @State private var copied = false
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(command)
+                .font(.system(.callout, design: .monospaced))
+                .foregroundStyle(Theme.text)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .lineLimit(2)
+                .minimumScaleFactor(0.8)
+            Button(action: copy) {
+                Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                    .foregroundStyle(copied ? Theme.green : Theme.accent)
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(copied ? "Copied" : "Copy command")
+        }
+        .padding(.vertical, 12).padding(.horizontal, 14)
+        .background(Theme.card, in: RoundedRectangle(cornerRadius: Theme.cardRadius))
+        .overlay(RoundedRectangle(cornerRadius: Theme.cardRadius).strokeBorder(Theme.border, lineWidth: Theme.hairline))
+        .padding(.horizontal, 24)
+    }
+    private func copy() {
+        UIPasteboard.general.string = command
+        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        withAnimation { copied = true }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
+            withAnimation { copied = false }
+        }
+    }
+}
+
+/// A selectable card (the My Mac / LISA Cloud + install-method choices).
+struct OnboardingChoiceCard: View {
+    let systemImage: String
+    let title: String
+    let subtitle: String
+    var badge: String? = nil
+    var selected: Bool = false
+    var disabled: Bool = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                Image(systemName: systemImage)
+                    .font(.title2)
+                    .foregroundStyle(disabled ? Theme.tertiary : Theme.accent)
+                    .frame(width: 32)
+                VStack(alignment: .leading, spacing: 3) {
+                    HStack(spacing: 8) {
+                        Text(title).font(.headline).foregroundStyle(Theme.text)
+                        if let badge { ThemePill(text: badge, color: Theme.green) }
+                    }
+                    Text(subtitle).font(.subheadline).foregroundStyle(Theme.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                Spacer(minLength: 0)
+                if selected { Image(systemName: "checkmark.circle.fill").foregroundStyle(Theme.accent) }
+            }
+            .padding(14)
+            .background(Theme.card, in: RoundedRectangle(cornerRadius: Theme.cardRadius))
+            .overlay(
+                RoundedRectangle(cornerRadius: Theme.cardRadius)
+                    .strokeBorder(selected ? Theme.accent : Theme.border, lineWidth: selected ? 1.5 : Theme.hairline)
+            )
+            .opacity(disabled ? 0.5 : 1)
+        }
+        .buttonStyle(.plain)
+        .disabled(disabled)
+        .padding(.horizontal, 24)
+    }
+}
+
+/// Primary cyan CTA pinned at the bottom of a screen.
+struct OnboardingPrimaryButton: View {
+    let title: String
+    var disabled: Bool = false
+    let action: () -> Void
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(Theme.bgDeep)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 15)
+                .background(Theme.accent, in: RoundedRectangle(cornerRadius: Theme.cardRadius))
+        }
+        .buttonStyle(.plain)
+        .opacity(disabled ? 0.5 : 1)
+        .disabled(disabled)
+        .padding(.horizontal, 24)
+    }
+}
+
+/// Secondary text link under the primary CTA (the escape hatches).
+struct OnboardingSecondaryButton: View {
+    let title: String
+    let action: () -> Void
+    var body: some View {
+        Button(action: action) {
+            Text(title).font(.subheadline.weight(.medium)).foregroundStyle(Theme.accent)
+        }
+        .buttonStyle(.plain)
+        .padding(.top, 4)
+    }
+}
+
+/// The persistent "Finish setup" banner shown over the app when the user skipped
+/// onboarding but still isn't paired. Tapping it re-enters the flow.
+struct SetupBanner: View {
+    let action: () -> Void
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                Text("Finish setting up — connect to your Mac")
+                    .font(.subheadline.weight(.medium))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                Image(systemName: "chevron.right").font(.caption.weight(.bold))
+            }
+            .foregroundStyle(Theme.bgDeep)
+            .padding(.horizontal, 16).padding(.vertical, 10)
+            .background(Theme.accent)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
@@ -5,6 +5,14 @@ import UIKit
 // Small composable pieces rather than one big generic scaffold, so each screen
 // reads top-to-bottom and compiles cleanly.
 
+/// Tasteful haptics for the flow — a success tap on copy / connect, a warning on a
+/// failed connect, a selection tick when picking a card.
+enum Haptics {
+    static func success()   { UINotificationFeedbackGenerator().notificationOccurred(.success) }
+    static func warning()   { UINotificationFeedbackGenerator().notificationOccurred(.warning) }
+    static func selection() { UISelectionFeedbackGenerator().selectionChanged() }
+}
+
 /// Progress dots for the dotted sub-sequence (install → connect). Hidden for the
 /// pre-flow steps (welcome / mode) and the cloud branch by passing `step: nil`.
 struct OnboardingDots: View {
@@ -97,7 +105,7 @@ struct CopyCommandRow: View {
     }
     private func copy() {
         UIPasteboard.general.string = command
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        Haptics.success()
         withAnimation { copied = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withAnimation { copied = false }
@@ -116,7 +124,7 @@ struct OnboardingChoiceCard: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
+        Button(action: { Haptics.selection(); action() }) {
             HStack(spacing: 14) {
                 Image(systemName: systemImage)
                     .font(.title2)

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -29,6 +29,14 @@ struct SettingsView: View {
                          : "Use hosted LISA Cloud — no Mac needed.")
                 }
 
+                Section {
+                    Button { app.presentOnboarding() } label: {
+                        Label("Set up / re-pair…", systemImage: "wand.and.stars")
+                    }
+                } footer: {
+                    Text("Walk through installing LISA on your Mac and pairing this iPhone.")
+                }
+
                 if app.connectionMode == .mac {
                     Section("Connection") {
                         TextField("Host (IP or tailnet name)", text: $host)

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -120,4 +120,30 @@ final class LisaPocketTests: XCTestCase {
         let s = try JSONDecoder().decode(AgentSession.self, from: Data(json.utf8))
         XCTAssertNil(s.lastMtime)
     }
+
+    // ── onboarding model: install commands are the real repo ones ──
+    func testInstallCommands() {
+        XCTAssertEqual(InstallMethod.homebrew.installCommand, "brew install oratis/tap/lisa")
+        XCTAssertEqual(InstallMethod.npm.installCommand, "npm install -g @oratis/lisa")
+        XCTAssertNil(InstallMethod.app.installCommand)            // .app downloads a .dmg instead
+        XCTAssertNotNil(InstallMethod.app.downloadURL)
+        XCTAssertNil(InstallMethod.homebrew.downloadURL)
+        XCTAssertEqual(InstallMethod.allCases.count, 3)
+    }
+
+    // CLI installs must instruct the LAN-reachable bind (the #1 pairing gotcha);
+    // the menu-bar app has nothing to type.
+    func testServeCommandReachableForCLIOnly() {
+        XCTAssertEqual(InstallMethod.npm.serveCommand, "lisa serve --web --host 0.0.0.0")
+        XCTAssertEqual(InstallMethod.homebrew.serveCommand, "lisa serve --web --host 0.0.0.0")
+        XCTAssertNil(InstallMethod.app.serveCommand)
+        XCTAssertTrue(InstallMethod.npm.isCLI)
+        XCTAssertFalse(InstallMethod.app.isCLI)
+    }
+
+    func testOnboardingDottedSequence() {
+        XCTAssertEqual(OnboardingStep.dotted, [.install, .start, .pair, .scan, .connect])
+        XCTAssertEqual(OnboardingStep.welcome.rawValue, 0)        // welcome/mode are pre-flow
+        XCTAssertLessThan(OnboardingStep.install.rawValue, OnboardingStep.connect.rawValue)
+    }
 }

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -146,4 +146,17 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertEqual(OnboardingStep.welcome.rawValue, 0)        // welcome/mode are pre-flow
         XCTAssertLessThan(OnboardingStep.install.rawValue, OnboardingStep.connect.rawValue)
     }
+
+    // ── M2: connect-failure recovery is outcome-specific ──
+    func testVerifyOutcomeRecovery() {
+        // A rejected token can't be retried — offer a fresh scan first.
+        XCTAssertEqual(VerifyOutcome.unauthorized.recovery.first, .rescan)
+        // A reachable-but-erroring or unreachable Mac is worth a retry.
+        XCTAssertEqual(VerifyOutcome.unreachable.recovery.first, .retry)
+        XCTAssertEqual(VerifyOutcome.serverError(500).recovery.first, .retry)
+        // Manual entry is always an escape hatch; success has nothing to recover.
+        XCTAssertTrue(VerifyOutcome.unauthorized.recovery.contains(.manual))
+        XCTAssertTrue(VerifyOutcome.ok.recovery.isEmpty)
+        XCTAssertEqual(RecoveryAction.rescan.label, "Scan a fresh code")
+    }
 }


### PR DESCRIPTION
**Stacks on #167 (M1)** — base is `feat/ios-onboarding`, so this diff is M2 only. Merge #167 first; GitHub will retarget this to `main`.

M2 of `docs/PLAN_IOS_ONBOARDING_v1.0.md` — error recovery + polish.

## Outcome-specific connect recovery
The connect screen's failure buttons now depend on *why* it failed (`VerifyOutcome.recovery` — pure + tested):
- **Token rejected** → **"Scan a fresh code"** (retrying a revoked token is pointless — the message already says to re-run `lisa pair`).
- **Unreachable / server error** → **"Try again"**.
- **Manual entry** stays an escape hatch on every failure; **Back** returns to the pair step.

## Haptics
A shared `Haptics` helper — a **selection** tick when picking My Mac / LISA Cloud, a **success** tap on a confirmed connection, a **warning** on a failed one. (Copy already buzzed in M1.)

## Already in M1 (per plan, noted for completeness)
Settings **"Set up / re-pair"** re-entry, the **"I already have LISA running"** shortcut, and copy haptics shipped with M1.

## Verification
- `packaging/ios-companion/build.sh` → **BUILD SUCCEEDED**.
- New `RecoveryAction` test in `LisaPocketTests`; mapping verified via the macOS `swift` interpreter (`ALL OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
