### PR TITLE
feat(ios): onboarding M2 — outcome-specific recovery + haptics (recovers #170)

### DIFF
--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -255,12 +255,27 @@ struct OnboardingFlow: View {
     @ViewBuilder private var footer: some View {
         if outcome == .ok {
             OnboardingPrimaryButton(title: "Enter") { app.finishOnboarding(paired: true) }
-        } else if !verifying, outcome != nil {
+        } else if !verifying, let outcome {
+            // Outcome-specific recovery: a rejected token re-scans, an unreachable
+            // Mac retries (see VerifyOutcome.recovery).
+            let actions = outcome.recovery
             VStack(spacing: 8) {
-                OnboardingPrimaryButton(title: "Try again") { Task { await verify() } }
-                OnboardingSecondaryButton(title: "Enter manually") { openManual(.mac) }
+                if let primary = actions.first {
+                    OnboardingPrimaryButton(title: primary.label) { perform(primary) }
+                }
+                ForEach(Array(actions.dropFirst()), id: \.self) { action in
+                    OnboardingSecondaryButton(title: action.label) { perform(action) }
+                }
                 OnboardingSecondaryButton(title: "Back") { go(.pair) }
             }
+        }
+    }
+
+    private func perform(_ action: RecoveryAction) {
+        switch action {
+        case .retry:  Task { await verify() }
+        case .rescan: scanNote = nil; go(.scan)
+        case .manual: openManual(.mac)
         }
     }
 
@@ -293,8 +308,10 @@ struct OnboardingFlow: View {
     @MainActor private func verify() async {
         verifying = true
         outcome = nil
-        outcome = await app.verifyConnection()
+        let result = await app.verifyConnection()
+        outcome = result
         verifying = false
+        if result == .ok { Haptics.success() } else { Haptics.warning() }
     }
 }
 

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
@@ -71,3 +71,30 @@ enum VerifyOutcome: Equatable {
     case unauthorized  // reached a server but the token was rejected (expired/revoked)
     case serverError(Int)
 }
+
+/// A recovery action offered on a failed connect (drives the connect screen's
+/// buttons). Kept pure so the outcome→action mapping is unit-testable.
+enum RecoveryAction: Hashable {
+    case retry, rescan, manual
+
+    var label: String {
+        switch self {
+        case .retry:  return "Try again"
+        case .rescan: return "Scan a fresh code"
+        case .manual: return "Enter manually"
+        }
+    }
+}
+
+extension VerifyOutcome {
+    /// Recovery actions for a failed connect, most-useful first. A rejected token
+    /// can't be retried — re-scan a fresh code (run `lisa pair` again); an
+    /// unreachable / erroring Mac is worth a retry.
+    var recovery: [RecoveryAction] {
+        switch self {
+        case .ok:                        return []
+        case .unauthorized:              return [.rescan, .manual]
+        case .unreachable, .serverError: return [.retry, .manual]
+        }
+    }
+}

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
@@ -5,6 +5,14 @@ import UIKit
 // Small composable pieces rather than one big generic scaffold, so each screen
 // reads top-to-bottom and compiles cleanly.
 
+/// Tasteful haptics for the flow — a success tap on copy / connect, a warning on a
+/// failed connect, a selection tick when picking a card.
+enum Haptics {
+    static func success()   { UINotificationFeedbackGenerator().notificationOccurred(.success) }
+    static func warning()   { UINotificationFeedbackGenerator().notificationOccurred(.warning) }
+    static func selection() { UISelectionFeedbackGenerator().selectionChanged() }
+}
+
 /// Progress dots for the dotted sub-sequence (install → connect). Hidden for the
 /// pre-flow steps (welcome / mode) and the cloud branch by passing `step: nil`.
 struct OnboardingDots: View {
@@ -97,7 +105,7 @@ struct CopyCommandRow: View {
     }
     private func copy() {
         UIPasteboard.general.string = command
-        UINotificationFeedbackGenerator().notificationOccurred(.success)
+        Haptics.success()
         withAnimation { copied = true }
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             withAnimation { copied = false }
@@ -116,7 +124,7 @@ struct OnboardingChoiceCard: View {
     let action: () -> Void
 
     var body: some View {
-        Button(action: action) {
+        Button(action: { Haptics.selection(); action() }) {
             HStack(spacing: 14) {
                 Image(systemName: systemImage)
                     .font(.title2)

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -146,4 +146,17 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertEqual(OnboardingStep.welcome.rawValue, 0)        // welcome/mode are pre-flow
         XCTAssertLessThan(OnboardingStep.install.rawValue, OnboardingStep.connect.rawValue)
     }
+
+    // ── M2: connect-failure recovery is outcome-specific ──
+    func testVerifyOutcomeRecovery() {
+        // A rejected token can't be retried — offer a fresh scan first.
+        XCTAssertEqual(VerifyOutcome.unauthorized.recovery.first, .rescan)
+        // A reachable-but-erroring or unreachable Mac is worth a retry.
+        XCTAssertEqual(VerifyOutcome.unreachable.recovery.first, .retry)
+        XCTAssertEqual(VerifyOutcome.serverError(500).recovery.first, .retry)
+        // Manual entry is always an escape hatch; success has nothing to recover.
+        XCTAssertTrue(VerifyOutcome.unauthorized.recovery.contains(.manual))
+        XCTAssertTrue(VerifyOutcome.ok.recovery.isEmpty)
+        XCTAssertEqual(RecoveryAction.rescan.label, "Scan a fresh code")
+    }
 }


### PR DESCRIPTION
**Recovers #170**, which auto-closed when its base branch (`feat/ios-onboarding`) was deleted during the #167 squash-merge. The M2 work was reviewed and approved there ("LGTM — merging after #167") but never landed, so this re-opens it cleanly: the single M2 commit cherry-picked onto current `main`, with #167's firewall-help line preserved (verified). No add/add conflict this time.

M2 of `docs/PLAN_IOS_ONBOARDING_v1.0.md` — error recovery + polish on top of the M1 flow already on `main`.

## Outcome-specific connect recovery
The connect screen's failure buttons now depend on *why* it failed (`VerifyOutcome.recovery` → `[RecoveryAction]`, pure + tested):
- **Token rejected** → **"Scan a fresh code"** first (retrying a revoked token is pointless — the message already says to re-run `lisa pair`).
- **Unreachable / server error** → **"Try again"**.
- **Manual entry** stays an escape hatch on every failure; **Back** returns to the pair step.

## Haptics
A shared `Haptics` helper (`OnboardingScaffold.swift`) — a **selection** tick when picking My Mac / LISA Cloud, a **success** tap on a confirmed connection, a **warning** on a failed one. (Copy already buzzed in M1.)

## Scope
4 files, +71/−6 — `OnboardingFlow.swift`, `OnboardingModel.swift` (`RecoveryAction` + `recovery`), `OnboardingScaffold.swift` (`Haptics`), and a `RecoveryAction` test. No server / Mac-client changes.

## Verification
- `packaging/ios-companion/build.sh` → **BUILD SUCCEEDED** (iPhone 17 Pro sim) — this is the M2-on-`main` combination, which had never been built before (the M2 branch predated #168's bundle-id move).
- `RecoveryAction` mapping covered by `testVerifyOutcomeRecovery`; the headless sim test runner can't launch here, so the pure mapping was additionally checked via the macOS `swift` interpreter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
