### PR TITLE
fix(ios): make testflight.sh actually upload — 3 archive/validation fixes

### DIFF
--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -36,6 +36,17 @@ targets:
         NSFaceIDUsageDescription: "Unlock Lisa Pocket with Face ID."
         NSLocalNetworkUsageDescription: "Connect to the Lisa backend running on your Mac over your local network."
         ITSAppUsesNonExemptEncryption: false
+        # Portrait-only on iPhone; iPad declares all four orientations, which App
+        # Store validation requires for any iPad-capable (device family 2) app that
+        # doesn't opt out of multitasking. Without these the upload is rejected
+        # ("No orientations were specified … To support iPad multitasking …").
+        UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+        UISupportedInterfaceOrientations~ipad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
         CFBundleURLTypes:
           - CFBundleURLName: ai.meetlisa.main
             CFBundleURLSchemes:

--- a/packaging/ios-companion/testflight.sh
+++ b/packaging/ios-companion/testflight.sh
@@ -43,6 +43,12 @@ command -v xcodegen >/dev/null || { echo "✗ need xcodegen — brew install xco
 TEAM_ID="${APPLE_TEAM_ID:-9LH9NBX7P4}"
 BUILD_NUMBER="${BUILD_NUMBER:-$(date +%Y%m%d%H%M)}"
 EXPORT_METHOD="${EXPORT_METHOD:-app-store-connect}"
+# project.yml hard-disables signing for simulator dev builds (CODE_SIGN_IDENTITY="").
+# For the archive that empty identity must be overridden, or app-extension targets
+# (the widget) silently skip their CodeSign step → ValidateEmbeddedBinary fails.
+# Automatic signing re-derives the real identity from the team; this just has to be
+# non-empty. Export re-signs for distribution via ExportOptions.
+SIGN_IDENTITY="${SIGN_IDENTITY:-Apple Development}"
 BUILD_DIR="build"
 ARCHIVE="$BUILD_DIR/LisaPocket.xcarchive"
 
@@ -73,7 +79,8 @@ xcodebuild archive \
   "${AUTH[@]}" \
   CODE_SIGN_STYLE=Automatic DEVELOPMENT_TEAM="$TEAM_ID" \
   CODE_SIGNING_ALLOWED=YES CODE_SIGNING_REQUIRED=YES \
-  CURRENT_PROJECT_VERSION="$BUILD_NUMBER" "${MV_ARG[@]}"
+  CODE_SIGN_IDENTITY="$SIGN_IDENTITY" \
+  CURRENT_PROJECT_VERSION="$BUILD_NUMBER" ${MV_ARG[@]+"${MV_ARG[@]}"}
 
 echo "==> write ExportOptions.plist (method=$EXPORT_METHOD, destination=upload)"
 cat > "$BUILD_DIR/ExportOptions.plist" <<PLIST


### PR DESCRIPTION
Found and fixed while shipping the **first TestFlight build** of Lisa Pocket (`0.1.0`). Each of these blocked the `testflight.sh` archive/upload; with all three applied, the build uploaded to App Store Connect successfully.

## Fixes
1. **`testflight.sh` — `set -u` empty-array crash.** On macOS's stock bash 3.2, `"${MV_ARG[@]}"` errors with `MV_ARG[@]: unbound variable` when `MARKETING_VERSION` is unset (the default). Use the portable `${MV_ARG[@]+"${MV_ARG[@]}"}`.
2. **`testflight.sh` — widget extension wasn't signed.** `project.yml` zeroes `CODE_SIGN_IDENTITY` for simulator dev builds. During the device archive that empty identity made the app-extension (`LisaPocketWidgets`) silently skip its `CodeSign` step, so `ValidateEmbeddedBinary` failed (*"Embedded binary is not signed…"*). The archive now passes a non-empty `CODE_SIGN_IDENTITY` (overridable via `SIGN_IDENTITY`, default `Apple Development`); automatic signing then signs **both** targets and export re-signs for distribution.
3. **`project.yml` — missing orientations.** App Store validation rejects any iPad-capable app (device family `1,2`) that doesn't declare `UISupportedInterfaceOrientations` (*"No orientations were specified … To support iPad multitasking…"*). Added portrait for iPhone and all four for iPad (`~ipad`).

## Result
`** EXPORT SUCCEEDED ** · Uploaded LisaPocket · build 202606271421` → now processing in TestFlight. Verified end-to-end on this Mac (Xcode 26.2, the reused Markup ASC API key); `-allowProvisioningUpdates` auto-created the App ID + provisioning profiles for both bundle ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
