### PR TITLE
fix(cli): lisa pair never printed the QR code

### DIFF
--- a/src/cli/pair.ts
+++ b/src/cli/pair.ts
@@ -105,7 +105,10 @@ export async function runPairCommand(argv: string[]): Promise<number> {
   const url = buildPairUrl(host, effPort, body.token, name);
 
   console.log(`\nScan in Lisa Pocket → Settings → Scan QR code:\n`);
-  await new Promise<void>((resolve) => qrcodeTerminal.generate(url, { small: true }, () => resolve()));
+  // qrcode-terminal's generate() passes the rendered QR to the callback INSTEAD of
+  // printing it when a callback is given — so the callback must print it (an empty
+  // callback silently swallowed the QR). generate() is synchronous; no await needed.
+  qrcodeTerminal.generate(url, { small: true }, (qr) => console.log(qr));
   console.log(`\nOr paste this in Settings → Pair:\n  ${url}\n`);
   // Broken-out fields for the "enter manually" path (when the link won't paste).
   console.log(`Or type these in Settings → Pair → enter manually:`);


### PR DESCRIPTION
`lisa pair` printed the "Scan in Lisa Pocket" header, the `lisa-pair://` link, and the manual host/port/token fields — **but never the QR code itself**.

## Root cause
`qrcode-terminal`'s `generate(input, opts, cb)` passes the rendered QR string **to the callback instead of printing it** when a callback is supplied (`lib/main.js`: `if (cb) cb(output); else console.log(output)`). `pair.ts` passed an empty callback (`() => resolve()`) that discarded the string, so the QR was silently swallowed. It had been broken since the command was written; it only surfaced now because the previously-installed global `lisa` predated the `pair` command entirely (so `lisa pair` fell through to a chat session).

## Fix
Print the QR in the callback. `generate()` is synchronous, so the `Promise`/`await` wrapper is dropped.

Verified: `lisa pair` against a running `lisa serve --web` now renders the 22-line QR block above the link + fields.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
