### PR TITLE
feat(pair): guide users past the loopback / terminal pitfalls

### DIFF
--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -175,10 +175,15 @@ struct OnboardingFlow: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 18) {
                     OnboardingTitle(title: "Pair this iPhone",
-                                    subtitle: "On your Mac, run this — it prints a QR code in the terminal.")
+                                    subtitle: "Keep LISA running on your Mac. Then, in a new terminal window, run this — it prints a QR code there.")
                     CopyCommandRow(command: pairCommand)
                     Text("Only someone with this code can connect — and only over your Wi-Fi or tailnet.")
                         .font(.caption).foregroundStyle(Theme.tertiary).padding(.horizontal, 24)
+                    Label("Using the Mac app? Click the Lisa icon in your menu bar → “Pair iPhone…” — no terminal needed.",
+                          systemImage: "menubar.rectangle")
+                        .font(.caption).foregroundStyle(Theme.secondary)
+                        .padding(.horizontal, 24)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
                 .padding(.vertical, 24)
             }

--- a/src/cli/pair.ts
+++ b/src/cli/pair.ts
@@ -12,6 +12,7 @@
 // qrcode-terminal is CommonJS — Node's ESM loader only exposes its default
 // export, so import the module object and call .generate off it.
 import qrcodeTerminal from "qrcode-terminal";
+import { Agent, setGlobalDispatcher } from "undici";
 import { detectLanHost, buildPairUrl } from "../web/pairing.js";
 
 // Re-exported so existing importers (and pair.test.ts) keep working after the
@@ -60,12 +61,30 @@ export function parsePairArgs(argv: string[]): PairArgs | { error: string } {
   return { host, port, name };
 }
 
+/**
+ * A loopback-only bind address — the #1 pairing failure: the QR is minted over
+ * loopback, but a phone on the LAN can't reach a server listening only there.
+ * "0.0.0.0" / a specific LAN IP / a tailnet name are all reachable. The server
+ * reports its own bind host (authoritative — no network probe that a firewall or
+ * the outbound HTTP proxy could skew).
+ */
+function isLoopbackBind(boundHost: string): boolean {
+  const h = boundHost.trim().toLowerCase();
+  return h === "127.0.0.1" || h === "localhost" || h === "::1" || h.startsWith("127.");
+}
+
 export async function runPairCommand(argv: string[]): Promise<number> {
   const parsed = parsePairArgs(argv);
   if ("error" in parsed) {
     console.error(parsed.error);
     return 2;
   }
+  // `lisa pair` only ever talks to the local server over loopback. LISA installs
+  // a global undici ProxyAgent (src/proxy-bootstrap.ts) with no localhost bypass,
+  // so under a proxy these loopback calls would be sent through it and fail. Use a
+  // direct dispatcher for this short-lived, loopback-only command.
+  setGlobalDispatcher(new Agent());
+
   const { port, name } = parsed;
   const host = parsed.host ?? detectLanHost();
   if (!host) {
@@ -82,9 +101,10 @@ export async function runPairCommand(argv: string[]): Promise<number> {
       body: JSON.stringify({ name, platform: "ios" }),
     });
   } catch (err) {
-    console.error(
-      `Could not reach LISA at ${base} — is \`lisa serve --web\` running? (${(err as Error).message})`,
-    );
+    console.error(`Could not reach LISA at ${base}. Start the server first — in a`);
+    console.error(`separate terminal (leave it running), so this iPhone can reach it:`);
+    console.error(`\n  lisa serve --web --host 0.0.0.0\n`);
+    console.error(`then run \`lisa pair\` again. (${(err as Error).message})`);
     return 1;
   }
   if (res.status === 403) {
@@ -96,7 +116,7 @@ export async function runPairCommand(argv: string[]): Promise<number> {
     return 1;
   }
 
-  const body = (await res.json().catch(() => ({}))) as { token?: string; id?: string; port?: number };
+  const body = (await res.json().catch(() => ({}))) as { token?: string; id?: string; port?: number; boundHost?: string };
   if (!body.token) {
     console.error("server returned no token");
     return 1;
@@ -116,8 +136,17 @@ export async function runPairCommand(argv: string[]): Promise<number> {
   console.log(`  Port:  ${effPort}`);
   console.log(`  Token: ${body.token}\n`);
   console.log(`Paired device "${name}" (id ${body.id ?? "?"}). Revoke it later from the app or POST /api/devices/revoke.`);
-  console.log(
-    `The phone must reach http://${host}:${port} — run serve with --host 0.0.0.0 on the same Wi-Fi, or use a Tailscale name as --host.`,
-  );
+  // The QR is minted over loopback, but the phone connects over the LAN. If the
+  // server is bound loopback-only the phone can't reach it however good the QR is —
+  // call that out loudly instead of a generic note. (boundHost may be absent on an
+  // older server; then we can't tell, so fall back to the gentle reminder.)
+  if (body.boundHost && isLoopbackBind(body.boundHost)) {
+    console.log(`\n⚠️  LISA is only listening on localhost, so this iPhone can't reach it yet.`);
+    console.log(`   Restart it on your network (in a separate terminal, leave it running):`);
+    console.log(`     lisa serve --web --host 0.0.0.0`);
+    console.log(`   …then run \`lisa pair\` again. (A Tailscale tailnet name as --host works too.)`);
+  } else {
+    console.log(`Keep this phone on the same Wi-Fi (or tailnet) as your Mac.`);
+  }
   return 0;
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -998,8 +998,11 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           ? payload.host.trim()
           : detectLanHost();
       const url = host ? buildPairUrl(host, opts.port, token, name) : undefined;
+      // The interface the server is actually bound to. If it's loopback-only, a
+      // phone can't reach it however good the QR is — the client warns on this.
+      const boundHost = opts.host ?? "127.0.0.1";
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ ok: true, id, token, port: opts.port, host, url, device }));
+      res.end(JSON.stringify({ ok: true, id, token, port: opts.port, host, url, boundHost, device }));
       return;
     }
     if (req.method === "GET" && url === "/api/devices") {


### PR DESCRIPTION
Making `lisa pair` + the iOS pair screen genuinely self-service, after watching a real user get stuck twice (serve bound to loopback so the phone couldn't connect; `lisa pair` run with no server up).

## CLI (`src/cli/pair.ts` + `src/web/server.ts`)
- **Loopback warning.** A QR minted over loopback is useless if the server is bound loopback-only — the phone can't reach it. `/api/pair/start` now reports the server's actual bind host, and `lisa pair` prints a loud ⚠️ telling the user to restart with `--host 0.0.0.0`. Uses the **authoritative bind host** from the server, not a network probe (a firewall or LISA's outbound proxy skews probing — confirmed during testing).
- **Clearer "not running" error** — tells you to start `lisa serve --web --host 0.0.0.0` in a separate terminal first, then re-run.
- **Proxy bypass** — `lisa pair` is loopback-only, but LISA installs a global undici `ProxyAgent` (`proxy-bootstrap.ts`) with no localhost exception; under a proxy the pairing calls would be routed through it and fail. Use a direct dispatcher for this command.

## iOS (`OnboardingFlow.swift`, pair screen)
- Say to **keep LISA running** and run `lisa pair` in a **new terminal window** (the previous copy implied one command in one place; the server occupies its terminal).
- Point Mac-app users at the menu-bar **"Pair iPhone…"** — the genuinely no-terminal path (already built, M3).

## Verification
- `lisa pair` warns on a loopback serve, stays quiet on `--host 0.0.0.0` (both confirmed against live servers).
- Backend typecheck clean; **13** pair/pairing tests pass; iOS build + **25** tests pass.

Background: surfaced alongside #178 (the QR was also never printed) — that's already merged; this is the guidance layer on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
