### PR TITLE
fix(ios): onboarding 'Start LISA' command was missing LISA_WEB_TOKEN

### DIFF
--- a/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingModel.swift
@@ -46,10 +46,14 @@ enum InstallMethod: String, CaseIterable, Identifiable {
     var isCLI: Bool { self != .app }
 
     /// What the user runs to start LISA *LAN-reachable* (the "start" step). CLI
-    /// installs print a copy-able command (the `--host 0.0.0.0` is the #1 gotcha);
-    /// the menu-bar app is launched from the menu bar, so there's nothing to type.
+    /// installs print a copy-able command; the menu-bar app needs nothing typed.
+    /// Includes `LISA_WEB_TOKEN` because the server REFUSES a non-loopback bind
+    /// without one (it would expose a full-tool agent to the whole Wi-Fi) — the
+    /// `--host 0.0.0.0`-without-token fatal is the #1 gotcha. The phone still gets
+    /// its own per-device token from `lisa pair`; this just arms the gate. Matches
+    /// packaging/ios-companion/README.md.
     var serveCommand: String? {
-        isCLI ? "lisa serve --web --host 0.0.0.0" : nil
+        isCLI ? "LISA_WEB_TOKEN=$(openssl rand -hex 24) lisa serve --web --host 0.0.0.0" : nil
     }
 
     /// One-line "start" instruction shown with (or instead of) the command.

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -149,11 +149,14 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertEqual(InstallMethod.allCases.count, 3)
     }
 
-    // CLI installs must instruct the LAN-reachable bind (the #1 pairing gotcha);
+    // CLI installs must instruct the LAN-reachable bind (the #1 pairing gotcha)
+    // AND arm LISA_WEB_TOKEN (the server refuses a non-loopback bind without it);
     // the menu-bar app has nothing to type.
     func testServeCommandReachableForCLIOnly() {
-        XCTAssertEqual(InstallMethod.npm.serveCommand, "lisa serve --web --host 0.0.0.0")
-        XCTAssertEqual(InstallMethod.homebrew.serveCommand, "lisa serve --web --host 0.0.0.0")
+        let expected = "LISA_WEB_TOKEN=$(openssl rand -hex 24) lisa serve --web --host 0.0.0.0"
+        XCTAssertEqual(InstallMethod.npm.serveCommand, expected)
+        XCTAssertEqual(InstallMethod.homebrew.serveCommand, expected)
+        XCTAssertTrue(InstallMethod.npm.serveCommand!.contains("--host 0.0.0.0"))
         XCTAssertNil(InstallMethod.app.serveCommand)
         XCTAssertTrue(InstallMethod.npm.isCLI)
         XCTAssertFalse(InstallMethod.app.isCLI)


### PR DESCRIPTION
A real user hit `fatal: refusing to bind 0.0.0.0 without LISA_WEB_TOKEN` while following onboarding — the CLI pairing path dead-ends here.

## Cause
The server deliberately refuses a non-loopback bind without `LISA_WEB_TOKEN` (binding `0.0.0.0` tokenless would expose a full-tool agent — RCE — to the whole Wi-Fi). But the onboarding "Start LISA" command was just `lisa serve --web --host 0.0.0.0`, with no token — so it fatal-errors immediately.

## Fix
Arm the token in the command:
```
LISA_WEB_TOKEN=$(openssl rand -hex 24) lisa serve --web --host 0.0.0.0
```
This matches `packaging/ios-companion/README.md`. The phone still gets its own per-device token from `lisa pair`; this just satisfies the bind gate. `lisa serve` auto-loads `~/.lisa/config.env`, so users who prefer a stable token can put it there instead — either works.

The menu-bar Mac app was already unaffected: `BackendController` mints + persists + injects the token, so its "Pair iPhone…" path is friction-free (and remains the recommended no-terminal route, surfaced on the pair screen in #179).

Verified: iOS build + **25** tests pass (serveCommand assertion updated).

This is the 3rd CLI-pairing pitfall surfaced from watching a real run — after #178 (QR never printed) and #179 (loopback / new-terminal guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
