### PR TITLE
feat(web): show a scannable QR in the 'Pair phone' modal

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -867,7 +867,9 @@ async function showPair() {
   const port = data.port || 5757;
   const host = data.host || '';
   const link = data.url || ('lisa-pair://v1?host=' + encodeURIComponent(host) + '&port=' + port + '&token=' + encodeURIComponent(data.token) + '&name=phone');
-  let html = '<div class="empty">In Lisa Pocket → Settings → Pair, paste the link below — or switch to “enter manually” and type the three fields. Keep the phone on the same Wi-Fi (or tailnet) as this Mac.</div>';
+  let html = '';
+  if (data.qrSvg) html += '<div class="pair-qr">' + data.qrSvg + '</div>';
+  html += '<div class="empty">Scan the code in Lisa Pocket → Settings → Scan QR — or paste the link / type the three fields below. Keep the phone on the same Wi-Fi (or tailnet) as this Mac.</div>';
   html += pairRow('Link', link);
   html += pairRow('Host', host || '(your Mac\\'s Wi-Fi IP)');
   html += pairRow('Port', String(port));

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -1355,6 +1355,18 @@ export const MAIN_CSS = `  :root {
     font-size: 12px;
   }
   .modal-body .desc { color: var(--fg-3); margin-top: 2px; }
+  .modal-body .pair-qr {
+    display: flex;
+    justify-content: center;
+    margin: 4px 0 14px;
+  }
+  .modal-body .pair-qr svg {
+    width: 200px;
+    height: 200px;
+    background: #fff;
+    padding: 10px;
+    border-radius: 12px;
+  }
   .modal-body .pair-row {
     display: flex;
     align-items: center;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -33,10 +33,12 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: a "Pair phone" function-bar button → showPair() modal that mints a
  * device token via /api/pair/start and shows copyable link + host/port/token
  * (browser counterpart to `lisa pair`), with its .pair-row CSS.
+ * Then: a scannable QR (server-rendered SVG from /api/pair/start) at the top of
+ * that modal, with .pair-qr CSS.
  */
-const EXPECTED_LENGTH = 150420;
+const EXPECTED_LENGTH = 150733;
 const EXPECTED_SHA256 =
-  "8a7b79c2ac406b4a79a03a2b742edfe46d121d8b6191922232bec44c0651bd03";
+  "f7adb8e271d8a3984a41810783f5e9918ad9c8b78b9d460cb5e3f7b122a2d6d8";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/qr-svg.test.ts
+++ b/src/web/qr-svg.test.ts
@@ -1,0 +1,44 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { qrSvg } from "./qr-svg.js";
+
+const URL = "lisa-pair://v1?host=192.168.3.42&port=5757&token=abc123def456&name=phone";
+
+test("produces a well-formed square SVG with a quiet zone", () => {
+  const svg = qrSvg(URL);
+  assert.ok(svg.startsWith("<svg"));
+  assert.ok(svg.trimEnd().endsWith("</svg>"));
+  // square: width === height
+  const w = svg.match(/width="(\d+)"/)?.[1];
+  const h = svg.match(/height="(\d+)"/)?.[1];
+  assert.equal(w, h);
+  // a white background rect + many black module rects
+  assert.match(svg, /fill="#fff"/);
+  assert.match(svg, /fill="#000"/);
+  const rects = svg.match(/<rect /g) ?? [];
+  assert.ok(rects.length > 50, `expected many modules, got ${rects.length}`);
+});
+
+test("viewBox is module-units and includes the margin (quiet zone)", () => {
+  const svg = qrSvg(URL, { margin: 4 });
+  const vb = svg.match(/viewBox="0 0 (\d+) (\d+)"/);
+  assert.ok(vb);
+  const total = Number(vb![1]);
+  // total = moduleCount + 2*margin; with margin 4 that's at least 8 bigger than 21 (v1)
+  assert.ok(total >= 21 + 8);
+  assert.equal(vb![1], vb![2]); // square
+});
+
+test("size option scales the pixel dimensions, not the viewBox", () => {
+  const a = qrSvg(URL, { size: 120 });
+  assert.match(a, /width="120"/);
+  // viewBox stays in module units regardless of pixel size
+  assert.match(a, /viewBox="0 0 \d+ \d+"/);
+});
+
+test("longer data yields a denser (>=) grid", () => {
+  const small = qrSvg("lisa-pair://v1?host=10.0.0.1&port=80&token=x&name=p");
+  const big = qrSvg(URL + "&extra=" + "z".repeat(120));
+  const tot = (s: string) => Number(s.match(/viewBox="0 0 (\d+)/)![1]);
+  assert.ok(tot(big) >= tot(small));
+});

--- a/src/web/qr-svg.ts
+++ b/src/web/qr-svg.ts
@@ -1,0 +1,56 @@
+/**
+ * Render a scannable QR code as an inline SVG string, reusing the QR encoder
+ * bundled inside `qrcode-terminal` (vendor/QRCode) — no extra dependency. Used by
+ * the web "Pair phone" modal so a phone can scan the `lisa-pair://` link instead
+ * of copy-pasting it. (The CLI renders the same data as a terminal QR; the Mac
+ * app via CoreImage — this is the browser equivalent.)
+ */
+import { createRequire } from "node:module";
+
+const require = createRequire(import.meta.url);
+
+interface QRCodeInstance {
+  addData(data: string): void;
+  make(): void;
+  getModuleCount(): number;
+  isDark(row: number, col: number): boolean;
+}
+type QRCodeCtor = new (typeNumber: number, errorCorrectLevel: number) => QRCodeInstance;
+
+// qrcode-terminal vendors a CommonJS QR encoder with no type declarations; load
+// it via require so TS doesn't need a .d.ts for the deep subpath.
+const QRCode = require("qrcode-terminal/vendor/QRCode") as QRCodeCtor;
+const QRErrorCorrectLevel = require(
+  "qrcode-terminal/vendor/QRCode/QRErrorCorrectLevel",
+) as { L: number; M: number; Q: number; H: number };
+
+/**
+ * Encode `data` as a QR and return a square SVG (black modules on white, with a
+ * quiet-zone margin). `size` is the rendered pixel size; the viewBox is in module
+ * units so it stays crisp at any size. Error-correction level M (matches the Mac
+ * app) tolerates some camera noise.
+ */
+export function qrSvg(data: string, opts: { size?: number; margin?: number } = {}): string {
+  const qr = new QRCode(-1, QRErrorCorrectLevel.M);
+  qr.addData(data);
+  qr.make();
+  const count = qr.getModuleCount();
+  const margin = opts.margin ?? 4; // quiet zone (modules) — scanners need ≥4
+  const total = count + margin * 2;
+  const size = opts.size ?? 240;
+
+  let rects = "";
+  for (let row = 0; row < count; row++) {
+    for (let col = 0; col < count; col++) {
+      if (qr.isDark(row, col)) {
+        rects += `<rect x="${col + margin}" y="${row + margin}" width="1" height="1"/>`;
+      }
+    }
+  }
+  return (
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" ` +
+    `viewBox="0 0 ${total} ${total}" shape-rendering="crispEdges" role="img" ` +
+    `aria-label="Pairing QR code"><rect width="${total}" height="${total}" fill="#fff"/>` +
+    `<g fill="#000">${rects}</g></svg>`
+  );
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -76,6 +76,7 @@ import {
   AppleAuthError,
 } from "./cloudAuth.js";
 import { detectLanHost, buildPairUrl } from "./pairing.js";
+import { qrSvg } from "./qr-svg.js";
 import type { ToolDefinition, StoredMessage } from "../types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -1001,8 +1002,11 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       // The interface the server is actually bound to. If it's loopback-only, a
       // phone can't reach it however good the QR is — the client warns on this.
       const boundHost = opts.host ?? "127.0.0.1";
+      // A scannable QR of the pairing link, for the web "Pair phone" modal (the
+      // browser equivalent of the CLI's terminal QR). Only when we have a url.
+      const qr = url ? qrSvg(url) : undefined;
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ ok: true, id, token, port: opts.port, host, url, boundHost, device }));
+      res.end(JSON.stringify({ ok: true, id, token, port: opts.port, host, url, boundHost, qrSvg: qr, device }));
       return;
     }
     if (req.method === "GET" && url === "/api/devices") {


### PR DESCRIPTION
The web **Pair phone** modal had only a copyable `lisa-pair://` link + host/port/token — no way to scan. This adds a scannable **QR** at the top, so you can point the phone's camera at the screen.

## How
- **`src/web/qr-svg.ts`** (new) — renders a QR as an inline **SVG**, reusing the QR encoder already bundled inside `qrcode-terminal` (`vendor/QRCode`) via `createRequire`, so **no new dependency**. Error-correction level M + a 4-module quiet zone (scanner-friendly). 4 unit tests.
- **`/api/pair/start`** now returns `qrSvg` next to the existing `url`/`host`/`port`/`token`.
- **`showPair()`** injects it as a white rounded card above the copyable rows; `.pair-qr` CSS. Byte snapshot re-pinned.

This makes the QR available on all three surfaces consistently: CLI (terminal blocks), Mac app (CoreImage), and now the web UI (SVG).

## Verification
Rendered live in the preview browser (screenshot: clean scannable QR atop the modal, finder patterns + quiet zone intact), no console errors. Backend typecheck clean; 4 qr-svg + snapshot/syntax tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
