### PR TITLE
fix(ios): P0 batch 1 — silent action failures (A1) + mail pref (A7) + Soul fields (A4)

### DIFF
--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -102,11 +102,23 @@ final class LisaClient {
         catch { throw LisaError.decode }
     }
 
+    /// Fire a mutating request and return the HTTP status WITHOUT throwing on a
+    /// non-2xx — for the few call sites that branch on a specific code (503 ⇒ PTY
+    /// off, 409 ⇒ session live, 403 ⇒ remote adoption disabled).
     @discardableResult
-    private func fire(_ path: String, method: String = "POST", json: [String: Any]? = nil) async throws -> Int {
+    private func fireCode(_ path: String, method: String = "POST", json: [String: Any]? = nil) async throws -> Int {
         let req = try makeRequest(path, method: method, json: json)
         let (_, resp) = try await session.data(for: req)
         return (resp as? HTTPURLResponse)?.statusCode ?? -1
+    }
+
+    /// Fire a mutating request that MUST succeed; throws `LisaError.http(code)` on
+    /// any non-2xx so control/mutation actions never fail silently (the #1 review
+    /// finding — a remote phone blocked by the control policy got 403 on every tap
+    /// with zero feedback). This is the default for all the action methods below.
+    private func fire(_ path: String, method: String = "POST", json: [String: Any]? = nil) async throws {
+        let code = try await fireCode(path, method: method, json: json)
+        guard (200..<300).contains(code) else { throw LisaError.http(code) }
     }
 
     // ── read ──
@@ -161,7 +173,7 @@ final class LisaClient {
     /// Spawn a fresh real CLI under a PTY (agent = "claude" | "codex"). Returns
     /// the HTTP code (503 ⇒ the PTY spike is off on the Mac: LISA_PTY_AGENTS=1).
     func ptyStart(agent: String, task: String) async throws -> Int {
-        try await fire("/api/agents/pty/start", json: ["agent": agent, "task": task])
+        try await fireCode("/api/agents/pty/start", json: ["agent": agent, "task": task])
     }
     func ptySend(_ id: String, _ text: String) async throws { try await fire("/api/agents/pty/\(id)/send", json: ["text": text]) }
     func ptyCancel(_ id: String) async throws { try await fire("/api/agents/pty/\(id)/cancel") }
@@ -172,7 +184,7 @@ final class LisaClient {
     /// Adopt an idle claude session by id (resume-adopt). Returns the HTTP code
     /// (409 ⇒ the session is still live; 403 ⇒ remote adoption disabled).
     func adopt(sessionId: String) async throws -> Int {
-        try await fire("/api/agents/pty/start", json: ["agent": "claude", "resumeSessionId": sessionId])
+        try await fireCode("/api/agents/pty/start", json: ["agent": "claude", "resumeSessionId": sessionId])
     }
 
     // ── push ──
@@ -181,7 +193,7 @@ final class LisaClient {
         try await fire("/api/push/live-activity", json: ["sessionId": sessionId, "token": token])
     }
     func pushRegister(kind: String, target: String, prefs: PushPrefs) async throws {
-        let p: [String: Any] = ["done": prefs.done, "error": prefs.error, "permission": prefs.permission, "idle": prefs.idle, "advisor": prefs.advisor]
+        let p: [String: Any] = ["done": prefs.done, "error": prefs.error, "permission": prefs.permission, "idle": prefs.idle, "advisor": prefs.advisor, "mail": prefs.mail]
         try await fire("/api/push/register", json: ["kind": kind, "target": target, "prefs": p])
     }
 

--- a/packaging/ios-companion/Sources/Models.swift
+++ b/packaging/ios-companion/Sources/Models.swift
@@ -194,10 +194,17 @@ struct Emotions: Codable {
 struct SoulItem: Codable, Hashable {
     var name: String?
     var statement: String?
-    var what: String?
+    var what: String?       // DesireEntry
+    var stance: String?     // OpinionEntry
+    var title: String?      // ValueEntry (headline)
+    var body: String?       // ValueEntry (detail)
     var text: String?
     var summary: String?
-    var label: String { statement ?? what ?? text ?? summary ?? name ?? "—" }
+    var slug: String?
+    // Each entry type carries a different headline key (values→title, opinions→
+    // stance, desires→what); pick the first present. Without title/stance, values
+    // and opinions rendered "—" (review A4).
+    var label: String { statement ?? what ?? stance ?? title ?? text ?? summary ?? body ?? name ?? slug ?? "—" }
 }
 
 struct MemoryResponse: Codable {


### PR DESCRIPTION
First implementation increment against the launch gate in [#182](https://github.com/oratis/LISA/pull/182) — the three smallest, highest-value P0 correctness fixes.

## A1 (blocker) — control/mutation actions no longer fail silently
`LisaClient.fire()` returned the HTTP status but **callers discarded it**, and it only threw on transport errors. So every `approve/deny/send/cancel/adopt`, `consentRevoke`, `advisorDismiss`, `setAutonomyState`, `pushRegister` that returned **403/404/409 looked like success**. The worst case: a remote phone blocked by the control policy got **403 on every control tap with zero feedback**.

`fire()` now **throws `LisaError.http(code)` on any non-2xx**; the two methods that intentionally branch on a code (`ptyStart` → 503, `adopt` → 409/403) use a new non-throwing `fireCode()`. The existing `do/catch` at the call sites (e.g. `RosterView.act()`) now surface the failure.

## A7 (high) — `mail` push pref was dropped on the wire
`pushRegister` built the prefs dict without `mail`; the server defaults `mail:true`, so toggling **"Mail digest + alerts" off was a silent no-op**. Now sent.

## A4 (high) — Soul Values & Opinions rendered `—`
`SoulItem.label` only checked `statement/what/text/summary/name`, but `/api/soul` returns Values as `{slug,title,body}` and Opinions as `{slug,stance,confidence}` (confirmed in `src/soul/types.ts`). Added `title/body/stance/slug` to the fallback chain — Values/Opinions now render.

## Verify
iOS build + **25 tests** pass; soul field names confirmed against `src/soul/types.ts`.

Next P0: A2 (chat error events) + A12 (auto-scroll), A6 (lock on `.inactive`), A8/A9 (Dispatch gating), A10/A11 (scanner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
