### PR TITLE
fix(ios): onboarding scanner re-arm + scan-sheet race (A10/A11)

### DIFF
--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -15,6 +15,7 @@ struct OnboardingFlow: View {
     @State private var showManual = false
     @State private var manualMode: ConnectionMode = .mac
     @State private var scanNote: String?
+    @State private var rescanToken = 0
     @State private var verifying = false
     @State private var outcome: VerifyOutcome?
 
@@ -200,10 +201,14 @@ struct OnboardingFlow: View {
         ZStack {
             QRScannerView(
                 onScan: { value in
+                    guard !showManual else { return }   // ignore decodes while the manual sheet is up (A11)
                     if app.applyPairing(value) { go(.connect) }
-                    else { scanNote = "That QR isn't a LISA pairing code."; openManual(.mac) }
+                    // Stay on the scanner and let them re-aim instead of yanking
+                    // them into a form for a momentary mis-scan (A10/A11).
+                    else { scanNote = "That isn't a LISA pairing code — line it up and try again."; rescanToken += 1 }
                 },
-                onError: { reason in scanNote = reason; openManual(.mac) }
+                onError: { reason in scanNote = reason; openManual(.mac) },
+                rescanToken: rescanToken
             )
             .ignoresSafeArea()
             VStack {

--- a/packaging/ios-companion/Sources/QRScannerView.swift
+++ b/packaging/ios-companion/Sources/QRScannerView.swift
@@ -7,19 +7,30 @@ import AVFoundation
 /// project.yml). Degrades honestly: no camera (e.g. the Simulator) or a denied
 /// permission surfaces via `onError` rather than a black screen.
 struct QRScannerView: UIViewControllerRepresentable {
-    /// Called once, on the main actor, with the decoded string of the first QR seen.
+    /// Called on the main actor with the decoded string of each accepted QR.
     var onScan: (String) -> Void
     /// Called with a human-readable reason when scanning can't start.
     var onError: (String) -> Void
+    /// Bump to re-arm after a rejected (non-LISA) scan so the user can re-aim
+    /// without the viewfinder freezing (review A10).
+    var rescanToken: Int = 0
 
     func makeUIViewController(context: Context) -> ScannerViewController {
         let vc = ScannerViewController()
         vc.onScan = onScan
         vc.onError = onError
+        vc.lastRescanToken = rescanToken
         return vc
     }
 
-    func updateUIViewController(_ vc: ScannerViewController, context: Context) {}
+    func updateUIViewController(_ vc: ScannerViewController, context: Context) {
+        vc.onScan = onScan
+        vc.onError = onError
+        if vc.lastRescanToken != rescanToken {
+            vc.lastRescanToken = rescanToken
+            vc.rearm()
+        }
+    }
 }
 
 /// AVFoundation plumbing for `QRScannerView`. A `UIViewController` (not a bare view)
@@ -30,7 +41,13 @@ final class ScannerViewController: UIViewController, AVCaptureMetadataOutputObje
 
     private let session = AVCaptureSession()
     private var preview: AVCaptureVideoPreviewLayer?
-    private var didScan = false  // single-shot: ignore everything after the first hit
+    private var didScan = false  // debounce: ignore further hits until re-armed
+    var lastRescanToken = 0
+
+    /// Re-accept scans after the caller rejected the last one (non-LISA QR). The
+    /// session keeps running (we no longer stop it on every decode), so this just
+    /// clears the debounce.
+    func rearm() { didScan = false }
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -108,9 +125,10 @@ final class ScannerViewController: UIViewController, AVCaptureMetadataOutputObje
               let code = metadataObjects.first as? AVMetadataMachineReadableCodeObject,
               code.type == .qr,
               let value = code.stringValue else { return }
+        // Debounce only (don't stop the session): a rejected scan re-arms via
+        // rearm(); a accepted one navigates away → viewWillDisappear stops it.
         didScan = true
         UINotificationFeedbackGenerator().notificationOccurred(.success)
-        stop()
         onScan?(value)
     }
 }


### PR DESCRIPTION
A10: the QR scanner latched + stopped the session on *any* decode, freezing the viewfinder permanently after a non-LISA scan. Now it only debounces and re-arms via a `rescanToken`. A11: a bad scan stays on the scanner with an inline 'try again' note (instead of force-routing to the manual form with the camera live), and decodes are ignored while the manual sheet is up. iOS build + 25 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)