### PR TITLE
fix(ios): Live Activity local lifecycle + off-tab widget snapshot (A3/A5)

### DIFF
--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -49,8 +49,10 @@ struct RootView: View {
                 SetupBanner { app.presentOnboarding() }
             }
         }
+        .task { await app.refreshWidgetSnapshot() }          // keep the widget fresh off-tab (A5)
         .onChange(of: scenePhase) { _, phase in
             if phase == .background { app.lockIfEnabled() }  // re-arm when leaving foreground
+            if phase == .active { Task { await app.refreshWidgetSnapshot() } }
         }
     }
 }

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import UIKit
 import UserNotifications
 import LocalAuthentication
+import WidgetKit
 
 /// A roster session a deep-link wants to open (agent + sessionId).
 struct PendingNav: Equatable { var agent: String; var id: String }
@@ -114,6 +115,15 @@ final class AppState: ObservableObject {
         guard let cfg = AppState.parsePairing(raw) else { return false }
         update(host: cfg.host, port: cfg.port, token: cfg.token, scheme: cfg.scheme)
         return true
+    }
+
+    /// Refresh the home-Widget snapshot independent of the Dispatch tab — it used
+    /// to be written only while that tab was on screen, so the widget went stale
+    /// whenever the user lived elsewhere (review A5). Called on launch + foreground.
+    func refreshWidgetSnapshot() async {
+        guard config.isConfigured, let s = try? await client.sessions() else { return }
+        SharedStore.writeSnapshot(rosterCounts(s))
+        WidgetCenter.shared.reloadAllTimelines()
     }
 
     /// Pure parse of a pairing string into a ServerConfig (no side effects) — so it's

--- a/packaging/ios-companion/Sources/LiveActivityController.swift
+++ b/packaging/ios-companion/Sources/LiveActivityController.swift
@@ -5,26 +5,31 @@ import Foundation
 /// can refresh it remotely (APNs `liveactivity`) while the app is backgrounded —
 /// the backend half is in src/web/push.ts (sendLiveActivityUpdate). Live remote
 /// updates still need an Apple push key; without one the activity is local-only.
+@MainActor
 enum LiveActivityController {
+    /// Pinned activities keyed by sessionId, so the app can `update`/`end` them
+    /// locally. Previously it only ever called `.request` — so a pinned activity
+    /// froze at its starting state forever and never auto-dismissed (review A3).
+    private static var activities: [String: Activity<AgentActivityAttributes>] = [:]
+
     @discardableResult
     static func start(for session: AgentSession, client: LisaClient? = nil) -> String? {
         guard ActivityAuthorizationInfo().areActivitiesEnabled else { return nil }
+        // Already pinned? Update in place rather than stacking a duplicate.
+        if let existing = activities[session.sessionId] { update(for: session); return existing.id }
         let attributes = AgentActivityAttributes(
             agent: session.agent,
             project: session.project,
             sessionId: session.sessionId
         )
-        let state = AgentActivityAttributes.ContentState(
-            state: session.state,
-            detail: detail(for: session),
-            turns: session.activity?.turnCount ?? 0
-        )
+        let state = contentState(for: session)
         do {
             let activity = try Activity.request(
                 attributes: attributes,
-                content: .init(state: state, staleDate: nil),
+                content: .init(state: state, staleDate: staleDate()),
                 pushType: .token
             )
+            activities[session.sessionId] = activity
             // Forward the activity's push token so the Mac can update it remotely.
             if let client {
                 Task {
@@ -39,6 +44,28 @@ enum LiveActivityController {
             return nil
         }
     }
+
+    /// Push the latest state into a pinned activity, or end it on a terminal state.
+    /// Called from the roster SSE merge so the activity actually ticks (and
+    /// auto-dismisses) while the app is running, independent of the dead APNs path.
+    static func update(for session: AgentSession) {
+        guard let activity = activities[session.sessionId] else { return }
+        let content = ActivityContent(state: contentState(for: session), staleDate: staleDate())
+        if isTerminal(session.state) {
+            activities[session.sessionId] = nil
+            Task { await activity.end(content, dismissalPolicy: .after(.now + 30)) }
+        } else {
+            Task { await activity.update(content) }
+        }
+    }
+
+    private static func contentState(for s: AgentSession) -> AgentActivityAttributes.ContentState {
+        AgentActivityAttributes.ContentState(state: s.state, detail: detail(for: s), turns: s.activity?.turnCount ?? 0)
+    }
+    private static func isTerminal(_ state: String) -> Bool { state == "done" || state == "error" }
+    /// Let iOS visually age an activity that stops getting updates (e.g. backgrounded
+    /// with no APNs key) instead of showing stale state as live indefinitely.
+    private static func staleDate() -> Date { .now + 1800 }   // 30 min
 
     static func detail(for s: AgentSession) -> String {
         if let pending = s.activity?.pendingPermission { return "⚠ \(pending)" }

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -54,6 +54,7 @@ final class RosterModel: ObservableObject {
         }
         sessions = sortRows(sessions)
         publishSnapshot()
+        LiveActivityController.update(for: s)   // tick / auto-end a pinned activity (A3)
     }
 
     /// Mirror the roster's counts (metadata only — no session content) to the App


### PR DESCRIPTION
A3: the app only ever called `Activity.request` — a pinned Live Activity froze forever and never auto-dismissed (remote refresh needs an absent Apple key). Added a `[sessionId: Activity]` registry + `update(for:)` driven from the roster SSE merge, so it ticks while running and ends on terminal states; duplicate pins update in place. A5: the widget snapshot was only written while the Dispatch tab was open — `AppState.refreshWidgetSnapshot()` now publishes app-wide on launch + foreground. iOS build + 25 tests pass (ActivityKit/App-Group only verifiable on a signed device).

🤖 Generated with [Claude Code](https://claude.com/claude-code)