### PR TITLE
feat(ios): share status palette + widget polish (I1/B22-B25/C10)

### DIFF
--- a/packaging/ios-companion/Shared/GlanceColors.swift
+++ b/packaging/ios-companion/Shared/GlanceColors.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+
+/// Canonical agent-status colors, shared by the app (via `Theme`) and the widget
+/// extension, so a given state looks identical in the roster, the Live Activity,
+/// and the home Widget. Lives in `Shared/` because the widget target doesn't
+/// compile `Theme.swift` — which is why the widget/activity previously hardcoded
+/// system `.blue/.yellow/.red/...` that visibly mismatched the app (review I1/B23).
+enum GlanceColors {
+    static let working = rgb(0x5B9DFF)
+    static let waiting = rgb(0xFFB84D)
+    static let error   = rgb(0xFF5D73)
+    static let done    = rgb(0x3DDC97)
+    static let idle    = rgb(0x6B7299)
+
+    /// State → color, using the same buckets as the roster.
+    static func forState(_ state: String) -> Color {
+        switch state {
+        case "working": return working
+        case "waiting": return waiting
+        case "error":   return error
+        case "done":    return done
+        default:        return idle
+        }
+    }
+
+    private static func rgb(_ hex: UInt32) -> Color {
+        Color(.sRGB,
+              red: Double((hex >> 16) & 0xFF) / 255,
+              green: Double((hex >> 8) & 0xFF) / 255,
+              blue: Double(hex & 0xFF) / 255,
+              opacity: 1)
+    }
+}

--- a/packaging/ios-companion/Sources/Theme.swift
+++ b/packaging/ios-companion/Sources/Theme.swift
@@ -20,12 +20,13 @@ enum Theme {
     static let gold   = Color(hex: 0xFFD066)   // Lisa identity
     static let green  = Color(hex: 0x3DDC97)   // proactive / live / done
 
-    // Status pips (mirror the web .pip / .ac-status colors)
-    static let working = Color(hex: 0x5B9DFF)
-    static let waiting = Color(hex: 0xFFB84D)
-    static let danger  = Color(hex: 0xFF5D73)
-    static let done    = green
-    static let idle    = Color(hex: 0x6B7299)
+    // Status pips — defined in Shared/GlanceColors so the widget extension (which
+    // can't see Theme) renders identical status colors (review I1/B23).
+    static let working = GlanceColors.working
+    static let waiting = GlanceColors.waiting
+    static let danger  = GlanceColors.error
+    static let done    = GlanceColors.done
+    static let idle    = GlanceColors.idle
 
     static let cardRadius: CGFloat = 12
     static let hairline: CGFloat = 0.5

--- a/packaging/ios-companion/Widgets/AgentCountWidget.swift
+++ b/packaging/ios-companion/Widgets/AgentCountWidget.swift
@@ -35,12 +35,36 @@ struct AgentCountWidgetView: View {
         switch family {
         case .accessoryInline:
             Text(inlineText)
+        case .accessoryCircular:
+            circular
         case .accessoryRectangular:
             rectangular
         default:
             if let snap = entry.snapshot, snap.updatedAt > .distantPast { populated(snap) }
             else { unconfigured }
         }
+    }
+
+    /// Round lock-screen / StandBy slot (C10): the most urgent number — stuck if
+    /// any, else active.
+    @ViewBuilder private var circular: some View {
+        if let s = entry.snapshot, s.updatedAt > .distantPast {
+            ZStack {
+                AccessoryWidgetBackground()
+                VStack(spacing: 0) {
+                    Image(systemName: "cpu").font(.system(size: 10))
+                    Text("\(s.stuck > 0 ? s.stuck : s.working)").font(.headline.bold())
+                }
+            }
+        } else {
+            Image(systemName: "cpu")
+        }
+    }
+
+    /// A snapshot older than 10 min is shown dimmed rather than as confidently
+    /// live (review B25); relative time (below) also conveys the age.
+    private func isStale(_ snap: AgentSnapshot) -> Bool {
+        entry.date.timeIntervalSince(snap.updatedAt) > 600
     }
 
     // Lock-screen accessory families: terse, no background (system styles them).
@@ -68,12 +92,12 @@ struct AgentCountWidgetView: View {
                 Image(systemName: "cpu").font(.caption2)
                 Text("Dispatch").font(.caption.bold())
                 Spacer()
-                Text(snap.updatedAt, style: .time)
+                Text(snap.updatedAt, style: .relative)               // B24 — "3 min" reads as freshness
                     .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
             }
             HStack(spacing: family == .systemMedium ? 20 : 12) {
-                stat(snap.working, "active", .blue)
-                stat(snap.stuck, "stuck", snap.stuck > 0 ? .orange : .secondary)
+                stat(snap.working, "active", GlanceColors.working)
+                stat(snap.stuck, "stuck", snap.stuck > 0 ? (snap.error > 0 ? GlanceColors.error : GlanceColors.waiting) : .secondary)
                 if family == .systemMedium {
                     stat(snap.total, "total", .secondary)
                 }
@@ -83,6 +107,7 @@ struct AgentCountWidgetView: View {
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .opacity(isStale(snap) ? 0.55 : 1)                           // B25 — dim a stale snapshot
     }
 
     private func stat(_ value: Int, _ label: String, _ color: Color) -> some View {
@@ -119,6 +144,6 @@ struct AgentCountWidget: Widget {
         }
         .configurationDisplayName("Agent activity")
         .description("Active and stuck agents on your Mac.")
-        .supportedFamilies([.systemSmall, .systemMedium, .accessoryRectangular, .accessoryInline])
+        .supportedFamilies([.systemSmall, .systemMedium, .accessoryCircular, .accessoryRectangular, .accessoryInline])
     }
 }

--- a/packaging/ios-companion/Widgets/AgentLiveActivity.swift
+++ b/packaging/ios-companion/Widgets/AgentLiveActivity.swift
@@ -25,9 +25,13 @@ struct AgentLiveActivity: Widget {
                     Label(context.attributes.agent, systemImage: "cpu").font(.caption)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text(context.state.state)
-                        .font(.caption.bold())
-                        .foregroundStyle(activityColor(context.state.state))
+                    VStack(alignment: .trailing, spacing: 1) {
+                        Text(context.state.state)
+                            .font(.caption.bold())
+                            .foregroundStyle(activityColor(context.state.state))
+                        Text("\(context.state.turns) turns")     // B22 — was dropped in expanded
+                            .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
+                    }
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     Text("\(context.attributes.project) — \(context.state.detail)")
@@ -44,12 +48,5 @@ struct AgentLiveActivity: Widget {
     }
 }
 
-func activityColor(_ state: String) -> Color {
-    switch state {
-    case "working": return .blue
-    case "waiting": return .yellow
-    case "error": return .red
-    case "done": return .green
-    default: return .gray
-    }
-}
+// Shared palette so the activity dot matches the roster + widget (I1/B23).
+func activityColor(_ state: String) -> Color { GlanceColors.forState(state) }


### PR DESCRIPTION
The widget extension can't see Theme, so the Live Activity + widget hardcoded system colors that mismatched the app. New `Shared/GlanceColors` is the single source the app, activity, and widget all use. Plus: expanded Dynamic Island now shows turns (B22); widget time is `.relative` (B24); stale (>10min) snapshots dim (B25); added `accessoryCircular` family (C10) with the most-urgent count. iOS build + 25 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)