### PR TITLE
feat(ios): toast + haptics feedback on mutating actions (J1/B13)

### DIFF
--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -40,6 +40,14 @@ struct RootView: View {
         // interruptions (banner, Control Center) just flash the cover — no Face ID,
         // unlike the biometric lock which arms only on a real `.background`.
         .overlay { if scenePhase != .active { PrivacyCover() } }
+        .overlay(alignment: .bottom) {
+            if let t = app.toast {
+                ToastView(message: t)
+                    .padding(.bottom, 72)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .accessibilityAddTraits(.updatesFrequently)
+            }
+        }
         .fullScreenCover(isPresented: $app.showOnboarding) {
             OnboardingFlow().environmentObject(app)
         }
@@ -54,6 +62,29 @@ struct RootView: View {
             if phase == .background { app.lockIfEnabled() }  // re-arm when leaving foreground
             if phase == .active { Task { await app.refreshWidgetSnapshot() } }
         }
+    }
+}
+
+/// A transient action-feedback toast (AppState.notify).
+struct ToastMessage: Equatable, Identifiable {
+    let id = UUID()
+    var text: String
+    var ok: Bool
+}
+
+struct ToastView: View {
+    let message: ToastMessage
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: message.ok ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(message.ok ? Theme.green : Theme.danger)
+            Text(message.text).font(.subheadline).foregroundStyle(Theme.text).lineLimit(2)
+        }
+        .padding(.horizontal, 16).padding(.vertical, 11)
+        .background(Theme.card, in: Capsule())
+        .overlay(Capsule().strokeBorder(Theme.border))
+        .shadow(color: .black.opacity(0.35), radius: 10, y: 3)
+        .padding(.horizontal, 24)
     }
 }
 

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -41,6 +41,21 @@ final class AppState: ObservableObject {
     @Published var pushStatus = ""
     /// Drives the first-run onboarding cover (docs/PLAN_IOS_ONBOARDING_v1.0.md).
     @Published var showOnboarding = false
+    /// Transient toast for action feedback (so a failed control/mutation — now
+    /// that A1 surfaces non-2xx — lands visibly instead of in a buried status row).
+    @Published var toast: ToastMessage?
+    private var toastClear: Task<Void, Never>?
+
+    /// Fire a haptic + show a brief toast. Use `ok: false` for failures.
+    func notify(_ text: String, ok: Bool = true) {
+        ok ? Haptics.success() : Haptics.warning()
+        withAnimation { toast = ToastMessage(text: text, ok: ok) }
+        toastClear?.cancel()
+        toastClear = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 2_600_000_000)
+            if !Task.isCancelled { withAnimation { toast = nil } }
+        }
+    }
 
     init() {
         let d = UserDefaults.standard

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -470,8 +470,13 @@ struct SessionDetailView: View {
 
     func act(_ work: @escaping () async throws -> Void) {
         Task { @MainActor in
-            do { try await work() }
-            catch { status = (error as? LocalizedError)?.errorDescription ?? "\(error)" }
+            do { try await work(); Haptics.success() }
+            catch {
+                // A1 surfaces non-2xx here; make the failure land visibly (J1).
+                let msg = (error as? LocalizedError)?.errorDescription ?? "Action failed."
+                status = msg
+                app.notify(msg, ok: false)
+            }
         }
     }
 }

--- a/packaging/ios-companion/Sources/SenseView.swift
+++ b/packaging/ios-companion/Sources/SenseView.swift
@@ -81,10 +81,20 @@ struct SenseView: View {
         error = grants.isEmpty && events.isEmpty ? "Couldn't reach Lisa." : nil
     }
 
+    // A silently-failed revoke is dangerous — the user believes a privacy signal
+    // is off when it isn't (review B13). Surface success/failure.
     private func revoke(_ signal: String) {
-        Task { try? await app.client.consentRevoke(signal: signal); await load() }
+        Task {
+            do { try await app.client.consentRevoke(signal: signal); app.notify("Revoked \(signal).") }
+            catch { app.notify("Couldn't revoke — still granted.", ok: false) }
+            await load()
+        }
     }
     private func revokeAll() {
-        Task { try? await app.client.consentRevokeAll(); await load() }
+        Task {
+            do { try await app.client.consentRevokeAll(); app.notify("All signals revoked.") }
+            catch { app.notify("Couldn't revoke all.", ok: false) }
+            await load()
+        }
     }
 }


### PR DESCRIPTION
Action results were buried in an off-screen status row, no haptics. `AppState.notify` fires a haptic + a transient bottom toast. Wired into Dispatch control actions (failures now land visibly — e.g. policy-blocked 403, 404 on a finished agent) and Sense revoke (a failed privacy revoke now says 'still granted' instead of being swallowed — B13). iOS build + 25 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)