### PR TITLE
feat(ios): minimal accessibility pass (D1-D5)

### DIFF
--- a/packaging/ios-companion/Sources/ChatView.swift
+++ b/packaging/ios-companion/Sources/ChatView.swift
@@ -161,6 +161,8 @@ struct MoodPortrait: View {
             MoodChip(mood: slug)
             Spacer()
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Lisa's mood: \(slug)")
     }
 }
 

--- a/packaging/ios-companion/Sources/InspectViews.swift
+++ b/packaging/ios-companion/Sources/InspectViews.swift
@@ -50,6 +50,9 @@ struct SoulView: View {
                                     Spacer()
                                     ProgressView(value: max(0, min(1, v))).frame(width: 120)
                                 }
+                                .accessibilityElement(children: .ignore)
+                                .accessibilityLabel(k)
+                                .accessibilityValue("\(Int((max(0, min(1, v))) * 100)) percent")
                             }
                         }
                     }

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
@@ -26,11 +26,17 @@ struct OnboardingDots: View {
             }
         }
         .animation(.easeInOut(duration: 0.2), value: step)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(stepLabel)
     }
     private func isCurrent(_ s: OnboardingStep) -> Bool { s == step }
     private func isActive(_ s: OnboardingStep) -> Bool {
         guard let step else { return false }
         return s.rawValue <= step.rawValue
+    }
+    private var stepLabel: String {
+        guard let step, let i = OnboardingStep.dotted.firstIndex(of: step) else { return "Setup progress" }
+        return "Step \(i + 1) of \(OnboardingStep.dotted.count)"
     }
 }
 
@@ -93,7 +99,8 @@ struct CopyCommandRow: View {
             Button(action: copy) {
                 Image(systemName: copied ? "checkmark" : "doc.on.doc")
                     .foregroundStyle(copied ? Theme.green : Theme.accent)
-                    .frame(width: 28, height: 28)
+                    .frame(width: 44, height: 44)   // ≥44pt tap target (D4)
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel(copied ? "Copied" : "Copy command")

--- a/packaging/ios-companion/Sources/ReveView.swift
+++ b/packaging/ios-companion/Sources/ReveView.swift
@@ -46,6 +46,7 @@ struct ReveView: View {
                                         Text(i.importance >= 3 ? "‼" : "!")
                                             .font(.caption.bold())
                                             .foregroundStyle(i.importance >= 3 ? .red : .orange)
+                                            .accessibilityLabel(i.importance >= 3 ? "urgent" : "important")   // D1: not color-only
                                         VStack(alignment: .leading, spacing: 1) {
                                             Text(i.subject.isEmpty ? "(no subject)" : i.subject).font(.callout).lineLimit(1)
                                             Text(i.reason).font(.caption2).foregroundStyle(.secondary).lineLimit(1)

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -213,6 +213,16 @@ struct RosterRow: View {
             }
         }
         .padding(.vertical, 2)
+        // One VoiceOver element — status isn't color-only (D1/D5).
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(rowLabel)
+    }
+
+    private var rowLabel: String {
+        var s = "\(session.project), \(session.agent), \(session.state)"
+        if let p = session.activity?.pendingPermission { s += ", needs you: \(p)" }
+        else if session.resumable == true { s += ", resumable" }
+        return s
     }
 
     var subtitle: String {


### PR DESCRIPTION
Launch-gate a11y minimum: RosterRow is one VoiceOver element with a spoken status label (not color-only, D1/D5); onboarding dots announce 'Step N of M' (D2); mail importance ‼/! and the Soul mood bars get spoken labels/values (D1); chat mood portrait labeled; copy button ≥44pt (D4). iOS build + 25 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)