### PR TITLE
feat(ios): design-system foundations — spacing scale + CodeBlock (P3a)

### DIFF
--- a/packaging/ios-companion/Sources/InspectViews.swift
+++ b/packaging/ios-companion/Sources/InspectViews.swift
@@ -86,10 +86,10 @@ struct MemoryView: View {
         AsyncContent(load: { try await app.client.memory() }) { mem in
             List {
                 if !mem.user.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Section("Who you are (user)") { Text(mem.user).font(.system(.callout, design: .monospaced)) }
+                    Section("Who you are (user)") { CodeBlock(text: mem.user, maxHeight: 240) }
                 }
                 if !mem.memory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    Section("Memory") { Text(mem.memory).font(.system(.callout, design: .monospaced)) }
+                    Section("Memory") { CodeBlock(text: mem.memory, maxHeight: 320) }
                 }
             }
         }

--- a/packaging/ios-companion/Sources/ReveView.swift
+++ b/packaging/ios-companion/Sources/ReveView.swift
@@ -65,7 +65,7 @@ struct ReveView: View {
                                 Text(loading ? "…" : "No agent activity in this window.")
                                     .font(.caption).foregroundStyle(.secondary)
                             } else {
-                                Text(recap).font(.system(.callout, design: .monospaced))
+                                CodeBlock(text: recap, maxHeight: 280)
                             }
                         } header: { Text("Recap") }
 

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -428,11 +428,7 @@ struct SessionDetailView: View {
                 }
                 Button("Load output") { act { output = try await app.client.ptyOutput(session.sessionId) } }
                 if !output.isEmpty {
-                    ScrollView {
-                        Text(output).font(.system(.caption, design: .monospaced))
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                    }
-                    .frame(maxHeight: 200)
+                    CodeBlock(text: output, maxHeight: 200)
                 }
             }
             .disabled(!isTerminal && !canControl)

--- a/packaging/ios-companion/Sources/Theme.swift
+++ b/packaging/ios-companion/Sources/Theme.swift
@@ -30,6 +30,37 @@ enum Theme {
 
     static let cardRadius: CGFloat = 12
     static let hairline: CGFloat = 0.5
+
+    /// One spacing scale so padding/stack-spacing is consistent across screens
+    /// (review I3 — values were ad-hoc 8/12/14/18/22/… everywhere).
+    enum Space {
+        static let xs: CGFloat = 4
+        static let s: CGFloat = 8
+        static let m: CGFloat = 14
+        static let l: CGFloat = 20
+        static let xl: CGFloat = 28
+    }
+}
+
+/// One code/log block — monospaced, selectable, scrollable in both axes (so long
+/// lines don't clip), on a sunken card. Replaces the three different mono
+/// treatments (PTY output / recap / memory) the review flagged (I4).
+struct CodeBlock: View {
+    let text: String
+    var maxHeight: CGFloat? = nil
+    var body: some View {
+        ScrollView([.horizontal, .vertical]) {
+            Text(text)
+                .font(.system(.caption, design: .monospaced))
+                .foregroundStyle(Theme.text)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(10)
+        }
+        .frame(maxHeight: maxHeight)
+        .background(Color.black.opacity(0.25), in: RoundedRectangle(cornerRadius: 8))
+        .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Theme.border, lineWidth: Theme.hairline))
+    }
 }
 
 extension Color {


### PR DESCRIPTION
Foundation for P2/P4. Adds `Theme.Space` (one spacing scale, I3) and a unified `CodeBlock` log component (mono + selectable + both-axes scroll on a sunken card, I4), applied to the three previously-divergent mono spots (PTY output, Reve recap, Memory) — long lines now scroll instead of clipping. iOS build + 25 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)