### PR TITLE
feat(ios): Chat redesign — bubbles + code blocks + tool chips + typing + history (P2)

### DIFF
--- a/packaging/ios-companion/Sources/ChatView.swift
+++ b/packaging/ios-companion/Sources/ChatView.swift
@@ -1,15 +1,50 @@
 import SwiftUI
 
+/// One chat turn. Lisa's text accumulates during streaming; `tools` collects the
+/// tool names she invokes (rendered as chips); `isError` flags a failed turn.
+struct ChatMessage: Identifiable, Equatable {
+    enum Role { case user, lisa }
+    let id = UUID()
+    var role: Role
+    var text: String = ""
+    var tools: [String] = []
+    var isError: Bool = false
+}
+
 @MainActor
 final class ChatModel: ObservableObject {
-    @Published var transcript = ""
+    @Published var messages: [ChatMessage] = []
     @Published var sending = false
     @Published var mood = ""
+    @Published var loadingHistory = false
+    @Published private(set) var hasMore = false
+    private var page = 0
     private var task: Task<Void, Never>?
     private var moodTask: Task<Void, Never>?
 
-    /// Seed the mood from a ping, then track the `mood` SSE — reconnecting with
-    /// backoff so a mid-session drop doesn't leave the portrait stale forever.
+    // ── history ──
+    func loadHistory(_ client: LisaClient) async {
+        guard messages.isEmpty, let r = try? await client.history(page: 0) else { return }
+        messages = r.messages.map(Self.map)
+        page = 0
+        hasMore = r.hasMore
+    }
+
+    func loadEarlier(_ client: LisaClient) async {
+        guard hasMore, !loadingHistory else { return }
+        loadingHistory = true
+        defer { loadingHistory = false }
+        guard let r = try? await client.history(page: page + 1) else { return }
+        messages.insert(contentsOf: r.messages.map(Self.map), at: 0)
+        page += 1
+        hasMore = r.hasMore
+    }
+
+    private static func map(_ m: HistoryMessage) -> ChatMessage {
+        ChatMessage(role: m.role == "user" ? .user : .lisa, text: m.content)
+    }
+
+    // ── mood (seed from a ping, then track the SSE, reconnect with backoff) ──
     func startMood(_ client: LisaClient) {
         moodTask?.cancel()
         moodTask = Task { @MainActor in
@@ -30,10 +65,13 @@ final class ChatModel: ObservableObject {
     }
     func stopMood() { moodTask?.cancel(); moodTask = nil }
 
+    // ── send ──
     func send(_ text: String, client: LisaClient) {
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
-        transcript += "\n\nYou: \(trimmed)\n\nLisa: "
+        messages.append(ChatMessage(role: .user, text: trimmed))
+        messages.append(ChatMessage(role: .lisa))
+        let idx = messages.count - 1
         sending = true
         task = Task { @MainActor in
             defer { sending = false }
@@ -41,18 +79,25 @@ final class ChatModel: ObservableObject {
                 for try await msg in client.chatStream(trimmed) {
                     switch msg.type {
                     case "text":
-                        if let t = msg.text { transcript += t }
+                        if let t = msg.text { messages[idx].text += t }
+                    case "tool_start":
+                        if let n = msg.object["name"] as? String, !messages[idx].tools.contains(n) {
+                            messages[idx].tools.append(n)
+                        }
                     case "error":
-                        // In-band error on a 200 stream — without this the turn just
-                        // hung at "…Lisa: " with no message (review A2).
+                        messages[idx].isError = true
                         let m = msg.object["message"] as? String ?? "the turn failed"
-                        transcript += "\n⚠️ \(m)"
+                        messages[idx].text += (messages[idx].text.isEmpty ? "" : "\n") + m
                     default:
-                        break   // tool_start/tool_end/done — ignored in the thin chat
+                        break
                     }
                 }
+                if messages[idx].text.isEmpty && messages[idx].tools.isEmpty && !messages[idx].isError {
+                    messages[idx].text = "(no response)"
+                }
             } catch {
-                transcript += "\n⚠️ \((error as? LocalizedError)?.errorDescription ?? "Couldn't reach Lisa.")"
+                messages[idx].isError = true
+                messages[idx].text = (error as? LocalizedError)?.errorDescription ?? "Couldn't reach Lisa."
             }
         }
     }
@@ -62,73 +107,168 @@ struct ChatView: View {
     @EnvironmentObject var app: AppState
     @StateObject private var model = ChatModel()
     @State private var input = ""
+    private static let bottomID = "chat-bottom"
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
                 if !model.mood.isEmpty {
                     MoodPortrait(mood: model.mood)
-                        .padding(.horizontal).padding(.vertical, 6)
+                        .padding(.horizontal).padding(.vertical, Theme.Space.s)
                     Divider()
                 }
-                ScrollViewReader { proxy in
-                    ScrollView {
-                        transcriptView
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .textSelection(.enabled)
-                            .padding()
-                        Color.clear.frame(height: 1).id(Self.bottomID)   // scroll anchor
-                    }
-                    .scrollDismissesKeyboard(.interactively)
-                    // Follow the streaming reply (review A12 — long replies scrolled off).
-                    .onChange(of: model.transcript) { _, _ in
-                        withAnimation(.easeOut(duration: 0.15)) { proxy.scrollTo(Self.bottomID, anchor: .bottom) }
-                    }
-                }
+                transcript
                 Divider()
-                HStack {
-                    TextField("Message…", text: $input, axis: .vertical)
-                        .textFieldStyle(.roundedBorder)
-                    Button {
-                        let text = input
-                        input = ""
-                        model.send(text, client: app.client)
-                    } label: {
-                        Image(systemName: "arrow.up.circle.fill").font(.title2)
-                    }
-                    .frame(width: 44, height: 44)                       // ≥44pt tap target
-                    .accessibilityLabel("Send message")
-                    .disabled(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || model.sending)
-                }
-                .padding()
+                composer
             }
             .background(Theme.bgDeep.ignoresSafeArea())
             .navigationTitle("Chat")
-            .task(id: app.config) { model.startMood(app.client) }
+            .task(id: app.config) { model.startMood(app.client); await model.loadHistory(app.client) }
             .onDisappear { model.stopMood() }
         }
     }
 
-    private static let bottomID = "chat-bottom"
-
-    /// Empty → dimmed placeholder; mid-stream → raw text (cheap as it grows);
-    /// settled → inline markdown (bold/links/`code`, newlines preserved). Full
-    /// message bubbles + code blocks are the deferred P2 redesign.
-    @ViewBuilder private var transcriptView: some View {
-        if model.transcript.isEmpty {
-            Text("Say hi to Lisa.").foregroundStyle(Theme.secondary)
-        } else if model.sending {
-            Text(model.transcript).foregroundStyle(Theme.text)
-        } else {
-            Text(renderedTranscript).foregroundStyle(Theme.text)
+    private var transcript: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                if model.hasMore {
+                    Button { Task { await model.loadEarlier(app.client) } } label: {
+                        if model.loadingHistory { ProgressView() }
+                        else { Text("Load earlier").font(.caption) }
+                    }
+                    .padding(.top, Theme.Space.s)
+                }
+                LazyVStack(spacing: Theme.Space.m) {
+                    if model.messages.isEmpty {
+                        Text("Say hi to Lisa.")
+                            .foregroundStyle(Theme.secondary)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.top, 40)
+                    }
+                    ForEach(model.messages) { MessageBubble(message: $0) }
+                    if model.sending {
+                        TypingIndicator().frame(maxWidth: .infinity, alignment: .leading)
+                    }
+                }
+                .padding()
+                Color.clear.frame(height: 1).id(Self.bottomID)
+            }
+            .scrollDismissesKeyboard(.interactively)
+            .onChange(of: model.messages) { _, _ in scrollToBottom(proxy) }
+            .onChange(of: model.sending) { _, _ in scrollToBottom(proxy) }
         }
     }
 
-    private var renderedTranscript: AttributedString {
-        (try? AttributedString(markdown: model.transcript,
-                               options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
-            ?? AttributedString(model.transcript)
+    private func scrollToBottom(_ proxy: ScrollViewProxy) {
+        withAnimation(.easeOut(duration: 0.15)) { proxy.scrollTo(Self.bottomID, anchor: .bottom) }
     }
+
+    private var composer: some View {
+        HStack(spacing: Theme.Space.s) {
+            TextField("Message…", text: $input, axis: .vertical)
+                .textFieldStyle(.roundedBorder)
+            Button {
+                let text = input
+                input = ""
+                model.send(text, client: app.client)
+            } label: {
+                Image(systemName: "arrow.up.circle.fill").font(.title2)
+            }
+            .frame(width: 44, height: 44)
+            .accessibilityLabel("Send message")
+            .disabled(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || model.sending)
+        }
+        .padding()
+    }
+}
+
+/// A user/Lisa chat bubble: markdown text segments + fenced code as CodeBlocks +
+/// tool chips for the tools Lisa ran this turn.
+struct MessageBubble: View {
+    let message: ChatMessage
+    var body: some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 36) }
+            VStack(alignment: .leading, spacing: Theme.Space.s) {
+                ForEach(Array(segments.enumerated()), id: \.offset) { _, seg in
+                    switch seg {
+                    case .text(let t):
+                        Text(renderMarkdown(t)).textSelection(.enabled)
+                    case .code(let c):
+                        CodeBlock(text: c)
+                    }
+                }
+                if !message.tools.isEmpty {
+                    HStack(spacing: Theme.Space.xs) {
+                        ForEach(message.tools, id: \.self) { tool in
+                            ThemePill(text: tool, color: Theme.accent)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 12).padding(.vertical, 9)
+            .background(bubbleBg, in: RoundedRectangle(cornerRadius: 14))
+            .foregroundStyle(message.isError ? Theme.danger : Theme.text)
+            .frame(maxWidth: 320, alignment: message.role == .user ? .trailing : .leading)
+            if message.role == .lisa { Spacer(minLength: 36) }
+        }
+        .frame(maxWidth: .infinity, alignment: message.role == .user ? .trailing : .leading)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(message.role == .user ? "You" : "Lisa"): \(message.text)")
+    }
+
+    private var segments: [MessageSegment] { parseSegments(message.text) }
+    private var bubbleBg: Color { message.role == .user ? Theme.accent.opacity(0.18) : Theme.card }
+}
+
+/// Animated "Lisa is typing" dots shown while a turn streams.
+struct TypingIndicator: View {
+    @State private var animate = false
+    var body: some View {
+        HStack(spacing: 5) {
+            ForEach(0..<3) { i in
+                Circle().fill(Theme.secondary).frame(width: 7, height: 7)
+                    .scaleEffect(animate ? 1 : 0.5)
+                    .animation(.easeInOut(duration: 0.5).repeatForever().delay(Double(i) * 0.15), value: animate)
+            }
+        }
+        .padding(.horizontal, 14).padding(.vertical, 12)
+        .background(Theme.card, in: RoundedRectangle(cornerRadius: 14))
+        .onAppear { animate = true }
+        .accessibilityLabel("Lisa is typing")
+    }
+}
+
+// ── markdown + fenced-code segmentation ──
+
+enum MessageSegment { case text(String); case code(String) }
+
+/// Split a message into prose vs ``` fenced code blocks, so code renders in a
+/// proper monospaced CodeBlock instead of as illegible inline text.
+func parseSegments(_ s: String) -> [MessageSegment] {
+    guard s.contains("```") else { return [.text(s)] }
+    var segs: [MessageSegment] = []
+    var inCode = false
+    var buf: [String] = []
+    func flush() {
+        let joined = buf.joined(separator: "\n")
+        if inCode { segs.append(.code(joined)) }
+        else if !joined.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { segs.append(.text(joined)) }
+        buf = []
+    }
+    for line in s.components(separatedBy: "\n") {
+        if line.hasPrefix("```") { flush(); inCode.toggle() }
+        else { buf.append(line) }
+    }
+    flush()
+    return segs.isEmpty ? [.text(s)] : segs
+}
+
+/// Inline markdown (bold/italic/links/`code`) preserving newlines.
+func renderMarkdown(_ s: String) -> AttributedString {
+    (try? AttributedString(markdown: s,
+                           options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)))
+        ?? AttributedString(s)
 }
 
 /// Lisa's current mood as a real portrait + label. The portrait is the server's

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -198,6 +198,9 @@ final class LisaClient {
     }
 
     // ── chat ──
+    func history(page: Int = 0) async throws -> HistoryResponse {
+        try await decode("/api/history?page=\(page)", as: HistoryResponse.self)
+    }
     func chatStream(_ message: String) -> AsyncThrowingStream<SSEMessage, Error> {
         sse("/chat", method: "POST", json: ["message": message])
     }

--- a/packaging/ios-companion/Sources/Models.swift
+++ b/packaging/ios-companion/Sources/Models.swift
@@ -123,6 +123,10 @@ struct ControlPolicy: Codable, Equatable {
     var remoteAdoptExternal: Bool
 }
 
+// /api/history?page=N — newest page first (page 0), older pages as N grows.
+struct HistoryResponse: Codable { var messages: [HistoryMessage]; var hasMore: Bool; var page: Int }
+struct HistoryMessage: Codable { var role: String; var content: String }
+
 /// /api/autonomy/state — the "Proactive mode" master switch (idle + heartbeat).
 struct AutonomyState: Codable, Equatable {
     var enabled: Bool


### PR DESCRIPTION
Replaces the concatenated-Text transcript with a real message UI: structured ChatMessage model, user/Lisa bubbles, markdown prose + fenced code in CodeBlock (the #1 coding-client fidelity gap), tool chips for tools Lisa ran, an animated typing indicator, and history pagination via `/api/history` ('Load earlier'). Mood header + auto-scroll retained. iOS build + 25 tests pass; visual QA is P5.4 on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)