### PR TITLE
feat(ios): 4-tab IA + Lisa home/overview (P4)

### DIFF
--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -16,17 +16,18 @@ struct RootView: View {
     @EnvironmentObject var app: AppState
     @Environment(\.scenePhase) private var scenePhase
     var body: some View {
+        // Four primary tabs (review P4/H1): Dispatch · Chat · Lisa (overview —
+        // mood, while-away, recap, advisor, Inspect) · Settings. Sense moved into
+        // Settings (it's a consent control); Reve folded into the Lisa home.
         TabView(selection: $app.selectedTab) {
             RosterView()
                 .tabItem { Label("Dispatch", systemImage: "cpu") }.tag(0)
             ChatView()
                 .tabItem { Label("Chat", systemImage: "bubble.left.and.bubble.right") }.tag(1)
             ReveView()
-                .tabItem { Label("Reve", systemImage: "moon.stars") }.tag(2)
-            SenseView()
-                .tabItem { Label("Sense", systemImage: "sensor.tag.radiowaves.forward") }.tag(3)
+                .tabItem { Label("Lisa", systemImage: "sparkles") }.tag(2)
             SettingsView()
-                .tabItem { Label("Settings", systemImage: "gearshape") }.tag(4)
+                .tabItem { Label("Settings", systemImage: "gearshape") }.tag(3)
         }
         .tint(Theme.accent)                                  // cyan active tab + links + controls
         .preferredColorScheme(.dark)                         // force the console dark look

--- a/packaging/ios-companion/Sources/ReveView.swift
+++ b/packaging/ios-companion/Sources/ReveView.swift
@@ -27,6 +27,8 @@ struct ReveView: View {
                                            description: Text("Add your Mac in Settings."))
                 } else {
                     List {
+                        Section { MoodPortrait(mood: ping?.mood ?? "neutral") }
+                            .listRowBackground(Color.clear)
                         if let p = ping {
                             if let note = p.last_idle_message_text, !note.isEmpty {
                                 Section("While you were away") { Text(note).font(.callout) }
@@ -84,12 +86,19 @@ struct ReveView: View {
                             }
                         }
 
+                        Section("Inspect Lisa") {
+                            NavigationLink { SoulView() } label: { Label("Soul", systemImage: "sparkles") }
+                            NavigationLink { MemoryView() } label: { Label("Memory", systemImage: "brain") }
+                            NavigationLink { NamedListView(title: "Skills", load: { try await app.client.skills() }) } label: { Label("Skills", systemImage: "wand.and.stars") }
+                            NavigationLink { NamedListView(title: "Tools", load: { try await app.client.tools() }) } label: { Label("Tools", systemImage: "wrench.and.screwdriver") }
+                        }
+
                         if let error { Section { Text(error).font(.caption).foregroundStyle(.secondary) } }
                     }
                 }
             }
             .consoleBackground()
-            .navigationTitle("Reve")
+            .navigationTitle("Lisa")
             .refreshable { await load() }
             .task(id: ReveLoadKey(window: window, configured: app.config.isConfigured)) { await load() }
             .onChange(of: scenePhase) { _, p in if p == .active { Task { await load() } } }
@@ -105,12 +114,15 @@ struct ReveView: View {
         async let advisorResult = app.client.advisorLatest()
         async let mailDigestResult = app.client.mailDigest()
         async let mailAccountsResult = app.client.mailAccounts()
-        ping = try? await pingResult
+        let p = try? await pingResult
+        ping = p
         recap = (try? await recapResult)?.text ?? ""
         suggestions = (try? await advisorResult)?.suggestions ?? []
         mailDigest = try? await mailDigestResult
         mailAccounts = (try? await mailAccountsResult)?.accounts.count ?? 0
-        error = nil
+        // The ping is the always-present call — if it failed, surface it instead of
+        // looking like a quiet-but-healthy day (review B12).
+        error = p == nil ? "Couldn't reach Lisa." : nil
     }
 
     private func dismiss(_ s: AdvisorSuggestion) {

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -150,8 +150,11 @@ struct SettingsView: View {
                         .font(.caption).foregroundStyle(.secondary)
                 }
 
-                Section {
+                Section("Privacy") {
                     NavigationLink { DevicesView() } label: { Label("Paired devices", systemImage: "iphone.gen3") }
+                    // Sense (ambient-signal consent) — a privacy control, so it
+                    // lives in Settings now rather than its own tab (review P4/H1).
+                    NavigationLink { SenseView() } label: { Label("Sense (consent)", systemImage: "sensor.tag.radiowaves.forward") }
                 }
 
                 Section("Security") {
@@ -169,16 +172,8 @@ struct SettingsView: View {
                         .font(.caption).foregroundStyle(.secondary)
                 }
 
-                Section("Inspect Lisa") {
-                    NavigationLink { SoulView() } label: { Label("Soul", systemImage: "sparkles") }
-                    NavigationLink { MemoryView() } label: { Label("Memory", systemImage: "brain") }
-                    NavigationLink { NamedListView(title: "Skills", load: { try await app.client.skills() }) } label: {
-                        Label("Skills", systemImage: "wand.and.stars")
-                    }
-                    NavigationLink { NamedListView(title: "Tools", load: { try await app.client.tools() }) } label: {
-                        Label("Tools", systemImage: "hammer")
-                    }
-                }
+                // "Inspect Lisa" (Soul/Memory/Skills/Tools) moved to the Lisa home
+                // tab — it's content about who Lisa is, not a setting (review H3).
 
                 if !status.isEmpty {
                     Section { Text(status).font(.caption).foregroundStyle(.secondary) }


### PR DESCRIPTION
Collapses 5 tabs → 4 (Dispatch · Chat · **Lisa** · Settings). The former Reve tab becomes the Lisa home: mood header + while-away/desire/mail/recap/advisor + a surfaced 'Inspect Lisa' section (Soul/Memory/Skills/Tools, moved out of Settings per H3). Sense → Settings → Privacy (consent control, H1). B12: the home now surfaces a load error. Deep-link tags unchanged (Dispatch=0, Chat=1). iOS build + 25 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)