### PR TITLE
fix(ios): automatic signing so testflight.sh archives cleanly

### DIFF
--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -14,9 +14,14 @@ settings:
     MARKETING_VERSION: "0.1.0"
     CURRENT_PROJECT_VERSION: "1"
     TARGETED_DEVICE_FAMILY: "1,2"
-    CODE_SIGNING_REQUIRED: NO
-    CODE_SIGNING_ALLOWED: NO
-    CODE_SIGN_IDENTITY: ""
+    # Automatic signing for device archives (testflight.sh): Xcode picks the
+    # Development identity for the archive and re-signs Distribution at export.
+    # Simulator builds (build.sh) pass CODE_SIGNING_ALLOWED=NO on the command
+    # line, so they need no certificate — keep the disable-flags OUT of the project
+    # so they don't clear the archive's signing identity (which left the widget
+    # unsigned and broke `testflight.sh`).
+    CODE_SIGN_STYLE: Automatic
+    DEVELOPMENT_TEAM: "9LH9NBX7P4"
 targets:
   LisaPocket:
     type: application


### PR DESCRIPTION
The last blocker before a successful **TestFlight upload**. `main` already has the bundle id `ai.meetlisa.main` + iPad orientations; this adds the missing piece — proper **automatic signing** in `project.yml`.

## Problem
`settings.base` carried simulator-only flags (`CODE_SIGNING_ALLOWED=NO`, `CODE_SIGN_IDENTITY=""`) that leaked into the **device archive**: with automatic signing they cleared the identity and left the **widget extension unsigned**, so `testflight.sh` failed at `ValidateEmbeddedBinary` ("Embedded binary is not signed with the same certificate as the parent app").

## Fix
Replace them with `CODE_SIGN_STYLE=Automatic` + `DEVELOPMENT_TEAM=9LH9NBX7P4`. `build.sh` (simulator) still passes `CODE_SIGNING_ALLOWED=NO` on the command line, so it needs no cert. The archive signs both targets (Development) and the export re-signs Distribution.

Discovered across the 4-attempt upload debug: ① wrong Issuer ID → ② widget unsigned (this fix) → ③ Distribution-vs-automatic conflict → ④ missing iPad orientations. With this, the full pipeline (archive → sign → export → upload to ASC) succeeds.

## Verified
`build.sh` → **BUILD SUCCEEDED** (simulator).

🤖 Generated with [Claude Code](https://claude.com/claude-code)