### PR TITLE
fix(ios): gate Sign in with Apple off for v1 (avoid App Store 5.1.1(v))

### DIFF
--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -381,8 +381,10 @@ struct OnboardingManualEntry: View {
         .preferredColorScheme(.dark)
     }
 
-    // ── Cloud: Sign in with Apple (primary) + paste-a-token (fallback) ──
+    // ── Cloud: paste a token link. Sign in with Apple is gated OFF for v1 (single-
+    // tenant M0 + App Store 5.1.1(v) account-deletion); re-enable via LISA_ENABLE_SIWA.
     @ViewBuilder private var cloudSections: some View {
+        #if LISA_ENABLE_SIWA
         Section {
             TextField("https://your-instance.run.app", text: $cloudURL)
                 .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
@@ -396,20 +398,21 @@ struct OnboardingManualEntry: View {
                 .opacity(appleBusy ? 0.5 : 1)
             if appleBusy { ProgressView().tint(Theme.accent) }
         } header: {
-            Text("LISA Cloud")
+            Text("Sign in")
         } footer: {
             Text("Enter your LISA Cloud URL, then sign in. Your Mac isn't needed.")
         }
+        #endif
 
         Section {
             TextField("https://…/?token=", text: $pasteText)
                 .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
-            Button("Connect with token") { apply(pasteText) }
+            Button("Connect") { apply(pasteText) }
                 .disabled(pasteText.isEmpty)
         } header: {
-            Text("Or paste a token link")
+            Text("LISA Cloud")
         } footer: {
-            Text("Have a ready-made cloud URL with its token? Paste it here instead.")
+            Text("Paste your LISA Cloud URL (including its ?token=…) — your Mac isn't needed.")
         }
     }
 
@@ -441,8 +444,10 @@ struct OnboardingManualEntry: View {
         }
     }
 
+    #if LISA_ENABLE_SIWA
     /// Handle the Sign in with Apple result: pull the identity token, exchange it
     /// at the entered cloud URL for a session token, and save the connection.
+    /// Gated OFF for v1 — see cloudSections.
     private func handleApple(_ result: Result<ASAuthorization, Error>) {
         error = nil
         switch result {
@@ -472,6 +477,7 @@ struct OnboardingManualEntry: View {
             }
         }
     }
+    #endif
 
     private func apply(_ raw: String) {
         if app.applyPairing(raw) { finish() }

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -81,9 +81,12 @@ struct SettingsView: View {
                             .autocorrectionDisabled()
                             .textInputAutocapitalization(.never)
                             .keyboardType(.URL)
-                        // Real Sign in with Apple against the entered cloud URL (the
-                        // backend exchange path is implemented — review F6, the dead
-                        // 'coming soon' button is gone).
+                        // Sign in with Apple is gated OFF for v1: the cloud is still
+                        // single-tenant (M0), and offering account creation would trip
+                        // App Store 5.1.1(v) (in-app account deletion). Re-enable by
+                        // adding LISA_ENABLE_SIWA to SWIFT_ACTIVE_COMPILATION_CONDITIONS
+                        // once per-uid isolation (C3) + account deletion land.
+                        #if LISA_ENABLE_SIWA
                         SignInWithAppleButton(.continue,
                             onRequest: { req in req.requestedScopes = [.fullName, .email] },
                             onCompletion: handleApple)
@@ -91,7 +94,8 @@ struct SettingsView: View {
                             .frame(height: 44)
                             .disabled(appleBusy || AppState.parseCloudBase(pairText) == nil)
                         if appleBusy { ProgressView() }
-                        Button("Connect with token") {
+                        #endif
+                        Button("Connect") {
                             if app.applyPairing(pairText) {
                                 syncFromConfig()
                                 app.notify("Connected to LISA Cloud.")
@@ -100,7 +104,7 @@ struct SettingsView: View {
                             }
                         }
                         .disabled(pairText.isEmpty)
-                        Text("Enter your LISA Cloud URL and sign in — or paste a URL that already has its ?token=.")
+                        Text("Paste your LISA Cloud URL (including its ?token=…) to connect.")
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 }
@@ -214,8 +218,10 @@ struct SettingsView: View {
         token = app.config.token ?? ""
     }
 
+    #if LISA_ENABLE_SIWA
     /// Sign in with Apple against the entered cloud URL, exchange the identity
-    /// token for the session token, and save the connection (review F6).
+    /// token for the session token, and save the connection (review F6). Gated OFF
+    /// for v1 — see the LISA_ENABLE_SIWA note above the button.
     private func handleApple(_ result: Result<ASAuthorization, Error>) {
         switch result {
         case .failure(let err):
@@ -242,6 +248,7 @@ struct SettingsView: View {
             }
         }
     }
+    #endif
 
     /// Apply a scanned code the same way pasted text is applied; on a parse failure,
     /// drop it into the text field so the user can see/fix what was scanned.

--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -64,8 +64,11 @@ targets:
         com.apple.security.application-groups:
           - group.ai.meetlisa.main
         aps-environment: development
-        com.apple.developer.applesignin:
-          - Default
+        # Sign in with Apple entitlement is intentionally omitted for v1 — the app
+        # doesn't offer account creation (SIWA is gated off; see LISA_ENABLE_SIWA),
+        # so declaring it would only invite App Store 5.1.1(v) scrutiny. Re-add
+        # `com.apple.developer.applesignin: [Default]` when SIWA + C3 + account
+        # deletion ship.
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: ai.meetlisa.main


### PR DESCRIPTION
SIWA = account creation ⇒ Apple requires in-app account deletion (Guideline **5.1.1(v)**). The cloud is still single-tenant M0 (SIWA isn't per-user yet), so it's not worth the review risk for the first submission.

- Gate the SIWA button + handler (SettingsView + OnboardingFlow) behind `#if LISA_ENABLE_SIWA` (undefined ⇒ compiled out). The **paste-cloud-URL (`?token=`)** path — what the reviewer uses — stays.
- Drop the `com.apple.developer.applesignin` entitlement from `project.yml`.

Re-enable via `LISA_ENABLE_SIWA` in `SWIFT_ACTIVE_COMPILATION_CONDITIONS` once C3 (per-uid) + account deletion ship.

Verified: `build.sh` **BUILD SUCCEEDED** (SIWA excluded); generated entitlements have no `applesignin`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)