### PR TITLE
fix(ios): TestFlight marketing-version + CFBundleVersion (lost from #207)

### DIFF
--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -11,7 +11,10 @@ options:
 settings:
   base:
     SWIFT_VERSION: "5.0"
-    MARKETING_VERSION: "0.1.0"
+    # Must be >= the app's App Store version (currently 1.0, PREPARE_FOR_SUBMISSION).
+    # A lower CFBundleShortVersionString (this was "0.1.0") is silently REJECTED by
+    # App Store Connect at ingestion — upload "succeeds" but no build ever appears.
+    MARKETING_VERSION: "1.0"
     CURRENT_PROJECT_VERSION: "1"
     TARGETED_DEVICE_FAMILY: "1,2"
     # Automatic signing for device archives (testflight.sh): Xcode picks the

--- a/packaging/ios-companion/testflight.sh
+++ b/packaging/ios-companion/testflight.sh
@@ -70,6 +70,16 @@ if [ -f Sources/LisaPocket.entitlements ]; then
   plutil -replace aps-environment -string production Sources/LisaPocket.entitlements
 fi
 
+# xcodegen bakes a LITERAL CFBundleVersion ("1") into the generated Info.plists,
+# so `xcodebuild ... CURRENT_PROJECT_VERSION=$BUILD_NUMBER` never reaches the
+# binary — every archive shipped build "1" and App Store Connect rejected the
+# duplicates ("Redundant Binary Upload … build number 1/8"). Patch the plists
+# directly. The app extension MUST carry the same version or embedded-binary
+# validation fails.
+echo "==> set CFBundleVersion=$BUILD_NUMBER (app + widget)"
+plutil -replace CFBundleVersion -string "$BUILD_NUMBER" Sources/Info.plist
+[ -f Widgets/Info.plist ] && plutil -replace CFBundleVersion -string "$BUILD_NUMBER" Widgets/Info.plist
+
 AUTH=(-allowProvisioningUpdates
   -authenticationKeyPath "$ASC_KEY_PATH"
   -authenticationKeyID "$ASC_KEY_ID"


### PR DESCRIPTION
PR #207 squash-merged with only its first commit (build# `date +%s`); these two fixes were pushed to the branch afterward and never reached main. Both are required — without them `./testflight.sh` from main still silently fails (verified: build `1782924012` — the one now VALID in TestFlight — was built with all three).

1. **`MARKETING_VERSION` 0.1.0 → 1.0** — must be ≥ the app's ASC version (1.0) or the upload is silently rejected at ingestion.
2. **Stamp `CFBundleVersion` into the generated Info.plists** (app + widget) after `xcodegen generate` — xcodegen bakes a literal "1", so the `CURRENT_PROJECT_VERSION` override was a no-op → "Redundant Binary Upload".

🤖 Generated with [Claude Code](https://claude.com/claude-code)