### PR TITLE
docs: surface Lisa Pocket (iOS) + cross-link extracted OSS repos + 4.1(a) response kit

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ which owns that auth. See [Coding plans](#coding-plans--use-a-subscription-inste
 - **Heartbeat** — `lisa heartbeat run` (manual) or `lisa heartbeat install` (launchd / cron)
 - **Autostart** — `lisa autostart install` keeps `lisa serve --web` running from login onward (launchd on macOS; prints a `systemd --user` unit on Linux), so the apps, island, and channels are always up. `lisa autostart status` / `uninstall` to inspect / remove.
 - **Mac menu bar** — Lisa.app lives in the menu bar with a mood glyph + live agent status, an About window with changelog + update discovery, and a ⌘, preferences pane (island toggle, screen-advisor interval, backend controls).
+- **iOS — Lisa Pocket** — a thin, private companion app for iPhone & iPad: chat with Lisa and watch / approve her agents while you're away from your Mac. Connects only to your own backend (or a LISA Cloud instance you choose). *Coming to the App Store.*
 
 ## Watching — and steering — your other agents (orchestrator)
 
@@ -624,6 +625,15 @@ scripts/
 ├── generate-lisa-moods.ts  parallel-batched Seedream generator + sharp transparency
 └── generate-pixel-assets.ts 6 base UI assets
 ```
+
+## Open-source building blocks
+
+Reusable pieces extracted from LISA into standalone MIT repos — useful on their own:
+
+- **[AsyncSSE](https://github.com/oratis/AsyncSSE)** — Server-Sent Events as a Swift `async`/`await` stream, for LLM token streaming. (Powers Lisa Pocket's chat.)
+- **[llm-provider-registry](https://github.com/oratis/llm-provider-registry)** ([npm](https://www.npmjs.com/package/llm-provider-registry)) — map any model name → API base URL + key env var; 16 providers incl. the Chinese ones. LISA's model auto-routing, packaged.
+- **[undici-proxy-env](https://github.com/oratis/undici-proxy-env)** ([npm](https://www.npmjs.com/package/undici-proxy-env)) — make Node's `fetch` honor `HTTP(S)_PROXY` and survive Clash/corporate-proxy mangling. LISA's proxy bootstrap.
+- **[claude-relay](https://github.com/oratis/claude-relay)** — transparent Anthropic reverse proxy for Cloud Run (key-swap gate). LISA's relay.
 
 ## License
 

--- a/packaging/ios-companion/APPSTORE_METADATA.md
+++ b/packaging/ios-companion/APPSTORE_METADATA.md
@@ -90,6 +90,13 @@ LISA is open source (MIT). Learn more at meetlisa.ai.
 
 ## Notes for whoever fills ASC
 
+- **⚠️ Guideline 4.1(a) (copycat) history**: the first submission was rejected as
+  resembling a third-party "Lisa.ai." It's a name collision (several unrelated
+  "Lisa" AI apps exist) — LISA is our own open-source, self-hosted product. The
+  appeal + fallback rename options live in
+  [`REVIEW_RESPONSE_4.1a.md`](REVIEW_RESPONSE_4.1a.md). Lead the **App Review
+  Notes** with the "our own open-source product (meetlisa.ai / github.com/oratis/LISA)"
+  framing (already updated in the submission checklist §7.3).
 - **App Privacy** answer must be **"Data Not Collected"** to match
   `Sources/PrivacyInfo.xcprivacy` — see [`RELEASE.md`](RELEASE.md) §"From
   TestFlight to App Store".

--- a/packaging/ios-companion/REVIEW_RESPONSE_4.1a.md
+++ b/packaging/ios-companion/REVIEW_RESPONSE_4.1a.md
@@ -1,0 +1,110 @@
+# App Review response — Guideline 4.1(a) Copycats (Lisa Pocket)
+
+**Rejection** (Submission `cb80235c-cf2f-4245-817c-ba80d9c8929d`, 2026-07-08, v1.0
+build 1782924012): *"The metadata appears to contain potentially misleading
+references to third-party content … content that resembles Lisa.ai without the
+necessary authorization."*
+
+## What actually triggered it
+
+Not a code issue — **metadata**. There are several pre-existing AI apps that
+share the common name "Lisa" (e.g. *Lisa Chat: AI Bot Assistant* `id6448847169`,
+*Lisa AI: Dance Video Maker* `id6443832829`, `lisaai.app`). The reviewer sees a
+new AI app named **"Lisa Pocket"** and flags it as resembling **"Lisa.ai."** The
+`lisa.ai` substring the reviewer likely spotted is inside our **own** domain,
+**meetlisa.ai**.
+
+## Why we win this (the differentiators — all publicly verifiable)
+
+LISA is **our own original product**, not an impersonation, and is categorically
+different from the cloud "Lisa" chatbots:
+
+| | Other "Lisa" apps | **LISA / Lisa Pocket** |
+|---|---|---|
+| Type | Hosted cloud chatbot / media generator | **Self-hosted, open-source (MIT)** agent on the user's own Mac |
+| Ours since | — | Website + **public GitHub (2026-05-02)** + npm (2026-05-13) |
+| App role | Standalone service | **Thin companion client** — connects only to the user's machine |
+| Brand | — | **meetlisa.ai** (our domain), GitHub `oratis/LISA` |
+
+Evidence links (all public, consistent branding — "An AI agent with a real self"):
+- Website: https://meetlisa.ai · Privacy: https://meetlisa.ai/privacy
+- Source (public, MIT, since 2026-05-02): https://github.com/oratis/LISA
+- Package (public): https://www.npmjs.com/package/@oratis/lisa
+- Install: https://github.com/oratis/homebrew-tap
+
+## Recommended path: reply with evidence, keep the name
+
+4.1(a) explicitly offers an "attach documentary evidence of your rights" path.
+Reply to the review message (no resubmit needed to send a reply). If Apple
+approves, done. If they still insist, fall back to a rename (below).
+
+### ✅ Paste-ready reply (App Store Connect → the review message → Reply)
+
+```
+Re: Submission ID cb80235c-cf2f-4245-817c-ba80d9c8929d — Guideline 4.1(a)
+
+Hello, and thank you for reviewing Lisa Pocket.
+
+Lisa Pocket is the official companion app for LISA, our own original,
+independently developed product. It is not affiliated with — and contains no
+references to or content from — "Lisa.ai" or any other third party. "Lisa" is a
+common given name and the name of our own software; any similarity to other apps
+that share this common name is coincidental.
+
+Please also note: the string "lisa.ai" in our metadata is part of our own
+domain name, meetlisa.ai, which we own and operate. It is not a reference to any
+third-party service.
+
+LISA is also meaningfully different from other "Lisa"-named apps: it is a free,
+open-source (MIT-licensed), self-hosted AI agent that runs locally on the user's
+own Mac. Lisa Pocket is a thin client that connects only to the user's own
+machine (or an instance the user chooses) — it is not a standalone cloud chatbot
+or media-generation service.
+
+Documentary evidence that this is our own product:
+- Official website: https://meetlisa.ai
+- Open-source code (public, MIT, first published May 2026):
+  https://github.com/oratis/LISA
+- Public software package: https://www.npmjs.com/package/@oratis/lisa
+- Installation tap: https://github.com/oratis/homebrew-tap
+
+We are the sole developer of both LISA and this app, and we are glad to adjust
+any specific element you identify. If a particular word, image, or field is the
+concern, please let us know exactly which one and we will revise it right away.
+
+Thank you for your time.
+Best regards,
+<your name>
+```
+
+> Replace `<your name>`. Keep the tone factual and cooperative — the closing
+> offer to change a specific element is what usually converts a 4.1(a) hold.
+
+### One thing to check before replying — identity match
+
+Apple may check that the **developer account owns the brand**. The account is
+**Telloria / wangharp@gmail.com**; the brand is **meetlisa.ai / oratis**. If
+those aren't obviously the same entity to a reviewer, add a line to the reply:
+*"I am the sole developer and operator of both the Lisa Pocket app account and
+meetlisa.ai / the oratis GitHub organization."*  (Optional booster: add an
+"iOS companion app" mention/link on meetlisa.ai so the marketing URL itself
+ties the app to the brand.)
+
+## Fallback (only if Apple rejects the appeal): differentiate the name
+
+Display name is metadata-only — the bundle id `ai.meetlisa.main` stays. Ranked:
+
+1. **`LISA — Agent Console`** (or `Lisa Agent Console`) — names the true category
+   (dev/agent tool), clearly not a generic "Lisa AI" chatbot. Strongest signal.
+2. **`meetlisa`** — matches the domain exactly; unmistakably our brand.
+3. **`LISA Pocket`** (all-caps LISA) — smallest change; weakest differentiation.
+
+If we rename, also drop the generic keyword **`assistant`** (it's what the cloud
+"Lisa" chatbots rank on) and lead the subtitle with the self-hosted angle, e.g.
+`Self-hosted AI agent, on the go`.
+
+## Not the trigger, but worth knowing
+
+Keywords/description name **Claude, Codex, Aider** (real integrations). Factual
+interoperability references are generally fine; the reviewer flagged "Lisa.ai,"
+not these. Leave them unless a future reviewer objects.

--- a/website/src/pages/index.astro
+++ b/website/src/pages/index.astro
@@ -114,6 +114,7 @@ import Base from "../layouts/Base.astro";
   <ul class="platforms">
     <li><strong>CLI</strong> (macOS / Linux): <code>lisa</code> for REPL, <code>lisa serve --web</code> for browser.</li>
     <li><strong>PWA</strong>: open the web UI on your phone, "Add to Home Screen" — Lisa runs as a standalone app shell.</li>
+    <li><strong>iOS — Lisa Pocket</strong>: our companion app for iPhone &amp; iPad. Chat with Lisa and watch / steer her agents while you're away from your Mac. <em>Coming to the App Store.</em></li>
     <li><strong>IM channels</strong>: Telegram / Discord / Slack / Feishu / iMessage / Webhook — talk to her from anywhere.</li>
     <li><strong>10+ LLM providers</strong>: Anthropic, OpenAI, Google Gemini, DeepSeek, Doubao, Qwen, Kimi, Grok, GLM, Ollama (local). Routes by model name. <a href="https://github.com/oratis/LISA/blob/main/docs/PROVIDERS.md">10 ready-to-use recipes →</a></li>
   </ul>

--- a/website/src/pages/install.astro
+++ b/website/src/pages/install.astro
@@ -33,6 +33,16 @@ import Base from "../layouts/Base.astro";
   <pre><code>npm install -g @oratis/lisa
 lisa serve --web                # the app loads http://localhost:5757</code></pre>
 
+  <h2>📱 Lisa Pocket (iOS companion)</h2>
+  <p>
+    <strong>Lisa Pocket</strong> is our official companion app for iPhone &amp;
+    iPad — a thin, private client to the LISA backend running on your own Mac
+    (or a LISA&nbsp;Cloud instance you point it at). Chat with Lisa on the go,
+    watch the coding agents she's running, and approve their next step from your
+    phone. It stores no account and collects nothing to a Lisa-operated server.
+  </p>
+  <p><em>Coming to the App Store</em> — bundle <code>ai.meetlisa.main</code>.</p>
+
   <h2>Homebrew (CLI only)</h2>
   <pre><code>brew tap oratis/tap
 brew install lisa

--- a/website/src/pages/zh-CN/index.astro
+++ b/website/src/pages/zh-CN/index.astro
@@ -111,6 +111,7 @@ import Base from "../../layouts/Base.astro";
   <ul class="platforms">
     <li><strong>CLI</strong>(macOS / Linux):<code>lisa</code> 进 REPL,<code>lisa serve --web</code> 起浏览器 UI。</li>
     <li><strong>PWA</strong>:手机打开 web UI,"添加到主屏幕" —— Lisa 作为独立 app shell 运行。</li>
+    <li><strong>iOS —— Lisa Pocket</strong>:我们为 iPhone 和 iPad 出的随身 app。离开 Mac 时也能和 Lisa 聊天、查看并指挥她的 agent。<em>即将上架 App Store。</em></li>
     <li><strong>IM 通道</strong>:Telegram / Discord / Slack / 飞书 / iMessage / Webhook —— 任何地方都能找到她。</li>
     <li><strong>10+ LLM</strong>:Anthropic、OpenAI、Gemini、DeepSeek、火山豆包、阿里 Qwen、月之暗面 Kimi、xAI Grok、智谱 GLM、本地 Ollama。按模型名前缀路由。<a href="https://github.com/oratis/LISA/blob/main/docs/PROVIDERS.md">10 个可直接 copy 的配方 →</a></li>
   </ul>


### PR DESCRIPTION
## What

Two doc-only changes that support the in-flight iOS launch and the OSS-followers push:

**1. Surface Lisa Pocket (iOS) on the site + README**
- `meetlisa.ai` homepage (EN + zh-CN) and the install page now list the **Lisa Pocket** iOS companion app.
- Ties the app to the brand so the App Store **Marketing/Support URL (meetlisa.ai) self-evidences ownership** — directly strengthens the pending **Guideline 4.1(a)** copycat appeal.

**2. Cross-link the extracted OSS repos from README**
- New **"Open-source building blocks"** section links the 4 MIT repos extracted from LISA — [AsyncSSE](https://github.com/oratis/AsyncSSE), [llm-provider-registry](https://github.com/oratis/llm-provider-registry), [undici-proxy-env](https://github.com/oratis/undici-proxy-env), [claude-relay](https://github.com/oratis/claude-relay) — to route repo traffic to them.

**3. App Review 4.1(a) response kit** (`packaging/ios-companion/REVIEW_RESPONSE_4.1a.md`)
- Paste-ready appeal with ownership evidence, fallback rename options, and a metadata note leading with the self-hosted open-source framing.

## Verify
- `npm run build` in `website/` — all 10 pages build; "Lisa Pocket" renders in `index`, `install`, `zh-CN/index`.

## After merge
- Website is **not** auto-deployed on merge — run `website/deploy/deploy.sh` to publish the iOS mention to meetlisa.ai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)