### PR TITLE
chore(release): v0.15.0 — version bump + release notes

### DIFF
--- a/docs/RELEASE_v0.15.0.md
+++ b/docs/RELEASE_v0.15.0.md
@@ -1,0 +1,60 @@
+# Lisa v0.15.0
+
+The **"she has a home now"** release. The headline is the **Lisa Room** — an
+ambient pixel-art living space where the full-body Lisa lives, every layer a
+read-only projection of her real state. Alongside it: ElevenLabs-first voice
+transcription and a hardened Anthropic relay for Cloud Run.
+
+Typecheck green · full test suite green (915 tests) · no breaking changes.
+
+## ✨ What's new since v0.14.0
+
+### Lisa Room — an ambient, state-driven living space (#214)
+
+- **`GET /room` + a ⌂ Room tab** in the GUI (lazily-loaded iframe): a cozy
+  pixel room rendered as a layered DOM/CSS 2.5D diorama — no canvas, no WebGL,
+  no bundler, zero new deps, same self-contained pattern as the Island.
+- **Everything is driven by her real state** (read-only — soul / mood /
+  heartbeat / Reve untouched): mood → pose (sitting at her glowing laptop while
+  `working-*`, curled asleep while `napping` or Reve-dreaming, standing idle
+  with breathing + blink otherwise), `chat_start` → pulsing monitor glow,
+  Reve → the room falls into night with floating Z's, and her ★
+  *while-you-were-away* note appears as a glowing letter on the desk.
+- **Full-body animatable spritesheet** (idle blink frames / sit / sleep),
+  generated via an anchor → keyframes → chroma-key + foot-anchor pipeline —
+  she finally stands on the floor instead of floating as a bust.
+- **Day / dusk / night** crossfade by her local clock; weather-flavored moods
+  bring rain/snow particles; fireflies at night.
+- Review hardening: ambient particles only rebuild when the mode actually
+  changes, the parallax loop idles when the tab is hidden (and stays off under
+  `prefers-reduced-motion`), honest state mapping (`sleepy` ≠ asleep, a
+  raincoat doesn't make it rain indoors), and in-GUI "Talk to her" switches
+  back to chat in place instead of spawning a duplicate tab.
+- Design + build notes: `docs/PLAN_ROOM_v1.0.md`.
+
+### Voice — ElevenLabs-first transcription (#174)
+
+- Transcription now prefers **ElevenLabs Scribe** (`ELEVENLABS_API_KEY`),
+  falling back to **OpenAI Whisper**; the no-key error names both providers.
+- Composer ＋ / 🎙 glyphs became line-style SVG icons matching the function bar.
+
+### Infra — Anthropic reverse-proxy relay for Cloud Run (#209)
+
+- `packaging/gcp-relay/`: a ~110-line zero-dep Node relay forwarding `/v1/*`
+  (streaming included) to `api.anthropic.com`, for reaching Claude reliably
+  from behind flaky networks by pointing `ANTHROPIC_BASE_URL` at it.
+- **Key-swap gate**: the real Anthropic key lives only in Secret Manager and is
+  injected server-side; clients present a revocable `RELAY_TOKEN` instead.
+
+### Docs
+
+- Lisa Pocket (iOS) surfaced in the README, extracted OSS repos cross-linked,
+  and an App Store 4.1(a) response kit (#213).
+- The no-clone `gh api` Homebrew-tap bump used for v0.14.0 is now the
+  documented path (#212).
+
+## Install / update
+
+- **Mac**: download `Lisa-Suite-v0.15.0.dmg` below, or let the in-app updater pull it.
+- **CLI**: `npm i -g @oratis/lisa@0.15.0` (or the `lisa-*-bundle` tarballs below).
+- **iOS**: via TestFlight (ships separately from this release).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oratis/lisa",
-  "version": "0.13.0",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oratis/lisa",
-      "version": "0.13.0",
+      "version": "0.15.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",
@@ -1047,6 +1047,7 @@
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
       "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@hono/node-server": "^1.19.9",
         "ajv": "^8.17.1",
@@ -1622,6 +1623,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -1949,6 +1951,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
       "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3077,6 +3080,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
       "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oratis/lisa",
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "An AI agent with a real self — runs locally, has desires, keeps a journal, evolves over time.",
   "keywords": [
     "ai",


### PR DESCRIPTION
## What

Release prep for **v0.15.0** (minor — new features since v0.14.0):

- `package.json` 0.14.0 → 0.15.0 via `npm version` (also fixes `package-lock.json` still saying 0.13.0)
- `docs/RELEASE_v0.15.0.md` — used as the GitHub Release body by `release.yml`

## Highlights in this release

- **Lisa Room** (#214) — ambient, state-driven pixel-art living space at `/room` + ⌂ Room GUI tab
- **ElevenLabs-first voice transcription** with Whisper fallback (#174)
- **Anthropic reverse-proxy relay for Cloud Run** (`packaging/gcp-relay`) (#209)
- Docs: Lisa Pocket surfacing + 4.1(a) kit (#213), no-clone Homebrew bump (#212)

## After merge

1. `git tag v0.15.0 && git push --tags` → `release.yml` builds + posts the GitHub Release
2. `npm publish --access public` (manual, needs npm login)
3. `gh workflow run "Release — Homebrew tap"` after the npm tarball lands

Typecheck green · 915 tests green on this tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)