### PR TITLE
fix(web): IME-safe Enter, distinct idle notes, language-matched reflections

### DIFF
--- a/src/idle/runner.ts
+++ b/src/idle/runner.ts
@@ -95,6 +95,12 @@ export async function runIdleOnce(opts: {
   signal: AbortSignal;
   model: string;
   idleMs: number;
+  /**
+   * A recent user message, used only to tell Lisa which language to write her
+   * while-you-were-away note in (so a Chinese user doesn't get English notes).
+   * Language-agnostic: she matches the sample rather than us detecting a locale.
+   */
+  userLanguageSample?: string;
 }): Promise<IdleRunResult> {
   // Proactive-mode master switch (web/iOS "Proactive" toggle → ~/.lisa/autonomy/
   // state.json). When autonomy is off, idle reflection no-ops: Lisa only acts on
@@ -108,7 +114,7 @@ export async function runIdleOnce(opts: {
   // concurrently and race on soul writes. timeoutMs:0 → if another idle run
   // is in flight, skip silently instead of queueing a second reflection.
   try {
-    return await withFileLock(IDLE_RUN_LOCK, () => runIdleInner(opts, idleMin), {
+    return await withFileLock(IDLE_RUN_LOCK, () => runIdleInner(opts, idleMin, opts.userLanguageSample), {
       timeoutMs: 0,
       staleMs: 2 * 60 * 60_000, // 2h: an idle run older than this is a crashed holder
     });
@@ -124,12 +130,16 @@ export async function runIdleOnce(opts: {
 async function runIdleInner(
   opts: { tools: ToolDefinition[]; cwd: string; signal: AbortSignal; model: string },
   idleMin: number,
+  userLanguageSample?: string,
 ): Promise<IdleRunResult> {
   const startedAt = new Date().toISOString();
   const t0 = Date.now();
+  const langLine = userLanguageSample
+    ? ` If you do write a note, write it in the same language the user has been speaking to you in — for reference, a recent message from them was: «${userLanguageSample.slice(0, 200)}». Match that language; don't default to English.`
+    : "";
   try {
     const result = await runSubagent({
-      prompt: `You have been idle for about ${idleMin} minute${idleMin === 1 ? "" : "s"}. The user is away. Decide what you want to do, then do it. Remember: end with "(no update)" if it's internal, or a brief honest message if you did something the user might want to know about.`,
+      prompt: `You have been idle for about ${idleMin} minute${idleMin === 1 ? "" : "s"}. The user is away. Decide what you want to do, then do it. Remember: end with "(no update)" if it's internal, or a brief honest message if you did something the user might want to know about.${langLine}`,
       systemPrompt: buildIdleSystemPrompt(),
       // Idle is fully self-driven and unattended — no shell / fs-mutation /
       // process-spawning tools by default (see AUTONOMOUS_BLOCKED_TOOL_NAMES).
@@ -139,8 +149,13 @@ async function runIdleInner(
       model: opts.model,
       budgetTokens: IDLE_BUDGET_TOKENS || undefined,
     });
-    const text = result.text.trim();
-    const silent = text === "" || /^\(no update\)$/i.test(text);
+    // The model is asked to end with "(no update)" for internal-only runs, but
+    // it doesn't always emit that on its own line — sometimes it writes a real
+    // note and then appends "(no update)", or wraps it in punctuation. Strip a
+    // trailing "(no update)" so the marker never leaks into a shown note; if
+    // nothing survives, the whole run was internal → silent.
+    const text = result.text.trim().replace(/\n*\(\s*no\s+update\s*\)[.。]?\s*$/i, "").trim();
+    const silent = text === "";
     const outcome: AutonomyOutcome =
       result.stopReason === "budget_exceeded" ? "blocked" : silent ? "no-update" : "done";
     await recordAutonomyRun({

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -406,6 +406,37 @@ fetch('/session').then(r => r.json()).then(s => {
   if (titlebarSession) titlebarSession.textContent = '· ' + s.id;
 });
 
+// ── While-you-were-away idle note: shared card builder + localized label ──
+// Idle reflections render as a distinct card — never a plain Lisa bubble — so
+// they don't blend into her actual replies, both live (SSE) and on history
+// reload. The label follows the UI language; the note body is already written
+// in the user's language by the idle runner.
+function idleHeaderLabel() {
+  var l = (navigator.language || 'en').toLowerCase();
+  if (l.indexOf('zh') === 0) return '你不在的时候';
+  if (l.indexOf('ja') === 0) return '不在のあいだに';
+  if (l.indexOf('ko') === 0) return '자리를 비운 사이';
+  return 'WHILE YOU WERE AWAY';
+}
+function buildIdleBlock(text, at) {
+  const block = document.createElement('div');
+  block.className = 'idle-block';
+  const head = document.createElement('div');
+  head.className = 'idle-head';
+  head.textContent = '★ ' + idleHeaderLabel();
+  if (at) {
+    const time = document.createElement('span');
+    time.className = 'idle-time';
+    try { time.textContent = new Date(at).toLocaleTimeString(); } catch (e) {}
+    head.appendChild(time);
+  }
+  block.appendChild(head);
+  const bodyEl = document.createElement('div');
+  bodyEl.textContent = text;
+  block.appendChild(bodyEl);
+  return block;
+}
+
 // ── Persistent /events SSE: mood updates + idle messages + Claude
 // activity, lifetime of page.
 function connectEvents() {
@@ -425,20 +456,7 @@ function connectEvents() {
       }
     } else if (ev.type === 'idle_message') {
       if (idlePulseEl) { idlePulseEl.remove(); idlePulseEl = null; }
-      const block = document.createElement('div');
-      block.className = 'idle-block';
-      const head = document.createElement('div');
-      head.className = 'idle-head';
-      head.textContent = '★ WHILE YOU WERE AWAY';
-      const time = document.createElement('span');
-      time.className = 'idle-time';
-      try { time.textContent = new Date(ev.at).toLocaleTimeString(); } catch {}
-      head.appendChild(time);
-      block.appendChild(head);
-      const bodyEl = document.createElement('div');
-      bodyEl.textContent = ev.text;
-      block.appendChild(bodyEl);
-      log.appendChild(block);
+      log.appendChild(buildIdleBlock(ev.text, ev.at));
       log.scrollTop = log.scrollHeight;
       // sidebar reflection card mirrors the latest while-you-were-away
       if (typeof updateReflection === 'function') updateReflection(ev.text);
@@ -676,6 +694,14 @@ function prependHistoryMessages(messages) {
   for (const msg of messages) {
     const text = textOfMessage(msg);
     if (!text) continue;
+    // Idle "while you were away" notes are persisted as assistant messages with
+    // a [while you were away] sentinel — render them as the distinct idle card
+    // (not a plain Lisa bubble) so they don't blend into her real replies.
+    if (msg.role !== 'user' && /^\[while you were away\]\s*/i.test(text)) {
+      const clean = text.replace(/^\[while you were away\]\s*/i, '');
+      fragment.appendChild(buildIdleBlock(clean, msg.at || msg.ts || null));
+      continue;
+    }
     const roleDiv = document.createElement('div');
     roleDiv.className = 'role ' + (msg.role === 'user' ? 'you' : 'lisa');
     roleDiv.textContent = msg.role === 'user' ? 'YOU' : 'LISA';
@@ -1157,7 +1183,11 @@ form.addEventListener('submit', (ev) => {
 });
 
 input.addEventListener('keydown', (ev) => {
-  if (ev.key === 'Enter' && !ev.shiftKey) {
+  // Enter sends — but NEVER while an IME composition is active (Chinese /
+  // Japanese / Korean input). That Enter is confirming a candidate from the
+  // IME popup, not sending the message. isComposing covers modern browsers;
+  // keyCode 229 is the legacy signal some IMEs still fire on the confirming key.
+  if (ev.key === 'Enter' && !ev.shiftKey && !ev.isComposing && ev.keyCode !== 229) {
     ev.preventDefault();
     form.dispatchEvent(new Event('submit'));
   }
@@ -1368,7 +1398,8 @@ if ('serviceWorker' in navigator) {
           inp.className = 'mc-send'; inp.type = 'text'; inp.placeholder = fam === 'pty' ? 'type into the CLI…' : 'send a follow-up…';
           inp.addEventListener('click', function (e) { e.stopPropagation(); });
           inp.addEventListener('keydown', function (e) {
-            if (e.key === 'Enter' && inp.value.trim()) { e.preventDefault(); agentAction(fam, id, 'send', { text: inp.value.trim() }); inp.value = ''; }
+            // Ignore the Enter that confirms an IME candidate (see main input).
+            if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && inp.value.trim()) { e.preventDefault(); agentAction(fam, id, 'send', { text: inp.value.trim() }); inp.value = ''; }
           });
           ctrl.appendChild(inp);
         }
@@ -1931,7 +1962,7 @@ if ('serviceWorker' in navigator) {
     Promise.all([getJSON('/api/island/ping'), getJSON('/api/agents/recap?sinceMinutes=' + encodeURIComponent(mins))]).then(function (res) {
       var ping = res[0] || {}; var recap = res[1] || {};
       var html = '';
-      if (ping.last_idle_message_text) html += '<div class="v-card"><h3>While you were away</h3><div style="font-size:13px;color:var(--fg);line-height:1.55">' + esc(ping.last_idle_message_text) + '</div></div>';
+      if (ping.last_idle_message_text) html += '<div class="v-card"><h3>' + esc(idleHeaderLabel()) + '</h3><div style="font-size:13px;color:var(--fg);line-height:1.55">' + esc(ping.last_idle_message_text) + '</div></div>';
       if (ping.current_desire) html += '<div class="v-card"><h3>Currently pursuing</h3><div style="font-size:13px;color:var(--fg)">' + esc(ping.current_desire) + '</div></div>';
       html += '<div class="v-card"><h3>Recap</h3><pre class="v-pre">' + esc(recap.text || 'No activity in this window.') + '</pre></div>';
       scroll.innerHTML = html;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -523,12 +523,36 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       );
       broadcast({ type: "idle_start", at: startedAt });
       try {
+        // Match the note's language to how the user actually writes (the most
+        // recent non-empty user message). Language-agnostic — Lisa mirrors it.
+        let userLanguageSample: string | undefined;
+        for (let i = history.length - 1; i >= 0; i--) {
+          const m = history[i];
+          if (!m || m.role !== "user") continue;
+          let t = "";
+          if (typeof m.content === "string") {
+            t = m.content;
+          } else if (Array.isArray(m.content)) {
+            t = m.content
+              .map((b) =>
+                b && typeof b === "object" && "text" in b && typeof b.text === "string"
+                  ? b.text
+                  : "",
+              )
+              .join(" ");
+          }
+          if (t.trim()) {
+            userLanguageSample = t.trim();
+            break;
+          }
+        }
         const result = await runIdleOnce({
           tools: opts.tools,
           cwd: process.cwd(),
           signal: abort.signal,
           model: opts.model,
           idleMs: watcher.idleFor(),
+          userLanguageSample,
         });
         if (result.silent) {
           console.error("[idle] (silent)");


### PR DESCRIPTION
Three fixes to the local chat UI, reported from daily use (mixed CN/EN typing + "while you were away" clutter).

### 1. IME composition Enter no longer sends
The chat input submitted on **any** Enter, so the Enter that confirms a Chinese/Japanese/Korean IME candidate also sent the half-typed message. Now guarded with `!ev.isComposing && ev.keyCode !== 229` (main input + agent inline-reply input).
**Verified in Chromium:** composing Enter → no send; legacy `keyCode 229` → no send; plain Enter → sends; `Shift+Enter` → newline.

### 2. "While you were away" notes stop blending into replies
Idle notes are persisted as assistant messages with a `[while you were away]` sentinel. The live SSE path rendered a distinct card, but **history reload** fell through to a plain LISA bubble — so on refresh they looked like part of her reply. Now `prependHistoryMessages` detects the sentinel and renders the same idle card.
Also: the idle runner **strips a trailing `(no update)`** — an internal-only run that didn't emit the marker cleanly (or appended it after real text) no longer leaks `(no update)` into the chat.

### 3. Reflection copy follows the user's language
The idle runner receives a sample of the user's most recent message and is told to write the note in **that** language — language-agnostic, she mirrors it (no locale detection). The idle-card **label** is localized to the UI language (zh/ja/ko/en) in the chat log and sidebar.

### Notes
- Idle cadence itself is unchanged (60-min default, fires once per idle window). The "too frequent" feel was accumulation + blending + the `(no update)` leak, all addressed here. If you want it rarer, `serve --web --idle-minutes N`.
- Typecheck clean; `build` green; client-JS syntax tests pass; logic unit-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)