### PR TITLE
fix(web): localize remaining 'while you were away' labels (island/room/push)

### DIFF
--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -549,7 +549,7 @@ export const ISLAND_HTML = `<!doctype html>
       <div class="section-body" id="desire-body">—</div>
     </div>
     <div id="idle-section">
-      <div class="section-label">★ while you were away</div>
+      <div class="section-label" id="idle-label">★ while you were away</div>
       <div id="idle-body"></div>
     </div>
     <div id="suggestion-section">
@@ -602,6 +602,13 @@ export const ISLAND_HTML = `<!doctype html>
   const expand       = document.getElementById('expand');
   const desireBody   = document.getElementById('desire-body');
   const idleBody     = document.getElementById('idle-body');
+  // Localize the "while you were away" label to the UI language.
+  (function () {
+    var l = (navigator.language || 'en').toLowerCase();
+    var t = l.indexOf('zh') === 0 ? '你不在的时候' : l.indexOf('ja') === 0 ? '不在のあいだに' : l.indexOf('ko') === 0 ? '자리를 비운 사이' : 'WHILE YOU WERE AWAY';
+    var el = document.getElementById('idle-label');
+    if (el) el.textContent = '★ ' + t;
+  })();
   const claudeList   = document.getElementById('claude-list');
   const claudeCount  = document.getElementById('claude-count');
   const notifyCta    = document.getElementById('notify-cta');

--- a/src/web/push.ts
+++ b/src/web/push.ts
@@ -470,8 +470,17 @@ export class PushBridge {
   }
 
   onIdleMessage(text: string): void {
+    // The note is written in the user's language (idle runner) — match the
+    // notification title to it. Hangul → ko; kana → ja; Han-only → zh; else en.
+    const title = /[가-힯]/.test(text)
+      ? "Lisa — 자리를 비운 사이"
+      : /[぀-ヿ]/.test(text)
+        ? "Lisa — 不在のあいだに"
+        : /[一-鿿]/.test(text)
+          ? "Lisa — 你不在的时候"
+          : "Lisa — while you were away";
     this.fire(
-      { pref: "idle", title: "Lisa — while you were away", body: text.slice(0, 200), priority: "default", tag: "idle" },
+      { pref: "idle", title, body: text.slice(0, 200), priority: "default", tag: "idle" },
       `idle#${this.now()}`,
     );
   }

--- a/src/web/room.ts
+++ b/src/web/room.ts
@@ -417,7 +417,7 @@ export const ROOM_HTML = `<!doctype html>
   <div id="desire"><span class="star">✦</span><span class="txt" id="desire-txt"></span></div>
 
   <div id="reader"><div class="card">
-    <h3>★ while you were away</h3>
+    <h3 id="reader-title">★ while you were away</h3>
     <div id="reader-text"></div>
     <span class="close" id="reader-close">Close</span>
   </div></div>
@@ -437,6 +437,13 @@ export const ROOM_HTML = `<!doctype html>
 <script>
 (() => {
   var $ = function (id) { return document.getElementById(id); };
+  // Localize the reader's "while you were away" title to the UI language.
+  (function () {
+    var l = (navigator.language || 'en').toLowerCase();
+    var t = l.indexOf('zh') === 0 ? '你不在的时候' : l.indexOf('ja') === 0 ? '不在のあいだに' : l.indexOf('ko') === 0 ? '자리를 비운 사이' : 'WHILE YOU WERE AWAY';
+    var el = $('reader-title');
+    if (el) el.textContent = '★ ' + t;
+  })();
   var body = document.body;
   var lisa = $('lisa'), doing = $('doing'), dot = $('dot');
   var stage = $('stage');


### PR DESCRIPTION
Follow-up to #229. Localizes the idle label on the three secondary surfaces so every surface follows the user's language: **island** + **Lisa Room** reader client-side via `navigator.language` (zh/ja/ko/en); **push notification** title server-side by detecting the note's script (the body is already in the user's language). Typecheck clean, build green, inline-script syntax tests pass, heuristic unit-checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)