### PR TITLE
fix(web): notebook icon for the Memory nav item (was a star)

### DIFF
--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -76,7 +76,7 @@ ${MAIN_CSS}
       <button class="nav-item" type="button" data-view="reve"><span class="nav-ico">☾</span>Rêve</button>
       <button class="nav-item" type="button" data-view="room"><span class="nav-ico">⌂</span>Room</button>
       <button class="nav-item" type="button" data-view="sense"><span class="nav-ico">◉</span>Sense</button>
-      <button class="nav-item" type="button" data-view="memory"><span class="nav-ico">✦</span>Memory</button>
+      <button class="nav-item" type="button" data-view="memory"><span class="nav-ico"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="display:block;margin:auto"><path d="M2 6h4M2 10h4M2 14h4M2 18h4"/><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M16 2v20"/></svg></span>Memory</button>
     </nav>
 
     <!-- Currently wanting -->


### PR DESCRIPTION
The Memory sidebar item used a ✦ star glyph; swap it for an inline notebook SVG that reads as a diary/notebook. Uses `currentColor` + stroke so it stays monochrome with the other nav icons and turns accent-colored when active (previewed both states). `MAIN_HTML` still parses; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)