### PR TITLE
fix(web): correct regex escaping so idle notes render as cards (follow-up to #229)

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -715,8 +715,8 @@ function prependHistoryMessages(messages) {
     // Idle "while you were away" notes are persisted as assistant messages with
     // a [while you were away] sentinel — render them as the distinct idle card
     // (not a plain Lisa bubble) so they don't blend into her real replies.
-    if (msg.role !== 'user' && /^\[while you were away\]\s*/i.test(text)) {
-      const clean = text.replace(/^\[while you were away\]\s*/i, '');
+    if (msg.role !== 'user' && /^\\[while you were away\\]\\s*/i.test(text)) {
+      const clean = text.replace(/^\\[while you were away\\]\\s*/i, '');
       fragment.appendChild(buildIdleBlock(clean, msg.at || msg.ts || null));
       continue;
     }


### PR DESCRIPTION
#229 added idle-note detection on history reload, but it never fired on the live app. The client is a **template-literal string** (`MAIN_CLIENT_JS`), so `/^\[while you were away\]\s*/i` written with single backslashes had its escapes eaten on evaluation → `/^[while you were away]s*/i` (a character class that can't match a leading `[`). Idle notes kept rendering as plain bubbles.

Fix: double-escape (matching the existing `\\s+` convention in the file). Verified by evaluating `MAIN_CLIENT_JS` — the regex comes out `/^\[while you were away\]\s*/i` and matches a real note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)