### PR TITLE
fix(cli): route mail subcommand flags to its handler (--email no longer "unknown flag")

### DIFF
--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -1,0 +1,72 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { parseArgs } from "./cli-args.js";
+
+describe("parseArgs — raw / passthrough subcommand routing", () => {
+  test("mail: every trailing flag reaches the handler verbatim, even would-be global ones", () => {
+    const a = parseArgs([
+      "mail", "connect",
+      "--email", "me@gmail.com",
+      "--host", "imap.gmail.com",
+      "--port", "993",
+      "--provider", "gmail",
+    ]);
+    assert.equal(a.subcommand, "mail");
+    assert.deepEqual(a.subargs, [
+      "connect",
+      "--email", "me@gmail.com",
+      "--host", "imap.gmail.com",
+      "--port", "993",
+      "--provider", "gmail",
+    ]);
+    // …and none of those were consumed as global settings:
+    assert.equal(a.host, "127.0.0.1");
+    assert.equal(a.port, 5757);
+  });
+
+  test("autostart: recognized global flags are parsed into the global fields (not swallowed)", () => {
+    const a = parseArgs([
+      "autostart", "install",
+      "--port", "8080",
+      "--channels", "imessage,sms",
+      "--imessage",
+    ]);
+    assert.equal(a.subcommand, "autostart");
+    assert.deepEqual(a.subargs, ["install"]);
+    assert.equal(a.port, 8080);
+    assert.deepEqual(a.serveChannels, ["imessage", "sms"]);
+    assert.equal(a.serveImessage, true);
+  });
+
+  test("autostart: an unrecognized flag is still collected verbatim for the handler", () => {
+    const a = parseArgs(["autostart", "install", "--no-load"]);
+    assert.deepEqual(a.subargs, ["install", "--no-load"]);
+  });
+
+  test("heartbeat: --model is parsed globally, not swallowed into subargs", () => {
+    const a = parseArgs(["heartbeat", "run", "--model", "claude-test"]);
+    assert.equal(a.subcommand, "heartbeat");
+    assert.deepEqual(a.subargs, ["run"]);
+    assert.equal(a.model, "claude-test");
+    assert.equal(a.modelExplicit, true);
+  });
+
+  test("global flags before the subcommand still apply", () => {
+    const a = parseArgs(["--model", "claude-test", "mail", "connect", "--email", "me@x.com"]);
+    assert.equal(a.model, "claude-test");
+    assert.equal(a.subcommand, "mail");
+    assert.deepEqual(a.subargs, ["connect", "--email", "me@x.com"]);
+  });
+
+  test("an unknown flag in global position throws", () => {
+    assert.throws(() => parseArgs(["--totallybogus"]), /unknown flag: --totallybogus/);
+  });
+
+  test("a flag value that happens to match a subcommand name is not misread as a subcommand", () => {
+    // --model consumes its value, so 'mail' here is the model, not a subcommand.
+    const a = parseArgs(["--model", "mail", "hello", "world"]);
+    assert.equal(a.model, "mail");
+    assert.equal(a.subcommand, undefined);
+    assert.equal(a.prompt, "hello world");
+  });
+});

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -1,0 +1,208 @@
+/**
+ * CLI argument parsing — pure, so it is unit-testable without importing the CLI
+ * entrypoint (`cli.ts` runs `main()` on import). `cli.ts` re-exports nothing but
+ * consumes `parseArgs`/`ParsedArgs` from here.
+ */
+import type { ApprovalMode } from "./approval.js";
+import { DEFAULT_MODEL } from "./llm.js";
+
+export interface ParsedArgs {
+  showHelp: boolean;
+  reflect: boolean;
+  thinking: boolean;
+  compaction: boolean;
+  model: string;
+  approval: ApprovalMode;
+  loadMcp: boolean;
+  loadPlugins: boolean;
+  voice: boolean;
+  idleMinutes: number;
+  /** True when --model was passed, so a LISA_MODEL default from config.env won't override it. */
+  modelExplicit: boolean;
+  subcommand?:
+    | "resume"
+    | "sessions"
+    | "serve"
+    | "heartbeat"
+    | "autostart"
+    | "search"
+    | "birth"
+    | "soul"
+    | "channels"
+    | "skills"
+    | "wishlist"
+    | "status"
+    | "doctor"
+    | "monitor"
+    | "autonomy"
+    | "model"
+    | "consent"
+    | "sense"
+    | "agents"
+    | "pair"
+    | "mail";
+  subargs: string[];
+  serveWeb: boolean;
+  serveImessage: boolean;
+  serveChannels: string[];
+  port: number;
+  host: string;
+  prompt: string | null;
+}
+
+/**
+ * Subcommands that parse a few *recognized* global flags out of their trailing
+ * args (`autostart install --port/--channels/--imessage`, `heartbeat run
+ * --model`), so those must still reach the global parser — only *unrecognized*
+ * trailing flags are collected verbatim for the handler.
+ */
+const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart"]);
+
+/**
+ * Subcommands whose handler re-parses *all* of its trailing args itself, so
+ * every token after it must be collected verbatim — even ones that look like
+ * global flags (`mail connect --host/--port/--provider …`), which would
+ * otherwise be swallowed as global settings and never reach the handler.
+ */
+const PASSTHROUGH_SUBCOMMANDS = new Set(["mail"]);
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const out: ParsedArgs = {
+    showHelp: false,
+    reflect: true,
+    thinking: false,
+    compaction: false,
+    model: DEFAULT_MODEL,
+    modelExplicit: false,
+    approval: "auto",
+    loadMcp: true,
+    loadPlugins: true,
+    voice: false,
+    idleMinutes: 60,
+    subargs: [],
+    serveWeb: false,
+    serveImessage: false,
+    serveChannels: [],
+    port: 5757,
+    host: "127.0.0.1",
+    prompt: null,
+  };
+  const positional: string[] = [];
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i]!;
+    // Once a full-passthrough subcommand (mail) has appeared, every following
+    // token is command-specific — collect it verbatim so global flag parsing
+    // (e.g. --provider, --host, --email) cannot swallow or reject the
+    // subcommand's own flags. Global flags still apply before the subcommand.
+    // (heartbeat/autostart are NOT here: they read a few recognized global
+    // flags — --port/--channels/--imessage/--model — so those must fall through
+    // to the parser below; only their *unrecognized* flags are collected, in
+    // the --flag branch.)
+    if (positional.some((p) => PASSTHROUGH_SUBCOMMANDS.has(p))) {
+      positional.push(arg);
+      continue;
+    }
+    if (arg === "--help" || arg === "-h") out.showHelp = true;
+    else if (arg === "--no-reflect") out.reflect = false;
+    else if (arg === "--think" || arg === "--thinking") out.thinking = true;
+    else if (arg === "--compact") out.compaction = true;
+    else if (arg === "--no-mcp") out.loadMcp = false;
+    else if (arg === "--no-plugins") out.loadPlugins = false;
+    else if (arg === "--voice") out.voice = true;
+    else if (arg === "--no-idle") out.idleMinutes = 0;
+    else if (arg === "--idle") {
+      const v = mustNext(argv, ++i, "--idle");
+      const n = parseInt(v, 10);
+      if (!Number.isFinite(n) || n < 0) throw new Error(`bad --idle: ${v}`);
+      out.idleMinutes = n;
+    }
+    else if (arg === "--web") out.serveWeb = true;
+    else if (arg === "--imessage") out.serveImessage = true;
+    else if (arg === "--channels") {
+      out.serveChannels = mustNext(argv, ++i, "--channels")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (arg.startsWith("--channels=")) {
+      out.serveChannels = arg
+        .slice("--channels=".length)
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    }
+    else if (arg === "--model") {
+      out.model = mustNext(argv, ++i, "--model");
+      out.modelExplicit = true;
+    } else if (arg.startsWith("--model=")) {
+      out.model = arg.slice("--model=".length);
+      out.modelExplicit = true;
+    }
+    else if (arg === "--provider") {
+      const v = mustNext(argv, ++i, "--provider");
+      process.env.LISA_PROVIDER = v;
+    } else if (arg === "--approval") {
+      const v = mustNext(argv, ++i, "--approval") as ApprovalMode;
+      if (!["auto", "ask", "ask-mutating"].includes(v)) {
+        throw new Error(`bad --approval mode: ${v}`);
+      }
+      out.approval = v;
+    } else if (arg === "--port") {
+      out.port = parseInt(mustNext(argv, ++i, "--port"), 10);
+    } else if (arg === "--host") {
+      out.host = mustNext(argv, ++i, "--host");
+    } else if (arg.startsWith("--host=")) {
+      out.host = arg.slice("--host=".length);
+    } else if (arg.startsWith("--")) {
+      // An unrecognized --flag. After a raw-args subcommand (heartbeat/
+      // autostart) it's command-specific — collect it verbatim instead of
+      // rejecting (e.g. `autostart install --no-load`). Otherwise it's a
+      // genuine unknown global flag. (mail's flags never reach here — they're
+      // collected wholesale by the passthrough guard at the top of the loop.)
+      if (positional.some((p) => RAW_SUBCOMMANDS.has(p))) {
+        positional.push(arg);
+      } else {
+        throw new Error(`unknown flag: ${arg}`);
+      }
+    } else {
+      positional.push(arg);
+    }
+  }
+  if (positional.length > 0) {
+    const first = positional[0]!;
+    if (
+      first === "resume" ||
+      first === "sessions" ||
+      first === "serve" ||
+      first === "heartbeat" ||
+      first === "autostart" ||
+      first === "search" ||
+      first === "birth" ||
+      first === "soul" ||
+      first === "channels" ||
+      first === "skills" ||
+      first === "wishlist" ||
+      first === "status" ||
+      first === "doctor" ||
+      first === "monitor" ||
+      first === "autonomy" ||
+      first === "model" ||
+      first === "consent" ||
+      first === "sense" ||
+      first === "agents" ||
+      first === "pair" ||
+      first === "mail"
+    ) {
+      out.subcommand = first;
+      out.subargs = positional.slice(1);
+    } else {
+      out.prompt = positional.join(" ");
+    }
+  }
+  return out;
+}
+
+function mustNext(argv: string[], idx: number, flag: string): string {
+  const v = argv[idx];
+  if (!v) throw new Error(`${flag} requires a value`);
+  return v;
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -187,9 +187,9 @@ interface ParsedArgs {
 }
 
 /** Subcommands whose trailing flags are command-specific, not global. */
-const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart"]);
+const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart", "mail"]);
 
-function parseArgs(argv: string[]): ParsedArgs {
+export function parseArgs(argv: string[]): ParsedArgs {
   const out: ParsedArgs = {
     showHelp: false,
     reflect: true,
@@ -213,6 +213,14 @@ function parseArgs(argv: string[]): ParsedArgs {
   const positional: string[] = [];
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i]!;
+    // Once a raw-args subcommand (heartbeat / autostart / mail) has appeared,
+    // every following token is command-specific — collect it verbatim so global
+    // flag parsing (e.g. --provider, --host, --email) cannot swallow or reject
+    // the subcommand's own flags. Global flags still apply before the subcommand.
+    if (positional.some((p) => RAW_SUBCOMMANDS.has(p))) {
+      positional.push(arg);
+      continue;
+    }
     if (arg === "--help" || arg === "-h") out.showHelp = true;
     else if (arg === "--no-reflect") out.reflect = false;
     else if (arg === "--think" || arg === "--thinking") out.thinking = true;
@@ -264,15 +272,9 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg.startsWith("--host=")) {
       out.host = arg.slice("--host=".length);
     } else if (arg.startsWith("--")) {
-      // Flags after a raw-args subcommand (heartbeat/autostart) are
-      // command-specific, not global — collect them verbatim instead of
-      // rejecting. (Without this, `heartbeat install --load` threw before
-      // its handler ever saw the flag.)
-      if (positional.some((p) => RAW_SUBCOMMANDS.has(p))) {
-        positional.push(arg);
-      } else {
-        throw new Error(`unknown flag: ${arg}`);
-      }
+      // An unrecognized --flag in global position (before any raw-args
+      // subcommand). Command-specific flags are captured by the guard above.
+      throw new Error(`unknown flag: ${arg}`);
     } else {
       positional.push(arg);
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,12 +10,13 @@ import { dirname, resolve as resolvePath } from "node:path";
 import { configureProxyFromEnv } from "./proxy-bootstrap.js";
 configureProxyFromEnv({ log: (m) => console.error(m) });
 import { runAgent } from "./agent.js";
-import { buildApprovalCallback, type ApprovalMode, DEFAULT_MUTATING_TOOLS, DEFAULT_MUTATING_ACTIONS } from "./approval.js";
+import { buildApprovalCallback, DEFAULT_MUTATING_TOOLS, DEFAULT_MUTATING_ACTIONS } from "./approval.js";
 import { CONFIG_ENV_PATH, loadConfigEnv } from "./env.js";
 import { ensureDir } from "./fs-utils.js";
 import { runHeartbeatOnce } from "./heartbeat/runner.js";
 import { fireHooks } from "./hooks/runner.js";
 import { DEFAULT_MODEL } from "./llm.js";
+import { parseArgs, type ParsedArgs } from "./cli-args.js";
 import { connectMcpServers } from "./mcp/client.js";
 import { loadMcpConfig } from "./mcp/config.js";
 import { LISA_HOME } from "./paths.js";
@@ -141,183 +142,6 @@ Plugins: ${PLUGINS_ROOT}/<name>/{commands,agents,skills,hooks,.lisa-plugin/plugi
 MCP:     ${LISA_HOME}/mcp.json   (Claude-Code-style {"mcpServers": {...}})
 Heartbeat: ${LISA_HOME}/heartbeat.json   ({"tasks": [{name, prompt, ...}]})
 Config:  ${CONFIG_ENV_PATH}   (KEY=VALUE)`;
-
-interface ParsedArgs {
-  showHelp: boolean;
-  reflect: boolean;
-  thinking: boolean;
-  compaction: boolean;
-  model: string;
-  approval: ApprovalMode;
-  loadMcp: boolean;
-  loadPlugins: boolean;
-  voice: boolean;
-  idleMinutes: number;
-  /** True when --model was passed, so a LISA_MODEL default from config.env won't override it. */
-  modelExplicit: boolean;
-  subcommand?:
-    | "resume"
-    | "sessions"
-    | "serve"
-    | "heartbeat"
-    | "autostart"
-    | "search"
-    | "birth"
-    | "soul"
-    | "channels"
-    | "skills"
-    | "wishlist"
-    | "status"
-    | "doctor"
-    | "monitor"
-    | "autonomy"
-    | "model"
-    | "consent"
-    | "sense"
-    | "agents"
-    | "pair"
-    | "mail";
-  subargs: string[];
-  serveWeb: boolean;
-  serveImessage: boolean;
-  serveChannels: string[];
-  port: number;
-  host: string;
-  prompt: string | null;
-}
-
-/** Subcommands whose trailing flags are command-specific, not global. */
-const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart", "mail"]);
-
-export function parseArgs(argv: string[]): ParsedArgs {
-  const out: ParsedArgs = {
-    showHelp: false,
-    reflect: true,
-    thinking: false,
-    compaction: false,
-    model: DEFAULT_MODEL,
-    modelExplicit: false,
-    approval: "auto",
-    loadMcp: true,
-    loadPlugins: true,
-    voice: false,
-    idleMinutes: 60,
-    subargs: [],
-    serveWeb: false,
-    serveImessage: false,
-    serveChannels: [],
-    port: 5757,
-    host: "127.0.0.1",
-    prompt: null,
-  };
-  const positional: string[] = [];
-  for (let i = 0; i < argv.length; i++) {
-    const arg = argv[i]!;
-    // Once a raw-args subcommand (heartbeat / autostart / mail) has appeared,
-    // every following token is command-specific — collect it verbatim so global
-    // flag parsing (e.g. --provider, --host, --email) cannot swallow or reject
-    // the subcommand's own flags. Global flags still apply before the subcommand.
-    if (positional.some((p) => RAW_SUBCOMMANDS.has(p))) {
-      positional.push(arg);
-      continue;
-    }
-    if (arg === "--help" || arg === "-h") out.showHelp = true;
-    else if (arg === "--no-reflect") out.reflect = false;
-    else if (arg === "--think" || arg === "--thinking") out.thinking = true;
-    else if (arg === "--compact") out.compaction = true;
-    else if (arg === "--no-mcp") out.loadMcp = false;
-    else if (arg === "--no-plugins") out.loadPlugins = false;
-    else if (arg === "--voice") out.voice = true;
-    else if (arg === "--no-idle") out.idleMinutes = 0;
-    else if (arg === "--idle") {
-      const v = mustNext(argv, ++i, "--idle");
-      const n = parseInt(v, 10);
-      if (!Number.isFinite(n) || n < 0) throw new Error(`bad --idle: ${v}`);
-      out.idleMinutes = n;
-    }
-    else if (arg === "--web") out.serveWeb = true;
-    else if (arg === "--imessage") out.serveImessage = true;
-    else if (arg === "--channels") {
-      out.serveChannels = mustNext(argv, ++i, "--channels")
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-    } else if (arg.startsWith("--channels=")) {
-      out.serveChannels = arg
-        .slice("--channels=".length)
-        .split(",")
-        .map((s) => s.trim())
-        .filter(Boolean);
-    }
-    else if (arg === "--model") {
-      out.model = mustNext(argv, ++i, "--model");
-      out.modelExplicit = true;
-    } else if (arg.startsWith("--model=")) {
-      out.model = arg.slice("--model=".length);
-      out.modelExplicit = true;
-    }
-    else if (arg === "--provider") {
-      const v = mustNext(argv, ++i, "--provider");
-      process.env.LISA_PROVIDER = v;
-    } else if (arg === "--approval") {
-      const v = mustNext(argv, ++i, "--approval") as ApprovalMode;
-      if (!["auto", "ask", "ask-mutating"].includes(v)) {
-        throw new Error(`bad --approval mode: ${v}`);
-      }
-      out.approval = v;
-    } else if (arg === "--port") {
-      out.port = parseInt(mustNext(argv, ++i, "--port"), 10);
-    } else if (arg === "--host") {
-      out.host = mustNext(argv, ++i, "--host");
-    } else if (arg.startsWith("--host=")) {
-      out.host = arg.slice("--host=".length);
-    } else if (arg.startsWith("--")) {
-      // An unrecognized --flag in global position (before any raw-args
-      // subcommand). Command-specific flags are captured by the guard above.
-      throw new Error(`unknown flag: ${arg}`);
-    } else {
-      positional.push(arg);
-    }
-  }
-  if (positional.length > 0) {
-    const first = positional[0]!;
-    if (
-      first === "resume" ||
-      first === "sessions" ||
-      first === "serve" ||
-      first === "heartbeat" ||
-      first === "autostart" ||
-      first === "search" ||
-      first === "birth" ||
-      first === "soul" ||
-      first === "channels" ||
-      first === "skills" ||
-      first === "wishlist" ||
-      first === "status" ||
-      first === "doctor" ||
-      first === "monitor" ||
-      first === "autonomy" ||
-      first === "model" ||
-      first === "consent" ||
-      first === "sense" ||
-      first === "agents" ||
-      first === "pair" ||
-      first === "mail"
-    ) {
-      out.subcommand = first;
-      out.subargs = positional.slice(1);
-    } else {
-      out.prompt = positional.join(" ");
-    }
-  }
-  return out;
-}
-
-function mustNext(argv: string[], idx: number, flag: string): string {
-  const v = argv[idx];
-  if (!v) throw new Error(`${flag} requires a value`);
-  return v;
-}
 
 function readPackageVersion(): string {
   try {


### PR DESCRIPTION
## Problem

`lisa mail connect --email you@gmail.com` fails with:

```
unknown flag: --email
```

`mail` is dispatched as a subcommand whose args are handed **verbatim** to `runMailCommand` (`cli.ts`), but it was **missing from `RAW_SUBCOMMANDS`**. So the top-level flag parser ran first and:

- **rejected** `--email` / `--pass` / `--client-id` / `--client-secret` / `--label` as "unknown flag", and
- **silently swallowed** `--provider` / `--host` / `--port` as *global* flags, so they never reached the mail handler (e.g. `--provider gmail` set the global provider instead of selecting the Gmail OAuth flow).

Net effect: the entire `lisa mail connect` CLI was unusable in 0.16.0.

## Fix

- Add `mail` to `RAW_SUBCOMMANDS`.
- Once **any** raw-args subcommand token has appeared, collect every following token verbatim, so global-flag handlers can no longer steal a subcommand's own flags. (This also fully realizes the pre-existing "flags after a raw subcommand are command-specific" intent that `heartbeat` / `autostart` only got partially.)
- Simplify the now-dead raw branch; export `parseArgs`.

Global flags **before** the subcommand still apply (e.g. `lisa --model X mail connect …`), and an unrecognized `--flag` in global position still throws.

## Verification

```
$ lisa mail connect --email wangharp@gmail.com --pass … --host imap.gmail.com
✓ connected wangharp@gmail.com (gmail-xxxxxx). Mail consent granted.
```

- `--totallybogusflag` in global position → still `unknown flag` ✓
- `heartbeat … --flag` pass-through → unaffected ✓
- `tsc --noEmit` clean · full test suite 919/919 ✓
