### PR TITLE
feat(kb): knowledge-base storage foundation (Karpathy 3-layer)

### DIFF
--- a/src/kb/git.ts
+++ b/src/kb/git.ts
@@ -1,0 +1,59 @@
+/**
+ * Best-effort git provenance for the knowledge base.
+ *
+ * The KB is its own git repo at ~/.lisa/kb/.git (separate from soul's). Every
+ * mutation records a commit so the user can see how their knowledge evolved.
+ * This is entirely best-effort: git may be missing, the repo may be in a weird
+ * state, hooks may fail — none of that must ever break a KB write, so every
+ * call swallows its errors. Callers already hold the KB write-lock, so commits
+ * are serialized (no separate git lock needed).
+ *
+ * Set LISA_KB_NO_GIT=1 to disable entirely (tests, or users who don't want a repo).
+ */
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import path from "node:path";
+import { ensureDir, pathExists } from "../fs-utils.js";
+import { KB_DIR } from "./paths.js";
+
+const pexec = promisify(execFile);
+
+function gitDisabled(): boolean {
+  return process.env.LISA_KB_NO_GIT === "1";
+}
+
+async function git(args: string[]): Promise<void> {
+  try {
+    await pexec("git", args, { cwd: KB_DIR, timeout: 10_000 });
+  } catch {
+    // best-effort — provenance is a nicety, never a blocker
+  }
+}
+
+let repoReady = false;
+
+/** Idempotent: create the KB dir and init a git repo with a stable identity. */
+export async function ensureKbRepo(): Promise<void> {
+  if (repoReady || gitDisabled()) return;
+  repoReady = true;
+  try {
+    await ensureDir(KB_DIR);
+    if (!(await pathExists(path.join(KB_DIR, ".git")))) {
+      await git(["init", "-q"]);
+      await git(["config", "user.name", "Lisa"]);
+      await git(["config", "user.email", "lisa@self"]);
+      await git(["config", "commit.gpgsign", "false"]);
+    }
+  } catch {
+    // ignore — commitKb calls are also best-effort
+  }
+}
+
+/** Stage everything under the KB and commit. No-op if nothing changed. */
+export async function commitKb(message: string): Promise<void> {
+  if (gitDisabled()) return;
+  await ensureKbRepo();
+  await git(["add", "-A"]);
+  // `git commit` exits non-zero when there's nothing staged — swallowed by git().
+  await git(["commit", "-q", "-m", message, "--no-gpg-sign"]);
+}

--- a/src/kb/paths.ts
+++ b/src/kb/paths.ts
@@ -1,0 +1,37 @@
+import path from "node:path";
+import { LISA_HOME } from "../paths.js";
+import { assertSafeSlug } from "../soul/slug.js";
+
+/**
+ * Personal knowledge base — the user-owned, Karpathy-style 3-layer store.
+ * Lives under ~/.lisa/kb/ as its own directory (and its own git repo for
+ * provenance), separate from soul/ so a large KB never bloats soul history and
+ * the privacy boundary stays clean (soul = Lisa's private self, kb = shared).
+ *
+ * Layers (see docs/PLAN_KNOWLEDGE_BASE_v1.0.md):
+ *   sources/  — Layer 1, immutable raw captures (chat excerpts, pasted docs)
+ *   wiki/     — Layer 2, Lisa-maintained concept/entity/synthesis pages
+ *   SCHEMA.md — Layer 3, the rules doc telling Lisa how to work the KB
+ *   index.md  — generated table-of-contents (kept small, injected always-on)
+ */
+export const KB_DIR = path.join(LISA_HOME, "kb");
+export const KB_SOURCES_DIR = path.join(KB_DIR, "sources");
+export const KB_WIKI_DIR = path.join(KB_DIR, "wiki");
+export const KB_SCHEMA_FILE = path.join(KB_DIR, "SCHEMA.md");
+export const KB_INDEX_FILE = path.join(KB_DIR, "index.md");
+export const KB_LOCK_PATH = path.join(KB_DIR, ".write.lock");
+
+export type KbLayer = "sources" | "wiki";
+
+export function layerDir(layer: KbLayer): string {
+  return layer === "sources" ? KB_SOURCES_DIR : KB_WIKI_DIR;
+}
+
+/**
+ * Filesystem path for an entry. The slug is run through assertSafeSlug (the
+ * shared path-traversal gate) so a slug like "../../etc/x" throws rather than
+ * escaping the KB dir — this is the single chokepoint jailing every KB write.
+ */
+export function entryFile(layer: KbLayer, slug: string): string {
+  return path.join(layerDir(layer), `${assertSafeSlug(slug)}.md`);
+}

--- a/src/kb/schema.ts
+++ b/src/kb/schema.ts
@@ -1,0 +1,59 @@
+/**
+ * Layer 3 — the KB "schema": a rules doc (like Karpathy's CLAUDE.md) that tells
+ * Lisa how the knowledge base is organized and the workflows to follow. Seeded
+ * with a sane default on first use; both the user and Lisa may edit it. It is
+ * injected always-on (see the prompt integration) so Lisa always knows the rules.
+ */
+import { atomicWrite, pathExists, readTextOrEmpty } from "../fs-utils.js";
+import { KB_SCHEMA_FILE } from "./paths.js";
+
+export const DEFAULT_SCHEMA = `# Knowledge base — schema & conventions
+
+This is the user's personal knowledge base. It has three layers:
+
+1. **Sources** (\`sources/\`) — raw, immutable captures: chat excerpts the user
+   saved, pasted notes, documents. **Never edit or delete a source** — it is the
+   user's own words, the source of truth. Read from it.
+2. **Wiki** (\`wiki/\`) — the pages you maintain: concepts, entities, syntheses,
+   overviews. **You own this layer.** Create and update pages from the sources
+   AND from what you know about the user (your memory + journal). One idea per
+   page; cross-link with \`[[slug]]\`; list the sources a page draws on in its
+   \`sources:\` frontmatter.
+3. This file (\`SCHEMA.md\`) — the rules. You and the user may edit it.
+
+## Workflows
+
+- **Answering from the KB.** The always-on \`index.md\` shows what exists. Reach
+  for \`kb_search\` / \`kb_read\` when a question touches the user's own knowledge.
+  Prefer the wiki for distilled answers; fall back to sources for specifics.
+- **Ingesting a new source.** When new sources appear, fold their content into
+  the relevant wiki page(s) with \`kb_write\` — create a page if none fits.
+  Reconcile contradictions, don't just append; cite the source slugs.
+- **Tending the wiki.** During reflection / idle time, review recent sources and
+  your own memory + journal, and keep the wiki current, consistent, cross-linked.
+
+## Conventions
+
+- Titles are human-readable; slugs are lowercase-dashed and stable.
+- Add a few \`tags:\` to every page for retrieval.
+- Wiki pages are for the user to read — write clearly, lead with the gist.
+- This KB is 100% local, under ~/.lisa/kb. Never send it anywhere.
+`;
+
+/** The schema text, or the built-in default if the user hasn't customized it. */
+export async function readSchema(): Promise<string> {
+  const text = await readTextOrEmpty(KB_SCHEMA_FILE);
+  return text.trim() ? text : DEFAULT_SCHEMA;
+}
+
+/** Write the default schema if none exists yet. Idempotent. */
+export async function ensureSchema(): Promise<void> {
+  if (!(await pathExists(KB_SCHEMA_FILE))) {
+    await atomicWrite(KB_SCHEMA_FILE, DEFAULT_SCHEMA);
+  }
+}
+
+/** Replace the schema (user or Lisa editing the rules). */
+export async function writeSchema(content: string): Promise<void> {
+  await atomicWrite(KB_SCHEMA_FILE, content.trimEnd() + "\n");
+}

--- a/src/kb/store.test.ts
+++ b/src/kb/store.test.ts
@@ -1,0 +1,113 @@
+import { test, describe, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// Point LISA_HOME at a temp dir and disable git BEFORE importing the modules
+// under test, so paths.ts (evaluated at import) resolves KB_DIR there. node's
+// test runner isolates each file in its own process, so this can't leak.
+const TMP = mkdtempSync(path.join(os.tmpdir(), "lisa-kb-test-"));
+process.env.LISA_HOME = TMP;
+process.env.LISA_KB_NO_GIT = "1";
+
+const store = await import("./store.js");
+const { KB_DIR, KB_SCHEMA_FILE, KB_INDEX_FILE, entryFile } = await import("./paths.js");
+
+after(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("kb store", () => {
+  test("addSource writes an immutable Layer-1 capture with frontmatter", async () => {
+    const e = await store.addSource({
+      title: "OAuth PKCE notes",
+      body: "PKCE adds a code_verifier / code_challenge to the auth-code flow.",
+      tags: ["oauth", "security"],
+      origin: "chat:sess-1",
+    });
+    assert.equal(e.layer, "sources");
+    assert.equal(e.slug, "oauth-pkce-notes");
+    assert.ok(e.created, "has a created timestamp");
+
+    const back = await store.readEntry("sources", "oauth-pkce-notes");
+    assert.ok(back);
+    assert.equal(back.title, "OAuth PKCE notes");
+    assert.deepEqual(back.tags, ["oauth", "security"]);
+    assert.equal(back.origin, "chat:sess-1");
+    assert.match(back.body, /code_verifier/);
+
+    // Raw file has a frontmatter block.
+    const raw = readFileSync(entryFile("sources", "oauth-pkce-notes"), "utf8");
+    assert.match(raw, /^---\ntitle: OAuth PKCE notes\n/);
+    assert.match(raw, /tags: \[oauth, security\]/);
+  });
+
+  test("addSource never overwrites — a colliding title gets a unique slug", async () => {
+    const a = await store.addSource({ title: "Dup", body: "first" });
+    const b = await store.addSource({ title: "Dup", body: "second" });
+    assert.equal(a.slug, "dup");
+    assert.equal(b.slug, "dup-2");
+    assert.equal((await store.readEntry("sources", "dup"))!.body, "first");
+    assert.equal((await store.readEntry("sources", "dup-2"))!.body, "second");
+  });
+
+  test("writeWiki upserts a Layer-2 page by slug", async () => {
+    const first = await store.writeWiki({
+      title: "OAuth",
+      body: "OAuth 2.0 is an authorization framework.",
+      tags: ["oauth"],
+      sources: ["oauth-pkce-notes"],
+    });
+    assert.equal(first.slug, "oauth");
+    assert.ok(first.updated);
+
+    // Same slug → update, not duplicate.
+    const updated = await store.writeWiki({
+      slug: "oauth",
+      title: "OAuth 2.0",
+      body: "OAuth 2.0 is an authorization framework. PKCE hardens the code flow.",
+    });
+    assert.equal(updated.slug, "oauth");
+    const wiki = await store.listEntries("wiki");
+    assert.equal(wiki.filter((w) => w.slug === "oauth").length, 1, "no duplicate");
+    assert.equal((await store.readEntry("wiki", "oauth"))!.title, "OAuth 2.0");
+    assert.match((await store.readEntry("wiki", "oauth"))!.body, /PKCE hardens/);
+  });
+
+  test("listEntries filters by layer and sorts newest-first", async () => {
+    const wiki = await store.listEntries("wiki");
+    assert.ok(wiki.every((e) => e.layer === "wiki"));
+    const sources = await store.listEntries("sources");
+    assert.ok(sources.every((e) => e.layer === "sources"));
+    assert.ok(sources.length >= 3);
+    // excerpt is present and bounded
+    assert.ok(sources[0]!.excerpt.length <= 160);
+  });
+
+  test("ensureScaffold seeds the schema and dirs", async () => {
+    await store.ensureKbScaffold();
+    assert.ok(existsSync(KB_SCHEMA_FILE), "SCHEMA.md seeded");
+    assert.ok(existsSync(path.join(KB_DIR, "sources")));
+    assert.ok(existsSync(path.join(KB_DIR, "wiki")));
+  });
+
+  test("index.md is regenerated with wiki titles + counts", async () => {
+    assert.ok(existsSync(KB_INDEX_FILE), "index.md exists after a write");
+    const idx = readFileSync(KB_INDEX_FILE, "utf8");
+    assert.match(idx, /# Knowledge base index/);
+    assert.match(idx, /wiki page\(s\)/);
+    assert.match(idx, /OAuth 2\.0/, "wiki title appears in the index");
+  });
+
+  test("removeEntry deletes and reports existence", async () => {
+    assert.equal(await store.removeEntry("sources", "dup-2"), true);
+    assert.equal(await store.readEntry("sources", "dup-2"), null);
+    assert.equal(await store.removeEntry("sources", "dup-2"), false, "already gone");
+  });
+
+  test("slug jail: a traversal slug throws rather than escaping the KB", async () => {
+    await assert.rejects(() => store.readEntry("wiki", "../../etc/passwd"));
+    await assert.rejects(() =>
+      store.writeWiki({ slug: "../escape", title: "x", body: "y" }),
+    );
+  });
+});

--- a/src/kb/store.ts
+++ b/src/kb/store.ts
@@ -1,0 +1,298 @@
+/**
+ * Knowledge-base storage layer.
+ *
+ * Mirrors the soul store's discipline — every mutation runs under a
+ * cross-process advisory write-lock (withFileLock) and records a best-effort
+ * git commit — but keeps the KB in its own dir/repo (see paths.ts). Entries are
+ * markdown files with a small frontmatter block; sources are append-only
+ * captures, wiki pages are upserted. index.md (the always-on table of contents)
+ * is regenerated on every mutation.
+ */
+import fs from "node:fs/promises";
+import { ensureDir, atomicWrite, pathExists, readTextOrEmpty } from "../fs-utils.js";
+import { withFileLock } from "../soul/lock.js";
+import { assertSafeSlug, normalizeSlug } from "../soul/slug.js";
+import { commitKb } from "./git.js";
+import { ensureSchema } from "./schema.js";
+import {
+  KB_INDEX_FILE,
+  KB_LOCK_PATH,
+  KB_SOURCES_DIR,
+  KB_WIKI_DIR,
+  entryFile,
+  layerDir,
+  type KbLayer,
+} from "./paths.js";
+
+export interface KbEntry {
+  layer: KbLayer;
+  slug: string;
+  title: string;
+  tags: string[];
+  /** Sources: ISO capture time. */
+  created?: string;
+  /** Wiki: ISO last-update time. */
+  updated?: string;
+  /** Sources: where it came from (session id | "manual" | "chat:<id>"). */
+  origin?: string;
+  /** Wiki: source slugs this page draws on. */
+  sources?: string[];
+  /** Markdown body (frontmatter stripped). */
+  body: string;
+}
+
+export interface KbEntryMeta {
+  layer: KbLayer;
+  slug: string;
+  title: string;
+  tags: string[];
+  created?: string;
+  updated?: string;
+  origin?: string;
+  sources?: string[];
+  /** First ~160 chars of the body, whitespace-collapsed. */
+  excerpt: string;
+}
+
+// ── frontmatter ───────────────────────────────────────────────────────
+
+function parseFrontmatter(raw: string): {
+  meta: Record<string, string | string[]>;
+  body: string;
+} {
+  const lines = raw.split("\n");
+  if (lines[0] !== "---") return { meta: {}, body: raw };
+  const meta: Record<string, string | string[]> = {};
+  let i = 1;
+  for (; i < lines.length; i++) {
+    if (lines[i] === "---") {
+      i++;
+      break;
+    }
+    const m = lines[i]!.match(/^([a-zA-Z_]+):\s*(.*)$/);
+    if (!m) continue;
+    const key = m[1]!;
+    const val = m[2]!.trim();
+    if (key === "tags" || key === "sources") {
+      meta[key] = val
+        .replace(/^\[|\]$/g, "")
+        .split(",")
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else {
+      meta[key] = val;
+    }
+  }
+  if (lines[i] === "") i++; // drop one blank line after the closing ---
+  return { meta, body: lines.slice(i).join("\n") };
+}
+
+function serializeEntry(entry: KbEntry): string {
+  const fm: string[] = ["---", `title: ${entry.title}`];
+  if (entry.tags.length) fm.push(`tags: [${entry.tags.join(", ")}]`);
+  if (entry.layer === "sources") {
+    if (entry.created) fm.push(`created: ${entry.created}`);
+    if (entry.origin) fm.push(`origin: ${entry.origin}`);
+  } else {
+    if (entry.updated) fm.push(`updated: ${entry.updated}`);
+    if (entry.sources?.length) fm.push(`sources: [${entry.sources.join(", ")}]`);
+  }
+  fm.push("---", "");
+  return fm.join("\n") + entry.body.trimEnd() + "\n";
+}
+
+function parseEntry(layer: KbLayer, slug: string, raw: string): KbEntry {
+  const { meta, body } = parseFrontmatter(raw);
+  return {
+    layer,
+    slug,
+    title: (meta.title as string) || slug,
+    tags: (meta.tags as string[]) ?? [],
+    created: meta.created as string | undefined,
+    updated: meta.updated as string | undefined,
+    origin: meta.origin as string | undefined,
+    sources: (meta.sources as string[]) ?? undefined,
+    // Serialization always appends a trailing newline; strip it on read so a
+    // write→read round-trip is stable (body "x" stores as "x\n", reads as "x").
+    body: body.trimEnd(),
+  };
+}
+
+function metaOf(entry: KbEntry): KbEntryMeta {
+  return {
+    layer: entry.layer,
+    slug: entry.slug,
+    title: entry.title,
+    tags: entry.tags,
+    created: entry.created,
+    updated: entry.updated,
+    origin: entry.origin,
+    sources: entry.sources,
+    excerpt: entry.body.replace(/\s+/g, " ").trim().slice(0, 160),
+  };
+}
+
+// ── scaffold ──────────────────────────────────────────────────────────
+
+/** Create the KB layout (dirs + default schema) if missing. Idempotent. */
+export async function ensureKbScaffold(): Promise<void> {
+  await ensureDir(KB_SOURCES_DIR);
+  await ensureDir(KB_WIKI_DIR);
+  await ensureSchema();
+}
+
+async function uniqueSlug(layer: KbLayer, base: string): Promise<string> {
+  const root = normalizeSlug(base) || `entry-${Date.now()}`;
+  let slug = root;
+  let n = 2;
+  while (await pathExists(entryFile(layer, slug))) {
+    slug = `${root}-${n++}`;
+  }
+  return slug;
+}
+
+// ── reads ─────────────────────────────────────────────────────────────
+
+export async function readEntry(layer: KbLayer, slug: string): Promise<KbEntry | null> {
+  const file = entryFile(layer, slug);
+  if (!(await pathExists(file))) return null;
+  return parseEntry(layer, slug, await fs.readFile(file, "utf8"));
+}
+
+/** List entry metadata (no full body), newest first. Omit `layer` for all. */
+export async function listEntries(layer?: KbLayer): Promise<KbEntryMeta[]> {
+  const layers: KbLayer[] = layer ? [layer] : ["wiki", "sources"];
+  const out: KbEntryMeta[] = [];
+  for (const L of layers) {
+    const dir = layerDir(L);
+    if (!(await pathExists(dir))) continue;
+    for (const f of await fs.readdir(dir)) {
+      if (!f.endsWith(".md")) continue;
+      const slug = f.slice(0, -3);
+      try {
+        out.push(metaOf(parseEntry(L, slug, await fs.readFile(`${dir}/${f}`, "utf8"))));
+      } catch {
+        // skip unparseable
+      }
+    }
+  }
+  out.sort((a, b) =>
+    (b.updated || b.created || "").localeCompare(a.updated || a.created || ""),
+  );
+  return out;
+}
+
+export async function readIndex(): Promise<string> {
+  return readTextOrEmpty(KB_INDEX_FILE);
+}
+
+// ── index regeneration ────────────────────────────────────────────────
+
+/** Rebuild index.md from the current wiki + sources. Assumes the lock is held. */
+async function regenerateIndexLocked(): Promise<void> {
+  const wiki = await listEntries("wiki");
+  const sources = await listEntries("sources");
+  const lines = [
+    "# Knowledge base index",
+    "",
+    `_${wiki.length} wiki page(s) · ${sources.length} source(s)_`,
+    "",
+  ];
+  if (wiki.length) {
+    lines.push("## Wiki pages", "");
+    for (const w of wiki) {
+      const tags = w.tags.length ? ` · ${w.tags.map((t) => `#${t}`).join(" ")}` : "";
+      lines.push(`- **${w.title}** (\`${w.slug}\`)${tags} — ${w.excerpt.slice(0, 100)}`);
+    }
+    lines.push("");
+  }
+  if (sources.length) {
+    lines.push("## Recent sources", "");
+    for (const s of sources.slice(0, 25)) {
+      const tags = s.tags.length ? ` · ${s.tags.map((t) => `#${t}`).join(" ")}` : "";
+      lines.push(`- ${s.title} (\`${s.slug}\`)${tags}`);
+    }
+    lines.push("");
+  }
+  await atomicWrite(KB_INDEX_FILE, lines.join("\n").trimEnd() + "\n");
+}
+
+/** Public index rebuild (acquires the lock). */
+export function regenerateIndex(): Promise<void> {
+  return withFileLock(KB_LOCK_PATH, regenerateIndexLocked);
+}
+
+// ── writes ────────────────────────────────────────────────────────────
+
+/**
+ * Capture a Layer-1 source (immutable raw). Each call writes a NEW file — the
+ * slug is made unique so nothing is ever overwritten. Backs the web "add to KB".
+ */
+export async function addSource(opts: {
+  title: string;
+  body: string;
+  tags?: string[];
+  origin?: string;
+}): Promise<KbEntry> {
+  await ensureKbScaffold();
+  return withFileLock(KB_LOCK_PATH, async () => {
+    const title = opts.title.trim() || "untitled";
+    const slug = await uniqueSlug("sources", title);
+    const entry: KbEntry = {
+      layer: "sources",
+      slug,
+      title,
+      tags: opts.tags ?? [],
+      created: new Date().toISOString(),
+      origin: opts.origin,
+      body: opts.body,
+    };
+    await atomicWrite(entryFile("sources", slug), serializeEntry(entry));
+    await regenerateIndexLocked();
+    await commitKb(`kb: add source ${slug}`);
+    return entry;
+  });
+}
+
+/**
+ * Create or update a Layer-2 wiki page (upsert by slug). Lisa's curation tool.
+ */
+export async function writeWiki(opts: {
+  slug?: string;
+  title: string;
+  body: string;
+  tags?: string[];
+  sources?: string[];
+}): Promise<KbEntry> {
+  await ensureKbScaffold();
+  return withFileLock(KB_LOCK_PATH, async () => {
+    const slug = opts.slug
+      ? assertSafeSlug(opts.slug)
+      : normalizeSlug(opts.title) || `page-${Date.now()}`;
+    const entry: KbEntry = {
+      layer: "wiki",
+      slug,
+      title: opts.title.trim() || slug,
+      tags: opts.tags ?? [],
+      updated: new Date().toISOString(),
+      sources: opts.sources ?? [],
+      body: opts.body,
+    };
+    await atomicWrite(entryFile("wiki", slug), serializeEntry(entry));
+    await regenerateIndexLocked();
+    await commitKb(`kb: write wiki ${slug}`);
+    return entry;
+  });
+}
+
+/** Delete an entry (user-initiated). Returns false if it didn't exist. */
+export async function removeEntry(layer: KbLayer, slug: string): Promise<boolean> {
+  return withFileLock(KB_LOCK_PATH, async () => {
+    const file = entryFile(layer, slug);
+    if (!(await pathExists(file))) return false;
+    await fs.rm(file, { force: true });
+    await regenerateIndexLocked();
+    await commitKb(`kb: remove ${layer}/${slug}`);
+    return true;
+  });
+}


### PR DESCRIPTION
**PR B** of the [PKB plan](docs/PLAN_KNOWLEDGE_BASE_v1.0.md). The storage layer under `~/.lisa/kb/` — **behavior-neutral** (nothing calls it yet; tools/prompt/web land in later PRs).

- **`paths.ts`** — layout (`sources/` `wiki/` `SCHEMA.md` `index.md`); `entryFile()` jailed through the shared `assertSafeSlug` traversal gate.
- **`store.ts`** — frontmatter parse/serialize; `addSource` (immutable Layer-1 captures — never overwritten, colliding titles get `-2`), `writeWiki` (Layer-2 upsert), `readEntry`, `listEntries` (newest-first meta + excerpt), `removeEntry`, `index.md` regeneration. Every mutation runs under the cross-process `withFileLock` + best-effort git.
- **`schema.ts`** — the Layer-3 rules doc (seeded default; user/Lisa editable).
- **`git.ts`** — best-effort provenance in the KB's own repo (`LISA_KB_NO_GIT` to disable); never blocks a write.
- **`store.test.ts`** — 8 tests (capture, unique-slug, upsert, list, scaffold, index, delete, slug-jail). Green; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)