### PR TITLE
feat(kb): knowledge-base tools + TF-IDF search

### DIFF
--- a/src/kb/search.ts
+++ b/src/kb/search.ts
@@ -1,0 +1,165 @@
+/**
+ * TF-IDF search over the knowledge base (sources + wiki), mirroring the memory
+ * transcript index (memory/vector.ts) but over KB entries keyed by layer/slug.
+ * Kept self-contained (own tokenizer) so the KB doesn't couple to memory's
+ * session-specific index. The index is fingerprint-cached over the KB dirs, so
+ * repeated searches in one conversation are free until the KB actually changes.
+ *
+ * (Semantic/embedding search is a deliberate future enhancement — it can reuse
+ * memory/embedding.ts the same way memory_search does; TF-IDF is the robust,
+ * dependency-free default and is well-suited to a curated KB with good titles.)
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathExists } from "../fs-utils.js";
+import { KB_SOURCES_DIR, KB_WIKI_DIR, layerDir, type KbLayer } from "./paths.js";
+import { readEntry } from "./store.js";
+
+interface KbDoc {
+  layer: KbLayer;
+  slug: string;
+  title: string;
+  text: string;
+  termFreq: Map<string, number>;
+}
+
+export interface KbIndex {
+  docs: KbDoc[];
+  idf: Map<string, number>;
+}
+
+export interface KbHit {
+  layer: KbLayer;
+  slug: string;
+  title: string;
+  score: number;
+  excerpt: string;
+}
+
+const STOPWORDS = new Set([
+  "the", "a", "an", "of", "to", "in", "and", "or", "for", "is", "it",
+  "this", "that", "be", "are", "was", "were", "with", "on", "as", "at",
+  "by", "from", "but", "not", "i", "you", "we", "they", "he", "she",
+]);
+
+function tokenize(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^a-z0-9一-鿿\s]/g, " ")
+    .split(/\s+/)
+    .filter((t) => t.length >= 2 && !STOPWORDS.has(t));
+}
+
+function excerptAround(text: string, qTokens: string[], width: number): string {
+  const lower = text.toLowerCase();
+  for (const t of qTokens) {
+    const idx = lower.indexOf(t);
+    if (idx >= 0) {
+      const start = Math.max(0, idx - width / 2);
+      const end = Math.min(text.length, idx + width / 2);
+      return (
+        (start > 0 ? "…" : "") +
+        text.slice(start, end).replace(/\s+/g, " ").trim() +
+        (end < text.length ? "…" : "")
+      );
+    }
+  }
+  return text.slice(0, width).replace(/\s+/g, " ").trim();
+}
+
+// ── fingerprint cache ─────────────────────────────────────────────────
+
+let cachedIndex: KbIndex | null = null;
+let cachedFingerprint = "";
+
+async function kbFingerprint(): Promise<string> {
+  const parts: string[] = [];
+  for (const dir of [KB_WIKI_DIR, KB_SOURCES_DIR]) {
+    if (!(await pathExists(dir))) continue;
+    for (const f of (await fs.readdir(dir)).sort()) {
+      if (!f.endsWith(".md")) continue;
+      try {
+        const st = await fs.stat(path.join(dir, f));
+        parts.push(`${dir}/${f}:${st.mtimeMs}:${st.size}`);
+      } catch {
+        // vanished between readdir and stat
+      }
+    }
+  }
+  return parts.join("|");
+}
+
+/** Drop the cached index (test hook / explicit invalidation). */
+export function clearKbIndexCache(): void {
+  cachedIndex = null;
+  cachedFingerprint = "";
+}
+
+export async function buildKbIndex(opts: { cache?: boolean } = {}): Promise<KbIndex> {
+  if (opts.cache !== false) {
+    const fp = await kbFingerprint();
+    if (cachedIndex && fp === cachedFingerprint) return cachedIndex;
+    const built = await buildUncached();
+    cachedIndex = built;
+    cachedFingerprint = fp;
+    return built;
+  }
+  return buildUncached();
+}
+
+async function buildUncached(): Promise<KbIndex> {
+  const docs: KbDoc[] = [];
+  const docFreq = new Map<string, number>();
+  for (const layer of ["wiki", "sources"] as KbLayer[]) {
+    const dir = layerDir(layer);
+    if (!(await pathExists(dir))) continue;
+    for (const f of await fs.readdir(dir)) {
+      if (!f.endsWith(".md")) continue;
+      const slug = f.slice(0, -3);
+      const e = await readEntry(layer, slug).catch(() => null);
+      if (!e) continue;
+      // Title + tags are weighted into the searchable text so a title/tag hit ranks.
+      const text = [e.title, e.tags.join(" "), e.body].filter(Boolean).join("\n");
+      const tokens = tokenize(text);
+      if (tokens.length === 0) continue;
+      const tf = new Map<string, number>();
+      for (const t of tokens) tf.set(t, (tf.get(t) ?? 0) + 1);
+      for (const t of new Set(tokens)) docFreq.set(t, (docFreq.get(t) ?? 0) + 1);
+      docs.push({ layer, slug, title: e.title, text, termFreq: tf });
+    }
+  }
+  const idf = new Map<string, number>();
+  const N = Math.max(1, docs.length);
+  for (const [term, df] of docFreq) idf.set(term, Math.log(1 + N / df));
+  return { docs, idf };
+}
+
+export function searchKbIndex(index: KbIndex, query: string, k = 5): KbHit[] {
+  const qTokens = tokenize(query);
+  if (qTokens.length === 0) return [];
+  const qFreq = new Map<string, number>();
+  for (const t of qTokens) qFreq.set(t, (qFreq.get(t) ?? 0) + 1);
+  const scored: { doc: KbDoc; score: number }[] = [];
+  for (const doc of index.docs) {
+    let score = 0;
+    for (const [term, qf] of qFreq) {
+      const tf = doc.termFreq.get(term) ?? 0;
+      if (tf === 0) continue;
+      score += qf * tf * (index.idf.get(term) ?? 0);
+    }
+    if (score > 0) scored.push({ doc, score });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored.slice(0, k).map((s) => ({
+    layer: s.doc.layer,
+    slug: s.doc.slug,
+    title: s.doc.title,
+    score: s.score,
+    excerpt: excerptAround(s.doc.text, qTokens, 200),
+  }));
+}
+
+/** Convenience: build (cached) + search. */
+export async function searchKb(query: string, k = 5): Promise<KbHit[]> {
+  return searchKbIndex(await buildKbIndex(), query, k);
+}

--- a/src/kb/tool.test.ts
+++ b/src/kb/tool.test.ts
@@ -1,0 +1,114 @@
+import { test, describe, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import type { ToolContext, ToolDefinition } from "../types.js";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "lisa-kb-tool-"));
+process.env.LISA_HOME = TMP;
+process.env.LISA_KB_NO_GIT = "1";
+
+const store = await import("./store.js");
+const search = await import("./search.js");
+const { kbTools } = await import("./tool.js");
+const registry = await import("../tools/registry.js");
+
+after(() => rmSync(TMP, { recursive: true, force: true }));
+
+const CTX: ToolContext = {
+  cwd: process.cwd(),
+  signal: new AbortController().signal,
+  log: () => {},
+};
+const tool = (name: string): ToolDefinition =>
+  kbTools.find((t) => t.name === name)!;
+const run = (name: string, input: unknown): Promise<unknown> =>
+  tool(name).execute(input, CTX);
+
+describe("kb search + tools", () => {
+  test("TF-IDF search ranks the relevant entry above an unrelated one", async () => {
+    search.clearKbIndexCache();
+    await store.addSource({
+      title: "OAuth PKCE",
+      body: "PKCE uses a code_verifier and code_challenge in the auth code flow.",
+      tags: ["oauth"],
+    });
+    await store.addSource({
+      title: "Sourdough",
+      body: "Feed the starter with flour and water each day.",
+      tags: ["baking"],
+    });
+    await store.writeWiki({
+      title: "OAuth",
+      body: "OAuth 2.0 authorization framework; PKCE hardens the code flow.",
+      tags: ["oauth"],
+    });
+    search.clearKbIndexCache();
+    const hits = await search.searchKb("pkce code verifier", 5);
+    assert.ok(hits.length >= 1, "found something");
+    assert.match(hits[0]!.title, /OAuth/i, "OAuth entry ranks first");
+    assert.ok(
+      !hits.some((h) => /sourdough/i.test(h.title)),
+      "unrelated entry not returned",
+    );
+  });
+
+  test("kb_add captures a source", async () => {
+    const out = (await run("kb_add", {
+      title: "Meeting notes",
+      content: "Decided to ship v2 next week.",
+      tags: ["work"],
+    })) as string;
+    assert.match(out, /Saved source/);
+    const e = await store.readEntry("sources", "meeting-notes");
+    assert.ok(e);
+    assert.match(e.body, /ship v2/);
+  });
+
+  test("kb_write upserts a wiki page", async () => {
+    const out = (await run("kb_write", {
+      slug: "projects",
+      title: "Projects",
+      content: "Current: v2 launch.",
+      tags: ["work"],
+    })) as string;
+    assert.match(out, /Wrote wiki page/);
+    const e = await store.readEntry("wiki", "projects");
+    assert.match(e!.body, /v2 launch/);
+  });
+
+  test("kb_read + kb_list format entries", async () => {
+    const read = (await run("kb_read", { layer: "wiki", slug: "projects" })) as string;
+    assert.match(read, /# Projects/);
+    assert.match(read, /v2 launch/);
+    const list = (await run("kb_list", {})) as string;
+    assert.match(list, /projects/);
+    assert.match(list, /meeting-notes/);
+  });
+
+  test("kb_search returns matches, and a clear miss message", async () => {
+    const out = (await run("kb_search", { query: "pkce" })) as string;
+    assert.match(out, /oauth/i);
+    const none = (await run("kb_search", { query: "zzzznotarealtoken" })) as string;
+    assert.match(none, /no matches/);
+  });
+
+  test("registry: kb tools registered with correct subset membership", async () => {
+    const all = registry.buildToolRegistry();
+    const names = new Set(all.map((t) => t.name));
+    for (const n of ["kb_search", "kb_read", "kb_list", "kb_add", "kb_write"]) {
+      assert.ok(names.has(n), `${n} is registered`);
+    }
+    const ro = new Set(registry.readOnlySubset(all).map((t) => t.name));
+    assert.ok(ro.has("kb_search") && ro.has("kb_read") && ro.has("kb_list"), "reads are read-only");
+    assert.ok(!ro.has("kb_add") && !ro.has("kb_write"), "writes are not read-only");
+
+    const auto = new Set(registry.autonomousSubset(all).map((t) => t.name));
+    assert.ok(auto.has("kb_add") && auto.has("kb_write"), "writes ALLOWED for autonomous (tend the wiki)");
+
+    const remote = new Set(registry.remoteSafeSubset(all).map((t) => t.name));
+    assert.ok(remote.has("kb_search"), "read tools are remote-safe");
+    assert.ok(!remote.has("kb_add") && !remote.has("kb_write"), "writes are remote-blocked");
+  });
+});

--- a/src/kb/tool.ts
+++ b/src/kb/tool.ts
@@ -1,0 +1,157 @@
+/**
+ * Knowledge-base tools exposed to the agent.
+ *
+ * Read tools (kb_search / kb_read / kb_list) are read-only + remote-safe.
+ * Write tools (kb_add / kb_write) are path-jailed to ~/.lisa/kb and are
+ * deliberately allowed for autonomous runs (so idle/heartbeat reflection can
+ * tend the wiki) — see registry subset membership.
+ */
+import type { ToolDefinition } from "../types.js";
+import { searchKb } from "./search.js";
+import { addSource, listEntries, readEntry, writeWiki } from "./store.js";
+import type { KbLayer } from "./paths.js";
+
+const kbSearch: ToolDefinition<{ query: string; limit?: number }, string> = {
+  name: "kb_search",
+  description:
+    "Search the user's personal knowledge base — their saved sources + the wiki pages you maintain. " +
+    "Reach for this whenever a question touches the user's own captured knowledge, notes, or documents. " +
+    "This is their curated KB, distinct from memory_search (raw past-conversation transcripts). " +
+    "Returns ranked layer/slug + title + excerpt; follow up with kb_read for the full page.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      limit: { type: "integer", minimum: 1, maximum: 20, default: 5 },
+    },
+    required: ["query"],
+  },
+  async execute(input) {
+    const hits = await searchKb(input.query, input.limit ?? 5);
+    if (hits.length === 0) return "(no matches in the knowledge base)";
+    return hits
+      .map(
+        (h) =>
+          `[${h.layer}/${h.slug}] ${h.title} (score=${h.score.toFixed(2)})\n  ${h.excerpt}`,
+      )
+      .join("\n\n");
+  },
+};
+
+const kbRead: ToolDefinition<{ layer: KbLayer; slug: string }, string> = {
+  name: "kb_read",
+  description:
+    "Read one knowledge-base entry in full, by layer + slug (from kb_search or index.md). " +
+    "layer is 'wiki' (pages you maintain) or 'sources' (the user's raw, immutable captures).",
+  inputSchema: {
+    type: "object",
+    properties: {
+      layer: { type: "string", enum: ["wiki", "sources"] },
+      slug: { type: "string" },
+    },
+    required: ["layer", "slug"],
+  },
+  async execute(input) {
+    const e = await readEntry(input.layer, input.slug);
+    if (!e) return `(no ${input.layer} entry "${input.slug}")`;
+    const meta = [
+      e.tags.length ? `tags: ${e.tags.join(", ")}` : "",
+      e.sources?.length ? `sources: ${e.sources.join(", ")}` : "",
+      e.origin ? `origin: ${e.origin}` : "",
+    ]
+      .filter(Boolean)
+      .join(" · ");
+    return `# ${e.title}${meta ? `\n_${meta}_` : ""}\n\n${e.body}`;
+  },
+};
+
+const kbList: ToolDefinition<{ layer?: KbLayer }, string> = {
+  name: "kb_list",
+  description:
+    "List knowledge-base entries (title + tags), newest first. Omit layer for both; " +
+    "pass 'wiki' or 'sources' to filter one layer.",
+  inputSchema: {
+    type: "object",
+    properties: { layer: { type: "string", enum: ["wiki", "sources"] } },
+  },
+  async execute(input) {
+    const entries = await listEntries(input.layer);
+    if (entries.length === 0) return "(knowledge base is empty)";
+    return entries
+      .map(
+        (e) =>
+          `[${e.layer}/${e.slug}] ${e.title}${e.tags.length ? ` · ${e.tags.map((t) => `#${t}`).join(" ")}` : ""}`,
+      )
+      .join("\n");
+  },
+};
+
+const kbAdd: ToolDefinition<
+  { title: string; content: string; tags?: string[] },
+  string
+> = {
+  name: "kb_add",
+  description:
+    "Capture a new SOURCE into the knowledge base (Layer 1 — raw, immutable). " +
+    "Use to save a document, decision, or something the user asked you to remember into their KB. " +
+    "Sources are never overwritten. To organize/distill, build a wiki page with kb_write.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      title: { type: "string" },
+      content: { type: "string" },
+      tags: { type: "array", items: { type: "string" } },
+    },
+    required: ["title", "content"],
+  },
+  async execute(input) {
+    const e = await addSource({
+      title: input.title,
+      body: input.content,
+      tags: input.tags,
+      origin: "lisa",
+    });
+    return `Saved source "${e.title}" (sources/${e.slug}).`;
+  },
+};
+
+const kbWrite: ToolDefinition<
+  { slug?: string; title: string; content: string; tags?: string[]; sources?: string[] },
+  string
+> = {
+  name: "kb_write",
+  description:
+    "Create or update a WIKI page (Layer 2 — the knowledge you maintain). Your curation tool: " +
+    "distill sources + what you know about the user into a clear, cross-linked page. Upserts by slug " +
+    "(omit slug to derive from the title). List the source slugs the page draws on.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      slug: { type: "string", description: "stable page id; omit to derive from title" },
+      title: { type: "string" },
+      content: { type: "string" },
+      tags: { type: "array", items: { type: "string" } },
+      sources: { type: "array", items: { type: "string" } },
+    },
+    required: ["title", "content"],
+  },
+  async execute(input) {
+    const e = await writeWiki({
+      slug: input.slug,
+      title: input.title,
+      body: input.content,
+      tags: input.tags,
+      sources: input.sources,
+    });
+    return `Wrote wiki page "${e.title}" (wiki/${e.slug}).`;
+  },
+};
+
+/** All KB tools (read tools first). Registered in tools/registry.ts. */
+export const kbTools: ToolDefinition[] = [
+  kbSearch as ToolDefinition,
+  kbRead as ToolDefinition,
+  kbList as ToolDefinition,
+  kbAdd as ToolDefinition,
+  kbWrite as ToolDefinition,
+];

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -44,6 +44,7 @@ import { webFetchTool } from "./web_fetch.js";
 import { webSearchTool } from "./web_search.js";
 import { takoapiTool } from "./takoapi.js";
 import { writeTool } from "./write.js";
+import { kbTools } from "../kb/tool.js";
 
 export interface ToolRegistryOptions {
   includeVoice?: boolean;
@@ -101,6 +102,9 @@ export function buildToolRegistry(opts: ToolRegistryOptions = {}): ToolDefinitio
     mcpTool as ToolDefinition,
     signalAgentTool as ToolDefinition,
     agentRecapTool as ToolDefinition,
+    // Personal knowledge base (docs/PLAN_KNOWLEDGE_BASE_v1.0.md):
+    // kb_search / kb_read / kb_list (read) + kb_add / kb_write (jailed writes).
+    ...kbTools,
   ];
   if (opts.includeVoice) {
     tools.push(speakTool as ToolDefinition, transcribeTool as ToolDefinition);
@@ -127,6 +131,9 @@ export const READ_ONLY_TOOL_NAMES = new Set([
   "web_fetch",
   "web_search",
   "agent_recap",
+  "kb_search",
+  "kb_read",
+  "kb_list",
 ]);
 
 export function readOnlySubset(tools: ToolDefinition[]): ToolDefinition[] {
@@ -191,6 +198,11 @@ export const REMOTE_BLOCKED_TOOL_NAMES = new Set([
   // (channel) callers. NOT autonomous-blocked: an autonomous run may read the
   // result of work it dispatched.
   "dispatch_status",
+  // KB writes: a remote-origin message shouldn't silently add to the user's
+  // knowledge base. NOT autonomous-blocked — idle/heartbeat reflection is
+  // exactly where Lisa tends the wiki (kb_add/kb_write are path-jailed to ~/.lisa/kb).
+  "kb_add",
+  "kb_write",
 ]);
 
 export function remoteSafeSubset(tools: ToolDefinition[]): ToolDefinition[] {


### PR DESCRIPTION
**PR C** of the [PKB plan](docs/PLAN_KNOWLEDGE_BASE_v1.0.md). Exposes the KB to the agent.

- **`search.ts`** — self-contained TF-IDF index over KB entries (sources + wiki), fingerprint-cached over the KB dirs (mirrors `memory/vector.ts`, keyed by layer/slug). Semantic/embedding search is a documented future enhancement; TF-IDF is the robust dependency-free default for a curated KB.
- **`tool.ts`** — `kb_search` / `kb_read` / `kb_list` (read) and `kb_add` (capture a Layer-1 source) / `kb_write` (upsert a Layer-2 wiki page).
- **registry** — the five tools registered; reads join **read-only + remote-safe**; `kb_add`/`kb_write` are **remote-blocked** but deliberately **NOT autonomous-blocked** (idle/heartbeat reflection is exactly where Lisa tends the wiki — both are path-jailed to `~/.lisa/kb`).
- **`tool.test.ts`** — 6 tests (TF-IDF ranking, each tool, subset membership). 14 KB tests total green; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)