### PR TITLE
feat(kb): always-on KB awareness in the system prompt + hot-reload

### DIFF
--- a/src/kb/prompt.test.ts
+++ b/src/kb/prompt.test.ts
@@ -1,0 +1,41 @@
+import { test, describe, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = mkdtempSync(path.join(os.tmpdir(), "lisa-kb-prompt-"));
+process.env.LISA_HOME = TMP;
+process.env.LISA_KB_NO_GIT = "1";
+
+const prompt = await import("../prompt.js");
+const kb = await import("./store.js");
+
+after(() => rmSync(TMP, { recursive: true, force: true }));
+
+describe("kb ⇄ prompt integration", () => {
+  test("empty KB → no knowledge-base section in the prompt", async () => {
+    const snap = await prompt.buildSystemPromptSnapshot();
+    assert.doesNotMatch(snap.text, /Personal knowledge base/);
+  });
+
+  test("capturing a source injects the KB section (schema + index)", async () => {
+    await kb.addSource({
+      title: "OAuth PKCE",
+      body: "code_verifier / code_challenge",
+      tags: ["oauth"],
+    });
+    const snap = await prompt.buildSystemPromptSnapshot();
+    assert.match(snap.text, /## Personal knowledge base/);
+    assert.match(snap.text, /### Schema/);
+    assert.match(snap.text, /### Index/);
+    assert.match(snap.text, /OAuth PKCE/, "the captured title shows up in the index");
+  });
+
+  test("getPromptFingerprint shifts when the KB changes (mid-session hot-reload)", async () => {
+    const before = await prompt.getPromptFingerprint();
+    await kb.writeWiki({ title: "OAuth", body: "authorization framework", tags: ["oauth"] });
+    const after = await prompt.getPromptFingerprint();
+    assert.notEqual(before, after, "a KB write must change the prompt fingerprint");
+  });
+});

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -3,6 +3,9 @@ import os from "node:os";
 import path from "node:path";
 import { listSkills } from "./skills/manager.js";
 import { readMemory } from "./memory/store.js";
+import { readIndex } from "./kb/store.js";
+import { readSchema } from "./kb/schema.js";
+import { KB_INDEX_FILE, KB_SCHEMA_FILE } from "./kb/paths.js";
 import { LISA_HOME, MEMORY_DIR, SKILLS_DIR } from "./paths.js";
 import { pathExists } from "./fs-utils.js";
 import { availableMoodSlugs } from "./tools/set_mood.js";
@@ -68,6 +71,10 @@ export async function buildSystemPromptSnapshot(): Promise<PromptSnapshot> {
 
   const userMem = (await readMemory("user")).trim();
   const agentMem = (await readMemory("memory")).trim();
+  // The KB index is the always-on "table of contents" — present only once the
+  // user has captured anything (store regenerates it on every write). Empty →
+  // no section (Lisa still discovers the KB via the kb_* tool descriptions).
+  const kbIndex = (await readIndex()).trim();
 
   const env = [
     `- platform: ${process.platform} (${os.release()})`,
@@ -148,6 +155,20 @@ export async function buildSystemPromptSnapshot(): Promise<PromptSnapshot> {
   );
   sections.push(`## What you remember about the user (USER.md)\n\n${userMem || "(empty)"}`);
   sections.push(`## Your own working memory (MEMORY.md)\n\n${agentMem || "(empty)"}`);
+  if (kbIndex) {
+    // Always-on KB awareness: the schema (rules — honors user customization)
+    // plus the index (what exists). Full pages come on-demand via kb_read /
+    // kb_search. Both capped so a large KB never dominates the prompt.
+    const schema = (await readSchema()).trim();
+    const capSchema = schema.length > 1800 ? `${schema.slice(0, 1800)}\n…` : schema;
+    const capIndex =
+      kbIndex.length > 2600
+        ? `${kbIndex.slice(0, 2600)}\n… (truncated — use kb_list / kb_search)`
+        : kbIndex;
+    sections.push(
+      `## Personal knowledge base\n\nThe user's own KB. Query it with \`kb_search\` / \`kb_read\` whenever a question touches their captured knowledge; keep the wiki current with \`kb_write\`.\n\n### Schema\n\n${capSchema}\n\n### Index\n\n${capIndex}`,
+    );
+  }
   sections.push(`## Avatar moods\n\n${moodSection}`);
 
   return {
@@ -192,6 +213,11 @@ export async function getPromptFingerprint(): Promise<string> {
     SOUL_EMOTIONS,
     path.join(MEMORY_DIR, "MEMORY.md"),
     path.join(MEMORY_DIR, "USER.md"),
+    // KB: index.md is rewritten on every KB mutation (store regenerates it), so
+    // its mtime is a cheap proxy for "the KB changed" — plus the schema file for
+    // rule edits. Lets KB captures/edits hot-reload into the prompt mid-session.
+    KB_INDEX_FILE,
+    KB_SCHEMA_FILE,
   ]) {
     parts.push(await mtimeOrZero(p));
   }


### PR DESCRIPTION
**PR D** of the [PKB plan](docs/PLAN_KNOWLEDGE_BASE_v1.0.md). Delivers the "real-time retrieval" feel without blowing the context.

- `buildSystemPromptSnapshot` injects a **Personal knowledge base** section — the **schema** (rules; honors user edits) + **index.md** (the always-on table of contents) — **only once the KB has content**, both **capped** so a large KB never dominates the prompt. Full pages stay on-demand via `kb_read`/`kb_search`.
- `getPromptFingerprint` now covers `KB_INDEX_FILE` (rewritten on every KB mutation → a cheap "KB changed" proxy) + `KB_SCHEMA_FILE`, so captures/edits **hot-reload** into the prompt mid-conversation.
- 3 tests (no section when empty · section on capture · fingerprint shifts on write). All KB tests + full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)