### PR TITLE
feat(kb): web Knowledge view — live search, browse, read (PR E1)

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1710,6 +1710,7 @@ if ('serviceWorker' in navigator) {
     room: document.getElementById('viewRoom'),
     sense: document.getElementById('viewSense'),
     memory: document.getElementById('viewMemory'),
+    kb: document.getElementById('viewKb'),
   };
   var loaded = {};
   var active = 'chat';
@@ -1759,6 +1760,8 @@ if ('serviceWorker' in navigator) {
 
   // ── view switching ──────────────────────────────────────────────
   function loadView(name) {
+    // KB builds once, then refreshes its list on every re-show (it changes).
+    if (name === 'kb') { if (!loaded.kb) { loaded.kb = true; loadKb(); } else { loadKbList(); } return; }
     if (loaded[name]) return;
     loaded[name] = true;
     if (name === 'dashboard') loadDashboard();
@@ -2051,6 +2054,92 @@ if ('serviceWorker' in navigator) {
       });
     }
   }
+
+  // ── Knowledge base view (docs/PLAN_KNOWLEDGE_BASE_v1.0.md) ──────────
+  function kbRenderList(entries, container) {
+    if (!entries || !entries.length) {
+      container.innerHTML = '<div class="view-empty">Nothing here yet. In Chat, select messages and "Add to KB", or ask Lisa to save something.</div>';
+      return;
+    }
+    var html = '';
+    for (var i = 0; i < entries.length; i++) {
+      var e = entries[i];
+      var tags = (e.tags && e.tags.length) ? e.tags.map(function (t) { return '#' + t; }).join(' ') : '';
+      html += '<button class="kb-item" data-layer="' + esc(e.layer) + '" data-slug="' + esc(e.slug) + '">'
+        + '<span class="kb-row"><span class="kb-badge ' + esc(e.layer) + '">' + (e.layer === 'wiki' ? 'wiki' : 'source') + '</span>'
+        + '<span class="kb-title">' + esc(e.title) + '</span></span>'
+        + (tags ? '<span class="kb-tags">' + esc(tags) + '</span>' : '')
+        + (e.excerpt ? '<span class="kb-excerpt">' + esc(e.excerpt) + '</span>' : '')
+        + '</button>';
+    }
+    container.innerHTML = html;
+    var items = container.querySelectorAll('.kb-item');
+    for (var j = 0; j < items.length; j++) {
+      items[j].addEventListener('click', function () {
+        kbOpen(this.getAttribute('data-layer'), this.getAttribute('data-slug'));
+      });
+    }
+  }
+  function kbOpen(layer, slug) {
+    var reader = document.getElementById('kbReader');
+    if (!reader) return;
+    reader.classList.add('open');
+    reader.innerHTML = '<div class="view-empty">loading…</div>';
+    getJSON('/api/kb/entry?layer=' + encodeURIComponent(layer) + '&slug=' + encodeURIComponent(slug)).then(function (d) {
+      if (!d || !d.entry) { reader.innerHTML = '<div class="view-empty">not found</div>'; return; }
+      var e = d.entry;
+      var meta = [];
+      if (e.tags && e.tags.length) meta.push('tags: ' + e.tags.join(', '));
+      if (e.sources && e.sources.length) meta.push('sources: ' + e.sources.join(', '));
+      if (e.origin) meta.push('origin: ' + e.origin);
+      reader.innerHTML =
+        '<div class="kb-reader-head"><span class="kb-badge ' + esc(e.layer) + '">' + (e.layer === 'wiki' ? 'wiki' : 'source') + '</span>'
+        + '<h3>' + esc(e.title) + '</h3><button class="kb-del" title="Delete">✕</button></div>'
+        + (meta.length ? '<div class="kb-reader-meta">' + esc(meta.join('  ·  ')) + '</div>' : '')
+        + '<pre class="kb-reader-body">' + esc(e.body) + '</pre>';
+      var del = reader.querySelector('.kb-del');
+      if (del) del.addEventListener('click', function () {
+        if (window.confirm('Delete "' + e.title + '"? This removes it from your knowledge base.')) kbDelete(e.layer, e.slug);
+      });
+    });
+  }
+  function kbDelete(layer, slug) {
+    fetch('/api/kb/remove', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ layer: layer, slug: slug }) })
+      .then(function () {
+        var reader = document.getElementById('kbReader');
+        if (reader) { reader.classList.remove('open'); reader.innerHTML = ''; }
+        loadKbList();
+      });
+  }
+  var kbSearchTimer = null;
+  function loadKbList() {
+    var listEl = document.getElementById('kbList');
+    if (!listEl) return;
+    var box = document.getElementById('kbSearch');
+    var q = box ? box.value : '';
+    if (q && q.trim()) {
+      getJSON('/api/kb/search?q=' + encodeURIComponent(q)).then(function (d) {
+        kbRenderList((d && d.hits) || [], listEl);
+      });
+    } else {
+      getJSON('/api/kb').then(function (d) {
+        kbRenderList((d && d.entries) || [], listEl);
+      });
+    }
+  }
+  function loadKb() {
+    views.kb.innerHTML =
+      '<div class="view-head"><div><h2>Knowledge Base</h2><div class="vh-sub">Sources + wiki · live search</div></div></div>'
+      + '<div class="kb-searchbar"><input id="kbSearch" class="kb-search" type="text" placeholder="Search your knowledge base…" autocomplete="off"></div>'
+      + '<div class="kb-body"><div id="kbList" class="kb-list"></div><div id="kbReader" class="kb-reader"></div></div>';
+    var s = document.getElementById('kbSearch');
+    if (s) s.addEventListener('input', function () {
+      if (kbSearchTimer) clearTimeout(kbSearchTimer);
+      kbSearchTimer = setTimeout(loadKbList, 200);
+    });
+    loadKbList();
+  }
+  window.lisaReloadKb = loadKbList;
 
   // ── live refresh: wrap the agent-session refresh so the active console
   //    view + the Control nav count update on SSE agent_session_update.

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -867,6 +867,47 @@ export const MAIN_CSS = `  :root {
   .mem-btn .mem-ico { font-size: 16px; width: 20px; text-align: center; }
   .mem-btn .mem-sub { margin-left: auto; font-size: 11px; color: var(--fg-3); font-weight: 400; }
 
+  /* ── Knowledge base view ── */
+  .kb-searchbar { padding: 12px 24px 0; }
+  .kb-search {
+    width: 100%; box-sizing: border-box; font-family: inherit; font-size: 13px;
+    padding: 9px 12px; border-radius: 9px; border: 1px solid var(--border);
+    background: var(--bg-card); color: var(--fg); outline: none;
+  }
+  .kb-search:focus { border-color: var(--accent); }
+  .kb-body { flex: 1; min-height: 0; display: flex; overflow: hidden; }
+  .kb-list { width: 320px; flex-shrink: 0; overflow-y: auto; padding: 12px 16px 20px; border-right: 1px solid var(--border); }
+  .kb-item {
+    display: block; width: 100%; text-align: left; font-family: inherit; cursor: pointer;
+    background: var(--bg-card); border: 1px solid var(--border); border-radius: 10px;
+    padding: 9px 11px; margin-bottom: 8px; color: var(--fg);
+  }
+  .kb-item:hover { background: var(--bg-card-strong); border-color: var(--border-strong); }
+  .kb-row { display: flex; align-items: center; gap: 7px; }
+  .kb-badge {
+    flex-shrink: 0; font-size: 9.5px; font-weight: 700; letter-spacing: 0.06em; text-transform: uppercase;
+    padding: 2px 6px; border-radius: 5px; background: var(--accent-soft); color: var(--accent);
+  }
+  .kb-badge.sources { background: rgba(255,255,255,0.06); color: var(--fg-3); }
+  .kb-title { font-size: 13px; font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .kb-tags { display: block; margin-top: 4px; font-size: 10.5px; color: var(--accent); opacity: 0.85; }
+  .kb-excerpt { display: block; margin-top: 4px; font-size: 11.5px; color: var(--fg-3); line-height: 1.45; max-height: 34px; overflow: hidden; }
+  .kb-reader { flex: 1; min-width: 0; overflow-y: auto; padding: 18px 24px 26px; display: none; }
+  .kb-reader.open { display: block; }
+  .kb-reader-head { display: flex; align-items: center; gap: 10px; }
+  .kb-reader-head h3 { margin: 0; font-size: 15px; font-weight: 700; color: var(--fg); flex: 1; }
+  .kb-del {
+    flex-shrink: 0; font-family: inherit; cursor: pointer; font-size: 12px; line-height: 1;
+    background: transparent; border: 1px solid var(--border); border-radius: 7px; color: var(--fg-3); padding: 5px 8px;
+  }
+  .kb-del:hover { border-color: #e0555f; color: #e0555f; }
+  .kb-reader-meta { margin-top: 6px; font-size: 11px; color: var(--fg-3); }
+  .kb-reader-body { margin-top: 14px; white-space: pre-wrap; word-wrap: break-word; font-family: inherit; font-size: 13px; line-height: 1.6; color: var(--fg-2); }
+  @media (max-width: 720px) {
+    .kb-body { flex-direction: column; }
+    .kb-list { width: auto; border-right: 0; border-bottom: 1px solid var(--border); max-height: 45%; }
+  }
+
   #log {
     overflow-y: auto;
     padding: 22px 28px 24px;

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -77,6 +77,7 @@ ${MAIN_CSS}
       <button class="nav-item" type="button" data-view="room"><span class="nav-ico">⌂</span>Room</button>
       <button class="nav-item" type="button" data-view="sense"><span class="nav-ico">◉</span>Sense</button>
       <button class="nav-item" type="button" data-view="memory"><span class="nav-ico"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="display:block;margin:auto"><path d="M2 6h4M2 10h4M2 14h4M2 18h4"/><rect x="4" y="2" width="16" height="20" rx="2"/><path d="M16 2v20"/></svg></span>Memory</button>
+      <button class="nav-item" type="button" data-view="kb"><span class="nav-ico"><svg viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" style="display:block;margin:auto"><path d="M12 2 2 7l10 5 10-5-10-5Z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg></span>Knowledge</button>
     </nav>
 
     <!-- Currently wanting -->
@@ -195,6 +196,7 @@ ${MAIN_CSS}
     </section>
     <section class="view" id="viewSense"></section>
     <section class="view" id="viewMemory"></section>
+    <section class="view" id="viewKb"></section>
   </div>
 </div>
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1740,6 +1740,73 @@ self.addEventListener('fetch', (event) => {
       return;
     }
 
+    // ── Personal knowledge base (docs/PLAN_KNOWLEDGE_BASE_v1.0.md) ──────
+    if (req.method === "GET" && url.startsWith("/api/kb/search")) {
+      const q = new URL(url, "http://localhost").searchParams.get("q") ?? "";
+      const { searchKb } = await import("../kb/search.js");
+      const hits = q.trim() ? await searchKb(q, 25) : [];
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ hits }));
+      return;
+    }
+    if (req.method === "GET" && url.startsWith("/api/kb/entry")) {
+      const p = new URL(url, "http://localhost").searchParams;
+      const layer = p.get("layer") === "wiki" ? "wiki" : "sources";
+      const { readEntry } = await import("../kb/store.js");
+      const entry = await readEntry(layer, p.get("slug") ?? "").catch(() => null);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ entry }));
+      return;
+    }
+    if (req.method === "GET" && url === "/api/kb") {
+      const { listEntries } = await import("../kb/store.js");
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ entries: await listEntries() }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/kb/add") {
+      let body = "";
+      for await (const chunk of req) body += chunk.toString("utf8");
+      let payload: { title?: string; content?: string; tags?: string[]; origin?: string };
+      try {
+        payload = JSON.parse(body || "{}");
+      } catch {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("bad json");
+        return;
+      }
+      const content = (payload.content ?? "").trim();
+      if (!content) {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("empty content");
+        return;
+      }
+      const title = (payload.title ?? "").trim() || content.split("\n")[0]!.slice(0, 60) || "capture";
+      const { addSource } = await import("../kb/store.js");
+      const entry = await addSource({ title, body: content, tags: payload.tags, origin: payload.origin || "chat" });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, entry: { layer: entry.layer, slug: entry.slug, title: entry.title } }));
+      return;
+    }
+    if (req.method === "POST" && url === "/api/kb/remove") {
+      let body = "";
+      for await (const chunk of req) body += chunk.toString("utf8");
+      let payload: { layer?: string; slug?: string };
+      try {
+        payload = JSON.parse(body || "{}");
+      } catch {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("bad json");
+        return;
+      }
+      const layer = payload.layer === "wiki" ? "wiki" : "sources";
+      const { removeEntry } = await import("../kb/store.js");
+      const removed = await removeEntry(layer, payload.slug ?? "").catch(() => false);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: removed }));
+      return;
+    }
+
     if (req.method === "GET" && url === "/api/tools") {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(


### PR DESCRIPTION
**PR E1** of the [PKB plan](docs/PLAN_KNOWLEDGE_BASE_v1.0.md) — the user-facing KB in the web console (**requirement #4**, real-time retrieval). PR E2 adds the chat→md capture UI.

**Server** (next to `/api/memory`): `GET /api/kb` · `GET /api/kb/search?q=` · `GET /api/kb/entry` · `POST /api/kb/add` · `POST /api/kb/remove`.

**Client**: a new **Knowledge** nav item (3-layers icon) + a live **search box** + a two-pane **browse ↔ read** view — entries show wiki/source badges, tags, excerpt; clicking opens the full page with a delete control. Debounced search hits `/api/kb/search`; empty query lists all. `window.lisaReloadKb` exposed for PR E2.

**Verified end-to-end** on a throwaway instance (screenshots): all five endpoints, and the view renders + reads + live-searches ("pkce" → OAuth + OAuth PKCE) + deletes. Inline client JS parses; full build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)