### PR TITLE
test(web): update MAIN_HTML snapshot for the KB view + capture UI

### DIFF
--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -43,10 +43,14 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: Room v2 — the room→parent bridge moved to a richer, same-origin-guarded
  * {type:'lisa-room', action, prefill} protocol (open-chat / switch-view) at
  * module scope; the old room_open_chat listener was removed as superseded.
+ * Then: personal knowledge base (docs/PLAN_KNOWLEDGE_BASE_v1.0.md) — a
+ * "Knowledge" nav item + #viewKb (a live-search list/reader over /api/kb*), a
+ * KB select-toggle in the function bar driving a floating capture bar (chat
+ * messages → md source), and the kbCapture client block, all with their CSS.
  */
-const EXPECTED_LENGTH = 152765;
+const EXPECTED_LENGTH = 168871;
 const EXPECTED_SHA256 =
-  "10f9f81fae155277f61c110eccca9e3c7de95d455ca4b170b46d681c3b5557b2";
+  "9b5eb6a037161133fbe1df097f00c2da0d9f4e52045e72a145436d2b3a664607";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);


### PR DESCRIPTION
The byte-exactness guard for `lisa-html.ts` locked MAIN_HTML to its pre-KB state; the Knowledge view (#240) + chat→md capture (#241) intentionally changed the served markup/CSS/JS. Recomputes length + sha256 per the test's own instructions and notes the change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)