### PR TITLE
feat(soul): surface the most recently active desire as current

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -12,9 +12,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { LISA_HOME, REFLECTIONS_DIR, SESSIONS_DIR } from "../paths.js";
 import {
+  desireActivity,
   isBorn,
   listDesires,
   listJournalDates,
+  pickCurrentDesire,
   readSoulSummary,
 } from "../soul/store.js";
 import { SOUL_DIR } from "../soul/paths.js";
@@ -87,13 +89,18 @@ export async function runStatus(): Promise<void> {
   if (desires.length === 0) {
     console.log(`  ${dim("(none)")}`);
   } else {
+    // The one surfaced as "current" in the room/island — mark it so `status`
+    // and the UI agree on what she's focused on.
+    const current = pickCurrentDesire(desires, await desireActivity(desires));
+    const mark = (d: (typeof desires)[number]) =>
+      d.slug === current?.slug ? `  ${dim("← current")}` : "";
     const actionable = desires.filter((d) => d.actionable);
     const dormant = desires.filter((d) => !d.actionable);
     for (const d of actionable) {
-      console.log(`  ${green("●")} ${d.what}  ${dim("[heartbeat-active]")}`);
+      console.log(`  ${green("●")} ${d.what}  ${dim("[heartbeat-active]")}${mark(d)}`);
     }
     for (const d of dormant) {
-      console.log(`  ${grey("○")} ${d.what}`);
+      console.log(`  ${grey("○")} ${d.what}${mark(d)}`);
     }
   }
 

--- a/src/soul/desire-activity.test.ts
+++ b/src/soul/desire-activity.test.ts
@@ -1,0 +1,76 @@
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import fsp from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+// PLAN_DESIRE_EVOLUTION_v1.0 §3 PR3: pick-desire.test.ts covers the PURE
+// pickCurrentDesire; this covers the I/O half — desireActivity reading real
+// file mtimes off disk and feeding pickCurrentDesire end-to-end. Uses a real
+// temp soul with mtimes pinned via fs.utimes so the assertions are deterministic.
+//
+// SOUL_DIR derives from LISA_HOME at import, so set a tmp home before importing.
+let store: typeof import("./store.js");
+let paths: typeof import("./paths.js");
+let home: string;
+
+before(async () => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-desire-activity-"));
+  process.env.LISA_HOME = home;
+  store = await import("./store.js");
+  paths = await import("./paths.js");
+  await store.ensureSoulDirs();
+});
+after(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+const iso = (s: string) => new Date(s).getTime() / 1000; // fs.utimes wants seconds
+
+async function seed(slug: string, bornAt: string) {
+  await store.writeDesire({
+    slug,
+    what: slug,
+    why: "",
+    actionable: true,
+    heartbeatPrompt: "pursue it",
+    bornAt,
+  });
+}
+
+describe("desireActivity (real fs.stat I/O)", () => {
+  test("reports the newer of the desire-file and progress-file mtime, per slug", async () => {
+    await seed("alpha", "2026-01-01T00:00:00.000Z");
+    await seed("beta", "2026-01-01T00:00:00.000Z");
+    // beta has been PURSUED recently (progress file appended), alpha hasn't.
+    await store.appendDesireProgress("beta", "did a thing");
+
+    // Pin mtimes deterministically: alpha's files old; beta's desire file old
+    // but its progress file fresh — so beta's activity should win.
+    await fsp.utimes(paths.desireFile("alpha"), iso("2026-02-01"), iso("2026-02-01"));
+    await fsp.utimes(paths.desireFile("beta"), iso("2026-02-01"), iso("2026-02-01"));
+    await fsp.utimes(paths.desireProgressFile("beta"), iso("2026-08-01"), iso("2026-08-01"));
+
+    const desires = await store.listDesires();
+    const activity = await store.desireActivity(desires);
+
+    // beta's activity reflects its fresh PROGRESS mtime (pursuit), not its older
+    // desire-file mtime.
+    assert.equal(activity["beta"]?.slice(0, 7), "2026-08");
+    assert.equal(activity["alpha"]?.slice(0, 7), "2026-02");
+
+    // End-to-end: the recently-pursued desire is surfaced as current.
+    assert.equal(store.pickCurrentDesire(desires, activity)?.slug, "beta");
+  });
+
+  test("floors at bornAt when no files are newer (and tolerates a missing progress file)", async () => {
+    // 'gamma' has a future bornAt but its files will be stat'd at creation time
+    // (now), which is < the future bornAt — so activity should floor at bornAt.
+    await seed("gamma", "2099-01-01T00:00:00.000Z");
+    const desires = (await store.listDesires()).filter((d) => d.slug === "gamma");
+    const activity = await store.desireActivity(desires);
+    // Missing progress file is not an error; bornAt dominates.
+    assert.equal(activity["gamma"]?.slice(0, 4), "2099");
+  });
+});

--- a/src/soul/pick-desire.test.ts
+++ b/src/soul/pick-desire.test.ts
@@ -1,0 +1,84 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { pickCurrentDesire } from "./store.js";
+import type { DesireEntry } from "./types.js";
+
+// PLAN_DESIRE_EVOLUTION_v1.0 §3 PR3: the surfaced "current desire" must track
+// real activity, not fs.readdir order. pickCurrentDesire is the pure core.
+
+function d(slug: string, over: Partial<DesireEntry> = {}): DesireEntry {
+  return {
+    slug,
+    what: slug,
+    why: "",
+    actionable: false,
+    bornAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("pickCurrentDesire", () => {
+  test("returns null for an empty list", () => {
+    assert.equal(pickCurrentDesire([]), null);
+  });
+
+  test("prefers actionable desires over dormant ones", () => {
+    const desires = [
+      d("dormant-newer", { bornAt: "2026-06-01T00:00:00.000Z" }),
+      d("actionable-older", { actionable: true, bornAt: "2026-02-01T00:00:00.000Z" }),
+    ];
+    // Even though the dormant one is newer, an actionable one is what she's
+    // actually pursuing, so it wins.
+    assert.equal(pickCurrentDesire(desires)?.slug, "actionable-older");
+  });
+
+  test("among actionable, the most recently active wins (via activity map)", () => {
+    const desires = [
+      d("a", { actionable: true, bornAt: "2026-01-01T00:00:00.000Z" }),
+      d("b", { actionable: true, bornAt: "2026-01-01T00:00:00.000Z" }),
+      d("c", { actionable: true, bornAt: "2026-01-01T00:00:00.000Z" }),
+    ];
+    const activityAt = {
+      a: "2026-03-01T00:00:00.000Z",
+      b: "2026-09-01T00:00:00.000Z", // most recently pursued
+      c: "2026-05-01T00:00:00.000Z",
+    };
+    assert.equal(pickCurrentDesire(desires, activityAt)?.slug, "b");
+  });
+
+  test("is independent of array (fs.readdir) order", () => {
+    const a = d("a", { actionable: true, bornAt: "2026-01-01T00:00:00.000Z" });
+    const b = d("b", { actionable: true, bornAt: "2026-08-01T00:00:00.000Z" });
+    // Newer 'b' is picked regardless of whether it's listed first or last.
+    assert.equal(pickCurrentDesire([a, b])?.slug, "b");
+    assert.equal(pickCurrentDesire([b, a])?.slug, "b");
+  });
+
+  test("falls back to bornAt when a slug has no activity entry", () => {
+    const desires = [
+      d("old", { actionable: true, bornAt: "2026-01-01T00:00:00.000Z" }),
+      d("new", { actionable: true, bornAt: "2026-07-01T00:00:00.000Z" }),
+    ];
+    // Empty activity map → ordering purely by bornAt.
+    assert.equal(pickCurrentDesire(desires, {})?.slug, "new");
+  });
+
+  test("activity recency beats a younger bornAt (pursuit refreshes an old desire)", () => {
+    const desires = [
+      d("young-idle", { actionable: true, bornAt: "2026-06-01T00:00:00.000Z" }),
+      d("old-but-pursued", { actionable: true, bornAt: "2026-01-01T00:00:00.000Z" }),
+    ];
+    const activityAt = {
+      "old-but-pursued": "2026-09-01T00:00:00.000Z", // pursued yesterday
+    };
+    assert.equal(pickCurrentDesire(desires, activityAt)?.slug, "old-but-pursued");
+  });
+
+  test("with no actionable desires, picks the most recent of all", () => {
+    const desires = [
+      d("x", { bornAt: "2026-01-01T00:00:00.000Z" }),
+      d("y", { bornAt: "2026-04-01T00:00:00.000Z" }),
+    ];
+    assert.equal(pickCurrentDesire(desires)?.slug, "y");
+  });
+});

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -279,6 +279,58 @@ function parseDesireFile(slug: string, raw: string): DesireEntry {
   return { slug, what, why, actionable, heartbeatPrompt, pursuit, bornAt: born };
 }
 
+/**
+ * Per-slug "last activity" timestamp (ISO), from the newer of the desire file
+ * and its progress file mtime, floored at bornAt. Cheap (fs.stat) and reflects
+ * BOTH authoring (add/revise rewrite <slug>.md) and pursuit (the heartbeat
+ * appends <slug>.progress.md). Feeds pickCurrentDesire so "current" tracks real
+ * events instead of filesystem-listing accident.
+ */
+export async function desireActivity(
+  desires: DesireEntry[],
+): Promise<Record<string, string>> {
+  const out: Record<string, string> = {};
+  for (const d of desires) {
+    let ms = Date.parse(d.bornAt) || 0;
+    for (const f of [desireFile(d.slug), desireProgressFile(d.slug)]) {
+      try {
+        const st = await fs.stat(f);
+        ms = Math.max(ms, Math.floor(st.mtimeMs));
+      } catch {
+        // progress file often doesn't exist yet — not an error
+      }
+    }
+    out[d.slug] = new Date(ms).toISOString();
+  }
+  return out;
+}
+
+/**
+ * Pick the single desire to surface as "current". Prefers actionable desires
+ * (the ones actually driving the heartbeat); within the chosen pool, the most
+ * recently active wins. Pure — the caller passes activity timestamps (the I/O
+ * lives in desireActivity), so this stays trivially testable. null when empty.
+ *
+ * Because the ordering key is a stored timestamp, the pick is STABLE between
+ * real events and only moves when something actually happens (a desire is
+ * added, revised, pursued, or closed) — that's fidelity, not per-request
+ * flicker, and it replaces the old fs.readdir-order accident.
+ */
+export function pickCurrentDesire(
+  desires: DesireEntry[],
+  activityAt?: Record<string, string>,
+): DesireEntry | null {
+  if (desires.length === 0) return null;
+  const recency = (d: DesireEntry): number => {
+    const a = activityAt?.[d.slug];
+    const fromActivity = a ? Date.parse(a) : NaN;
+    return Number.isNaN(fromActivity) ? Date.parse(d.bornAt) || 0 : fromActivity;
+  };
+  const actionable = desires.filter((d) => d.actionable);
+  const pool = actionable.length > 0 ? actionable : desires;
+  return [...pool].sort((x, y) => recency(y) - recency(x))[0] ?? null;
+}
+
 /** Can the autonomous heartbeat pursue this desire unattended? Pure (R4). */
 export function isAutoPursuable(d: DesireEntry): boolean {
   return !!(d.actionable && d.heartbeatPrompt) && d.pursuit !== "needs-user";

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -27,7 +27,7 @@ import {
   countUserMessages,
   decideReflect,
 } from "./reflect-scheduler.js";
-import { listDesires } from "../soul/store.js";
+import { listDesires, desireActivity, pickCurrentDesire } from "../soul/store.js";
 import { ISLAND_HTML } from "./island.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
@@ -833,8 +833,11 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       let currentDesire: string | null = null;
       try {
         const desires = await listDesires();
-        const actionable = desires.find((d) => d.actionable);
-        currentDesire = (actionable ?? desires[0])?.what ?? null;
+        // Surface the most recently ACTIVE desire (authored or pursued), not
+        // whichever actionable one fs.readdir happened to list first — so the
+        // ticker moves when something real changes. See PLAN_DESIRE_EVOLUTION.
+        const activity = await desireActivity(desires);
+        currentDesire = pickCurrentDesire(desires, activity)?.what ?? null;
       } catch {
         // listDesires can fail before soul is born; that's fine.
       }


### PR DESCRIPTION
> **Stacked PR (3/3).** Base is `claude/desire-reflect-evolve` (#249), not `main` — GitHub retargets automatically as parents merge. Merge order: **#242 → #249 → #247**. The diff below is only this PR's own changes.

## Why

The "current desire" ticker (room/island, and the web client) reads `current_desire` from `GET /api/island/ping`, which computed it as `desires.find(d => d.actionable)` over **`fs.readdir` order** — an arbitrary, static pick decoupled from recency and relevance. So even once desires start changing (PR #242 / #249), the *surfaced* one still wouldn't move (root cause #1 in the plan doc).

## What

Two store helpers:

- **`pickCurrentDesire(desires, activityAt?)`** — pure. Prefers actionable desires (what's actually driving the heartbeat); within that pool the most-recently-active wins; falls back to most-recently-born. Because the ordering key is a *stored timestamp*, the pick is **stable between real events** and only moves when something actually happens — add / revise / pursue / close. That's fidelity, not per-request flicker.
- **`desireActivity(desires)`** — cheap `fs.stat` over each `<slug>.md` and `<slug>.progress.md`, so "activity" reflects both **authoring** (add/revise rewrite the desire file) and **pursuit** (the heartbeat appends the progress file).

Wired into `GET /api/island/ping` — which the room, island, and web client all consume, so all three update from one change — and marked (`← current`) in `lisa status` so the CLI and UI agree.

## Design rationale (正反方辩论)

Plan doc Debate 3 weighs *recency sort (feels alive)* vs *stable pick (steady north-star)*. Decision: **sort by activity** — the reframing that dissolves the tension is that a timestamp-driven key is stable between events, so you get the north-star feel *and* the responsiveness, which the readdir accident gave neither of. Full debate in [`docs/PLAN_DESIRE_EVOLUTION_v1.0.md`](docs/PLAN_DESIRE_EVOLUTION_v1.0.md) §4 (landed in #242).

## Testing

- `src/soul/pick-desire.test.ts` — 7 tests: empty→null, actionable preference, activity-recency ordering, **independence from array/readdir order**, bornAt fallback, pursuit refreshing an old desire, all-dormant fallback.
- `npm test`: **zero regressions** — the 3 failures present (`mail/scheduler`, `mail/service` from the missing `imapflow` optional dep; `web/auth`) fail identically on `main` with and without this change (verified by stash-and-compare); +7 new passing tests. Typecheck clean.

## Merge order

Independent of #242 and #249 (touches disjoint regions of `store.ts` / `server.ts`), but the series reads best merged **#242 → #249 → this**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

