### PR TITLE
feat(web): surface the desire the conversation is about (intra-session focus)

### DIFF
--- a/docs/PLAN_DESIRE_EVOLUTION_v1.0.md
+++ b/docs/PLAN_DESIRE_EVOLUTION_v1.0.md
@@ -138,9 +138,22 @@ Closes G3.
 Files: `src/soul/store.ts`, `src/web/server.ts`, `src/cli/status.ts`,
 test `src/soul/pick-desire.test.ts`.
 
-**Recommended merge order: PR1 → PR2 → PR3.** They branch independently off `main` and touch
-disjoint regions of the two shared files (`web/server.ts`: idle handler vs ping endpoint;
-`store.ts`: revise/close vs pick helper), so conflicts are trivial-to-none.
+### PR 4 — `feat(web): surface the desire the conversation is about (intra-session focus)`
+Implements F1 (Debate 4), added at the owner's request after PR1–3. Conservative by construction.
+
+- Pure `pickFocusedDesire(desires, recentText)` + `tokenize` + `recentUserText` in
+  `src/soul/desire-focus.ts`. Lexical overlap only — **no per-turn LLM call, no persisted state.**
+- Cross-lingual: latin word-tokens **and** CJK character bigrams, so it works when Lisa and the
+  user converse in Chinese (no segmenter needed).
+- Wired into `GET /api/island/ping`: when the conversation is fresh (`idleFor() <
+  FOCUS_FRESHNESS_MS`) and *clearly* about one desire, surface it; otherwise fall back to PR3's
+  `pickCurrentDesire`. A tie or weak match returns null, so it can never invent focus.
+
+Files: `src/soul/desire-focus.ts`, `src/web/server.ts`, test `src/soul/desire-focus.test.ts`.
+
+**Merge order: PR1 → PR2 → PR3 → PR4**, landed as a stack (each branched on the previous). The
+owner also pushed a hardening commit onto PR1 (clamp the debounce env; make the "dream" idle
+defer to an in-flight reflect) — folded into the series.
 
 ---
 
@@ -215,6 +228,12 @@ current. Real-time-per-sentence is a want we invented, not one that was asked fo
 still feels frozen, and only then consider a *conservative* heuristic focus (reuse an existing
 desire via a cheap match — never mint per-turn state). Documented in §6 as a gated follow-up.
 
+> **Update (2026-07-15): implemented as PR4, conservatively, at the owner's request** ("全部进行").
+> It stays strictly inside the 反方 guardrails — pure lexical overlap (no per-turn LLM call), no
+> persisted state, display-only, and it returns null (→ recency fallback) unless the live
+> conversation *clearly* matches one existing desire. Cross-lingual (latin word-tokens + CJK
+> bigrams) and gated on conversation freshness so a stale chat can't pin a stale focus.
+
 ---
 
 ## 5. Testing & verification
@@ -234,9 +253,9 @@ desire via a cheap match — never mint per-turn state). Documented in §6 as a 
 
 ## 6. Deferred / future work
 
-- **F1. Conservative intra-session focus (Debate 4).** If pause-granularity still feels static,
-  add a cheap match from the live transcript to an *existing* desire for display only — no new
-  persisted state, no per-turn LLM call beyond what already runs.
+- **F1. Conservative intra-session focus (Debate 4). — DONE, PR4.** A cheap lexical match from
+  the live transcript to an *existing* desire, display-only, no persisted state, cross-lingual,
+  freshness-gated. `src/soul/desire-focus.ts`, wired into `GET /api/island/ping`.
 - **F2. Reflection-driven reprioritization signal to the heartbeat** (e.g. "pursue this next"),
   once revise/close data shows the list staying healthy.
 - **F3. Surface reflection outcomes in the room/island UI** ("she just realized she wants to …").
@@ -246,3 +265,6 @@ desire via a cheap match — never mint per-turn state). Documented in §6 as a 
 ## 7. Changelog
 
 - 2026-07-15 — doc created; PR1–3 scoped; debates recorded; decisions locked to recommendations.
+- 2026-07-15 — PR1–3 implemented + stacked; owner hardened PR1 (debounce clamp + symmetric
+  dream/reflect guard); F1 (intra-session focus) implemented conservatively as PR4 at owner's
+  request. Series merges PR1 → PR2 → PR3 → PR4.

--- a/src/soul/desire-focus.test.ts
+++ b/src/soul/desire-focus.test.ts
@@ -1,0 +1,101 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FOCUS_MIN_OVERLAP,
+  pickFocusedDesire,
+  recentUserText,
+  tokenize,
+} from "./desire-focus.js";
+import type { DesireEntry } from "./types.js";
+import type { StoredMessage } from "../types.js";
+
+function d(slug: string, what: string, why = ""): DesireEntry {
+  return { slug, what, why, actionable: true, bornAt: "2026-01-01T00:00:00.000Z" };
+}
+
+describe("tokenize", () => {
+  test("keeps latin words ≥3 chars and drops stopwords", () => {
+    const t = tokenize("I want to learn Rust for systems programming");
+    assert.ok(t.has("learn"));
+    assert.ok(t.has("rust"));
+    assert.ok(t.has("systems"));
+    assert.ok(t.has("programming"));
+    assert.ok(!t.has("want"), "stopword dropped");
+    assert.ok(!t.has("to"), "short token dropped");
+  });
+
+  test("emits CJK bigrams within a run", () => {
+    const t = tokenize("学习编程");
+    assert.ok(t.has("学习"));
+    assert.ok(t.has("习编"));
+    assert.ok(t.has("编程"));
+  });
+});
+
+describe("pickFocusedDesire", () => {
+  const desires = [
+    d("learn-rust", "learn Rust", "systems programming fluency"),
+    d("write-novel", "write a novel", "tell a story about the sea"),
+  ];
+
+  test("surfaces the desire the conversation is clearly about", () => {
+    const text = "can you help me debug this Rust borrow checker error in my systems code";
+    assert.equal(pickFocusedDesire(desires, text)?.slug, "learn-rust");
+  });
+
+  test("returns null when nothing matches (→ caller falls back to recency)", () => {
+    assert.equal(pickFocusedDesire(desires, "what's the weather tomorrow"), null);
+  });
+
+  test("returns null on a weak (single-token) match, below the threshold", () => {
+    // Only "rust" overlaps → 1 < FOCUS_MIN_OVERLAP.
+    assert.equal(FOCUS_MIN_OVERLAP, 2);
+    assert.equal(pickFocusedDesire(desires, "there's rust on my bike"), null);
+  });
+
+  test("returns null on a tie (no single desire is clearly the subject)", () => {
+    const tie = [
+      d("a", "alpha beta", "gamma delta"),
+      d("b", "alpha beta", "gamma delta"),
+    ];
+    assert.equal(pickFocusedDesire(tie, "alpha beta gamma"), null);
+  });
+
+  test("works cross-lingually on Chinese via CJK bigrams", () => {
+    const zh = [
+      d("learn-rust", "学习 Rust 编程", "掌握系统级编程"),
+      d("write-novel", "写一本小说", "讲一个关于海的故事"),
+    ];
+    // Conversation in Chinese about programming → matches the rust desire.
+    assert.equal(pickFocusedDesire(zh, "我想学习编程，尤其是系统编程")?.slug, "learn-rust");
+  });
+
+  test("empty conversation text → null", () => {
+    assert.equal(pickFocusedDesire(desires, ""), null);
+  });
+});
+
+describe("recentUserText", () => {
+  const mk = (role: StoredMessage["role"], text: string): StoredMessage =>
+    ({ role, content: [{ type: "text", text }] }) as StoredMessage;
+
+  test("joins the last N user messages, ignoring assistant turns", () => {
+    const history: StoredMessage[] = [
+      mk("user", "first"),
+      mk("assistant", "reply"),
+      mk("user", "second"),
+      mk("user", "third"),
+    ];
+    const text = recentUserText(history, 2);
+    assert.ok(text.includes("second"));
+    assert.ok(text.includes("third"));
+    assert.ok(!text.includes("first"), "older than the last 2 user msgs");
+    assert.ok(!text.includes("reply"), "assistant turns excluded");
+  });
+
+  test("handles string content and empty history", () => {
+    assert.equal(recentUserText([]), "");
+    const history = [{ role: "user", content: "plain string" } as StoredMessage];
+    assert.ok(recentUserText(history).includes("plain string"));
+  });
+});

--- a/src/soul/desire-focus.ts
+++ b/src/soul/desire-focus.ts
@@ -1,0 +1,113 @@
+/**
+ * Intra-session focus (PLAN_DESIRE_EVOLUTION_v1.0 §6 F1, the conservative
+ * variant): while a conversation is live, surface the EXISTING desire it's
+ * about — so the "current desire" tracks the conversation at turn granularity,
+ * not just at reflection pauses.
+ *
+ * Deliberately cheap and safe, per Debate 4's concerns:
+ *  - Pure lexical overlap. NO per-turn LLM call, NO persisted state.
+ *  - Display-only. It never writes a desire; it only chooses which existing one
+ *    to show. When nothing matches clearly it returns null and the caller falls
+ *    back to the recency pick (pickCurrentDesire), so it can't invent focus.
+ *  - Cross-lingual: matches English word tokens AND CJK character bigrams, so it
+ *    works when Lisa and the user converse in Chinese (no segmenter needed).
+ */
+import type { DesireEntry } from "./types.js";
+import type { StoredMessage } from "../types.js";
+
+/** How recently the conversation must have been active for focus to apply. Past
+ *  this, a "focus" derived from old messages is stale — fall back to recency. */
+export const FOCUS_FRESHNESS_MS = 15 * 60_000;
+
+/** Minimum shared tokens for a desire to count as "what this is about". */
+export const FOCUS_MIN_OVERLAP = 2;
+
+// Small English stoplist — the frequent glue words that would create spurious
+// overlap. Intentionally short; rarer words carry the signal.
+const STOPWORDS = new Set([
+  "the", "and", "for", "you", "your", "that", "this", "with", "have", "has",
+  "was", "are", "but", "not", "can", "will", "would", "about", "what", "how",
+  "why", "when", "which", "them", "they", "from", "into", "out", "get", "got",
+  "want", "wanted", "like", "just", "some", "any", "all", "one", "two", "more",
+  "she", "her", "his", "him", "its", "our", "their", "been", "being", "there",
+]);
+
+/**
+ * Tokenize into a comparable set: lowercased latin word-tokens (len ≥ 3, minus
+ * stopwords) plus CJK character bigrams within each contiguous CJK run. Pure.
+ */
+export function tokenize(text: string): Set<string> {
+  const out = new Set<string>();
+  const lower = text.toLowerCase();
+  for (const m of lower.matchAll(/[a-z0-9]{3,}/g)) {
+    if (!STOPWORDS.has(m[0])) out.add(m[0]);
+  }
+  // Contiguous CJK runs (Han + kana + Hangul) → overlapping 2-char shingles.
+  for (const m of text.matchAll(/[一-鿿぀-ヿ가-힯]{2,}/g)) {
+    const run = m[0];
+    for (let i = 0; i + 1 < run.length; i++) out.add(run.slice(i, i + 2));
+  }
+  return out;
+}
+
+/**
+ * Pick the desire the recent conversation is clearly about, or null. Scores each
+ * desire by token overlap with `recentText`; returns the STRICT top scorer when
+ * it clears FOCUS_MIN_OVERLAP. A tie (no single desire is clearly the subject)
+ * returns null so the caller can fall back to the recency pick rather than pick
+ * arbitrarily. Pure.
+ */
+export function pickFocusedDesire(
+  desires: DesireEntry[],
+  recentText: string,
+  opts: { minOverlap?: number } = {},
+): DesireEntry | null {
+  const min = opts.minOverlap ?? FOCUS_MIN_OVERLAP;
+  const convo = tokenize(recentText);
+  if (convo.size === 0) return null;
+  let best: DesireEntry | null = null;
+  let bestScore = 0;
+  let tied = false;
+  for (const d of desires) {
+    const dt = tokenize(`${d.what} ${d.why}`);
+    let score = 0;
+    for (const t of dt) if (convo.has(t)) score++;
+    if (score > bestScore) {
+      best = d;
+      bestScore = score;
+      tied = false;
+    } else if (score === bestScore && score > 0) {
+      tied = true;
+    }
+  }
+  if (bestScore < min || tied) return null;
+  return best;
+}
+
+/** Join the last `maxMessages` user-authored messages into one string for
+ *  matching. Latest-weighted context of what the user is actually talking about. */
+export function recentUserText(
+  history: readonly StoredMessage[],
+  maxMessages = 3,
+): string {
+  const texts: string[] = [];
+  for (let i = history.length - 1; i >= 0 && texts.length < maxMessages; i--) {
+    const m = history[i];
+    if (!m || m.role !== "user") continue;
+    const t = messageText(m.content);
+    if (t.trim()) texts.push(t);
+  }
+  return texts.reverse().join(" ");
+}
+
+function messageText(content: StoredMessage["content"]): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((b) =>
+      b && typeof b === "object" && "text" in b && typeof b.text === "string"
+        ? b.text
+        : "",
+    )
+    .join(" ");
+}

--- a/src/soul/desire-focus.ts
+++ b/src/soul/desire-focus.ts
@@ -68,7 +68,11 @@ export function pickFocusedDesire(
   let best: DesireEntry | null = null;
   let bestScore = 0;
   let tied = false;
-  for (const d of desires) {
+  // Only actionable desires can be the conversation's focus — mirror
+  // pickCurrentDesire so a lexically-matching CLOSED/dormant desire
+  // (actionable:false, still returned by listDesires) can't get surfaced.
+  const pool = desires.filter((d) => d.actionable);
+  for (const d of pool) {
     const dt = tokenize(`${d.what} ${d.why}`);
     let score = 0;
     for (const t of dt) if (convo.has(t)) score++;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -28,6 +28,11 @@ import {
   decideReflect,
 } from "./reflect-scheduler.js";
 import { listDesires, desireActivity, pickCurrentDesire } from "../soul/store.js";
+import {
+  FOCUS_FRESHNESS_MS,
+  pickFocusedDesire,
+  recentUserText,
+} from "../soul/desire-focus.js";
 import { ISLAND_HTML } from "./island.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
@@ -833,11 +838,17 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       let currentDesire: string | null = null;
       try {
         const desires = await listDesires();
-        // Surface the most recently ACTIVE desire (authored or pursued), not
-        // whichever actionable one fs.readdir happened to list first — so the
-        // ticker moves when something real changes. See PLAN_DESIRE_EVOLUTION.
+        // If the conversation is live and clearly about one of her desires,
+        // surface THAT (intra-session focus — tracks the turn-by-turn topic).
+        // Otherwise fall back to the most recently ACTIVE desire (authored or
+        // pursued), not whichever fs.readdir listed first. See PLAN_DESIRE_EVOLUTION.
+        const focused =
+          reflectClock.idleFor() < FOCUS_FRESHNESS_MS
+            ? pickFocusedDesire(desires, recentUserText(history))
+            : null;
         const activity = await desireActivity(desires);
-        currentDesire = pickCurrentDesire(desires, activity)?.what ?? null;
+        currentDesire =
+          (focused ?? pickCurrentDesire(desires, activity))?.what ?? null;
       } catch {
         // listDesires can fail before soul is born; that's fine.
       }


### PR DESCRIPTION
> **Stacked PR (4/4).** Base is `claude/desire-current-pick` (#247) — GitHub retargets automatically as parents merge. Merge order: **#242 → #249 → #247 → this**. Diff below is only this PR's own changes.

## Why

PR1–3 make desires change at reflection **pauses**. This closes the last gap from Debate 4: making the *surfaced* desire track the conversation **turn-by-turn** — the finest-grained version of "the wish follows what we talk about." Originally deferred (§6 F1); implemented now at the owner's request ("全部进行"), staying strictly inside the guardrails I set for it.

## What

- Pure `pickFocusedDesire(desires, recentText)` + `tokenize` + `recentUserText` in `src/soul/desire-focus.ts`: lexical overlap between the recent user turns and each desire's `what`/`why`. **No per-turn LLM call. No persisted state. Display-only.**
- **Cross-lingual**: latin word-tokens *and* CJK character bigrams, so it works when Lisa and the user converse in Chinese (no segmenter needed).
- Wired into `GET /api/island/ping`: when the conversation is fresh (`idleFor() < FOCUS_FRESHNESS_MS`, 15 min) and *clearly* about one desire, surface it; otherwise fall back to PR3's `pickCurrentDesire`. A tie or weak match (< 2 shared tokens) returns `null`, so it **can never invent focus** — worst case it degrades to the recency pick.

## Why it's safe (Debate 4's 反方 concerns, addressed)

| Concern | Mitigation |
|---|---|
| Per-turn cost | Pure string overlap, no model call |
| Thrashing | Freshness gate + strict-winner + `FOCUS_MIN_OVERLAP=2`; ties → fallback |
| Two notions of "want" | Focus only *chooses which existing desire to show* — it never creates one |

## Testing

- `src/soul/desire-focus.test.ts` — 10 tests: tokenizer (latin + CJK bigrams), match / no-match / weak / tie, **Chinese cross-lingual match**, `recentUserText` gathering. All green.
- `npm test`: **zero regressions** — same 3 pre-existing failures as `main` (`imapflow` mail tests, `web/auth`); +10 new passing. Typecheck clean.

Backend/data-selection change; the pure logic is fully unit-tested (browser preview would need a seeded born-soul fixture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
