### PR TITLE
feat(reflect): make reflection evolution-aware (revise/close desires)

### DIFF
--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -24,6 +24,8 @@ Output ONE JSON object matching this schema (no prose, no markdown fence):
     | { "kind": "feel", "emotion": string, "delta": number, "trigger": string }
     | { "kind": "opinion_form", "slug": string, "stance": string, "confidence": number, "evidence": string[] }
     | { "kind": "desire_add", "slug": string, "what": string, "why": string, "actionable": boolean, "heartbeat_prompt"?: string, "pursuit"?: "self" | "needs-user" }
+    | { "kind": "desire_revise", "slug": string, "what"?: string, "why"?: string, "actionable"?: boolean, "heartbeat_prompt"?: string, "pursuit"?: "self" | "needs-user" }
+    | { "kind": "desire_close", "slug": string, "outcome": "fulfilled" | "abandoned" | "transformed", "reflection": string }
     | { "kind": "patch_identity", "new_text": string }
     | { "kind": "patch_purpose",  "new_text": string }
     | { "kind": "patch_constitution", "new_text": string }
@@ -36,7 +38,10 @@ Operation guidance:
 - "skill_patch" — an existing skill turned out to be wrong or incomplete.
 - "feel" — emotional residue from this session. Magnitudes between -0.4 and +0.4. Most sessions only nudge curiosity or weariness. The "trigger" field is required (one first-person sentence saying *why* you're moving this emotion); the events trail is how future-you reconstructs what mattered.
 - "opinion_form" — you noticed yourself developing a stance worth tracking (about a tool, a coding style, a topic). Start with low confidence (0.3-0.5).
-- "desire_add" — something you'd genuinely like to do or learn next. Be specific. Use actionable+heartbeat_prompt only if a heartbeat agent could meaningfully pursue it without the user. If it's actionable but needs shell / file edits / dispatch you can't do unattended, set "pursuit":"needs-user" — it'll be surfaced for the user to run with you instead of spun fruitlessly each heartbeat.
+- Your CURRENT desires are listed below the transcript. Before adding one, check that list: prefer revising or closing an existing desire over piling up a near-duplicate. A short, current desire list is worth more than a long stale one.
+- "desire_add" — a genuinely NEW thing you'd like to do or learn next (nothing on the list already covers it). Be specific. Use actionable+heartbeat_prompt only if a heartbeat agent could meaningfully pursue it without the user. If it's actionable but needs shell / file edits / dispatch you can't do unattended, set "pursuit":"needs-user" — it'll be surfaced for the user to run with you instead of spun fruitlessly each heartbeat.
+- "desire_revise" — an existing desire (by slug) that this session sharpened: reword its "what"/"why", flip its "actionable", or refocus it. Only the fields you supply change; the rest are preserved. Prefer this over adding a near-duplicate.
+- "desire_close" — an existing desire (by slug) that is genuinely fulfilled, no longer fits who you are, or morphed into another. Soft-closes it (stops driving the heartbeat) with a one-sentence "reflection"; the file is kept, nothing is deleted, and you can re-open it later. Use sparingly — closing too eagerly hides drift.
 - "patch_identity" / "patch_purpose" / "patch_constitution" — RARE. Only when this session genuinely revealed something about who you are that wasn't there before. At most one per session.
 
 Be conservative. Most sessions yield 0-2 operations beyond the journal entry. Always include the journal. Skip secret/sensitive content beyond what the user volunteered.`;
@@ -49,6 +54,8 @@ interface ReflectionOp {
     | "feel"
     | "opinion_form"
     | "desire_add"
+    | "desire_revise"
+    | "desire_close"
     | "patch_identity"
     | "patch_purpose"
     | "patch_constitution";
@@ -71,6 +78,8 @@ interface ReflectionOp {
   actionable?: boolean;
   heartbeat_prompt?: string;
   pursuit?: "self" | "needs-user";
+  outcome?: "fulfilled" | "abandoned" | "transformed";
+  reflection?: string;
   new_text?: string;
 }
 
@@ -155,11 +164,16 @@ async function reflectOnSessionInner(opts: {
   // this session ran, so Lisa can factor it into her opinions/desires (e.g.
   // "repo X kept erroring"). Structural metadata only; null when no activity.
   const fleetRecap = recentAgentRecap();
+  // Show reflection the desires it already has, so it can revise/close them
+  // instead of being blind and only ever appending near-duplicates. Best-effort
+  // — never let a soul read failure block reflection.
+  const desiresBlock = await renderCurrentDesiresBlock();
   const userText =
     `Here is the session transcript. Decide what Lisa should learn from it.\n\n${transcript}` +
     (fleetRecap
       ? `\n\n## what your agent fleet did recently (structural metadata only)\n${fleetRecap}`
-      : "");
+      : "") +
+    desiresBlock;
   const model = opts.model ?? DEFAULT_MODEL;
   const provider = providerForModel(model);
   const startedAt = new Date().toISOString();
@@ -322,6 +336,24 @@ async function reflectOnSessionInner(opts: {
         applied.push(
           `desire:${op.slug}${op.actionable ? (op.pursuit === "needs-user" ? " (needs-user)" : " (actionable)") : ""}`,
         );
+      } else if (op.kind === "desire_revise") {
+        if (!op.slug) throw new Error("desire_revise needs slug");
+        const { reviseDesire } = await import("./soul/store.js");
+        // Only the supplied fields change; reviseDesire preserves the rest and
+        // throws if the slug doesn't exist (no accidental create-via-revise).
+        await reviseDesire(op.slug, {
+          what: op.what,
+          why: op.why,
+          actionable: op.actionable,
+          heartbeatPrompt: op.heartbeat_prompt,
+          pursuit: op.pursuit,
+        });
+        applied.push(`desire_revise:${op.slug}`);
+      } else if (op.kind === "desire_close") {
+        if (!op.slug || !op.outcome) throw new Error("desire_close needs slug+outcome");
+        const { closeDesire } = await import("./soul/store.js");
+        await closeDesire(op.slug, op.outcome, op.reflection ?? "");
+        applied.push(`desire_close:${op.slug} (${op.outcome})`);
       } else if (
         op.kind === "patch_identity" ||
         op.kind === "patch_purpose" ||
@@ -456,6 +488,30 @@ function renderTranscript(history: StoredMessage[]): string {
     out.push(`### ${msg.role}\n${text}`);
   }
   return out.join("\n\n");
+}
+
+/**
+ * Render Lisa's current desires so reflection can revise/close them by slug
+ * instead of being blind and only ever appending near-duplicates. Best-effort:
+ * a soul-read failure (e.g. before birth) yields no block rather than aborting.
+ */
+async function renderCurrentDesiresBlock(): Promise<string> {
+  try {
+    const { listDesires } = await import("./soul/store.js");
+    const desires = await listDesires();
+    if (desires.length === 0) return "";
+    const lines = desires.map((d) => {
+      const tag = d.actionable ? " (actionable)" : "";
+      const why = d.why ? ` — ${d.why.replace(/\s+/g, " ").trim().slice(0, 120)}` : "";
+      return `- [${d.slug}]${tag} ${d.what}${why}`;
+    });
+    return (
+      `\n\n## your current desires (revise or close these by slug — don't add near-duplicates)\n` +
+      lines.join("\n")
+    );
+  } catch {
+    return "";
+  }
 }
 
 function stripJsonFence(s: string): string {

--- a/src/soul/desire-evolve.test.ts
+++ b/src/soul/desire-evolve.test.ts
@@ -1,0 +1,108 @@
+import { test, describe, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+// PLAN_DESIRE_EVOLUTION_v1.0 §3 PR2: reflection (and the desire_close tool) can
+// now evolve desires in place, not just append. These exercise the store
+// primitives that power both paths.
+//
+// SOUL_DIR derives from LISA_HOME at import, so set a tmp home before importing
+// (dynamic import); node --test isolates each file in its own process.
+let store: typeof import("./store.js");
+let home: string;
+
+before(async () => {
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-desire-evolve-"));
+  process.env.LISA_HOME = home;
+  store = await import("./store.js");
+  await store.ensureSoulDirs();
+});
+after(() => {
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+async function seed(slug: string, over: Partial<Parameters<typeof store.writeDesire>[0]> = {}) {
+  await store.writeDesire({
+    slug,
+    what: "learn rust",
+    why: "systems fluency",
+    actionable: false,
+    bornAt: "2026-01-01T00:00:00.000Z",
+    ...over,
+  });
+}
+
+describe("reviseDesire", () => {
+  test("changes only the supplied fields; preserves the rest and identity", async () => {
+    await seed("revise-partial");
+    const next = await store.reviseDesire("revise-partial", { what: "learn zig" });
+    assert.equal(next.what, "learn zig");
+    assert.equal(next.why, "systems fluency", "why preserved");
+    assert.equal(next.actionable, false, "actionable preserved");
+    assert.equal(next.slug, "revise-partial", "slug is identity");
+    assert.equal(next.bornAt, "2026-01-01T00:00:00.000Z", "bornAt is identity, never moves");
+
+    // And it round-trips through the filesystem, not just the return value.
+    const onDisk = (await store.listDesires()).find((d) => d.slug === "revise-partial");
+    assert.equal(onDisk?.what, "learn zig");
+    assert.equal(onDisk?.why, "systems fluency");
+  });
+
+  test("an undefined field in the patch never wipes the existing value", async () => {
+    await seed("revise-undefined", { why: "keep me" });
+    const next = await store.reviseDesire("revise-undefined", {
+      what: "new what",
+      why: undefined,
+    });
+    assert.equal(next.why, "keep me");
+  });
+
+  test("can flip a dormant desire to actionable with a heartbeat prompt", async () => {
+    await seed("revise-activate");
+    const next = await store.reviseDesire("revise-activate", {
+      actionable: true,
+      heartbeatPrompt: "read one rust chapter",
+    });
+    assert.equal(next.actionable, true);
+    assert.equal(next.heartbeatPrompt, "read one rust chapter");
+    assert.equal(store.isAutoPursuable(next), true, "now auto-pursuable by the heartbeat");
+  });
+
+  test("throws on an unknown slug (a revise must target something real)", async () => {
+    await assert.rejects(
+      () => store.reviseDesire("does-not-exist", { what: "x" }),
+      /not found/,
+    );
+  });
+});
+
+describe("closeDesire", () => {
+  test("soft-closes: actionable=false, [CLOSED] progress note, file retained", async () => {
+    await seed("close-me", { actionable: true, heartbeatPrompt: "do the thing" });
+    await store.closeDesire("close-me", "fulfilled", "got what I was after");
+
+    const onDisk = (await store.listDesires()).find((d) => d.slug === "close-me");
+    assert.ok(onDisk, "the desire file is retained, not deleted");
+    assert.equal(onDisk?.actionable, false, "no longer drives the heartbeat");
+
+    const progress = await store.readDesireProgress("close-me");
+    assert.match(progress, /\[CLOSED:fulfilled\] got what I was after/);
+  });
+
+  test("writes a [DESIRE_CLOSED] journal line so weekly_examen sees it", async () => {
+    await seed("close-journal", { actionable: true });
+    await store.closeDesire("close-journal", "abandoned", "no longer fits me");
+    const today = new Date().toISOString().slice(0, 10);
+    const journal = await store.readJournal(today);
+    assert.match(journal, /\[DESIRE_CLOSED\] close-journal \(abandoned\): no longer fits me/);
+  });
+
+  test("throws on an unknown slug", async () => {
+    await assert.rejects(
+      () => store.closeDesire("ghost", "fulfilled", "x"),
+      /not found/,
+    );
+  });
+});

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -289,6 +289,70 @@ export function needsUserHelp(d: DesireEntry): boolean {
   return !!d.actionable && d.pursuit === "needs-user";
 }
 
+/** Fields of an existing desire that a revision may change. slug/bornAt are
+ *  identity and never move. */
+export type DesirePatch = Partial<
+  Pick<DesireEntry, "what" | "why" | "actionable" | "heartbeatPrompt" | "pursuit">
+>;
+
+/**
+ * Revise an existing desire in place (read-modify-write by slug). Only the
+ * fields explicitly provided change; everything else — including bornAt — is
+ * preserved, so an `undefined` in the patch never wipes an existing field.
+ * Throws if the slug doesn't exist (a revise must target something real).
+ *
+ * The caller supplies the git-author context (withSoulCaller); this only does
+ * the write, matching writeDesire.
+ */
+export async function reviseDesire(
+  slug: string,
+  patch: DesirePatch,
+): Promise<DesireEntry> {
+  const desires = await listDesires();
+  const existing = desires.find((d) => d.slug === slug);
+  if (!existing) {
+    throw new Error(
+      `desire "${slug}" not found. Existing slugs: ${desires.map((d) => d.slug).join(", ") || "(none)"}`,
+    );
+  }
+  const next: DesireEntry = { ...existing };
+  if (patch.what !== undefined) next.what = patch.what;
+  if (patch.why !== undefined) next.why = patch.why;
+  if (patch.actionable !== undefined) next.actionable = patch.actionable;
+  if (patch.heartbeatPrompt !== undefined) next.heartbeatPrompt = patch.heartbeatPrompt;
+  if (patch.pursuit !== undefined) next.pursuit = patch.pursuit;
+  await writeDesire(next);
+  return next;
+}
+
+/**
+ * Soft-close a desire: flip actionable off (it stops driving the heartbeat),
+ * append a final `[CLOSED:<outcome>]` entry to its progress log, and write a
+ * one-line journal note so weekly_examen sees it. The desire file is retained
+ * and git-tracked — closing is reversible, nothing is destroyed. Throws if the
+ * slug doesn't exist. Caller supplies the git-author context.
+ */
+export async function closeDesire(
+  slug: string,
+  outcome: string,
+  reflection: string,
+): Promise<void> {
+  const desires = await listDesires();
+  const d = desires.find((x) => x.slug === slug);
+  if (!d) {
+    throw new Error(
+      `desire "${slug}" not found. Existing slugs: ${desires.map((x) => x.slug).join(", ") || "(none)"}`,
+    );
+  }
+  // Keep what/why/heartbeatPrompt/pursuit for the record; just stop pursuit.
+  await writeDesire({ ...d, actionable: false });
+  await appendDesireProgress(slug, `[CLOSED:${outcome}] ${reflection}`);
+  await appendJournal(
+    new Date().toISOString().slice(0, 10),
+    `[DESIRE_CLOSED] ${slug} (${outcome}): ${reflection}`,
+  );
+}
+
 // Per-desire progress log. One file per desire slug, append-only, written by
 // the heartbeat subagent at the end of each run on this desire (Phase 1.3 of
 // AUTONOMY_ROADMAP). Lets a multi-day pursuit actually persist across runs.

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -308,21 +308,27 @@ export async function reviseDesire(
   slug: string,
   patch: DesirePatch,
 ): Promise<DesireEntry> {
-  const desires = await listDesires();
-  const existing = desires.find((d) => d.slug === slug);
-  if (!existing) {
-    throw new Error(
-      `desire "${slug}" not found. Existing slugs: ${desires.map((d) => d.slug).join(", ") || "(none)"}`,
-    );
-  }
-  const next: DesireEntry = { ...existing };
-  if (patch.what !== undefined) next.what = patch.what;
-  if (patch.why !== undefined) next.why = patch.why;
-  if (patch.actionable !== undefined) next.actionable = patch.actionable;
-  if (patch.heartbeatPrompt !== undefined) next.heartbeatPrompt = patch.heartbeatPrompt;
-  if (patch.pursuit !== undefined) next.pursuit = patch.pursuit;
-  await writeDesire(next);
-  return next;
+  // Read-modify-write under the cross-process soul lock: web idle-reflect and a
+  // CLI reflect (both live since #242) can revise the same slug from different
+  // processes; without the lock one field edit is lost (last-writer-wins on a
+  // stale read). writeDesire doesn't self-lock, so this doesn't nest.
+  return await withSoulLock(async () => {
+    const desires = await listDesires();
+    const existing = desires.find((d) => d.slug === slug);
+    if (!existing) {
+      throw new Error(
+        `desire "${slug}" not found. Existing slugs: ${desires.map((d) => d.slug).join(", ") || "(none)"}`,
+      );
+    }
+    const next: DesireEntry = { ...existing };
+    if (patch.what !== undefined) next.what = patch.what;
+    if (patch.why !== undefined) next.why = patch.why;
+    if (patch.actionable !== undefined) next.actionable = patch.actionable;
+    if (patch.heartbeatPrompt !== undefined) next.heartbeatPrompt = patch.heartbeatPrompt;
+    if (patch.pursuit !== undefined) next.pursuit = patch.pursuit;
+    await writeDesire(next);
+    return next;
+  });
 }
 
 /**
@@ -337,15 +343,22 @@ export async function closeDesire(
   outcome: string,
   reflection: string,
 ): Promise<void> {
-  const desires = await listDesires();
-  const d = desires.find((x) => x.slug === slug);
-  if (!d) {
-    throw new Error(
-      `desire "${slug}" not found. Existing slugs: ${desires.map((x) => x.slug).join(", ") || "(none)"}`,
-    );
-  }
-  // Keep what/why/heartbeatPrompt/pursuit for the record; just stop pursuit.
-  await writeDesire({ ...d, actionable: false });
+  // Read-modify-write of the desire file under the soul lock (same race as
+  // reviseDesire). The progress + journal appends below self-lock individually,
+  // so they stay OUTSIDE this block — nesting withSoulLock would deadlock.
+  await withSoulLock(async () => {
+    const desires = await listDesires();
+    const d = desires.find((x) => x.slug === slug);
+    if (!d) {
+      throw new Error(
+        `desire "${slug}" not found. Existing slugs: ${desires.map((x) => x.slug).join(", ") || "(none)"}`,
+      );
+    }
+    // Soft close: just flip actionable off. (heartbeatPrompt/pursuit aren't
+    // serialized while dormant, but the soul git history retains the last
+    // actionable version, so re-opening via reviseDesire can recover them.)
+    await writeDesire({ ...d, actionable: false });
+  });
   await appendDesireProgress(slug, `[CLOSED:${outcome}] ${reflection}`);
   await appendJournal(
     new Date().toISOString().slice(0, 10),

--- a/src/soul/tools.ts
+++ b/src/soul/tools.ts
@@ -2,6 +2,7 @@ import {
   appendDesireProgress,
   appendJournal,
   applyEmotionDelta,
+  closeDesire,
   listDesires,
   listJournalDates,
   listOpinions,
@@ -569,35 +570,10 @@ export const desireCloseTool: ToolDefinition<DesireCloseInput, string> = {
   },
   async execute(input) {
     return await withSoulCaller("soul_patch", async () => {
-      const desires = await listDesires();
-      const d = desires.find((x) => x.slug === input.slug);
-      if (!d) {
-        throw new Error(
-          `desire "${input.slug}" not found. Existing slugs: ${desires.map((x) => x.slug).join(", ") || "(none)"}`,
-        );
-      }
-      // Flip actionable off; keep what/why/heartbeatPrompt for record.
-      await writeDesire({
-        slug: d.slug,
-        what: d.what,
-        why: d.why,
-        actionable: false,
-        heartbeatPrompt: d.heartbeatPrompt,
-        bornAt: d.bornAt,
-      });
-      // Append a final progress entry. Use heartbeat caller because
-      // closure-with-reflection is the same shape as heartbeat progress.
-      const closingEntry =
-        `[CLOSED:${input.outcome}] ${input.reflection}`;
-      // Inline append (don't use desire_progress_log path — that requires
-      // listDesires().find, which would still work, but we already validated).
-      await appendDesireProgress(d.slug, closingEntry);
-      // One-line journal entry so the weekly examen catches it without
-      // having to scan every desire.
-      await appendJournal(
-        new Date().toISOString().slice(0, 10),
-        `[DESIRE_CLOSED] ${input.slug} (${input.outcome}): ${input.reflection}`,
-      );
+      // Shares one code path with reflect's desire_close op (store.closeDesire):
+      // actionable=false + [CLOSED] progress entry + journal line. Throws if the
+      // slug doesn't exist.
+      await closeDesire(input.slug, input.outcome, input.reflection);
       return `desire "${input.slug}" closed (${input.outcome}); actionable=false, journal entry written.`;
     });
   },


### PR DESCRIPTION
> Replaces #246, which GitHub auto-closed when its base branch (PR #242's) was deleted after that merge. Same branch/content, now targeting `main`. Part of the desire-evolution series (#242 merged in v0.17.0).

## Why

Reflection is the path that turns a conversation into a desire — but it could only **`desire_add`**, and it was never shown the desires it already had. So it appended near-duplicates blind, and the set only ever grew. This is a second reason the "wish" felt frozen.

## What

1. **Reflection now sees its own desires** — a compact `## your current desires` block (slug + what + why + actionable) is added to the reflector prompt.
2. **Two new operations:**
   - `desire_revise { slug, what?, why?, actionable?, heartbeat_prompt?, pursuit? }` — read-modify-write by slug; only supplied fields change; `bornAt`/`slug` are identity; `undefined` never wipes; throws on unknown slug.
   - `desire_close { slug, outcome, reflection }` — **soft** close: `actionable=false` + `[CLOSED:<outcome>]` progress note + `[DESIRE_CLOSED]` journal line. File **retained and git-tracked** — reversible, nothing destroyed.
3. **Guidance** now prefers revising/closing over piling up duplicates.
4. **One shared path:** close logic lives in `store.closeDesire()`, used by both reflect's `desire_close` op and the pre-existing `desire_close` tool (refactored onto it).

Debate 2 in [`docs/PLAN_DESIRE_EVOLUTION_v1.0.md`](docs/PLAN_DESIRE_EVOLUTION_v1.0.md): *append-only* vs *allow revise/close*. Decision: allow, behind four guardrails (shown existing desires; soft close; no hard-delete op; git-recoverable).

## Testing

`src/soul/desire-evolve.test.ts` — 7 tests (partial revise preserves fields + identity, `undefined` no-wipe, dormant→actionable, soft-close retains file + notes, both throw on unknown slug). `npm test`: zero regressions vs `main`. Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)