### PR TITLE
fix(soul): desire review follow-ups — closed marker + restart-safe focus gate

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -90,8 +90,12 @@ export async function runStatus(): Promise<void> {
     console.log(`  ${dim("(none)")}`);
   } else {
     // The one surfaced as "current" in the room/island — mark it so `status`
-    // and the UI agree on what she's focused on.
-    const current = pickCurrentDesire(desires, await desireActivity(desires));
+    // and the UI agree on what she's focused on. Closed desires are excluded
+    // from the pick (they're finished) though still listed below for the record.
+    const current = pickCurrentDesire(
+      desires.filter((d) => !d.closed),
+      await desireActivity(desires),
+    );
     const mark = (d: (typeof desires)[number]) =>
       d.slug === current?.slug ? `  ${dim("← current")}` : "";
     const actionable = desires.filter((d) => d.actionable);

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -498,7 +498,9 @@ function renderTranscript(history: StoredMessage[]): string {
 async function renderCurrentDesiresBlock(): Promise<string> {
   try {
     const { listDesires } = await import("./soul/store.js");
-    const desires = await listDesires();
+    // Closed desires are done — keep them out of the "revise or close" block so
+    // the list actually shrinks and a closed one can't be re-closed each pass.
+    const desires = (await listDesires()).filter((d) => !d.closed);
     if (desires.length === 0) return "";
     const lines = desires.map((d) => {
       const tag = d.actionable ? " (actionable)" : "";

--- a/src/soul/desire-evolve.test.ts
+++ b/src/soul/desire-evolve.test.ts
@@ -99,6 +99,43 @@ describe("closeDesire", () => {
     assert.match(journal, /\[DESIRE_CLOSED\] close-journal \(abandoned\): no longer fits me/);
   });
 
+  test("marks closed:true and keeps heartbeatPrompt for a later re-open", async () => {
+    await seed("close-mark", { actionable: true, heartbeatPrompt: "ping it" });
+    await store.closeDesire("close-mark", "fulfilled", "done");
+    const onDisk = (await store.listDesires()).find((d) => d.slug === "close-mark");
+    assert.equal(onDisk?.closed, true, "distinct closed marker, not just actionable:false");
+    assert.equal(onDisk?.actionable, false);
+    assert.equal(
+      onDisk?.heartbeatPrompt,
+      "ping it",
+      "heartbeatPrompt retained so re-open restores auto-pursuit",
+    );
+  });
+
+  test("re-closing an already-closed desire is idempotent (no duplicate notes)", async () => {
+    await seed("close-twice", { actionable: true });
+    await store.closeDesire("close-twice", "fulfilled", "first");
+    await store.closeDesire("close-twice", "fulfilled", "second"); // guarded no-op
+    const progress = await store.readDesireProgress("close-twice");
+    const journal = await store.readJournal(new Date().toISOString().slice(0, 10));
+    assert.equal((progress.match(/\[CLOSED:/g) ?? []).length, 1, "one [CLOSED] progress note");
+    assert.equal(
+      (journal.match(/\[DESIRE_CLOSED\] close-twice/g) ?? []).length,
+      1,
+      "one [DESIRE_CLOSED] journal line",
+    );
+  });
+
+  test("reviseDesire re-opens a closed desire — clears closed, restores actionable", async () => {
+    await seed("reopen-me", { actionable: true, heartbeatPrompt: "keep pinging" });
+    await store.closeDesire("reopen-me", "abandoned", "then reconsidered");
+    await store.reviseDesire("reopen-me", { actionable: true });
+    const onDisk = (await store.listDesires()).find((d) => d.slug === "reopen-me");
+    assert.equal(onDisk?.closed ?? false, false, "re-opening clears the closed flag");
+    assert.equal(onDisk?.actionable, true);
+    assert.equal(onDisk?.heartbeatPrompt, "keep pinging", "auto-pursuit restored on re-open");
+  });
+
   test("throws on an unknown slug", async () => {
     await assert.rejects(
       () => store.closeDesire("ghost", "fulfilled", "x"),

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -256,13 +256,16 @@ export async function writeDesire(entry: DesireEntry): Promise<void> {
     "",
     `actionable: ${entry.actionable ? "yes" : "no"}`,
   ];
-  // Only meaningful for actionable desires; omit the default ("self") to keep
-  // existing files byte-stable.
-  if (entry.actionable && entry.pursuit === "needs-user") {
+  if (entry.closed) lines.push(`closed: yes`);
+  // pursuit/heartbeat are serialized whenever present (not gated on actionable)
+  // so closing a desire — which flips actionable off — preserves them for the
+  // record and lets a later reviseDesire re-open it with auto-pursuit intact.
+  // (Actionable desires already had them, so existing files stay byte-stable.)
+  if (entry.pursuit === "needs-user") {
     lines.push(`pursuit: needs-user`);
   }
   lines.push(`born: ${entry.bornAt}`, "", `## why`, entry.why.trim());
-  if (entry.actionable && entry.heartbeatPrompt) {
+  if (entry.heartbeatPrompt) {
     lines.push("", "## heartbeat", entry.heartbeatPrompt.trim());
   }
   await atomicWrite(desireFile(entry.slug), lines.join("\n") + "\n");
@@ -276,7 +279,8 @@ function parseDesireFile(slug: string, raw: string): DesireEntry {
   const why = (raw.match(/## why([\s\S]*?)(?:\n## |\n*$)/)?.[1] ?? "").trim();
   const heartbeatPrompt = (raw.match(/## heartbeat([\s\S]*)$/)?.[1] ?? "").trim() || undefined;
   const pursuit = /^pursuit:\s*needs-user\s*$/im.test(raw) ? "needs-user" : undefined;
-  return { slug, what, why, actionable, heartbeatPrompt, pursuit, bornAt: born };
+  const closed = /^closed:\s*yes\s*$/im.test(raw) || undefined;
+  return { slug, what, why, actionable, heartbeatPrompt, pursuit, closed, bornAt: born };
 }
 
 /**
@@ -387,7 +391,12 @@ export async function reviseDesire(
     const next: DesireEntry = { ...existing };
     if (patch.what !== undefined) next.what = patch.what;
     if (patch.why !== undefined) next.why = patch.why;
-    if (patch.actionable !== undefined) next.actionable = patch.actionable;
+    if (patch.actionable !== undefined) {
+      next.actionable = patch.actionable;
+      // Re-opening — making a closed desire actionable again — clears the closed
+      // flag so it rejoins the reflector's block and can surface as current.
+      if (patch.actionable) next.closed = false;
+    }
     if (patch.heartbeatPrompt !== undefined) next.heartbeatPrompt = patch.heartbeatPrompt;
     if (patch.pursuit !== undefined) next.pursuit = patch.pursuit;
     await writeDesire(next);
@@ -410,7 +419,7 @@ export async function closeDesire(
   // Read-modify-write of the desire file under the soul lock (same race as
   // reviseDesire). The progress + journal appends below self-lock individually,
   // so they stay OUTSIDE this block — nesting withSoulLock would deadlock.
-  await withSoulLock(async () => {
+  const wasAlreadyClosed = await withSoulLock(async () => {
     const desires = await listDesires();
     const d = desires.find((x) => x.slug === slug);
     if (!d) {
@@ -418,11 +427,16 @@ export async function closeDesire(
         `desire "${slug}" not found. Existing slugs: ${desires.map((x) => x.slug).join(", ") || "(none)"}`,
       );
     }
-    // Soft close: just flip actionable off. (heartbeatPrompt/pursuit aren't
-    // serialized while dormant, but the soul git history retains the last
-    // actionable version, so re-opening via reviseDesire can recover them.)
-    await writeDesire({ ...d, actionable: false });
+    // Idempotent: a desire the reflector already closed stays out of its "revise
+    // or close" block, but guard anyway so a re-close can't append a duplicate
+    // [DESIRE_CLOSED] journal line + [CLOSED] progress entry.
+    if (d.closed) return true;
+    // Mark closed and drop it from the heartbeat. heartbeatPrompt/pursuit are
+    // now preserved by writeDesire, so reviseDesire can re-open it cleanly.
+    await writeDesire({ ...d, actionable: false, closed: true });
+    return false;
   });
+  if (wasAlreadyClosed) return;
   await appendDesireProgress(slug, `[CLOSED:${outcome}] ${reflection}`);
   await appendJournal(
     new Date().toISOString().slice(0, 10),

--- a/src/soul/types.ts
+++ b/src/soul/types.ts
@@ -104,6 +104,14 @@ export interface DesireEntry {
    * Undefined is treated as "self" for backward compatibility.
    */
   pursuit?: "self" | "needs-user";
+  /**
+   * Closed = deliberately finished/abandoned via reflection, distinct from a
+   * merely non-actionable "dormant" wish. Closed desires are kept on disk (git
+   * history + the record) but filtered out of the reflector's "revise or close"
+   * block and never surfaced as her current/focused desire. Re-opening (a
+   * reviseDesire that sets actionable:true) clears it.
+   */
+  closed?: boolean;
   bornAt: string;
 }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -643,6 +643,11 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   // matters if we happen to be its first caller, and we never use its 'idle'
   // event here (that drives the separate, hour-long "dream" idle above).
   const reflectClock = getIdleWatcher(reflectDebounceMs);
+  // Wall-clock of the last real user message (0 until one arrives this process).
+  // Gates intra-session desire focus: unlike reflectClock.idleFor() — which reads
+  // "fresh" right after a launchd restart — this stays 0 across a restart, so a
+  // stale resumed conversation can't pin a focus. Stamped in the POST /chat path.
+  let lastUserMessageAt = 0;
   // Seed from the resumed history so we never re-reflect prior sessions on the
   // first quiet window — only conversation added while this server is live.
   let lastReflectedUserCount = countUserMessages(history);
@@ -837,13 +842,19 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     if (req.method === "GET" && url === "/api/island/ping") {
       let currentDesire: string | null = null;
       try {
-        const desires = await listDesires();
+        // Closed desires are finished — never surface one as her current/focused.
+        const desires = (await listDesires()).filter((d) => !d.closed);
         // If the conversation is live and clearly about one of her desires,
         // surface THAT (intra-session focus — tracks the turn-by-turn topic).
         // Otherwise fall back to the most recently ACTIVE desire (authored or
         // pursued), not whichever fs.readdir listed first. See PLAN_DESIRE_EVOLUTION.
+        // Freshness is measured from the last real user message (lastUserMessageAt,
+        // reset to 0 on restart) — NOT the process-wide idle clock, which starts
+        // "fresh" after a launchd restart and would pin focus onto a stale
+        // resumed conversation for up to FOCUS_FRESHNESS_MS.
         const focused =
-          reflectClock.idleFor() < FOCUS_FRESHNESS_MS
+          lastUserMessageAt > 0 &&
+          Date.now() - lastUserMessageAt < FOCUS_FRESHNESS_MS
             ? pickFocusedDesire(desires, recentUserText(history))
             : null;
         // Only compute activity (an fs.stat per desire) when we actually fall
@@ -2174,8 +2185,9 @@ self.addEventListener('fetch', (event) => {
         res.end(JSON.stringify({ error: `bad request: ${(err as Error).message}` }));
         return;
       }
-      // User just talked — reset the idle watcher.
+      // User just talked — reset the idle watcher + stamp focus freshness.
       try { getIdleWatcher(60 * 60_000).tick(); } catch {}
+      lastUserMessageAt = Date.now();
       res.writeHead(200, {
         "content-type": "text/event-stream",
         "cache-control": "no-cache",


### PR DESCRIPTION
The two **MED** findings from the #248/#249 reviews that weren't already covered by #250's review fix (which added the `withSoulLock` + the `desireActivity` slug guard) or v0.18.0's perf nit.

## 1. Persisted CLOSED marker (#249)
`closeDesire` only flipped `actionable:false`, so closed desires were indistinguishable from dormant ones — they kept coming back into the reflector's "revise or close these" block and could be re-closed every pass (duplicate `[DESIRE_CLOSED]` journal noise).

- `DesireEntry` gains `closed`; `writeDesire` serializes `closed: yes` and now keeps `heartbeatPrompt`/`pursuit` even when not actionable (so closing preserves them — fixes the "re-open loses auto-pursuit" nit too).
- `closeDesire` sets `closed` + `actionable:false` and is **idempotent** (already-closed → no-op, no duplicate journal/progress).
- `reviseDesire` clears `closed` when it re-opens (`actionable:true`).
- Closed desires are filtered from the reflector block and never surface as current/focused (`/api/island/ping` + `lisa status`).

## 2. Restart-safe focus freshness (#248)
The intra-session focus gate keyed on `reflectClock.idleFor()`, which reads *fresh* right after a launchd restart — so a stale resumed conversation could pin a focus for ≤15 min. Now gated on a new `lastUserMessageAt` (0 until a real `POST /chat`, so a restart keeps the gate closed until the user actually talks).

## Tests / verify
- New store tests: closed-marker round-trip, `heartbeatPrompt` retention, idempotent re-close, re-open clears closed.
- `npm run typecheck` clean · full suite **1013 pass / 0 fail** (+3).

Rebased onto v0.18.0 (integrates cleanly with the island-ping perf commit). Ships in **v0.18.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)