### PR TITLE
chore(release): v0.18.1 — desire close/focus hardening

### DIFF
--- a/docs/RELEASE_v0.18.1.md
+++ b/docs/RELEASE_v0.18.1.md
@@ -1,0 +1,43 @@
+# Lisa v0.18.1
+
+A hardening patch on the **desire-evolution** arc that v0.18.0 shipped — two
+review follow-ups so a *closed* desire truly stays closed, and so intra-session
+focus can't latch onto a stale conversation after a restart.
+
+Typecheck green · full test suite green (**1014 tests**, 1013 pass) · no breaking
+changes.
+
+## 🔧 Fixes
+
+### A closed desire actually stays closed (#251)
+
+v0.18.0's `desire_close` was a *soft* close — it only flipped `actionable` off,
+which is indistinguishable from a merely dormant wish. So closed desires kept
+coming back into reflection's "revise or close these" block and could be
+re-closed on every pass (duplicate `[DESIRE_CLOSED]` journal noise), and the
+list she was asked to tend never actually shrank.
+
+- **Persisted `closed` marker.** `desire_close` now records a distinct `closed`
+  state (kept on disk for the record + git history) and is **idempotent** — an
+  already-closed desire is a no-op, so no duplicate journal / progress entries.
+- **Clean re-open.** Closing now **preserves** `heartbeatPrompt` / `pursuit`, so
+  a later `desire_revise` that makes it actionable again restores her
+  auto-pursuit intact (previously the prompt was silently dropped).
+- Closed desires are filtered out of the reflector's block (the list finally
+  shrinks) and are never surfaced as her current / focused desire — in the
+  room, the island ping, or `lisa status`.
+
+### Intra-session focus survives a restart (#251)
+
+The "what the conversation is about" focus was gated on the process idle clock,
+which reads *fresh* immediately after a launchd restart — so a stale resumed
+chat could pin a focus onto an old topic for up to 15 minutes. It's now gated on
+the **last real user message** (reset across restarts), so focus only applies
+while the conversation is genuinely live.
+
+## 📝 Notes
+
+- Soul / mood / heartbeat / Reve are untouched; existing desire files round-trip
+  byte-stable (the `closed:` line only appears once a desire is actually closed).
+- New store tests cover the closed-marker round-trip, `heartbeatPrompt`
+  retention, idempotent re-close, and re-open clearing `closed`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@oratis/lisa",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@oratis/lisa",
-      "version": "0.18.0",
+      "version": "0.18.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.92.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@oratis/lisa",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "An AI agent with a real self — runs locally, has desires, keeps a journal, evolves over time.",
   "keywords": [
     "ai",


### PR DESCRIPTION
Cuts **v0.18.1**. Bumps 0.18.0 → 0.18.1 + release notes; merging gates the `v0.18.1` tag (→ `release.yml` + Mac DMG build).

Ships the #251 review follow-ups: persisted **closed** desire marker (idempotent close, clean re-open, filtered everywhere) + **restart-safe** intra-session focus gate. Full notes: [`docs/RELEASE_v0.18.1.md`](docs/RELEASE_v0.18.1.md). No breaking changes; suite green (1013 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)