### PR TITLE
feat(web): clickable Control sessions — inspector + inline problems

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -2195,39 +2195,143 @@ if ('serviceWorker' in navigator) {
   }
 
   // ── Control ─────────────────────────────────────────────────────
-  function controlRowHTML(s) {
-    var act = actLine(s);
-    var fam = s.controllable === 'pty' ? 'pty' : (s.controllable === 'managed' ? 'managed' : '');
-    var pend = s.activity && s.activity.pendingPermission;
-    var id = esc(s.sessionId);
-    var ctrl = '';
-    if (fam && pend) {
-      ctrl += '<button class="mc approve" data-fam="' + fam + '" data-id="' + id + '" data-act="approve">approve</button>';
-      ctrl += '<button class="mc deny" data-fam="' + fam + '" data-id="' + id + '" data-act="deny">deny</button>';
+  // Progress-only activity line (turns/tokens/cmd/tool·file) — the pending
+  // and error states get their own dedicated inline lines below.
+  function ctrlProgress(s) {
+    var a = s.activity; if (!a || typeof a !== 'object') return '';
+    var bits = [];
+    if (typeof a.turnCount === 'number' && a.turnCount > 0) bits.push('turn ' + a.turnCount);
+    if (a.tokens && (a.tokens.input || a.tokens.output)) {
+      var tot = (a.tokens.input || 0) + (a.tokens.output || 0);
+      bits.push(tot >= 1000 ? Math.round(tot / 1000) + 'k tok' : tot + ' tok');
     }
-    if (fam) ctrl += '<button class="mc cancel" data-fam="' + fam + '" data-id="' + id + '" data-act="cancel">cancel</button>';
-    if (fam === 'pty') ctrl += '<button class="mc" data-id="' + id + '" data-act="output">output</button>';
-    var badge = (s.agent && s.agent !== 'claude-code') ? '<span class="agent-badge">' + esc(s.agent) + '</span>' : '';
-    return '<div class="session-row">' +
-      '<div class="pip ' + (s.state || 'unknown') + '"></div>' +
-      '<div class="name">' + badge + esc(s.project || s.agent || 'agent') + '</div>' +
-      '<div class="when">' + (s.controllable ? esc(s.controllable) : esc(statusLabel(s.state))) + '</div>' +
-      (act ? '<div class="session-act">' + esc(act) + '</div>' : '') +
-      (ctrl ? '<div class="session-ctrl">' + ctrl + '</div>' : '') +
-      '</div>';
+    if (a.lastCommandName) bits.push('$ ' + a.lastCommandName);
+    var tool = a.lastTools && a.lastTools.length ? a.lastTools[a.lastTools.length - 1] : '';
+    var file = a.filesTouched && a.filesTouched.length ? (String(a.filesTouched[a.filesTouched.length - 1]).split('/').pop() || '') : '';
+    if (tool && file) bits.push(tool + ' ' + file);
+    else if (tool) bits.push(tool);
+    else if (file) bits.push(file);
+    return bits.join(' · ');
   }
-  function controlAction(fam, id, action) {
-    return fetch('/api/agents/' + fam + '/' + encodeURIComponent(id) + '/' + action, { method: 'POST' })
-      .then(function (r) { if (!r.ok) return r.text().then(function (t) { throw new Error(String(r.status) + (t ? ' ' + t : '')); }); });
+  function ctrlRowHTML(s) {
+    var id = esc(s.sessionId);
+    var scls = statusClass(s.state);
+    var a = s.activity || {};
+    var pend = a.pendingPermission;
+    var err = a.lastError || (s.state === 'error' ? (s.stateReason || 'errored') : '');
+    var label = s.project || s.sessionId || 'agent';
+    if (a.gitBranch) { var br = String(a.gitBranch); label = br.indexOf('claude/') === 0 ? br.slice(7) : br; }
+    var badge = (s.agent && s.agent !== 'claude-code') ? '<span class="cr-badge">' + esc(s.agent) + '</span>' : '';
+    var sub = ctrlProgress(s);
+    var rowCls = 'ctrl-row' + (err ? ' problem' : (pend ? ' pending' : ''));
+    var h = '<div class="' + rowCls + '" data-sid="' + id + '" role="button" tabindex="0">';
+    h += '<div class="cr-pip ' + scls + '"></div>';
+    h += '<div class="cr-name">' + badge + '<span class="cr-id" title="' + esc(label) + '">' + esc(label) + '</span></div>';
+    h += '<span class="st-chip ' + scls + '">' + esc(statusLabel(s.state)) + '<span class="cr-arrow"> ›</span></span>';
+    if (sub) h += '<div class="cr-sub">' + esc(sub) + '</div>';
+    if (pend) {
+      h += '<div class="cr-pend">⚠ wants to run ' + esc(pend);
+      if (s.controllable === 'managed') {
+        h += '<button class="cr-quick ok" data-q="approve" data-sid="' + id + '">approve</button>';
+        h += '<button class="cr-quick no" data-q="deny" data-sid="' + id + '">deny</button>';
+      }
+      h += '</div>';
+    } else if (err) {
+      h += '<div class="cr-err" title="' + esc(err) + '">✗ ' + esc(err) + '</div>';
+    }
+    h += '</div>';
+    return h;
   }
-  function ctrlPtyOutput(id) {
-    getJSON('/api/agents/pty/' + encodeURIComponent(id) + '/output').then(function (d) {
-      if (typeof openModal === 'function') openModal('agent output', '<pre>' + esc(d && d.output ? d.output : '(no output yet)') + '</pre>');
+  // POST an action to the right agent family, surfacing the server error text.
+  function sdAction(fam, id, action, body) {
+    return fetch('/api/agents/' + fam + '/' + encodeURIComponent(id) + '/' + action, {
+      method: 'POST',
+      headers: body ? { 'content-type': 'application/json' } : {},
+      body: body ? JSON.stringify(body) : undefined,
+    }).then(function (r) {
+      if (!r.ok) return r.text().then(function (t) { throw new Error(String(r.status) + (t ? ' ' + t : '')); });
+      return r.json().catch(function () { return {}; });
+    });
+  }
+  // Click a Control row → a rich per-session inspector (status + follow-up
+  // actions + surfaced problem). Re-fetches on open so it always reflects truth.
+  function openSessionDetail(id) {
+    getJSON('/api/agents/sessions').then(function (res) {
+      var sessions = (res && res.sessions) || [];
+      var s = null;
+      for (var i = 0; i < sessions.length; i++) { if (sessions[i].sessionId === id) { s = sessions[i]; break; } }
+      if (!s) { openModal('Session', '<div class="sd"><div class="sd-note">This session is no longer active.</div></div>'); return; }
+      var a = s.activity || {};
+      var fam = s.controllable;
+      var scls = statusClass(s.state);
+      var title = (s.agent && s.agent !== 'claude-code' ? s.agent + ' · ' : '') + (s.project || 'agent');
+      function rel(iso) { var ms = Date.now() - new Date(iso).getTime(); if (ms < 60000) return 'just now'; if (ms < 3600000) return Math.round(ms / 60000) + 'm ago'; if (ms < 86400000) return Math.round(ms / 3600000) + 'h ago'; return Math.round(ms / 86400000) + 'd ago'; }
+      function row(k, v) { return '<dt>' + k + '</dt><dd>' + v + '</dd>'; }
+      var h = '<div class="sd">';
+      h += '<div class="sd-top"><span class="st-chip ' + scls + '">' + esc(statusLabel(s.state)) + '</span>';
+      if (fam) h += '<span class="sd-chip">' + esc(fam) + '</span>';
+      if (s.resumable) h += '<span class="sd-chip">adoptable</span>';
+      h += '<span class="sd-id">' + esc(s.sessionId) + '</span></div>';
+      if (a.pendingPermission) {
+        h += '<div class="sd-banner pend"><div>⚠ Waiting for approval to run <b>' + esc(a.pendingPermission) + '</b></div>';
+        if (fam === 'managed') h += '<div class="sd-b-row"><button class="sd-btn ok" data-sd="approve">Approve</button><button class="sd-btn danger" data-sd="deny">Deny</button></div>';
+        h += '</div>';
+      }
+      if (a.lastError || s.state === 'error') {
+        h += '<div class="sd-banner err">✗ ' + esc(a.lastError || s.stateReason || 'errored') + '</div>';
+      }
+      h += '<dl class="sd-grid">';
+      h += row('State', esc(statusLabel(s.state)) + (s.stateReason ? ' <span style="color:var(--fg-3)">(' + esc(s.stateReason) + ')</span>' : ''));
+      if (typeof a.turnCount === 'number' && a.turnCount > 0) h += row('Turns', String(a.turnCount));
+      if (a.tokens && (a.tokens.input || a.tokens.output)) h += row('Tokens', String(a.tokens.input || 0) + ' in · ' + String(a.tokens.output || 0) + ' out');
+      if (a.gitBranch) h += row('Branch', esc(a.gitBranch));
+      if (a.lastCommandName) h += row('Last command', esc(a.lastCommandName));
+      if (a.lastTools && a.lastTools.length) h += row('Recent tools', '<div class="sd-chips">' + a.lastTools.slice(-6).map(function (t) { return '<span class="sd-chip">' + esc(t) + '</span>'; }).join('') + '</div>');
+      if (a.filesTouched && a.filesTouched.length) h += row('Files', '<div class="sd-chips">' + a.filesTouched.slice(-8).map(function (f) { return '<span class="sd-chip">' + esc(String(f).split('/').pop() || f) + '</span>'; }).join('') + '</div>');
+      if (s.cwd) h += row('Path', esc(s.cwd));
+      h += row('Last activity', esc(rel(s.lastMtime)));
+      h += '</dl>';
+      h += '<div class="sd-actions">';
+      if (fam && s.state !== 'done' && !a.pendingPermission) {
+        h += '<input class="sd-send" id="sdSend" type="text" placeholder="' + (fam === 'pty' ? 'type into the CLI…' : 'send a follow-up…') + '">';
+        h += '<button class="sd-btn primary" data-sd="send">Send</button>';
+      }
+      if (fam === 'pty') h += '<button class="sd-btn" data-sd="output">View output</button>';
+      if (fam && s.state !== 'done') h += '<button class="sd-btn danger" data-sd="cancel">Cancel</button>';
+      if (s.resumable) h += '<button class="sd-btn ok" data-sd="adopt">⇲ Adopt</button>';
+      if (!fam && !s.resumable) h += '<span class="sd-note">Observe-only — no control channel for this session.</span>';
+      h += '</div>';
+      h += '<pre class="sd-out" id="sdOut" style="display:none"></pre>';
+      h += '</div>';
+      openModal(title, h);
+      var body = document.getElementById('modalBody');
+      if (!body) return;
+      function sdErr(err) { body.insertAdjacentHTML('afterbegin', '<div class="sd-banner err" style="margin-bottom:12px">✗ ' + esc(err && err.message ? err.message : 'action failed') + '</div>'); }
+      function afterAct(p) { p.then(function () { if (window.refreshClaudeSessions) window.refreshClaudeSessions(); openSessionDetail(id); }).catch(sdErr); }
+      function doSend() { var inp = document.getElementById('sdSend'); var t = inp && inp.value.trim(); if (t) afterAct(sdAction(fam, id, 'send', { text: t })); }
+      var btns = body.querySelectorAll('[data-sd]');
+      for (var j = 0; j < btns.length; j++) {
+        btns[j].addEventListener('click', function () {
+          var act = this.getAttribute('data-sd');
+          if (act === 'approve') afterAct(sdAction('managed', id, 'approve', { allow: true }));
+          else if (act === 'deny') afterAct(sdAction('managed', id, 'approve', { allow: false }));
+          else if (act === 'cancel') afterAct(sdAction(fam, id, 'cancel', null));
+          else if (act === 'send') doSend();
+          else if (act === 'adopt') afterAct(fetch('/api/agents/pty/start', { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ agent: 'claude', resumeSessionId: s.sessionId, cwd: s.cwd || '' }) }).then(function (r) { if (!r.ok) return r.text().then(function (t) { throw new Error(t); }); }));
+          else if (act === 'output') {
+            var out = document.getElementById('sdOut');
+            if (out) { out.style.display = 'block'; out.textContent = 'loading…'; }
+            getJSON('/api/agents/pty/' + encodeURIComponent(id) + '/output').then(function (d) { if (out) out.textContent = (d && d.output) ? d.output : '(no output yet)'; });
+          }
+        });
+      }
+      var sendInp = document.getElementById('sdSend');
+      if (sendInp) { sendInp.focus(); sendInp.addEventListener('keydown', function (e) { if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229) { e.preventDefault(); doSend(); } }); }
     });
   }
   function loadControl() {
     views.control.innerHTML =
-      '<div class="view-head"><div><h2>Control</h2><div class="vh-sub">Live agents &amp; control plane</div></div>' +
+      '<div class="view-head"><div><h2>Control</h2><div class="vh-sub">Live agents &amp; control plane · click a session to inspect</div></div>' +
       '<button class="view-act" id="ctrlDelegate">+ Delegate a task</button></div>' +
       '<div class="view-scroll" id="ctrlScroll"><div class="view-empty">loading…</div></div>';
     var del = document.getElementById('ctrlDelegate');
@@ -2241,23 +2345,39 @@ if ('serviceWorker' in navigator) {
       var sessions = (res[0] && res[0].sessions) || [];
       var policy = res[1] || {};
       updateAgentCount(sessions.length);
-      var html = '<div class="pp-tags" style="margin-bottom:14px">' +
+      // Surface problems first: error → waiting(needs you) → working → rest.
+      var rank = { error: 0, waiting: 1, working: 2, done: 4, idle: 5 };
+      sessions = sessions.slice().sort(function (x, y) {
+        var rx = rank[x.state]; if (rx === undefined) rx = 3;
+        var ry = rank[y.state]; if (ry === undefined) ry = 3;
+        if (rx !== ry) return rx - ry;
+        return new Date(y.lastMtime).getTime() - new Date(x.lastMtime).getTime();
+      });
+      var html = '<div class="ctrl-policy">' +
         '<span class="pp-tag">remote control: ' + (policy.remoteControl ? 'on' : 'off') + '</span>' +
         '<span class="pp-tag">adopt external: ' + (policy.remoteAdoptExternal ? 'on' : 'off') + '</span></div>';
       if (!sessions.length) { scroll.innerHTML = html + '<div class="view-empty">No agents running. Delegate a task to start one.</div>'; return; }
-      sessions.forEach(function (s) { html += controlRowHTML(s); });
+      html += '<div class="ctrl-list">';
+      sessions.forEach(function (s) { html += ctrlRowHTML(s); });
+      html += '</div>';
       scroll.innerHTML = html;
-      var btns = scroll.querySelectorAll('[data-act]');
-      for (var i = 0; i < btns.length; i++) {
-        btns[i].addEventListener('click', function () {
-          var act = this.getAttribute('data-act');
-          var fam = this.getAttribute('data-fam');
-          var id = this.getAttribute('data-id');
-          if (act === 'output') { ctrlPtyOutput(id); return; }
-          controlAction(fam, id, act).then(function () { renderControl(); }).catch(function (err) {
-            scroll.insertAdjacentHTML('afterbegin', '<div class="view-empty" style="color:var(--err-color)">' + esc(err.message) + '</div>');
-          });
+      // Inline quick approve/deny — stopPropagation so they do not open the detail.
+      var quicks = scroll.querySelectorAll('.cr-quick');
+      for (var q = 0; q < quicks.length; q++) {
+        quicks[q].addEventListener('click', function (e) {
+          e.stopPropagation();
+          var self = this;
+          self.disabled = true;
+          sdAction('managed', self.getAttribute('data-sid'), 'approve', { allow: self.getAttribute('data-q') === 'approve' })
+            .then(function () { if (window.refreshClaudeSessions) window.refreshClaudeSessions(); renderControl(); })
+            .catch(function (err) { self.disabled = false; scroll.insertAdjacentHTML('afterbegin', '<div class="view-empty" style="color:var(--err-color)">' + esc(err.message) + '</div>'); });
         });
+      }
+      // Row → detail inspector.
+      var rows = scroll.querySelectorAll('.ctrl-row');
+      for (var r = 0; r < rows.length; r++) {
+        rows[r].addEventListener('click', function () { openSessionDetail(this.getAttribute('data-sid')); });
+        rows[r].addEventListener('keydown', function (e) { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); openSessionDetail(this.getAttribute('data-sid')); } });
       }
     });
   }

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -378,6 +378,108 @@ export const MAIN_CSS = `  :root {
     background: rgba(0,0,0,0.25);
     color: var(--fg);
   }
+  /* ══ Control view: session roster (polished, clickable) ══════════ */
+  .ctrl-policy { display: flex; flex-wrap: wrap; gap: 8px; margin-bottom: 16px; }
+  .ctrl-list { display: flex; flex-direction: column; gap: 8px; }
+  .ctrl-row {
+    position: relative;
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 4px 12px;
+    padding: 12px 15px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 12px;
+    cursor: pointer;
+    transition: background 120ms ease, border-color 120ms ease, transform 80ms ease;
+  }
+  .ctrl-row:hover { background: var(--bg-card-strong); border-color: var(--border-strong); }
+  .ctrl-row:active { transform: translateY(1px); }
+  .ctrl-row .cr-pip { width: 9px; height: 9px; border-radius: 50%; background: var(--fg-faint); }
+  .ctrl-row .cr-pip.working { background: var(--claude); animation: breathe 2.6s ease-in-out infinite; }
+  .ctrl-row .cr-pip.waiting { background: var(--warm); animation: needsYou 2s ease-in-out infinite; }
+  .ctrl-row .cr-pip.error { background: var(--err-color); }
+  .ctrl-row .cr-pip.done { background: var(--proactive); }
+  .ctrl-row .cr-name { display: flex; align-items: center; gap: 7px; min-width: 0; }
+  .ctrl-row .cr-id {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 12.5px; font-weight: 600; color: var(--fg);
+    overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+  }
+  .ctrl-row .cr-badge {
+    flex-shrink: 0;
+    font-size: 9px; font-weight: 700; letter-spacing: 0.02em; text-transform: lowercase;
+    color: var(--claude); background: rgba(255,140,66,0.12);
+    border: 1px solid rgba(255,140,66,0.22); border-radius: 999px; padding: 1px 6px;
+  }
+  .ctrl-row .cr-arrow { color: var(--fg-faint); font-size: 13px; margin-left: 2px; opacity: 0; transition: opacity 120ms ease; }
+  .ctrl-row:hover .cr-arrow { opacity: 1; }
+  .ctrl-row .cr-sub {
+    grid-column: 2 / -1; margin-top: 3px;
+    font-size: 10.5px; color: var(--fg-3);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+  }
+  /* Status chip (right) */
+  .st-chip {
+    flex-shrink: 0;
+    font-size: 10px; font-weight: 700; letter-spacing: 0.04em; text-transform: uppercase;
+    border-radius: 999px; padding: 3px 9px;
+    border: 1px solid var(--border-new); color: var(--fg-3); background: var(--bg-3);
+  }
+  .st-chip.working { color: var(--claude); border-color: rgba(255,140,66,0.4); background: rgba(255,140,66,0.12); }
+  .st-chip.waiting { color: var(--warm); border-color: rgba(255,183,77,0.4); background: rgba(255,183,77,0.12); }
+  .st-chip.error   { color: var(--err-color); border-color: rgba(255,85,119,0.45); background: rgba(255,85,119,0.13); }
+  .st-chip.done    { color: var(--proactive); border-color: var(--proactive-glow); background: var(--proactive-soft); }
+  /* Problem / pending rows: coloured left accent + inline line */
+  .ctrl-row.problem { border-color: rgba(255,85,119,0.4); }
+  .ctrl-row.pending { border-color: rgba(255,183,77,0.45); }
+  .ctrl-row.problem::before, .ctrl-row.pending::before {
+    content: ""; position: absolute; left: 0; top: 11px; bottom: 11px; width: 3px;
+    border-radius: 0 3px 3px 0;
+  }
+  .ctrl-row.problem::before { background: var(--err-color); }
+  .ctrl-row.pending::before { background: var(--warm); }
+  .ctrl-row .cr-err {
+    grid-column: 2 / -1; margin-top: 6px;
+    font-size: 11px; color: var(--err-color);
+    overflow: hidden; white-space: nowrap; text-overflow: ellipsis;
+  }
+  .ctrl-row .cr-pend { grid-column: 2 / -1; margin-top: 7px; display: flex; align-items: center; gap: 8px; flex-wrap: wrap; font-size: 11px; color: var(--warm); }
+  .ctrl-row .cr-quick {
+    font-family: inherit; font-size: 10.5px; font-weight: 600;
+    padding: 3px 10px; border-radius: 7px; cursor: pointer;
+    border: 1px solid var(--border-new); background: var(--bg-3); color: var(--fg);
+  }
+  .ctrl-row .cr-quick.ok { color: var(--proactive); border-color: var(--proactive-glow); }
+  .ctrl-row .cr-quick.no { color: var(--err-color); border-color: rgba(255,85,119,0.4); }
+  .ctrl-row .cr-quick:hover { background: rgba(255,255,255,0.09); }
+
+  /* ══ Session detail (inspector modal) ════════════════════════════ */
+  .sd { display: flex; flex-direction: column; gap: 14px; }
+  .sd-top { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
+  .sd-id { font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: 11.5px; color: var(--fg-3); overflow-wrap: anywhere; }
+  .sd-banner { border-radius: 10px; padding: 11px 13px; font-size: 12.5px; line-height: 1.5; display: flex; flex-direction: column; gap: 9px; }
+  .sd-banner.err  { color: var(--err-color); background: rgba(255,85,119,0.10); border: 1px solid rgba(255,85,119,0.35); }
+  .sd-banner.pend { color: var(--warm); background: rgba(255,183,77,0.10); border: 1px solid rgba(255,183,77,0.35); }
+  .sd-banner .sd-b-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+  .sd-grid { display: grid; grid-template-columns: max-content 1fr; gap: 8px 16px; font-size: 12.5px; margin: 0; }
+  .sd-grid dt { color: var(--fg-3); }
+  .sd-grid dd { margin: 0; color: var(--fg); overflow-wrap: anywhere; }
+  .sd-chips { display: flex; flex-wrap: wrap; gap: 5px; }
+  .sd-chip { font-size: 10.5px; color: var(--fg-2); background: var(--bg-3); border: 1px solid var(--border-new); border-radius: 6px; padding: 1px 7px; font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+  .sd-actions { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; border-top: 1px solid var(--border-new); padding-top: 13px; }
+  .sd-send { flex: 1; min-width: 150px; font-family: inherit; font-size: 12.5px; padding: 8px 11px; border-radius: 8px; border: 1px solid var(--border-new); background: var(--bg-3); color: var(--fg); }
+  .sd-send:focus { outline: none; border-color: var(--accent-glow); box-shadow: 0 0 0 3px var(--accent-soft); }
+  .sd-btn { font-family: inherit; font-size: 12px; font-weight: 600; padding: 8px 13px; border-radius: 8px; cursor: pointer; border: 1px solid var(--border-new); background: var(--bg-3); color: var(--fg); transition: filter 120ms ease; }
+  .sd-btn.primary { background: var(--accent); border-color: var(--accent); color: #06141b; }
+  .sd-btn.danger { color: var(--err-color); border-color: rgba(255,85,119,0.4); }
+  .sd-btn.ok { color: var(--proactive); border-color: var(--proactive-glow); }
+  .sd-btn:hover { filter: brightness(1.1); }
+  .sd-out { margin: 0; max-height: 240px; overflow: auto; background: rgba(0,0,0,0.3); border: 1px solid var(--border-new); border-radius: 8px; padding: 10px; font-size: 11px; white-space: pre-wrap; word-break: break-word; color: var(--fg-2); font-family: ui-monospace, "SF Mono", Menlo, monospace; }
+  .sd-note { font-size: 11.5px; color: var(--fg-3); font-style: italic; }
+
   /* "Delegate a task" → a single full-width button that opens a modal. */
   .delegate-btn {
     width: 100%;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -73,10 +73,15 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: locked the launcher to a clean 3×3 — the Mail tile was removed (9
  * tiles: Chat/Dashboard/Control/Rêve/Room/Sense/Memory/Knowledge/Settings);
  * Mail's entry moved to the sidebar Mail card, whose header now opens #viewMail.
+ * Then: Control view overhaul — polished clickable session rows (.ctrl-row,
+ * status chips, error/pending accents, problems-first sort), a per-session
+ * inspector modal (openSessionDetail: metadata + surfaced error/pending banner +
+ * approve/deny/send/cancel/adopt/view-output actions), and inline quick
+ * approve/deny on pending rows. Sidebar .session-row styling left untouched.
  */
-const EXPECTED_LENGTH = 204332;
+const EXPECTED_LENGTH = 219777;
 const EXPECTED_SHA256 =
-  "1bf4ee94395153b01920c1f327f9ff2351925018a4ef6e4d9129c221345f7c5e";
+  "d8483b766c3d28785437d0f47986fefdf29976aac48e3d465af10fc7a666494b";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);


### PR DESCRIPTION
## What & why

The **Control** view (Live agents & control plane) listed sessions as a flat, non-interactive text list — you couldn't open a session, act on it, or see at a glance which ones had a problem. This makes each session **legible and actionable**.

Independent of PR #245 (nav 九宫格) — this branch is cut from current `main` (v0.19.0) and only touches the Control view code + its snapshot constants.

## Changes

**Polished, clickable rows**
- Card rows with status chips coloured by state (Error / Waiting / Working / Done / Unknown), an agent-kind badge, a progress sub-line, and a hover affordance.
- **Problems-first sort**: error → waiting (needs you) → working → rest.

**Inline problem surfacing** ("show the problem right here")
- Errored session → red left accent + `✗ <lastError>` line.
- Blocked on a permission → amber accent + `⚠ wants to run <tool>` with inline **approve / deny** (managed).

**Click a row → per-session inspector** (`openSessionDetail`)
- Full status/metadata: state + reason, turns, tokens, git branch, recent tools, files touched, path, last activity.
- Prominent error / pending banner.
- Follow-up actions by session kind: **approve/deny**, **send a follow-up**, **cancel**, **adopt** (resumable claude session), **view PTY output**.
- Re-fetches on open and after every action, so it always reflects live state.

Reuses the existing `/api/agents/*` control endpoints — **no server changes**. Sidebar `.session-row` styling is untouched (new `.ctrl-*` / `.sd-*` classes).

## Verification
- Drove the whole flow in a browser against a stub roster (error / pending-managed / working / pty / resumable / observe-only / done), on this branch's `main`+Control build: rows render & sort, error and pending surface inline, click opens the inspector, and **approve** + **send** round-trip (session flips state, list + modal refresh). No console errors.
- `lisa-html-snapshot.test.ts` ✅ passes (constants regenerated for main+Control); `typecheck` clean except the pre-existing, unrelated `imapflow`-not-installed error.

## Note
Both this and #245 modify the byte-exact `MAIN_HTML` snapshot constant, so whichever merges second will need a one-line recompute of `EXPECTED_LENGTH`/`EXPECTED_SHA256`. (Also FYI: `main` now ships its own 3×3 launcher with a Knowledge tile, which overlaps #245's nav work — worth reconciling separately.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)