### PR TITLE
feat(accounts): B1 server core — accounts, sessions, auth endpoints, in-app deletion

### DIFF
--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -1,0 +1,99 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-accounts-"));
+process.env.LISA_HOME = TMP;
+const FILE = path.join(TMP, "accounts.json");
+
+const {
+  createEmailAccount,
+  verifyEmailLogin,
+  upsertAppleAccount,
+  deleteAccount,
+  getAccount,
+  getAccountByEmail,
+  sessionAccountValid,
+  resetLoginThrottles,
+  appleUid,
+  AccountError,
+} = await import("./accounts.js");
+
+beforeEach(() => {
+  fs.rmSync(FILE, { force: true });
+  resetLoginThrottles();
+});
+
+describe("email accounts", () => {
+  test("register → login round-trip; email is normalized", () => {
+    const rec = createEmailAccount("  Reviewer@MeetLisa.AI ", "correct-horse-1");
+    assert.match(rec.uid, /^em-[0-9a-f]{18}$/);
+    assert.equal(rec.email, "reviewer@meetlisa.ai");
+    assert.equal(rec.verified, false);
+    const back = verifyEmailLogin("reviewer@meetlisa.ai", "correct-horse-1");
+    assert.equal(back?.uid, rec.uid);
+  });
+
+  test("wrong password / unknown email → null (no throw, no enumeration)", () => {
+    createEmailAccount("a@b.co", "password-123");
+    assert.equal(verifyEmailLogin("a@b.co", "wrong-password"), null);
+    assert.equal(verifyEmailLogin("nobody@b.co", "password-123"), null);
+  });
+
+  test("invalid email / weak password / duplicate → typed AccountError", () => {
+    assert.throws(() => createEmailAccount("not-an-email", "password-123"), (e: unknown) => (e as InstanceType<typeof AccountError>).code === "invalid_email");
+    assert.throws(() => createEmailAccount("a@b.co", "short"), (e: unknown) => (e as InstanceType<typeof AccountError>).code === "weak_password");
+    createEmailAccount("a@b.co", "password-123");
+    assert.throws(() => createEmailAccount("A@B.CO", "password-456"), (e: unknown) => (e as InstanceType<typeof AccountError>).code === "email_taken");
+  });
+
+  test("raw password never persisted; store is 0600", { skip: process.platform === "win32" }, () => {
+    createEmailAccount("a@b.co", "super-secret-pw");
+    const raw = fs.readFileSync(FILE, "utf8");
+    assert.equal(raw.includes("super-secret-pw"), false);
+    assert.match(raw, /scrypt/);
+    assert.equal(fs.statSync(FILE).mode & 0o777, 0o600);
+  });
+
+  test("5 failures lock the email for 15 min; correct password clears the count", () => {
+    createEmailAccount("a@b.co", "password-123");
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 5; i++) assert.equal(verifyEmailLogin("a@b.co", "wrong", t0), null);
+    assert.throws(() => verifyEmailLogin("a@b.co", "password-123", t0 + 1), (e: unknown) => (e as InstanceType<typeof AccountError>).code === "throttled");
+    // lock expires
+    const after = verifyEmailLogin("a@b.co", "password-123", t0 + 16 * 60 * 1000);
+    assert.equal(after?.email, "a@b.co");
+  });
+});
+
+describe("apple accounts", () => {
+  test("upsert creates once, then updates lastLoginAt; uid is fs-safe", () => {
+    const a = upsertAppleAccount("001234.abcdef.5678", "user@example.com", 1000);
+    assert.equal(a.uid, "apple-001234.abcdef.5678");
+    assert.equal(a.verified, true);
+    const b = upsertAppleAccount("001234.abcdef.5678", undefined, 2000);
+    assert.equal(b.uid, a.uid);
+    assert.equal(b.lastLoginAt, 2000);
+    assert.equal(b.email, "user@example.com"); // kept from first sign-in
+  });
+
+  test("appleUid sanitizes hostile subs", () => {
+    assert.equal(appleUid("../../etc"), "apple-.._.._etc".replace("__", "__"));
+    assert.ok(!appleUid("a/b").includes("/"));
+  });
+});
+
+describe("deletion + session validity", () => {
+  test("delete kills the record and its sessions via sv-check", () => {
+    const rec = createEmailAccount("a@b.co", "password-123");
+    assert.equal(sessionAccountValid(rec.uid, rec.sessionVersion), true);
+    assert.equal(sessionAccountValid(rec.uid, rec.sessionVersion + 1), false);
+    assert.equal(deleteAccount(rec.uid), true);
+    assert.equal(sessionAccountValid(rec.uid, rec.sessionVersion), false);
+    assert.equal(getAccount(rec.uid), null);
+    assert.equal(getAccountByEmail("a@b.co"), null);
+    assert.equal(deleteAccount(rec.uid), false);
+  });
+});

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -1,0 +1,291 @@
+/**
+ * LISA accounts — the cloud edition's user directory
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.1, milestone B1).
+ *
+ * Two account kinds share one store (`$LISA_HOME/accounts.json`, 0600):
+ *  - **Apple** (`apple-<sub>`): created/updated on every verified Sign in with
+ *    Apple. No password material — Apple is the authority.
+ *  - **Email** (`em-<random>`): self-serve email+password, scrypt-hashed. This
+ *    is what App Review's demo account uses (ASC insists on user/pass), and the
+ *    path for desktop/web users without an Apple ID.
+ *
+ * Every account carries a `sessionVersion`; session tokens embed it and the
+ *  gate rejects a mismatch — so deleting an account (App Store 5.1.1(v)) or a
+ * future password change invalidates all outstanding sessions statelessly.
+ *
+ * Login throttling is in-memory (per normalized email, 5 fails → 15 min lock):
+ * the cloud runs a single instance (min=max=1), so process-local is correct
+ * until the Firestore move (B2), which takes this table with it.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+export type AccountKind = "apple" | "email";
+
+export interface ScryptParams {
+  saltHex: string;
+  keyHex: string;
+  N: number;
+  r: number;
+  p: number;
+}
+
+export interface AccountRecord {
+  uid: string;
+  kind: AccountKind;
+  /** Normalized (trimmed, lowercased). Optional for Apple (user may hide it). */
+  email?: string;
+  /** Password material — email accounts only. */
+  scrypt?: ScryptParams;
+  createdAt: number;
+  lastLoginAt: number;
+  /** Email ownership verified (B7 wires actual mail); Apple counts as verified. */
+  verified: boolean;
+  /** Bump to invalidate every outstanding session for this uid. */
+  sessionVersion: number;
+}
+
+export class AccountError extends Error {
+  constructor(public code: "invalid_email" | "weak_password" | "email_taken" | "throttled") {
+    super(code);
+    this.name = "AccountError";
+  }
+}
+
+const SCRYPT = { N: 16384, r: 8, p: 1, keyLen: 32 } as const;
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+function accountsPath(): string {
+  return path.join(lisaHome(), "accounts.json");
+}
+
+export function loadAccounts(): AccountRecord[] {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(accountsPath(), "utf8"));
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (a): a is AccountRecord =>
+        !!a && typeof (a as AccountRecord).uid === "string" && typeof (a as AccountRecord).sessionVersion === "number",
+    );
+  } catch {
+    return [];
+  }
+}
+
+function saveAccounts(list: AccountRecord[]): void {
+  const file = accountsPath();
+  // Password hashes are credentials — private store, same posture as devices.json.
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(list, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, file);
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // best effort
+  }
+}
+
+export function normalizeEmail(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+/** Deliberately loose — real ownership proof is the (B7) verification mail. */
+export function validEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) && email.length <= 254;
+}
+
+export function validPassword(pw: string): boolean {
+  return pw.length >= 8 && pw.length <= 256;
+}
+
+function hashPassword(pw: string): ScryptParams {
+  const salt = crypto.randomBytes(16);
+  const key = crypto.scryptSync(pw, salt, SCRYPT.keyLen, SCRYPT);
+  return { saltHex: salt.toString("hex"), keyHex: key.toString("hex"), N: SCRYPT.N, r: SCRYPT.r, p: SCRYPT.p };
+}
+
+function passwordMatches(pw: string, p: ScryptParams): boolean {
+  let stored: Buffer;
+  try {
+    stored = Buffer.from(p.keyHex, "hex");
+  } catch {
+    return false;
+  }
+  const derived = crypto.scryptSync(pw, Buffer.from(p.saltHex, "hex"), stored.length, {
+    N: p.N,
+    r: p.r,
+    p: p.p,
+  });
+  return derived.length === stored.length && crypto.timingSafeEqual(derived, stored);
+}
+
+/** Stable uid for an Apple `sub` (filesystem-safe: sub is digits/dots/dashes). */
+export function appleUid(sub: string): string {
+  return `apple-${sub.replace(/[^A-Za-z0-9._-]/g, "_")}`;
+}
+
+// ── login throttle (in-memory; single-instance cloud) ───────────────────────
+interface Throttle {
+  fails: number;
+  lockedUntil: number;
+}
+const throttles = new Map<string, Throttle>();
+const THROTTLE_MAX_FAILS = 5;
+const THROTTLE_LOCK_MS = 15 * 60 * 1000;
+
+export function loginThrottled(email: string, now: number = Date.now()): boolean {
+  const t = throttles.get(normalizeEmail(email));
+  return !!t && t.lockedUntil > now;
+}
+
+function noteLoginFailure(email: string, now: number): void {
+  const key = normalizeEmail(email);
+  const t = throttles.get(key) ?? { fails: 0, lockedUntil: 0 };
+  t.fails += 1;
+  if (t.fails >= THROTTLE_MAX_FAILS) {
+    t.lockedUntil = now + THROTTLE_LOCK_MS;
+    t.fails = 0;
+  }
+  throttles.set(key, t);
+}
+
+function clearThrottle(email: string): void {
+  throttles.delete(normalizeEmail(email));
+}
+
+/** Test seam. */
+export function resetLoginThrottles(): void {
+  throttles.clear();
+}
+
+// ── account operations ──────────────────────────────────────────────────────
+
+export function getAccount(uid: string): AccountRecord | null {
+  return loadAccounts().find((a) => a.uid === uid) ?? null;
+}
+
+export function getAccountByEmail(email: string): AccountRecord | null {
+  const norm = normalizeEmail(email);
+  return loadAccounts().find((a) => a.kind === "email" && a.email === norm) ?? null;
+}
+
+/** Create an email+password account. Throws AccountError on bad input / dup. */
+export function createEmailAccount(
+  emailRaw: string,
+  password: string,
+  now: number = Date.now(),
+): AccountRecord {
+  const email = normalizeEmail(emailRaw);
+  if (!validEmail(email)) throw new AccountError("invalid_email");
+  if (!validPassword(password)) throw new AccountError("weak_password");
+  const list = loadAccounts();
+  if (list.some((a) => a.kind === "email" && a.email === email)) throw new AccountError("email_taken");
+  const rec: AccountRecord = {
+    uid: `em-${crypto.randomBytes(9).toString("hex")}`,
+    kind: "email",
+    email,
+    scrypt: hashPassword(password),
+    createdAt: now,
+    lastLoginAt: now,
+    verified: false,
+    sessionVersion: 0,
+  };
+  list.push(rec);
+  saveAccounts(list);
+  return rec;
+}
+
+/**
+ * Email+password login. Returns the account or null; throws AccountError
+ * ("throttled") while the email is locked out. A wrong password on an unknown
+ * email burns the same scrypt work as a known one (no user-enumeration timing).
+ */
+export function verifyEmailLogin(
+  emailRaw: string,
+  password: string,
+  now: number = Date.now(),
+): AccountRecord | null {
+  const email = normalizeEmail(emailRaw);
+  if (loginThrottled(email, now)) throw new AccountError("throttled");
+  const acct = getAccountByEmail(email);
+  const params: ScryptParams = acct?.scrypt ?? {
+    // Decoy: constant-cost verify against a random key for unknown emails.
+    saltHex: "00".repeat(16),
+    keyHex: "00".repeat(32),
+    N: SCRYPT.N,
+    r: SCRYPT.r,
+    p: SCRYPT.p,
+  };
+  const ok = passwordMatches(password, params) && !!acct;
+  if (!ok) {
+    noteLoginFailure(email, now);
+    return null;
+  }
+  clearThrottle(email);
+  const list = loadAccounts();
+  const live = list.find((a) => a.uid === acct.uid);
+  if (live) {
+    live.lastLoginAt = now;
+    saveAccounts(list);
+  }
+  return acct;
+}
+
+/**
+ * Upsert the account record for a verified Apple identity. Called on every
+ * successful Sign in with Apple — first sign-in creates the record.
+ */
+export function upsertAppleAccount(
+  sub: string,
+  email: string | undefined,
+  now: number = Date.now(),
+): AccountRecord {
+  const uid = appleUid(sub);
+  const list = loadAccounts();
+  const existing = list.find((a) => a.uid === uid);
+  if (existing) {
+    existing.lastLoginAt = now;
+    if (email && !existing.email) existing.email = normalizeEmail(email);
+    saveAccounts(list);
+    return existing;
+  }
+  const rec: AccountRecord = {
+    uid,
+    kind: "apple",
+    email: email ? normalizeEmail(email) : undefined,
+    createdAt: now,
+    lastLoginAt: now,
+    verified: true,
+    sessionVersion: 0,
+  };
+  list.push(rec);
+  saveAccounts(list);
+  return rec;
+}
+
+/**
+ * Delete an account (App Store 5.1.1(v)). Removes the record — which kills all
+ * of its sessions via the sessionVersion check — and returns true if one existed.
+ * The caller deletes the per-uid home directory (server-side, B2 layout).
+ */
+export function deleteAccount(uid: string): boolean {
+  const list = loadAccounts();
+  const next = list.filter((a) => a.uid !== uid);
+  if (next.length === list.length) return false;
+  saveAccounts(next);
+  return true;
+}
+
+/**
+ * The gate's session check: does this (uid, sv) pair name a live account?
+ * Wrong/stale sv ⇒ revoked (deleted account, future password change).
+ */
+export function sessionAccountValid(uid: string, sv: number): boolean {
+  const acct = getAccount(uid);
+  return !!acct && acct.sessionVersion === sv;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -65,6 +65,22 @@ import { listRecentDispatches, isAlive, toDispatchView, readDispatchOutput } fro
 import { loadControlPolicy, saveControlPolicy, type ControlPolicy } from "../control/policy.js";
 import { loadAutonomyState, saveAutonomyState, type AutonomyState } from "../autonomy/state.js";
 import { mintDevice, verifyDeviceToken, touchDevice, listDevices, revokeDevice } from "./devices.js";
+import {
+  loadOrCreateSessionSecret,
+  mintSession,
+  verifySession,
+  looksLikeSession,
+  shouldRenew,
+} from "./sessions-auth.js";
+import {
+  AccountError,
+  createEmailAccount,
+  verifyEmailLogin,
+  upsertAppleAccount,
+  deleteAccount,
+  getAccount,
+  sessionAccountValid,
+} from "./accounts.js";
 import { PushBridge, listPush, registerPush, unregisterPush, setPushPrefs, registerLiveActivity, unregisterLiveActivity, type PushPrefs } from "./push.js";
 import { SenseService } from "../sense/service.js";
 import { ScreenSource } from "../sense/screen.js";
@@ -191,6 +207,18 @@ function presentedToken(req: http.IncomingMessage, url: string): string | null {
   return null;
 }
 
+/** Read and JSON-parse a request body (tolerant: bad/empty JSON ⇒ {}). */
+async function readJsonBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  let body = "";
+  for await (const chunk of req) body += chunk.toString("utf8");
+  try {
+    const parsed: unknown = body ? JSON.parse(body) : {};
+    return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
 async function resumeOrCreateWebSession(model: string): Promise<SessionStore> {
   const lastId = await readActiveWebSession();
   if (lastId) {
@@ -231,6 +259,11 @@ async function resumeOrCreateWebSession(model: string): Promise<SessionStore> {
 export async function startWebServer(opts: WebServerOptions): Promise<http.Server> {
   const host = opts.host ?? "127.0.0.1";
   const webToken = process.env.LISA_WEB_TOKEN?.trim() || null;
+  // Account sessions (PLAN_ACCOUNTS_BILLING B1): the signing secret lives in
+  // $LISA_HOME (auto-created 0600; durable on the cloud's /data mount). Only the
+  // cloud edition mints/verifies account sessions today — the Mac edition gains
+  // a client-side use in B6 (managed inference).
+  const sessionSecret = isCloud() ? loadOrCreateSessionSecret() : null;
   if (!isLoopbackAddress(host) && !webToken) {
     throw new Error(
       `refusing to bind ${host} without LISA_WEB_TOKEN — every endpoint drives a ` +
@@ -725,15 +758,12 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end("apple sign-in not available");
         return;
       }
-      if (!webToken) {
+      if (!sessionSecret) {
         res.writeHead(503, { "content-type": "text/plain" });
-        res.end("cloud sign-in misconfigured (no session token)");
+        res.end("cloud sign-in misconfigured (no session secret)");
         return;
       }
-      let abBody = "";
-      for await (const chunk of req) abBody += chunk.toString("utf8");
-      let payload: { identityToken?: unknown } = {};
-      try { payload = abBody ? JSON.parse(abBody) : {}; } catch { /* tolerate */ }
+      const payload = await readJsonBody(req);
       const idToken = typeof payload.identityToken === "string" ? payload.identityToken : "";
       if (!idToken) {
         res.writeHead(400, { "content-type": "text/plain" });
@@ -750,8 +780,12 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           res.end("this Apple ID is not allowed on this LISA Cloud instance");
           return;
         }
+        // B1: mint a per-uid account session (no longer the shared LISA_WEB_TOKEN).
+        // The uid keys per-user isolation (B2) and billing (B3+).
+        const acct = upsertAppleAccount(id.sub, id.email);
+        const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
         res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ ok: true, token: webToken }));
+        res.end(JSON.stringify({ ok: true, token: session, uid: acct.uid }));
       } catch (e) {
         const msg = e instanceof AppleAuthError ? e.message : "verification failed";
         res.writeHead(401, { "content-type": "text/plain" });
@@ -760,10 +794,87 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // ── Email accounts (cloud edition; PLAN_ACCOUNTS_BILLING B1) ─────────────
+    // Register/login mint access, so they run BEFORE the token gate — same
+    // posture as /api/auth/apple. 404 outside the cloud edition.
+    if (req.method === "POST" && (url === "/api/auth/register" || url === "/api/auth/login")) {
+      if (!cloud || !sessionSecret) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("accounts not available on this edition");
+        return;
+      }
+      const body = await readJsonBody(req);
+      const email = typeof body.email === "string" ? body.email : "";
+      const password = typeof body.password === "string" ? body.password : "";
+      try {
+        const acct =
+          url === "/api/auth/register"
+            ? createEmailAccount(email, password)
+            : verifyEmailLogin(email, password);
+        if (!acct) {
+          res.writeHead(401, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "bad_credentials" }));
+          return;
+        }
+        const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
+        res.writeHead(200, {
+          "content-type": "application/json",
+          // Pin the session for browser clients (web island); Bearer clients ignore it.
+          "set-cookie": `lisa_token=${encodeURIComponent(session)}; HttpOnly; SameSite=Strict; Path=/`,
+        });
+        res.end(JSON.stringify({ ok: true, token: session, uid: acct.uid, verified: acct.verified }));
+      } catch (e) {
+        if (e instanceof AccountError) {
+          const status = e.code === "throttled" ? 429 : e.code === "email_taken" ? 409 : 400;
+          res.writeHead(status, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: e.code }));
+          return;
+        }
+        res.writeHead(500, { "content-type": "text/plain" });
+        res.end("account operation failed");
+      }
+      return;
+    }
+
+    if (req.method === "POST" && url === "/api/auth/logout") {
+      // Stateless sessions: logout = drop the credential client-side; here we
+      // just expire the cookie for browsers. (Account-wide revocation is the
+      // sessionVersion bump; per-device logout needs no server state.)
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "set-cookie": "lisa_token=; Max-Age=0; HttpOnly; SameSite=Strict; Path=/",
+      });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    // uid of the authenticated LISA account, when the caller used an account
+    // session (B1). null = legacy shared-token / device-token / loopback caller.
+    let accountUid: string | null = null;
+    let renewedCookie = false;
     if (cloud || !isLoopbackAddress(remoteAddr)) {
       const presented = presentedToken(req, url);
       // Authorized by the global LISA_WEB_TOKEN OR a non-revoked per-device token.
       let authed = isRequestAuthorized(remoteAddr, webToken, presented, !cloud);
+      // Account session (cheap prefix check first). sv must still match the
+      // account record, so deleted accounts lose access immediately.
+      if (!authed && presented && sessionSecret && looksLikeSession(presented)) {
+        const claims = verifySession(presented, sessionSecret);
+        if (claims && sessionAccountValid(claims.uid, claims.sv)) {
+          authed = true;
+          accountUid = claims.uid;
+          if (shouldRenew(claims)) {
+            // Sliding renewal for cookie clients (web). Bearer clients (iOS)
+            // keep their token until expiry and re-run sign-in then.
+            const fresh = mintSession(claims.uid, sessionSecret, { sv: claims.sv });
+            res.setHeader(
+              "set-cookie",
+              `lisa_token=${encodeURIComponent(fresh)}; HttpOnly; SameSite=Strict; Path=/`,
+            );
+            renewedCookie = true;
+          }
+        }
+      }
       if (!authed && presented) {
         const device = verifyDeviceToken(presented);
         if (device) {
@@ -787,13 +898,59 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       // Token arrived via query param (first open from a phone): pin it as a
       // cookie so subsequent same-origin fetch/EventSource calls authenticate.
       // presented is non-null here — isRequestAuthorized returned true for a
-      // non-loopback caller, which requires a matching token.
-      if (presented && !req.headers.cookie?.includes("lisa_token=")) {
+      // non-loopback caller, which requires a matching token. (Skip when the
+      // sliding renewal above already set a fresher cookie.)
+      if (presented && !renewedCookie && !req.headers.cookie?.includes("lisa_token=")) {
         res.setHeader(
           "set-cookie",
           `lisa_token=${encodeURIComponent(presented)}; HttpOnly; SameSite=Strict; Path=/`,
         );
       }
+    }
+
+    // ── Account introspection + deletion (post-gate; PLAN_ACCOUNTS_BILLING B1) ──
+    if (req.method === "GET" && url === "/api/auth/me") {
+      const acct = accountUid ? getAccount(accountUid) : null;
+      res.writeHead(200, { "content-type": "application/json" });
+      // plan/tier is a placeholder until the quota engine (B4) lands.
+      res.end(
+        JSON.stringify(
+          acct
+            ? { signedIn: true, uid: acct.uid, kind: acct.kind, email: acct.email ?? null, verified: acct.verified, plan: "free" }
+            : { signedIn: false },
+        ),
+      );
+      return;
+    }
+
+    if (req.method === "DELETE" && url === "/api/account") {
+      // App Store 5.1.1(v): in-app account deletion. Session-authed only — the
+      // shared demo token must not be able to delete accounts.
+      if (!accountUid) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "account_session_required" }));
+        return;
+      }
+      const removed = deleteAccount(accountUid);
+      // Remove the per-uid home (B2 layout; a no-op before it exists). The
+      // account record going away already killed every session via sv-check.
+      try {
+        const home = process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+        const userHome = path.join(home, "users", accountUid);
+        // Refuse to follow a surprising path — belt & braces against uid tampering
+        // (uids are server-minted, but cheap to double-check).
+        if (userHome.startsWith(path.join(home, "users") + path.sep)) {
+          await fs.rm(userHome, { recursive: true, force: true });
+        }
+      } catch (e) {
+        console.error(`[auth] account home cleanup failed: ${(e as Error).message}`);
+      }
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "set-cookie": "lisa_token=; Max-Age=0; HttpOnly; SameSite=Strict; Path=/",
+      });
+      res.end(JSON.stringify({ ok: true, removed }));
+      return;
     }
 
     // Per-request gate for high-risk control actions from REMOTE callers. The Mac

--- a/src/web/sessions-auth.test.ts
+++ b/src/web/sessions-auth.test.ts
@@ -1,0 +1,65 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-sessions-"));
+process.env.LISA_HOME = TMP;
+
+const { mintSession, verifySession, looksLikeSession, shouldRenew, loadOrCreateSessionSecret, SESSION_TTL_MS } =
+  await import("./sessions-auth.js");
+
+const SECRET = "test-secret";
+const T0 = 1_700_000_000_000;
+
+describe("account sessions", () => {
+  test("mint → verify round-trips uid/sv; token has the s1 shape", () => {
+    const tok = mintSession("apple-001.abc", SECRET, { now: T0, sv: 3 });
+    assert.ok(looksLikeSession(tok));
+    const claims = verifySession(tok, SECRET, T0 + 1000);
+    assert.equal(claims?.uid, "apple-001.abc");
+    assert.equal(claims?.sv, 3);
+    assert.equal(claims?.exp, T0 + SESSION_TTL_MS);
+  });
+
+  test("expired token → null; boundary is exclusive", () => {
+    const tok = mintSession("u", SECRET, { now: T0, ttlMs: 1000 });
+    assert.ok(verifySession(tok, SECRET, T0 + 999));
+    assert.equal(verifySession(tok, SECRET, T0 + 1000), null);
+  });
+
+  test("wrong secret / tampered payload / garbage → null", () => {
+    const tok = mintSession("u", SECRET, { now: T0 });
+    assert.equal(verifySession(tok, "other-secret", T0), null);
+    const parts = tok.split(".");
+    const forged = Buffer.from(JSON.stringify({ uid: "admin", iat: T0, exp: T0 + 9e9, sv: 0 }), "utf8").toString(
+      "base64url",
+    );
+    assert.equal(verifySession(`${parts[0]}.${forged}.${parts[2]}`, SECRET, T0), null);
+    assert.equal(verifySession("s1.not.athing", SECRET, T0), null);
+    assert.equal(verifySession("", SECRET, T0), null);
+    assert.equal(verifySession("lisa-demo-abcdef", SECRET, T0), null);
+  });
+
+  test("looksLikeSession distinguishes sessions from raw web tokens", () => {
+    assert.equal(looksLikeSession("s1.x.y"), true);
+    assert.equal(looksLikeSession("a1b2c3d4"), false);
+  });
+
+  test("shouldRenew flips past half-life", () => {
+    const tok = mintSession("u", SECRET, { now: T0, ttlMs: 1000 });
+    const claims = verifySession(tok, SECRET, T0 + 1)!;
+    assert.equal(shouldRenew(claims, T0 + 400), false);
+    assert.equal(shouldRenew(claims, T0 + 600), true);
+  });
+
+  test("secret auto-creates once, private (0600), and is stable across loads", { skip: process.platform === "win32" }, () => {
+    const a = loadOrCreateSessionSecret();
+    const b = loadOrCreateSessionSecret();
+    assert.equal(a, b);
+    assert.ok(a.length >= 64);
+    const file = path.join(TMP, "session-secret");
+    assert.equal(fs.statSync(file).mode & 0o777, 0o600);
+  });
+});

--- a/src/web/sessions-auth.ts
+++ b/src/web/sessions-auth.ts
@@ -1,0 +1,135 @@
+/**
+ * LISA account sessions — compact HMAC-signed bearer tokens for the cloud
+ * edition (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.1, milestone B1).
+ *
+ * After a sign-in (Sign in with Apple, or email+password from accounts.ts) the
+ * server mints `s1.<payload>.<mac>` where payload is base64url JSON
+ * `{uid, iat, exp, sv}`. Every later request presents it through the existing
+ * Bearer/cookie/query token channels — no client protocol change. Verification
+ * is pure (secret + clock injected) so it unit-tests offline.
+ *
+ * `sv` is the account's session version: bumping it (or deleting the account)
+ * invalidates every outstanding session for that uid without any server-side
+ * session store. Stateless by design — the single secret lives next to the
+ * other credentials in `$LISA_HOME` (0600), auto-created on first use so the
+ * cloud container needs no extra env to turn accounts on.
+ */
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import crypto from "node:crypto";
+
+export interface SessionClaims {
+  uid: string;
+  /** Issued-at, ms since epoch. */
+  iat: number;
+  /** Expiry, ms since epoch. */
+  exp: number;
+  /** Account session version — must match the account record at verify time. */
+  sv: number;
+}
+
+/** 30 days — long enough that a phone rarely re-logs, short enough to expire leaks. */
+export const SESSION_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+const PREFIX = "s1";
+
+function lisaHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
+
+function secretPath(): string {
+  return path.join(lisaHome(), "session-secret");
+}
+
+/**
+ * Load the session-signing secret, creating (and persisting, 0600) a random one
+ * on first use. On the cloud image `$LISA_HOME` is the durable /data mount, so
+ * sessions survive restarts; losing the file merely signs everyone out.
+ */
+export function loadOrCreateSessionSecret(): string {
+  const file = secretPath();
+  try {
+    const s = fs.readFileSync(file, "utf8").trim();
+    if (s) return s;
+  } catch {
+    /* fall through to create */
+  }
+  const fresh = crypto.randomBytes(48).toString("hex");
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, fresh + "\n", { mode: 0o600 });
+  try {
+    fs.chmodSync(file, 0o600);
+  } catch {
+    // best effort — non-POSIX filesystems may reject chmod
+  }
+  return fresh;
+}
+
+function mac(data: string, secret: string): Buffer {
+  return crypto.createHmac("sha256", secret).update(data).digest();
+}
+
+/** Mint a session token for `uid`. Pure given (secret, now). */
+export function mintSession(
+  uid: string,
+  secret: string,
+  opts: { now?: number; ttlMs?: number; sv?: number } = {},
+): string {
+  const iat = opts.now ?? Date.now();
+  const claims: SessionClaims = {
+    uid,
+    iat,
+    exp: iat + (opts.ttlMs ?? SESSION_TTL_MS),
+    sv: opts.sv ?? 0,
+  };
+  const payload = Buffer.from(JSON.stringify(claims), "utf8").toString("base64url");
+  const sig = mac(`${PREFIX}.${payload}`, secret).toString("base64url");
+  return `${PREFIX}.${payload}.${sig}`;
+}
+
+/** True when `token` even looks like one of our session tokens (cheap pre-check). */
+export function looksLikeSession(token: string): boolean {
+  return token.startsWith(`${PREFIX}.`);
+}
+
+/**
+ * Verify a session token: signature (constant-time), shape, expiry. Returns the
+ * claims or null — the caller still has to check `sv` against the account record
+ * (accounts.ts) so deleted accounts lose access immediately.
+ */
+export function verifySession(
+  token: string,
+  secret: string,
+  now: number = Date.now(),
+): SessionClaims | null {
+  const parts = token.split(".");
+  if (parts.length !== 3 || parts[0] !== PREFIX) return null;
+  const payload = parts[1] as string;
+  const sig = parts[2] as string;
+  const expected = mac(`${PREFIX}.${payload}`, secret);
+  let presented: Buffer;
+  try {
+    presented = Buffer.from(sig, "base64url");
+  } catch {
+    return null;
+  }
+  if (presented.length !== expected.length || !crypto.timingSafeEqual(presented, expected)) {
+    return null;
+  }
+  let claims: SessionClaims;
+  try {
+    claims = JSON.parse(Buffer.from(payload, "base64url").toString("utf8")) as SessionClaims;
+  } catch {
+    return null;
+  }
+  if (typeof claims.uid !== "string" || !claims.uid) return null;
+  if (typeof claims.exp !== "number" || claims.exp <= now) return null;
+  if (typeof claims.sv !== "number") return null;
+  return claims;
+}
+
+/** Renew when more than half the lifetime is gone (sliding sessions via cookie). */
+export function shouldRenew(claims: SessionClaims, now: number = Date.now()): boolean {
+  return now > claims.iat + (claims.exp - claims.iat) / 2;
+}


### PR DESCRIPTION
**Stacked on #259** (B0). Implements the server half of milestone **B1** from `docs/PLAN_ACCOUNTS_BILLING_v1.0.md`.

## What

- **`src/web/accounts.ts`** — one account store (`$LISA_HOME/accounts.json`, 0600) for both kinds:
  - **Apple** (`apple-<sub>`): upserted on every verified Sign in with Apple; no password material.
  - **Email** (`em-<random>`): scrypt-hashed passwords, normalized emails, constant-cost verify for unknown emails (no user enumeration), 5 fails → 15-min lockout.
  - `sessionVersion` per record → stateless account-wide revocation.
- **`src/web/sessions-auth.ts`** — `s1.<payload>.<hmac>` sessions ({uid, iat, exp, sv}), 30-day TTL, sliding cookie renewal past half-life. Signing secret auto-created (0600) under `$LISA_HOME` → durable on the cloud `/data` mount, **no new deploy env needed**.
- **`server.ts`**:
  - `POST /api/auth/register` / `login` / `logout` (cloud-only, pre-gate — they mint access, like `/api/auth/apple`). Typed error codes (`email_taken`, `weak_password`, `throttled`→429…).
  - `/api/auth/apple` now returns a **per-uid session** instead of the shared `LISA_WEB_TOKEN` — the uid keys per-user isolation (B2) and billing (B3+).
  - Auth gate accepts sessions (sv checked against the live record); shared-token and device-token paths untouched (BYO escape hatch preserved).
  - `GET /api/auth/me`; `DELETE /api/account` (**App Store 5.1.1(v)**) — session-authed only, removes record + `users/<uid>` subtree, expires the cookie.

## Tests

14 new tests (sessions: round-trip / tamper / expiry / renewal / secret perms; accounts: register / login / throttle / delete / no-plaintext-on-disk / store perms). Full suite: **1032 pass / 0 fail**.

## Notes

- iOS/web clients pick this up in the next PR (B1-clients): SIWA UI un-gated, onboarding flip, web login page.
- Pre-B2 all uids still share the single demo soul; isolation is the next milestone and deletion's home-cleanup is already per-uid-shaped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)