### PR TITLE
feat(accounts): B1 clients — SIWA on, sign-in as primary iOS flow, web login page

### DIFF
--- a/packaging/ios-companion/APPSTORE_METADATA.md
+++ b/packaging/ios-companion/APPSTORE_METADATA.md
@@ -75,15 +75,15 @@ Live Activities and the Dynamic Island keep the current agent's progress on your
 lock screen. Home Screen widgets show it without opening the app.
 
 PRIVATE BY DESIGN
-Lisa Pocket is a client, not a service. Pairing is QR-based and every connection
-is gated by a per-device token you can revoke. Nothing is collected to a
-Lisa-operated server; the app stores no account.
+Your choice of two ways to run: sign in to LISA Cloud (email or Apple — a free
+usage allowance refreshes every 12 hours), or connect your own Mac, where
+pairing is QR-based, every connection is gated by a revocable per-device token,
+and nothing ever reaches a Lisa-operated server.
 
 GETTING STARTED
-You'll need LISA running on a Mac (free and open source — install with Homebrew,
-npm, or the Mac app). The in-app setup walks you through installing it, starting
-it reachably, and scanning the pairing QR. No Mac yet? Point the app at a LISA
-Cloud URL instead.
+Sign in and go — no setup needed. Prefer fully local? LISA is free and open
+source: the in-app setup walks you through installing it on your Mac, starting
+it reachably, and scanning the pairing QR.
 
 LISA is open source (MIT). Learn more at meetlisa.ai.
 ```
@@ -97,9 +97,10 @@ LISA is open source (MIT). Learn more at meetlisa.ai.
   [`REVIEW_RESPONSE_4.1a.md`](REVIEW_RESPONSE_4.1a.md). Lead the **App Review
   Notes** with the "our own open-source product (meetlisa.ai / github.com/oratis/LISA)"
   framing (already updated in the submission checklist §7.3).
-- **App Privacy** answer must be **"Data Not Collected"** to match
-  `Sources/PrivacyInfo.xcprivacy` — see [`RELEASE.md`](RELEASE.md) §"From
-  TestFlight to App Store".
+- **App Privacy** (updated for B1 accounts): declare **Email Address** and
+  **User ID** — App Functionality, linked to the user, **no tracking** — to match
+  `Sources/PrivacyInfo.xcprivacy`. The local (My Mac) and BYO-token modes still
+  collect nothing, but ASC's answer covers the app's maximum collection.
 - **App Review Information** → sign-in / demo notes are already drafted in
   [`RELEASE.md`](RELEASE.md) §"App Review notes" (point the reviewer at the LISA
   Cloud demo so they need no Mac).

--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -1,0 +1,193 @@
+import SwiftUI
+import AuthenticationServices
+
+/// Shared cloud sign-in form (PLAN_ACCOUNTS_BILLING B1) — the PRIMARY flow:
+/// Sign in with Apple first, email+password second, and the legacy paste-a-token
+/// link tucked behind an "Advanced" disclosure. Used from both Settings and the
+/// first-run onboarding sheet so the two entry points can't drift apart.
+///
+/// Emits `onSignedIn` after the connection is saved AND live-verified — the
+/// parse-only fake success is what got build 1782924012 rejected (2.1).
+struct CloudSignInForm: View {
+    @EnvironmentObject var app: AppState
+    /// Called with the verify outcome after a credential/URL was applied.
+    let onResult: (VerifyOutcome) -> Void
+
+    @State private var cloudURL = AppState.defaultCloudBase
+    @State private var email = ""
+    @State private var password = ""
+    @State private var pasteText = ""
+    @State private var busy = false
+    @State private var error: String?
+
+    var body: some View {
+        Section {
+            TextField("LISA Cloud URL", text: $cloudURL)
+                .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
+            #if LISA_ENABLE_SIWA
+            SignInWithAppleButton(.continue,
+                onRequest: { req in req.requestedScopes = [.fullName, .email] },
+                onCompletion: handleApple)
+                .signInWithAppleButtonStyle(.white)
+                .frame(height: 46)
+                .cornerRadius(Theme.cardRadius)
+                .disabled(busy || AppState.parseCloudBase(cloudURL) == nil)
+                .opacity(busy ? 0.5 : 1)
+            #endif
+            TextField("Email", text: $email)
+                .autocorrectionDisabled().textInputAutocapitalization(.never)
+                .keyboardType(.emailAddress).textContentType(.username)
+            SecureField("Password (8+ characters)", text: $password)
+                .textContentType(.password)
+            HStack {
+                Button("Sign in") { emailAuth(register: false) }
+                    .disabled(!emailFormReady)
+                Spacer()
+                Button("Create account") { emailAuth(register: true) }
+                    .disabled(!emailFormReady)
+            }
+            if busy { ProgressView().tint(Theme.accent) }
+        } header: {
+            Text("LISA account")
+        } footer: {
+            Text("Sign in and go — no Mac, no API key. A free usage allowance refreshes every 12 hours.")
+        }
+
+        Section {
+            DisclosureGroup("Advanced: connect with a token link") {
+                TextField("https://…/?token=", text: $pasteText)
+                    .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
+                Button("Connect") { applyPaste() }
+                    .disabled(pasteText.isEmpty || busy)
+            }
+        } footer: {
+            Text("For self-hosted instances using a shared LISA_WEB_TOKEN.")
+        }
+
+        if let error {
+            Section { Text(error).font(.caption).foregroundStyle(Theme.danger) }
+        }
+    }
+
+    private var emailFormReady: Bool {
+        !busy && !email.isEmpty && password.count >= 8 && AppState.parseCloudBase(cloudURL) != nil
+    }
+
+    /// Verify after saving so success is REAL success (2.1 fix), then report.
+    private func verifyThenReport() async {
+        let outcome = await app.verifyConnection()
+        busy = false
+        onResult(outcome)
+    }
+
+    private func emailAuth(register: Bool) {
+        error = nil
+        busy = true
+        Task {
+            do {
+                try await app.connectCloudWithEmail(baseURL: cloudURL, email: email,
+                                                    password: password, register: register)
+                await verifyThenReport()
+            } catch LisaError.http(let code) {
+                busy = false
+                switch code {
+                case 401: error = "Wrong email or password."
+                case 409: error = "That email already has an account — use Sign in."
+                case 429: error = "Too many attempts — wait 15 minutes and try again."
+                case 404: error = "This instance doesn't offer accounts — use the token link below."
+                case 400: error = "Check the email address and use 8+ characters for the password."
+                default:  error = "The server answered with an error (\(code))."
+                }
+            } catch {
+                busy = false
+                self.error = "Couldn't reach that LISA Cloud URL."
+            }
+        }
+    }
+
+    private func applyPaste() {
+        error = nil
+        guard app.applyPairing(pasteText) else {
+            error = "Couldn't read that cloud URL — paste the full https://…/?token=… link."
+            return
+        }
+        busy = true
+        Task { await verifyThenReport() }
+    }
+
+    #if LISA_ENABLE_SIWA
+    private func handleApple(_ result: Result<ASAuthorization, Error>) {
+        error = nil
+        switch result {
+        case .failure(let err):
+            if (err as? ASAuthorizationError)?.code == .canceled { return }
+            error = err.localizedDescription
+        case .success(let auth):
+            guard let cred = auth.credential as? ASAuthorizationAppleIDCredential,
+                  let data = cred.identityToken, let idToken = String(data: data, encoding: .utf8) else {
+                error = "Apple didn't return an identity token."
+                return
+            }
+            busy = true
+            Task {
+                do {
+                    try await app.connectCloudWithApple(baseURL: cloudURL, identityToken: idToken)
+                    await verifyThenReport()
+                } catch LisaError.http(404) {
+                    busy = false
+                    error = "This instance hasn't enabled Sign in with Apple — use email or a token link."
+                } catch LisaError.http(401), LisaError.http(403) {
+                    busy = false
+                    error = "Apple sign-in was rejected by this instance."
+                } catch {
+                    busy = false
+                    self.error = "Couldn't reach that LISA Cloud URL."
+                }
+            }
+        }
+    }
+    #endif
+}
+
+/// The signed-in account card for Settings: who you are, sign out, and the
+/// App Store 5.1.1(v) in-app deletion (confirm dialog; destructive).
+struct AccountCard: View {
+    @EnvironmentObject var app: AppState
+    @State private var showDeleteConfirm = false
+    @State private var deleting = false
+
+    var body: some View {
+        Section("LISA account") {
+            if let acct = app.account, acct.signedIn {
+                LabeledContent("Signed in as", value: acct.email ?? acct.uid ?? "—")
+                LabeledContent("Plan", value: (acct.plan ?? "free").capitalized)
+                Button("Sign out") {
+                    app.signOutCloud()
+                    app.notify("Signed out.")
+                }
+                Button("Delete account…", role: .destructive) { showDeleteConfirm = true }
+                    .disabled(deleting)
+            } else {
+                // Connected with a legacy shared/device token — not an account.
+                LabeledContent("Signed in", value: "No (token connection)")
+            }
+        }
+        .confirmationDialog("Delete your LISA account?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
+            Button("Delete account and data", role: .destructive) {
+                deleting = true
+                Task {
+                    defer { deleting = false }
+                    do {
+                        try await app.deleteCloudAccount()
+                        app.notify("Account deleted.")
+                    } catch {
+                        app.notify("Couldn't delete the account — try again.", ok: false)
+                    }
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Deletes your account and its cloud data permanently. Purchased credits are handled by Apple's refund process and are not restored by re-registering.")
+        }
+    }
+}

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -221,6 +221,54 @@ final class AppState: ObservableObject {
         guard let base = AppState.parseCloudBase(raw) else { throw LisaError.notConfigured }
         let token = try await LisaClient.exchangeAppleToken(base: base, identityToken: identityToken)
         update(host: base.host, port: base.port, token: token, scheme: base.scheme)
+        await refreshAccount()
+    }
+
+    // ── LISA accounts (PLAN_ACCOUNTS_BILLING B1) ──
+    /// The official hosted instance — prefilled (editable) wherever a cloud URL is
+    /// asked for, so the primary flow is "open app → sign in → go". Self-hosters
+    /// just type their own URL over it.
+    nonisolated static let defaultCloudBase = "https://cloud.meetlisa.ai"
+
+    /// The signed-in account behind the current connection (`/api/auth/me`), or
+    /// nil when unknown/unreachable. `signedIn == false` ⇒ legacy token auth.
+    @Published var account: LisaClient.AccountMe?
+
+    /// Email sign-in / registration against a LISA Cloud instance; on success the
+    /// account session becomes the connection token (same Bearer channel).
+    func connectCloudWithEmail(baseURL raw: String, email: String, password: String,
+                               register: Bool) async throws {
+        guard let base = AppState.parseCloudBase(raw) else { throw LisaError.notConfigured }
+        let token = try await LisaClient.emailAuth(base: base, email: email,
+                                                  password: password, register: register)
+        update(host: base.host, port: base.port, token: token, scheme: base.scheme)
+        await refreshAccount()
+    }
+
+    /// Refresh `account` (best-effort — leaves the last value on transport errors,
+    /// clears to signed-out shape on a definitive 401).
+    func refreshAccount() async {
+        guard config.isConfigured else { account = nil; return }
+        do {
+            account = try await client.authMe()
+        } catch LisaError.http(401), LisaError.http(403) {
+            account = LisaClient.AccountMe(signedIn: false)
+        } catch {
+            // unreachable — keep whatever we knew
+        }
+    }
+
+    /// Drop the account session locally (the token is stateless server-side).
+    func signOutCloud() {
+        update(host: config.host, port: config.port, token: nil, scheme: config.scheme)
+        account = nil
+    }
+
+    /// In-app account deletion (App Store 5.1.1(v)): server-side delete, then
+    /// local sign-out. Throws so the UI can surface a failure.
+    func deleteCloudAccount() async throws {
+        try await client.deleteAccount()
+        signOutCloud()
     }
 
     // ── first-run onboarding (docs/PLAN_IOS_ONBOARDING_v1.0.md) ──

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -76,6 +76,56 @@ final class LisaClient {
         return r.token
     }
 
+    /// Email-account sign-in / registration against a LISA Cloud instance
+    /// (`POST /api/auth/login` / `/register` — PLAN_ACCOUNTS_BILLING B1). Like
+    /// `exchangeAppleToken`, this *mints* access, so it's a static helper over the
+    /// bare cloud base. Returns the account session token. Throws `LisaError.http`
+    /// with the server's typed status: 401 bad credentials, 409 email taken,
+    /// 429 throttled, 404 instance without accounts.
+    static func emailAuth(base: ServerConfig, email: String, password: String,
+                          register: Bool, session: URLSession = .shared) async throws -> String {
+        let path = register ? "/api/auth/register" : "/api/auth/login"
+        guard let baseURL = base.baseURL, let url = URL(string: path, relativeTo: baseURL) else {
+            throw LisaError.notConfigured
+        }
+        var req = URLRequest(url: url)
+        req.httpMethod = "POST"
+        req.timeoutInterval = 15
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try JSONSerialization.data(withJSONObject: ["email": email, "password": password])
+        let (data, resp) = try await session.data(for: req)
+        let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(code) else { throw LisaError.http(code) }
+        struct R: Decodable { let token: String }
+        guard let r = try? JSONDecoder().decode(R.self, from: data), !r.token.isEmpty else {
+            throw LisaError.decode
+        }
+        return r.token
+    }
+
+    /// The signed-in account behind the current session (`GET /api/auth/me`).
+    /// `signedIn: false` means the connection authenticates with a legacy shared
+    /// or device token rather than a LISA account.
+    struct AccountMe: Decodable, Equatable {
+        var signedIn: Bool
+        var uid: String?
+        var kind: String?
+        var email: String?
+        var verified: Bool?
+        var plan: String?
+    }
+
+    func authMe() async throws -> AccountMe {
+        try await decode("/api/auth/me", as: AccountMe.self)
+    }
+
+    /// In-app account deletion (App Store 5.1.1(v)) — `DELETE /api/account`.
+    /// Only works when the connection uses an account session.
+    func deleteAccount() async throws {
+        struct R: Decodable { let ok: Bool }
+        _ = try await decode("/api/account", method: "DELETE", as: R.self)
+    }
+
     /// URL for a server asset (e.g. a mood portrait at /assets/lisa/<slug>.png),
     /// carrying the token as a query param so AsyncImage — which can't set an
     /// Authorization header — still authenticates against a non-loopback server.

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -89,16 +89,18 @@ struct OnboardingFlow: View {
             ScrollView {
                 VStack(spacing: 18) {
                     OnboardingTitle(title: "Where does Lisa live?",
-                                    subtitle: "Lisa runs on a Mac. Connect to your own, or use hosted LISA Cloud.")
-                    OnboardingChoiceCard(systemImage: "desktopcomputer",
-                                         title: "My Mac", subtitle: "Private and local — your data never leaves your Mac.",
-                                         badge: "Recommended", selected: app.connectionMode == .mac) {
-                        app.setConnectionMode(.mac); go(.install)
-                    }
+                                    subtitle: "Sign in and go — or connect your own Mac for the fully local edition.")
+                    // Primary flow (PLAN_ACCOUNTS_BILLING B1): the hosted cloud with a
+                    // LISA account. The Mac path stays one tap away — never hidden.
                     OnboardingChoiceCard(systemImage: "cloud",
-                                         title: "LISA Cloud", subtitle: "No Mac needed. Paste a cloud URL + token for now.",
-                                         selected: app.connectionMode == .cloud) {
+                                         title: "LISA Cloud", subtitle: "Sign in with Apple or email — no Mac, no API key. Free daily allowance included.",
+                                         badge: "Recommended", selected: app.connectionMode == .cloud) {
                         app.setConnectionMode(.cloud); openManual(.cloud)
+                    }
+                    OnboardingChoiceCard(systemImage: "desktopcomputer",
+                                         title: "My Mac", subtitle: "Advanced: private and local — your data never leaves your Mac.",
+                                         selected: app.connectionMode == .mac) {
+                        app.setConnectionMode(.mac); go(.install)
                     }
                 }
                 .padding(.vertical, 24)
@@ -358,8 +360,6 @@ struct OnboardingManualEntry: View {
     @State private var host = ""
     @State private var portText = "5757"
     @State private var token = ""
-    @State private var cloudURL = ""
-    @State private var appleBusy = false
     @State private var error: String?
 
     var body: some View {
@@ -381,39 +381,23 @@ struct OnboardingManualEntry: View {
         .preferredColorScheme(.dark)
     }
 
-    // ── Cloud: paste a token link. Sign in with Apple is gated OFF for v1 (single-
-    // tenant M0 + App Store 5.1.1(v) account-deletion); re-enable via LISA_ENABLE_SIWA.
+    // ── Cloud: the shared account sign-in form (SIWA / email / advanced token
+    // link) — same component Settings uses, so the flows can't drift (B1).
     @ViewBuilder private var cloudSections: some View {
-        #if LISA_ENABLE_SIWA
-        Section {
-            TextField("https://your-instance.run.app", text: $cloudURL)
-                .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
-            SignInWithAppleButton(.continue,
-                onRequest: { req in req.requestedScopes = [.fullName, .email] },
-                onCompletion: handleApple)
-                .signInWithAppleButtonStyle(.white)
-                .frame(height: 46)
-                .cornerRadius(Theme.cardRadius)
-                .disabled(appleBusy || AppState.parseCloudBase(cloudURL) == nil)
-                .opacity(appleBusy ? 0.5 : 1)
-            if appleBusy { ProgressView().tint(Theme.accent) }
-        } header: {
-            Text("Sign in")
-        } footer: {
-            Text("Enter your LISA Cloud URL, then sign in. Your Mac isn't needed.")
+        CloudSignInForm { outcome in
+            if outcome == .ok {
+                finish()
+            } else {
+                error = {
+                    switch outcome {
+                    case .unauthorized: return "Signed in, but the connection was rejected — try again."
+                    case .serverError(let code): return "The server answered with an error (\(code))."
+                    default: return "Signed in, but the instance is unreachable right now."
+                    }
+                }()
+            }
         }
-        #endif
-
-        Section {
-            TextField("https://…/?token=", text: $pasteText)
-                .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
-            Button("Connect") { apply(pasteText) }
-                .disabled(pasteText.isEmpty)
-        } header: {
-            Text("LISA Cloud")
-        } footer: {
-            Text("Paste your LISA Cloud URL (including its ?token=…) — your Mac isn't needed.")
-        }
+        .environmentObject(app)
     }
 
     // ── Mac: paste a pairing link, or enter host/port/token ──
@@ -443,41 +427,6 @@ struct OnboardingManualEntry: View {
             .disabled(host.isEmpty || token.isEmpty)
         }
     }
-
-    #if LISA_ENABLE_SIWA
-    /// Handle the Sign in with Apple result: pull the identity token, exchange it
-    /// at the entered cloud URL for a session token, and save the connection.
-    /// Gated OFF for v1 — see cloudSections.
-    private func handleApple(_ result: Result<ASAuthorization, Error>) {
-        error = nil
-        switch result {
-        case .failure(let err):
-            // A user-cancelled prompt isn't an error worth shouting about.
-            if (err as? ASAuthorizationError)?.code == .canceled { return }
-            error = err.localizedDescription
-        case .success(let auth):
-            guard let cred = auth.credential as? ASAuthorizationAppleIDCredential,
-                  let data = cred.identityToken, let idToken = String(data: data, encoding: .utf8) else {
-                error = "Apple didn't return an identity token."
-                return
-            }
-            appleBusy = true
-            Task {
-                defer { appleBusy = false }
-                do {
-                    try await app.connectCloudWithApple(baseURL: cloudURL, identityToken: idToken)
-                    finish()
-                } catch LisaError.http(404) {
-                    error = "This LISA Cloud instance hasn't enabled Sign in with Apple. Paste a token link instead."
-                } catch LisaError.http(401), LisaError.http(403) {
-                    error = "Apple sign-in was rejected by this instance."
-                } catch {
-                    self.error = "Couldn't reach that LISA Cloud URL."
-                }
-            }
-        }
-    }
-    #endif
 
     private func apply(_ raw: String) {
         if app.applyPairing(raw) { finish() }

--- a/packaging/ios-companion/Sources/PrivacyInfo.xcprivacy
+++ b/packaging/ios-companion/Sources/PrivacyInfo.xcprivacy
@@ -10,13 +10,12 @@
   snapshot the widget reads), C617.1 (file timestamps, app-owned files), 35F9.1
   (boot time, session age), 85F4.1 (disk space, cache management).
 
-  DIFFERS from Telloria on data collection: Telloria collects email / user-id /
-  purchase / analytics / crash data to its own backend, so it declares them.
-  Lisa Pocket is a THIN CLIENT to the user's OWN Lisa backend (their Mac, or
-  later their own LISA Cloud instance, BYO key) — nothing is collected to a
-  Lisa-operated server and there is no tracking. So NSPrivacyTracking is false,
-  NSPrivacyTrackingDomains is empty, and NSPrivacyCollectedDataTypes is empty.
-  (Revisit if/when a Lisa-operated multi-tenant cloud ships.)
+  Data collection (updated for B1 accounts, PLAN_ACCOUNTS_BILLING): the optional
+  LISA account (Sign in with Apple / email+password on the hosted LISA Cloud)
+  collects an email address and a user ID, linked to the user, for app
+  functionality only — no tracking, no third parties. The My Mac (local) mode
+  and BYO-token cloud mode collect nothing. ASC App Privacy answers must match:
+  "Email Address" + "User ID" (App Functionality, linked, no tracking).
 -->
 <plist version="1.0">
 <dict>
@@ -25,7 +24,28 @@
     <key>NSPrivacyTrackingDomains</key>
     <array/>
     <key>NSPrivacyCollectedDataTypes</key>
-    <array/>
+    <array>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeEmailAddress</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array><string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string></array>
+        </dict>
+        <dict>
+            <key>NSPrivacyCollectedDataType</key>
+            <string>NSPrivacyCollectedDataTypeUserID</string>
+            <key>NSPrivacyCollectedDataTypeLinked</key>
+            <true/>
+            <key>NSPrivacyCollectedDataTypeTracking</key>
+            <false/>
+            <key>NSPrivacyCollectedDataTypePurposes</key>
+            <array><string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string></array>
+        </dict>
+    </array>
     <key>NSPrivacyAccessedAPITypes</key>
     <array>
         <dict>

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -13,7 +13,6 @@ struct SettingsView: View {
     @State private var status = ""
     @State private var showScanner = false
     @State private var showUnpairConfirm = false
-    @State private var appleBusy = false
     @State private var connectBusy = false
 
     var body: some View {
@@ -77,33 +76,24 @@ struct SettingsView: View {
                             .font(.caption).foregroundStyle(.secondary)
                     }
                 } else {
-                    Section("LISA Cloud") {
-                        TextField("https://your-instance.run.app", text: $pairText)
-                            .autocorrectionDisabled()
-                            .textInputAutocapitalization(.never)
-                            .keyboardType(.URL)
-                        // Sign in with Apple is gated OFF for v1: the cloud is still
-                        // single-tenant (M0), and offering account creation would trip
-                        // App Store 5.1.1(v) (in-app account deletion). Re-enable by
-                        // adding LISA_ENABLE_SIWA to SWIFT_ACTIVE_COMPILATION_CONDITIONS
-                        // once per-uid isolation (C3) + account deletion land.
-                        #if LISA_ENABLE_SIWA
-                        SignInWithAppleButton(.continue,
-                            onRequest: { req in req.requestedScopes = [.fullName, .email] },
-                            onCompletion: handleApple)
-                            .signInWithAppleButtonStyle(.white)
-                            .frame(height: 44)
-                            .disabled(appleBusy || AppState.parseCloudBase(pairText) == nil)
-                        if appleBusy { ProgressView() }
-                        #endif
-                        Button {
-                            connectCloud()
-                        } label: {
-                            if connectBusy { ProgressView() } else { Text("Connect") }
+                    // Cloud data plane: LISA accounts are the primary flow (B1) —
+                    // signed-in card when we have an account session, the shared
+                    // sign-in form (SIWA / email / advanced token link) otherwise.
+                    if app.account?.signedIn == true {
+                        AccountCard()
+                    } else {
+                        CloudSignInForm { outcome in
+                            switch outcome {
+                            case .ok:
+                                app.notify("Connected to LISA Cloud.")
+                            case .unauthorized:
+                                app.notify("Signed in, but the connection was rejected (401) — try again.", ok: false)
+                            case .serverError(let code):
+                                app.notify("LISA Cloud responded with an error (\(code)).", ok: false)
+                            case .unreachable:
+                                app.notify("Couldn't reach LISA Cloud — check the URL and your connection.", ok: false)
+                            }
                         }
-                        .disabled(pairText.isEmpty || connectBusy)
-                        Text("Paste your LISA Cloud URL (including its ?token=…) to connect.")
-                            .font(.caption).foregroundStyle(.secondary)
                     }
                 }
 
@@ -193,7 +183,7 @@ struct SettingsView: View {
             .consoleBackground()
             .navigationTitle("Settings")
             .onAppear(perform: syncFromConfig)
-            .task { policy = try? await app.client.controlPolicy(); await app.loadProactive() }
+            .task { policy = try? await app.client.controlPolicy(); await app.loadProactive(); await app.refreshAccount() }
             .sheet(isPresented: $showScanner) {
                 QRScanSheet(onScanned: handleScan, onError: { status = $0 })
             }
@@ -216,33 +206,6 @@ struct SettingsView: View {
         token = app.config.token ?? ""
     }
 
-    /// Apply the pasted cloud URL, then actually probe it (authed ping) before
-    /// declaring success. The old parse-only "Connected to LISA Cloud." hid a bad
-    /// token until the first Chat message — the observed App Review 2.1 failure
-    /// ("we were unable to sign in when we entered the code"). Mirrors the
-    /// Onboarding verify step so both entry points behave the same.
-    private func connectCloud() {
-        guard app.applyPairing(pairText) else {
-            app.notify("Couldn't parse that cloud URL — paste the full https://…/?token=… link.", ok: false)
-            return
-        }
-        syncFromConfig()
-        connectBusy = true
-        Task {
-            defer { connectBusy = false }
-            switch await app.verifyConnection() {
-            case .ok:
-                app.notify("Connected to LISA Cloud.")
-            case .unauthorized:
-                app.notify("The token was rejected (401) — re-copy the ENTIRE URL, including everything after ?token=.", ok: false)
-            case .serverError(let code):
-                app.notify("LISA Cloud responded with an error (\(code)). Try again in a minute.", ok: false)
-            case .unreachable:
-                app.notify("Couldn't reach that LISA Cloud URL — check the address and your connection.", ok: false)
-            }
-        }
-    }
-
     /// Probe the just-applied Mac pairing and report the real outcome into the
     /// status line (same fake-success fix as connectCloud, for the LAN path).
     private func verifyAndReport(prefix: String) {
@@ -262,38 +225,6 @@ struct SettingsView: View {
             }
         }
     }
-
-    #if LISA_ENABLE_SIWA
-    /// Sign in with Apple against the entered cloud URL, exchange the identity
-    /// token for the session token, and save the connection (review F6). Gated OFF
-    /// for v1 — see the LISA_ENABLE_SIWA note above the button.
-    private func handleApple(_ result: Result<ASAuthorization, Error>) {
-        switch result {
-        case .failure(let err):
-            if (err as? ASAuthorizationError)?.code == .canceled { return }
-            app.notify(err.localizedDescription, ok: false)
-        case .success(let auth):
-            guard let cred = auth.credential as? ASAuthorizationAppleIDCredential,
-                  let data = cred.identityToken, let idToken = String(data: data, encoding: .utf8) else {
-                app.notify("Apple didn't return an identity token.", ok: false)
-                return
-            }
-            appleBusy = true
-            Task {
-                defer { appleBusy = false }
-                do {
-                    try await app.connectCloudWithApple(baseURL: pairText, identityToken: idToken)
-                    syncFromConfig()
-                    app.notify("Signed in to LISA Cloud.")
-                } catch LisaError.http(404) {
-                    app.notify("This instance hasn't enabled Sign in with Apple — paste a token instead.", ok: false)
-                } catch {
-                    app.notify("Couldn't reach that LISA Cloud URL.", ok: false)
-                }
-            }
-        }
-    }
-    #endif
 
     /// Apply a scanned code the same way pasted text is applied; on a parse failure,
     /// drop it into the text field so the user can see/fix what was scanned.

--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -67,14 +67,18 @@ targets:
         com.apple.security.application-groups:
           - group.ai.meetlisa.main
         aps-environment: development
-        # Sign in with Apple entitlement is intentionally omitted for v1 — the app
-        # doesn't offer account creation (SIWA is gated off; see LISA_ENABLE_SIWA),
-        # so declaring it would only invite App Store 5.1.1(v) scrutiny. Re-add
-        # `com.apple.developer.applesignin: [Default]` when SIWA + C3 + account
-        # deletion ship.
+        # Sign in with Apple (B1, PLAN_ACCOUNTS_BILLING): accounts are now the
+        # primary cloud flow and in-app deletion ships alongside (5.1.1(v)), so
+        # the entitlement is back. Requires the capability enabled on the App ID
+        # in the Developer portal before a signed (device/TestFlight) build.
+        com.apple.developer.applesignin:
+          - Default
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: ai.meetlisa.main
+        # LISA_ENABLE_SIWA: compile in the Sign in with Apple UI (B1 — accounts
+        # are the primary cloud flow now). $(inherited) keeps DEBUG etc. intact.
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) LISA_ENABLE_SIWA"
 
   LisaPocketWidgets:
     type: app-extension

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -1,0 +1,96 @@
+/**
+ * LISA Cloud login page (PLAN_ACCOUNTS_BILLING B1) — served with a 401 status to
+ * unauthenticated *browser* requests on the cloud edition, instead of the bare
+ * JSON error (API callers still get JSON; the Accept header decides).
+ *
+ * Email + password only for now: Sign in with Apple on the WEB needs a Services
+ * ID + domain verification in the Apple portal (JS flow) — tracked for B7. The
+ * page posts to /api/auth/login | /register; the server pins the session cookie
+ * and a reload lands in the authed island UI.
+ *
+ * NOTE: one template literal — NO backticks inside (see the island.ts trap).
+ */
+export const LOGIN_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LISA Cloud — Sign in</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    min-height: 100vh; display: grid; place-items: center;
+    background: #0b0e13; color: #e6e9ef;
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  .card {
+    width: min(92vw, 380px); padding: 32px 28px; border-radius: 16px;
+    background: #12161e; border: 1px solid #232a36;
+  }
+  h1 { font-size: 22px; margin-bottom: 4px; }
+  p.sub { color: #8a93a5; font-size: 14px; margin-bottom: 22px; }
+  label { display: block; font-size: 13px; color: #8a93a5; margin: 12px 0 4px; }
+  input {
+    width: 100%; padding: 10px 12px; border-radius: 10px; font-size: 16px;
+    background: #0b0e13; color: #e6e9ef; border: 1px solid #2a3342; outline: none;
+  }
+  input:focus { border-color: #5b8cff; }
+  button {
+    width: 100%; margin-top: 18px; padding: 12px; border: 0; border-radius: 10px;
+    background: #5b8cff; color: #fff; font-size: 16px; font-weight: 600; cursor: pointer;
+  }
+  button.secondary { background: transparent; color: #8a93a5; font-weight: 500; margin-top: 8px; }
+  button:disabled { opacity: .5; cursor: default; }
+  .err { color: #ff7a7a; font-size: 13px; margin-top: 12px; min-height: 1.2em; }
+  .hint { color: #5d6575; font-size: 12px; margin-top: 18px; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>LISA Cloud</h1>
+  <p class="sub">Sign in to reach your Lisa. A free usage allowance refreshes every 12 hours.</p>
+  <form id="f">
+    <label for="email">Email</label>
+    <input id="email" type="email" autocomplete="username" required>
+    <label for="pw">Password</label>
+    <input id="pw" type="password" autocomplete="current-password" minlength="8" required>
+    <button id="login" type="submit">Sign in</button>
+    <button id="register" type="button" class="secondary">Create an account</button>
+    <div class="err" id="err"></div>
+  </form>
+  <div class="hint">Self-hosted with a shared token? Open this page as /?token=&lt;your token&gt;.</div>
+</div>
+<script>
+  const f = document.getElementById("f");
+  const err = document.getElementById("err");
+  const email = document.getElementById("email");
+  const pw = document.getElementById("pw");
+  const MSG = {
+    bad_credentials: "Wrong email or password.",
+    email_taken: "That email already has an account — use Sign in.",
+    weak_password: "Use at least 8 characters.",
+    invalid_email: "That doesn't look like an email address.",
+    throttled: "Too many attempts — wait 15 minutes.",
+  };
+  async function auth(path) {
+    err.textContent = "";
+    const res = await fetch(path, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email: email.value.trim(), password: pw.value }),
+    }).catch(() => null);
+    if (!res) { err.textContent = "Network error — try again."; return; }
+    if (res.ok) { location.replace("/"); return; }
+    let code = "";
+    try { code = (await res.json()).error || ""; } catch {}
+    err.textContent = MSG[code] || ("Sign-in failed (" + res.status + ").");
+  }
+  f.addEventListener("submit", (e) => { e.preventDefault(); auth("/api/auth/login"); });
+  document.getElementById("register").addEventListener("click", () => {
+    if (f.reportValidity()) auth("/api/auth/register");
+  });
+</script>
+</body>
+</html>
+`;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -36,6 +36,7 @@ import {
   recentUserText,
 } from "../soul/desire-focus.js";
 import { ISLAND_HTML } from "./island.js";
+import { LOGIN_HTML } from "./login.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
@@ -883,9 +884,16 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         }
       }
       if (!authed) {
-        // Structured 401 so a client (or a reviewer reading the response) can
-        // tell WHY: no token presented vs a mismatch vs an instance with no
-        // token configured at all. The presented value is never echoed back.
+        // Browsers hitting the cloud edition get the login page (still 401 —
+        // correct semantics, human-usable body). API callers get structured
+        // JSON: no token presented vs a mismatch vs an instance with no token
+        // configured at all. The presented value is never echoed back.
+        const wantsHtml = (req.headers.accept ?? "").includes("text/html");
+        if (cloud && req.method === "GET" && wantsHtml) {
+          res.writeHead(401, { "content-type": "text/html; charset=utf-8" });
+          res.end(LOGIN_HTML);
+          return;
+        }
         const reason = !webToken
           ? "server_not_configured"
           : presented


### PR DESCRIPTION
**Stacked on #260** (B1 server). Client half of milestone B1: the decision that **centralized accounts are the primary flow on every surface**, with the BYO-key / Mac-pairing path preserved as the always-visible escape hatch.

## iOS

- **Sign in with Apple is ON**: `applesignin` entitlement restored in `project.yml` + `LISA_ENABLE_SIWA` compiled in. The original reason for gating it off (5.1.1(v) account deletion) is resolved — deletion ships in the same build.
- **Shared `CloudSignInForm`** (new `AccountViews.swift`): SIWA → email+password → "Advanced: token link" disclosure. Used by **both** Settings and onboarding so the two entry points can't drift; every path live-verifies before declaring success (the 2.1 fix from B0, now on all flows).
- **`AccountCard`**: signed-in state, Sign out, confirm-gated **Delete account** (5.1.1(v)).
- **Onboarding flipped**: LISA Cloud ("Sign in and go", *Recommended*) first; My Mac ("Advanced: private and local") second — unchanged and never hidden.
- `AppState`: `connectCloudWithEmail` / `refreshAccount` / `signOutCloud` / `deleteCloudAccount`; `defaultCloudBase` prefill (**cloud.meetlisa.ai**).
- Privacy manifest + store metadata updated: **Email Address + User ID** (app functionality, linked, no tracking).

## Web

- `src/web/login.ts`: email+password login/register page, served with **401 status** to unauthenticated browser GETs on the cloud edition (API callers keep the structured JSON 401 from B0). SIWA-on-web needs an Apple Services ID → deferred to B7.

## Verification

Typecheck + full suite green; iOS simulator build **SUCCEEDED** (with SIWA compiled in).

## Operator actions

1. **Apple Developer portal**: enable *Sign in with Apple* on the App ID `ai.meetlisa.main` (required before the next signed/TestFlight build — automatic signing will fail without it).
2. **DNS/Cloud Run**: map `cloud.meetlisa.ai` to the `lisa-cloud` service (the app prefills that URL), or change `AppState.defaultCloudBase` before release.
3. **Cloud env**: set `LISA_CLOUD_APPLE_SIGNIN=1` on deploy (deploy.sh already passes it through).
4. ASC **App Privacy**: switch answers to Email Address + User ID per `APPSTORE_METADATA.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)