### PR TITLE
feat(cloud): B2 — per-uid home isolation (AsyncLocalStorage seam) + lazy per-user birth

### DIFF
--- a/src/advisor/engine.ts
+++ b/src/advisor/engine.ts
@@ -11,7 +11,7 @@
 
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 import { atomicWrite } from "../fs-utils.js";
 import { withFileLock } from "../soul/lock.js";
 import { runAllDetectors } from "./detectors.js";
@@ -30,7 +30,9 @@ const MIN_SCORE = 1.5; // relevance bar: below this → journal, not user
 const DIGEST_THROTTLE_MS = 3 * 60 * 60_000; // ≤1 non-urgent digest / 3h
 const RE_ARM_MS = 24 * 60 * 60_000; // a standing condition can re-surface daily
 
-export const ADVISOR_STATE_PATH = path.join(LISA_HOME, "advisor-state.json");
+export function advisorStatePath(): string {
+  return path.join(lisaHome(), "advisor-state.json");
+}
 
 /** Relevance score = urgency × actionability × dismissal-decay. */
 export function scoreSuggestion(s: Suggestion, state: AdvisorState): number {
@@ -133,7 +135,7 @@ export function applyDismissal(
 export async function dismissSuggestion(
   id: string,
   category: SuggestionCategory,
-  statePath: string = ADVISOR_STATE_PATH,
+  statePath: string = advisorStatePath(),
 ): Promise<void> {
   await withFileLock(statePath + ".lock", async () => {
     const state = await loadAdvisorState(statePath);
@@ -144,7 +146,7 @@ export async function dismissSuggestion(
 // ── I/O ─────────────────────────────────────────────────────────────────
 
 export async function loadAdvisorState(
-  p: string = ADVISOR_STATE_PATH,
+  p: string = advisorStatePath(),
 ): Promise<AdvisorState> {
   try {
     const raw = await fsp.readFile(p, "utf8");
@@ -157,7 +159,7 @@ export async function loadAdvisorState(
 
 export async function saveAdvisorState(
   state: AdvisorState,
-  p: string = ADVISOR_STATE_PATH,
+  p: string = advisorStatePath(),
 ): Promise<void> {
   await atomicWrite(p, JSON.stringify(state, null, 2));
 }
@@ -168,7 +170,7 @@ export async function saveAdvisorState(
  */
 export async function advise(
   input: AdvisorInput,
-  statePath: string = ADVISOR_STATE_PATH,
+  statePath: string = advisorStatePath(),
 ): Promise<AdvisorDecision> {
   return withFileLock(statePath + ".lock", async () => {
     const state = await loadAdvisorState(statePath);

--- a/src/autonomy/runs.test.ts
+++ b/src/autonomy/runs.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// Isolate the ledger to a throwaway dir. paths.ts captures LISA_HOME at import
+// Isolate the ledger to a throwaway dir. paths.ts captures lisaHome() at import
 // time, so set it BEFORE the first import of the module under test.
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-autonomy-"));
 process.env.LISA_HOME = TMP;

--- a/src/autonomy/runs.ts
+++ b/src/autonomy/runs.ts
@@ -14,13 +14,15 @@
  * cross-process lock.
  */
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 import { appendLine, atomicWrite, readTextOrEmpty } from "../fs-utils.js";
 import { withFileLock } from "../soul/lock.js";
 
-export const AUTONOMY_DIR = path.join(LISA_HOME, "autonomy");
-const RUNS_FILE = path.join(AUTONOMY_DIR, "runs.jsonl");
-const RUNS_LOCK = path.join(AUTONOMY_DIR, "runs.lock");
+export function autonomyDir(): string {
+  return path.join(lisaHome(), "autonomy");
+}
+const RUNS_FILE = path.join(autonomyDir(), "runs.jsonl");
+const RUNS_LOCK = path.join(autonomyDir(), "runs.lock");
 const MAX_RUNS = 2000;
 
 /** Which self-driven mechanism produced the run. */

--- a/src/autonomy/state.ts
+++ b/src/autonomy/state.ts
@@ -12,7 +12,7 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 
 export interface AutonomyState {
   /** Whether unattended self-driven runs (idle + heartbeat) are allowed. */
@@ -30,9 +30,9 @@ export function normalizeAutonomyState(s: Partial<AutonomyState> | null | undefi
   return { enabled: typeof s.enabled === "boolean" ? s.enabled : base.enabled };
 }
 
-/** Resolved lazily so tests can point LISA_HOME at a tmp dir. */
+/** Resolved lazily so tests can point lisaHome() at a tmp dir. */
 function statePath(): string {
-  return path.join(LISA_HOME, "autonomy", "state.json");
+  return path.join(lisaHome(), "autonomy", "state.json");
 }
 
 /** Read the state, merged over defaults; tolerant of a missing/corrupt file. */

--- a/src/autostart/install.ts
+++ b/src/autostart/install.ts
@@ -11,7 +11,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { atomicWrite } from "../fs-utils.js";
-import { LISA_HOME } from "../paths.js";
+import { lisaGlobalHome } from "../paths.js";
 import { escapeXml, resolveLisaArgv, resolveLisaBin, runCmd } from "../launchd.js";
 
 export interface AutostartOptions {
@@ -34,7 +34,7 @@ const PLIST_PATH = path.join(
   "LaunchAgents",
   `${PLIST_LABEL}.plist`,
 );
-const AUTOSTART_LOG = path.join(LISA_HOME, "autostart.log");
+const AUTOSTART_LOG = path.join(lisaGlobalHome(), "autostart.log");
 
 /** The `serve …` argv tail that the agent launches. Exported for testing. */
 export function serveArgs(opts: AutostartOptions): string[] {

--- a/src/channels/config.ts
+++ b/src/channels/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaGlobalHome } from "../paths.js";
 import { pathExists } from "../fs-utils.js";
 
 export interface ChannelConfigEntry {
@@ -13,7 +13,7 @@ export interface ChannelsConfig {
   channels: Record<string, ChannelConfigEntry>;
 }
 
-export const CHANNELS_CONFIG_PATH = path.join(LISA_HOME, "channels.json");
+export const CHANNELS_CONFIG_PATH = path.join(lisaGlobalHome(), "channels.json");
 
 export async function loadChannelsConfig(): Promise<ChannelsConfig> {
   if (!(await pathExists(CHANNELS_CONFIG_PATH))) return { channels: {} };

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,7 @@ import { DEFAULT_MODEL } from "./llm.js";
 import { parseArgs, type ParsedArgs } from "./cli-args.js";
 import { connectMcpServers } from "./mcp/client.js";
 import { loadMcpConfig } from "./mcp/config.js";
-import { LISA_HOME } from "./paths.js";
+import { lisaHome } from "./paths.js";
 import { loadAllPlugins, PLUGINS_ROOT } from "./plugins/loader.js";
 import type { HookSpec } from "./plugins/types.js";
 import { buildSystemPromptSnapshot, getPromptFingerprint } from "./prompt.js";
@@ -137,10 +137,10 @@ REPL slash commands:
   /clear                Forget current in-memory history (session log preserved).
   /save <text>          Append to MEMORY.md immediately.
 
-Data: ${LISA_HOME}
+Data: ${lisaHome()}
 Plugins: ${PLUGINS_ROOT}/<name>/{commands,agents,skills,hooks,.lisa-plugin/plugin.json}
-MCP:     ${LISA_HOME}/mcp.json   (Claude-Code-style {"mcpServers": {...}})
-Heartbeat: ${LISA_HOME}/heartbeat.json   ({"tasks": [{name, prompt, ...}]})
+MCP:     ${lisaHome()}/mcp.json   (Claude-Code-style {"mcpServers": {...}})
+Heartbeat: ${lisaHome()}/heartbeat.json   ({"tasks": [{name, prompt, ...}]})
 Config:  ${CONFIG_ENV_PATH}   (KEY=VALUE)`;
 
 function readPackageVersion(): string {
@@ -176,7 +176,7 @@ async function main(): Promise<void> {
     return;
   }
 
-  await ensureDir(LISA_HOME);
+  await ensureDir(lisaHome());
   loadConfigEnv();
   // If the user didn't pass --model, resolve the default now that config.env is
   // loaded: an explicit LISA_MODEL (e.g. `lisa model use`) wins, else auto-detect
@@ -658,7 +658,7 @@ async function main(): Promise<void> {
         const r = await fireHooks(
           "PreToolUse",
           allHooks,
-          { TOOL_NAME: name, TOOL_INPUT: JSON.stringify(input), SESSION_ID: session.id, LISA_HOME, CLAUDE_PROJECT_DIR: cwd },
+          { TOOL_NAME: name, TOOL_INPUT: JSON.stringify(input), SESSION_ID: session.id, LISA_HOME: lisaHome(), CLAUDE_PROJECT_DIR: cwd },
           cwd,
         );
         if (r.blocked.length > 0) return { block: r.blocked.join("; ") };
@@ -673,7 +673,7 @@ async function main(): Promise<void> {
             TOOL_RESULT: result,
             TOOL_ERROR: isError ? "1" : "",
             SESSION_ID: session.id,
-            LISA_HOME,
+            LISA_HOME: lisaHome(),
             CLAUDE_PROJECT_DIR: cwd,
           },
           cwd,
@@ -716,7 +716,7 @@ async function main(): Promise<void> {
     await fireHooks(
       "SessionEnd",
       allHooks,
-      { SESSION_ID: session.id, LISA_HOME },
+      { SESSION_ID: session.id, LISA_HOME: lisaHome() },
       cwd,
     );
     await Promise.all(mcpConnections.map((c) => c.close()));
@@ -731,7 +731,7 @@ async function main(): Promise<void> {
   await fireHooks(
     "SessionStart",
     allHooks,
-    { SESSION_ID: session.id, LISA_HOME },
+    { SESSION_ID: session.id, LISA_HOME: lisaHome() },
     cwd,
   );
 
@@ -774,7 +774,7 @@ async function main(): Promise<void> {
       const r = await fireHooks(
         "UserPromptSubmit",
         allHooks,
-        { USER_PROMPT: line, SESSION_ID: session.id, LISA_HOME },
+        { USER_PROMPT: line, SESSION_ID: session.id, LISA_HOME: lisaHome() },
         cwd,
       );
       if (r.blocked.length > 0) {

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -24,9 +24,9 @@ import {
   rule,
   warn,
 } from "./colors.js";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 import { CONFIG_ENV_PATH } from "../env.js";
-import { SOUL_DIR } from "../soul/paths.js";
+import { soulDir } from "../soul/paths.js";
 import { listConfiguredProviders, OPENAI_COMPAT_PRESETS } from "../providers/registry.js";
 import { isBorn } from "../soul/store.js";
 import { pathExists } from "../fs-utils.js";
@@ -64,9 +64,9 @@ const checks: Check[] = [
     label: "~/.lisa/ exists",
     critical: false,
     run: async () => {
-      return (await pathExists(LISA_HOME))
-        ? { ok: true, detail: LISA_HOME }
-        : { ok: false, detail: `${LISA_HOME} not yet created (will be on first run)` };
+      return (await pathExists(lisaHome()))
+        ? { ok: true, detail: lisaHome() }
+        : { ok: false, detail: `${lisaHome()} not yet created (will be on first run)` };
     },
   },
   {
@@ -91,7 +91,7 @@ const checks: Check[] = [
     label: "Soul git repo initialized",
     critical: false,
     run: async () => {
-      const dotGit = path.join(SOUL_DIR, ".git");
+      const dotGit = path.join(soulDir(), ".git");
       return (await pathExists(dotGit))
         ? { ok: true, detail: dotGit }
         : { ok: false, detail: "init pending; will run automatically on next start" };
@@ -143,7 +143,7 @@ export async function runDoctor(): Promise<void> {
   console.log(heading("Environment"));
   console.log(`  ${dim("platform:")}  ${process.platform} ${os.release()}`);
   console.log(`  ${dim("node:")}      ${process.versions.node}`);
-  console.log(`  ${dim("LISA_HOME:")} ${LISA_HOME}`);
+  console.log(`  ${dim("lisaHome():")} ${lisaHome()}`);
   if (process.env.HTTPS_PROXY || process.env.HTTP_PROXY) {
     console.log(`  ${dim("proxy:")}     ${process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY}`);
   } else {

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -23,8 +23,8 @@ import {
   rule,
   warn,
 } from "./colors.js";
-import { LISA_HOME } from "../paths.js";
-import { SOUL_DIR } from "../soul/paths.js";
+import { lisaHome } from "../paths.js";
+import { soulDir } from "../soul/paths.js";
 import { isBorn, readSoulSummary } from "../soul/store.js";
 import { pathExists, readTextOrEmpty } from "../fs-utils.js";
 
@@ -97,10 +97,10 @@ async function render(): Promise<void> {
   // ── Recent soul commits ──
   console.log(heading("Recent soul commits"));
   try {
-    const dotGit = path.join(SOUL_DIR, ".git");
+    const dotGit = path.join(soulDir(), ".git");
     if (await pathExists(dotGit)) {
       const log = execSync(
-        `git -C "${SOUL_DIR}" log --pretty=format:"%cr %h %s" -n 5 2>/dev/null`,
+        `git -C "${soulDir()}" log --pretty=format:"%cr %h %s" -n 5 2>/dev/null`,
         { encoding: "utf8" },
       ).trim();
       if (log) {
@@ -118,7 +118,7 @@ async function render(): Promise<void> {
   }
 
   // ── Heartbeat last-run ──
-  const hbFile = path.join(LISA_HOME, "heartbeat-state.json");
+  const hbFile = path.join(lisaHome(), "heartbeat-state.json");
   if (await pathExists(hbFile)) {
     try {
       const raw = await readTextOrEmpty(hbFile);
@@ -138,7 +138,7 @@ async function render(): Promise<void> {
   }
 
   // ── Currently set mood (from tool) ──
-  const moodFile = path.join(LISA_HOME, "current-mood.txt");
+  const moodFile = path.join(lisaHome(), "current-mood.txt");
   if (await pathExists(moodFile)) {
     const slug = (await readTextOrEmpty(moodFile)).trim();
     if (slug) {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -10,7 +10,7 @@
 import { execSync } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME, REFLECTIONS_DIR, SESSIONS_DIR } from "../paths.js";
+import { lisaHome, reflectionsDir, sessionsDir } from "../paths.js";
 import {
   desireActivity,
   isBorn,
@@ -19,7 +19,7 @@ import {
   pickCurrentDesire,
   readSoulSummary,
 } from "../soul/store.js";
-import { SOUL_DIR } from "../soul/paths.js";
+import { soulDir } from "../soul/paths.js";
 import { discoverExecutableSkills } from "../skills/executable.js";
 import { listSkills } from "../skills/manager.js";
 import { listConfiguredProviders } from "../providers/registry.js";
@@ -119,10 +119,10 @@ export async function runStatus(): Promise<void> {
   }
   // Soul git history (if available)
   try {
-    const dotGit = path.join(SOUL_DIR, ".git");
+    const dotGit = path.join(soulDir(), ".git");
     if (await pathExists(dotGit)) {
       const log = execSync(
-        `git -C "${SOUL_DIR}" log --pretty=format:"%cr %s" -n 5 2>/dev/null`,
+        `git -C "${soulDir()}" log --pretty=format:"%cr %s" -n 5 2>/dev/null`,
         { encoding: "utf8" },
       );
       const lines = log.split("\n").filter(Boolean);
@@ -136,8 +136,8 @@ export async function runStatus(): Promise<void> {
   }
 
   // ── Sessions / reflections ───────────────────────────────────────────
-  const sessionCount = await countDir(SESSIONS_DIR);
-  const reflCount = await countDir(REFLECTIONS_DIR);
+  const sessionCount = await countDir(sessionsDir());
+  const reflCount = await countDir(reflectionsDir());
   console.log(heading("History"));
   console.log(`  ${dim("sessions:")}     ${sessionCount}`);
   console.log(`  ${dim("reflections:")}  ${reflCount}`);
@@ -166,7 +166,7 @@ export async function runStatus(): Promise<void> {
   }
 
   // ── Heartbeat ────────────────────────────────────────────────────────
-  const hbStateFile = path.join(LISA_HOME, "heartbeat-state.json");
+  const hbStateFile = path.join(lisaHome(), "heartbeat-state.json");
   if (await pathExists(hbStateFile)) {
     try {
       const raw = await readTextOrEmpty(hbStateFile);

--- a/src/cli/wishlist.ts
+++ b/src/cli/wishlist.ts
@@ -13,7 +13,7 @@
  * invoke the handler without bootstrapping the rest of the CLI.
  */
 import path from "node:path";
-import { SOUL_DESIRES_DIR, SOUL_JOURNAL_DIR } from "../soul/paths.js";
+import { soulDesiresDir, soulJournalDir } from "../soul/paths.js";
 import {
   listDesires,
   listJournalDates,
@@ -85,8 +85,8 @@ export async function renderWishlist(opts: WishlistRenderOptions = {}): Promise<
       `(empty)\n\n` +
       `Nothing yet. Lisa fills this when she notices the toolset itself is missing or redundant — she'll mention it during weekly_examen, or in any session when she catches herself wishing.\n\n` +
       `She uses: soul_patch(field="desire", slug="${META_WISHLIST_SLUG}", what="...", why="...", actionable=false)\n` +
-      `Path: ${path.join(SOUL_DESIRES_DIR, META_WISHLIST_SLUG + ".md")}\n` +
-      `Journal scan: anywhere in ${SOUL_JOURNAL_DIR} containing [WISHLIST] or [I want]`,
+      `Path: ${path.join(soulDesiresDir(), META_WISHLIST_SLUG + ".md")}\n` +
+      `Journal scan: anywhere in ${soulJournalDir()} containing [WISHLIST] or [I want]`,
     );
   }
 }

--- a/src/consent/store.ts
+++ b/src/consent/store.ts
@@ -55,7 +55,7 @@ function lisaHome(): string {
   return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
 }
 
-/** Resolved lazily so tests can point LISA_HOME at a tmp dir. */
+/** Resolved lazily so tests can point lisaHome() at a tmp dir. */
 function consentPath(): string {
   return path.join(lisaHome(), "consent.json");
 }

--- a/src/control/policy.test.ts
+++ b/src/control/policy.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// Isolate the policy file to a throwaway dir (read lazily via LISA_HOME).
+// Isolate the policy file to a throwaway dir (read lazily via lisaHome()).
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-policy-"));
 process.env.LISA_HOME = TMP;
 const FILE = path.join(TMP, "control-policy.json");

--- a/src/control/policy.ts
+++ b/src/control/policy.ts
@@ -44,7 +44,7 @@ function lisaHome(): string {
   return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
 }
 
-/** Resolved lazily so tests can point LISA_HOME at a tmp dir. */
+/** Resolved lazily so tests can point lisaHome() at a tmp dir. */
 function policyPath(): string {
   return path.join(lisaHome(), "control-policy.json");
 }

--- a/src/env.ts
+++ b/src/env.ts
@@ -1,10 +1,10 @@
 import fs from "node:fs";
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "./paths.js";
+import { lisaGlobalHome } from "./paths.js";
 import { ensureDir } from "./fs-utils.js";
 
-export const CONFIG_ENV_PATH = path.join(LISA_HOME, "config.env");
+export const CONFIG_ENV_PATH = path.join(lisaGlobalHome(), "config.env");
 
 /**
  * Update or insert keys in ~/.lisa/config.env, preserving other variables,

--- a/src/heartbeat/config.ts
+++ b/src/heartbeat/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaGlobalHome } from "../paths.js";
 import { pathExists } from "../fs-utils.js";
 
 export interface HeartbeatTask {
@@ -26,7 +26,7 @@ export interface HeartbeatConfig {
 /** Default per-run token ceiling when heartbeat.json doesn't set one. */
 export const DEFAULT_HEARTBEAT_BUDGET_TOKENS = 500_000;
 
-const FILE = path.join(LISA_HOME, "heartbeat.json");
+const FILE = path.join(lisaGlobalHome(), "heartbeat.json");
 
 export async function loadHeartbeatConfig(): Promise<HeartbeatConfig> {
   if (!(await pathExists(FILE))) return { tasks: [], budgetTokens: DEFAULT_HEARTBEAT_BUDGET_TOKENS };

--- a/src/heartbeat/install.ts
+++ b/src/heartbeat/install.ts
@@ -2,7 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { atomicWrite } from "../fs-utils.js";
-import { LISA_HOME } from "../paths.js";
+import { lisaGlobalHome } from "../paths.js";
 import { escapeXml, resolveLisaArgv, resolveLisaBin, runCmd } from "../launchd.js";
 
 export interface InstallOptions {
@@ -21,7 +21,7 @@ const PLIST_PATH = path.join(
   "LaunchAgents",
   `${PLIST_LABEL}.plist`,
 );
-const HEARTBEAT_LOG = path.join(LISA_HOME, "heartbeat.log");
+const HEARTBEAT_LOG = path.join(lisaGlobalHome(), "heartbeat.log");
 
 export async function installHeartbeat(
   opts: InstallOptions = {},

--- a/src/heartbeat/runner.ts
+++ b/src/heartbeat/runner.ts
@@ -1,6 +1,6 @@
 import path from "node:path";
 import { atomicWrite, readTextOrEmpty } from "../fs-utils.js";
-import { LISA_HOME } from "../paths.js";
+import { lisaGlobalHome } from "../paths.js";
 import {
   appendDesireProgress,
   isAutoPursuable,
@@ -23,8 +23,8 @@ import {
   type HeartbeatTask,
 } from "./config.js";
 
-const STATE_FILE = path.join(LISA_HOME, "heartbeat-state.json");
-const RUN_LOCK = path.join(LISA_HOME, "heartbeat.lock");
+const STATE_FILE = path.join(lisaGlobalHome(), "heartbeat-state.json");
+const RUN_LOCK = path.join(lisaGlobalHome(), "heartbeat.lock");
 
 interface HeartbeatState {
   lastRunAt: Record<string, string>;

--- a/src/idle/runner.ts
+++ b/src/idle/runner.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 import { withFileLock } from "../soul/lock.js";
 import { autonomousSubset } from "../tools/registry.js";
 import { runSubagent } from "../subagent.js";
@@ -8,7 +8,9 @@ import { getAutonomyEnabled } from "../autonomy/state.js";
 import { readIndex } from "../kb/store.js";
 import type { ToolDefinition } from "../types.js";
 
-const IDLE_RUN_LOCK = path.join(LISA_HOME, "idle.lock");
+function idleRunLock(): string {
+  return path.join(lisaHome(), "idle.lock");
+}
 
 /**
  * Per-idle-run token ceiling (cost circuit-breaker, PLAN_REVE R2). Idle used to
@@ -117,7 +119,7 @@ export async function runIdleOnce(opts: {
   // concurrently and race on soul writes. timeoutMs:0 → if another idle run
   // is in flight, skip silently instead of queueing a second reflection.
   try {
-    return await withFileLock(IDLE_RUN_LOCK, () => runIdleInner(opts, idleMin, opts.userLanguageSample), {
+    return await withFileLock(idleRunLock(), () => runIdleInner(opts, idleMin, opts.userLanguageSample), {
       timeoutMs: 0,
       staleMs: 2 * 60 * 60_000, // 2h: an idle run older than this is a crashed holder
     });

--- a/src/integrations/comparisons.ts
+++ b/src/integrations/comparisons.ts
@@ -8,7 +8,7 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { readFile } from "node:fs/promises";
 import { atomicWrite } from "../fs-utils.js";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 
 export type CompareAgentKind = "claude" | "codex" | "opencode" | "aider";
 
@@ -28,9 +28,13 @@ export interface ComparisonJob {
   entries: ComparisonEntry[];
 }
 
-const FILE = path.join(LISA_HOME, "comparisons.json");
+function comparisonsFile(): string {
+  return path.join(lisaHome(), "comparisons.json");
+}
 /** Where worktrees live — outside the repo, so they never get committed. */
-export const COMPARE_ROOT = path.join(LISA_HOME, "compare");
+export function compareRoot(): string {
+  return path.join(lisaHome(), "compare");
+}
 
 interface Store {
   jobs: ComparisonJob[];
@@ -38,7 +42,7 @@ interface Store {
 
 export async function loadComparisons(): Promise<ComparisonJob[]> {
   try {
-    const store = JSON.parse(await readFile(FILE, "utf8")) as Store;
+    const store = JSON.parse(await readFile(comparisonsFile(), "utf8")) as Store;
     return Array.isArray(store.jobs) ? store.jobs : [];
   } catch {
     return [];
@@ -46,7 +50,7 @@ export async function loadComparisons(): Promise<ComparisonJob[]> {
 }
 
 async function save(jobs: ComparisonJob[]): Promise<void> {
-  await atomicWrite(FILE, JSON.stringify({ jobs }, null, 2));
+  await atomicWrite(comparisonsFile(), JSON.stringify({ jobs }, null, 2));
 }
 
 export function newJobId(): string {

--- a/src/integrations/dispatch-ledger.test.ts
+++ b/src/integrations/dispatch-ledger.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// Isolate the ledger to a throwaway dir. dispatch-ledger reads LISA_HOME
+// Isolate the ledger to a throwaway dir. dispatch-ledger reads lisaHome()
 // lazily (at call time), so setting it here — before any function runs — is
 // enough; this test file runs in its own process.
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-ledger-"));

--- a/src/integrations/dispatch-ledger.ts
+++ b/src/integrations/dispatch-ledger.ts
@@ -40,7 +40,7 @@ function lisaHome(): string {
   return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
 }
 
-/** Resolved lazily (reads env at call time) so tests can point LISA_HOME at a tmp dir. */
+/** Resolved lazily (reads env at call time) so tests can point lisaHome() at a tmp dir. */
 function ledgerPath(): string {
   return path.join(lisaHome(), "dispatches.json");
 }

--- a/src/integrations/dispatch-output.test.ts
+++ b/src/integrations/dispatch-output.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// Isolate to a throwaway LISA_HOME before importing the ledger (it reads the
+// Isolate to a throwaway lisaHome() before importing the ledger (it reads the
 // env lazily, but set it up front to be safe).
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-dispatch-out-"));
 process.env.LISA_HOME = TMP;

--- a/src/integrations/scheduled-dispatch.ts
+++ b/src/integrations/scheduled-dispatch.ts
@@ -11,7 +11,7 @@ import { randomUUID } from "node:crypto";
 import path from "node:path";
 import { readFile } from "node:fs/promises";
 import { atomicWrite } from "../fs-utils.js";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 
 export type ScheduledAgent = "claude" | "codex" | "opencode" | "aider";
 
@@ -28,7 +28,9 @@ export interface ScheduledDispatch {
   createdAt: number;
 }
 
-const FILE = path.join(LISA_HOME, "scheduled-dispatches.json");
+function scheduleFile(): string {
+  return path.join(lisaHome(), "scheduled-dispatches.json");
+}
 export const DEFAULT_MAX_RUNS = 30;
 
 interface Store {
@@ -37,7 +39,7 @@ interface Store {
 
 export async function loadScheduled(): Promise<ScheduledDispatch[]> {
   try {
-    const raw = await readFile(FILE, "utf8");
+    const raw = await readFile(scheduleFile(), "utf8");
     const store = JSON.parse(raw) as Store;
     return Array.isArray(store.entries) ? store.entries : [];
   } catch {
@@ -46,7 +48,7 @@ export async function loadScheduled(): Promise<ScheduledDispatch[]> {
 }
 
 async function saveScheduled(entries: ScheduledDispatch[]): Promise<void> {
-  await atomicWrite(FILE, JSON.stringify({ entries }, null, 2));
+  await atomicWrite(scheduleFile(), JSON.stringify({ entries }, null, 2));
 }
 
 export async function addScheduled(

--- a/src/integrations/takoapi/ledger.test.ts
+++ b/src/integrations/takoapi/ledger.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { recordTakoCall, listTakoCalls, loadTakoLedger } from "./ledger.js";
 
-// LISA_HOME-tmp isolation: the ledger resolves its path lazily (reads LISA_HOME
+// lisaHome()-tmp isolation: the ledger resolves its path lazily (reads lisaHome()
 // at call time), so a per-test tmp dir keeps writes off the real ~/.lisa.
 let home: string;
 let prev: string | undefined;

--- a/src/integrations/takoapi/ledger.ts
+++ b/src/integrations/takoapi/ledger.ts
@@ -45,7 +45,7 @@ function lisaHome(): string {
   return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
 }
 
-/** Resolved lazily (reads env at call time) so tests can point LISA_HOME at a tmp dir. */
+/** Resolved lazily (reads env at call time) so tests can point lisaHome() at a tmp dir. */
 function ledgerPath(): string {
   return path.join(lisaHome(), "takoapi-calls.json");
 }

--- a/src/integrations/takoapi/observer.test.ts
+++ b/src/integrations/takoapi/observer.test.ts
@@ -51,7 +51,7 @@ describe("pinsOf", () => {
   });
 });
 
-describe("TakoApiObserver (ledger-driven, LISA_HOME-tmp)", () => {
+describe("TakoApiObserver (ledger-driven, lisaHome()-tmp)", () => {
   let home: string;
   let prev: string | undefined;
   beforeEach(() => {

--- a/src/kb/git.ts
+++ b/src/kb/git.ts
@@ -14,7 +14,7 @@ import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import path from "node:path";
 import { ensureDir, pathExists } from "../fs-utils.js";
-import { KB_DIR } from "./paths.js";
+import { kbDir } from "./paths.js";
 
 const pexec = promisify(execFile);
 
@@ -24,7 +24,7 @@ function gitDisabled(): boolean {
 
 async function git(args: string[]): Promise<void> {
   try {
-    await pexec("git", args, { cwd: KB_DIR, timeout: 10_000 });
+    await pexec("git", args, { cwd: kbDir(), timeout: 10_000 });
   } catch {
     // best-effort — provenance is a nicety, never a blocker
   }
@@ -37,8 +37,8 @@ export async function ensureKbRepo(): Promise<void> {
   if (repoReady || gitDisabled()) return;
   repoReady = true;
   try {
-    await ensureDir(KB_DIR);
-    if (!(await pathExists(path.join(KB_DIR, ".git")))) {
+    await ensureDir(kbDir());
+    if (!(await pathExists(path.join(kbDir(), ".git")))) {
       await git(["init", "-q"]);
       await git(["config", "user.name", "Lisa"]);
       await git(["config", "user.email", "lisa@self"]);

--- a/src/kb/paths.ts
+++ b/src/kb/paths.ts
@@ -1,5 +1,5 @@
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 import { assertSafeSlug } from "../soul/slug.js";
 
 /**
@@ -14,17 +14,30 @@ import { assertSafeSlug } from "../soul/slug.js";
  *   SCHEMA.md — Layer 3, the rules doc telling Lisa how to work the KB
  *   index.md  — generated table-of-contents (kept small, injected always-on)
  */
-export const KB_DIR = path.join(LISA_HOME, "kb");
-export const KB_SOURCES_DIR = path.join(KB_DIR, "sources");
-export const KB_WIKI_DIR = path.join(KB_DIR, "wiki");
-export const KB_SCHEMA_FILE = path.join(KB_DIR, "SCHEMA.md");
-export const KB_INDEX_FILE = path.join(KB_DIR, "index.md");
-export const KB_LOCK_PATH = path.join(KB_DIR, ".write.lock");
+// KB paths are FUNCTIONS of the active home (per-uid under the cloud edition).
+export function kbDir(): string {
+  return path.join(lisaHome(), "kb");
+}
+export function kbSourcesDir(): string {
+  return path.join(kbDir(), "sources");
+}
+export function kbWikiDir(): string {
+  return path.join(kbDir(), "wiki");
+}
+export function kbSchemaFile(): string {
+  return path.join(kbDir(), "SCHEMA.md");
+}
+export function kbIndexFile(): string {
+  return path.join(kbDir(), "index.md");
+}
+export function kbLockPath(): string {
+  return path.join(kbDir(), ".write.lock");
+}
 
 export type KbLayer = "sources" | "wiki";
 
 export function layerDir(layer: KbLayer): string {
-  return layer === "sources" ? KB_SOURCES_DIR : KB_WIKI_DIR;
+  return layer === "sources" ? kbSourcesDir() : kbWikiDir();
 }
 
 /**

--- a/src/kb/schema.ts
+++ b/src/kb/schema.ts
@@ -5,7 +5,7 @@
  * injected always-on (see the prompt integration) so Lisa always knows the rules.
  */
 import { atomicWrite, pathExists, readTextOrEmpty } from "../fs-utils.js";
-import { KB_SCHEMA_FILE } from "./paths.js";
+import { kbSchemaFile } from "./paths.js";
 
 export const DEFAULT_SCHEMA = `# Knowledge base — schema & conventions
 
@@ -42,18 +42,18 @@ This is the user's personal knowledge base. It has three layers:
 
 /** The schema text, or the built-in default if the user hasn't customized it. */
 export async function readSchema(): Promise<string> {
-  const text = await readTextOrEmpty(KB_SCHEMA_FILE);
+  const text = await readTextOrEmpty(kbSchemaFile());
   return text.trim() ? text : DEFAULT_SCHEMA;
 }
 
 /** Write the default schema if none exists yet. Idempotent. */
 export async function ensureSchema(): Promise<void> {
-  if (!(await pathExists(KB_SCHEMA_FILE))) {
-    await atomicWrite(KB_SCHEMA_FILE, DEFAULT_SCHEMA);
+  if (!(await pathExists(kbSchemaFile()))) {
+    await atomicWrite(kbSchemaFile(), DEFAULT_SCHEMA);
   }
 }
 
 /** Replace the schema (user or Lisa editing the rules). */
 export async function writeSchema(content: string): Promise<void> {
-  await atomicWrite(KB_SCHEMA_FILE, content.trimEnd() + "\n");
+  await atomicWrite(kbSchemaFile(), content.trimEnd() + "\n");
 }

--- a/src/kb/search.ts
+++ b/src/kb/search.ts
@@ -12,7 +12,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathExists } from "../fs-utils.js";
-import { KB_SOURCES_DIR, KB_WIKI_DIR, layerDir, type KbLayer } from "./paths.js";
+import { kbSourcesDir, kbWikiDir, layerDir, type KbLayer } from "./paths.js";
 import { readEntry } from "./store.js";
 
 interface KbDoc {
@@ -74,7 +74,7 @@ let cachedFingerprint = "";
 
 async function kbFingerprint(): Promise<string> {
   const parts: string[] = [];
-  for (const dir of [KB_WIKI_DIR, KB_SOURCES_DIR]) {
+  for (const dir of [kbWikiDir(), kbSourcesDir()]) {
     if (!(await pathExists(dir))) continue;
     for (const f of (await fs.readdir(dir)).sort()) {
       if (!f.endsWith(".md")) continue;

--- a/src/kb/store.test.ts
+++ b/src/kb/store.test.ts
@@ -4,15 +4,15 @@ import { mkdtempSync, rmSync, readFileSync, existsSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// Point LISA_HOME at a temp dir and disable git BEFORE importing the modules
-// under test, so paths.ts (evaluated at import) resolves KB_DIR there. node's
+// Point lisaHome() at a temp dir and disable git BEFORE importing the modules
+// under test, so paths.ts (evaluated at import) resolves kbDir() there. node's
 // test runner isolates each file in its own process, so this can't leak.
 const TMP = mkdtempSync(path.join(os.tmpdir(), "lisa-kb-test-"));
 process.env.LISA_HOME = TMP;
 process.env.LISA_KB_NO_GIT = "1";
 
 const store = await import("./store.js");
-const { KB_DIR, KB_SCHEMA_FILE, KB_INDEX_FILE, entryFile } = await import("./paths.js");
+const { kbDir, kbSchemaFile, kbIndexFile, entryFile } = await import("./paths.js");
 
 after(() => rmSync(TMP, { recursive: true, force: true }));
 
@@ -85,14 +85,14 @@ describe("kb store", () => {
 
   test("ensureScaffold seeds the schema and dirs", async () => {
     await store.ensureKbScaffold();
-    assert.ok(existsSync(KB_SCHEMA_FILE), "SCHEMA.md seeded");
-    assert.ok(existsSync(path.join(KB_DIR, "sources")));
-    assert.ok(existsSync(path.join(KB_DIR, "wiki")));
+    assert.ok(existsSync(kbSchemaFile()), "SCHEMA.md seeded");
+    assert.ok(existsSync(path.join(kbDir(), "sources")));
+    assert.ok(existsSync(path.join(kbDir(), "wiki")));
   });
 
   test("index.md is regenerated with wiki titles + counts", async () => {
-    assert.ok(existsSync(KB_INDEX_FILE), "index.md exists after a write");
-    const idx = readFileSync(KB_INDEX_FILE, "utf8");
+    assert.ok(existsSync(kbIndexFile()), "index.md exists after a write");
+    const idx = readFileSync(kbIndexFile(), "utf8");
     assert.match(idx, /# Knowledge base index/);
     assert.match(idx, /wiki page\(s\)/);
     assert.match(idx, /OAuth 2\.0/, "wiki title appears in the index");

--- a/src/kb/store.ts
+++ b/src/kb/store.ts
@@ -15,10 +15,10 @@ import { assertSafeSlug, normalizeSlug } from "../soul/slug.js";
 import { commitKb } from "./git.js";
 import { ensureSchema } from "./schema.js";
 import {
-  KB_INDEX_FILE,
-  KB_LOCK_PATH,
-  KB_SOURCES_DIR,
-  KB_WIKI_DIR,
+  kbIndexFile,
+  kbLockPath,
+  kbSourcesDir,
+  kbWikiDir,
   entryFile,
   layerDir,
   type KbLayer,
@@ -136,8 +136,8 @@ function metaOf(entry: KbEntry): KbEntryMeta {
 
 /** Create the KB layout (dirs + default schema) if missing. Idempotent. */
 export async function ensureKbScaffold(): Promise<void> {
-  await ensureDir(KB_SOURCES_DIR);
-  await ensureDir(KB_WIKI_DIR);
+  await ensureDir(kbSourcesDir());
+  await ensureDir(kbWikiDir());
   await ensureSchema();
 }
 
@@ -183,7 +183,7 @@ export async function listEntries(layer?: KbLayer): Promise<KbEntryMeta[]> {
 }
 
 export async function readIndex(): Promise<string> {
-  return readTextOrEmpty(KB_INDEX_FILE);
+  return readTextOrEmpty(kbIndexFile());
 }
 
 // ── index regeneration ────────────────────────────────────────────────
@@ -214,12 +214,12 @@ async function regenerateIndexLocked(): Promise<void> {
     }
     lines.push("");
   }
-  await atomicWrite(KB_INDEX_FILE, lines.join("\n").trimEnd() + "\n");
+  await atomicWrite(kbIndexFile(), lines.join("\n").trimEnd() + "\n");
 }
 
 /** Public index rebuild (acquires the lock). */
 export function regenerateIndex(): Promise<void> {
-  return withFileLock(KB_LOCK_PATH, regenerateIndexLocked);
+  return withFileLock(kbLockPath(), regenerateIndexLocked);
 }
 
 // ── writes ────────────────────────────────────────────────────────────
@@ -235,7 +235,7 @@ export async function addSource(opts: {
   origin?: string;
 }): Promise<KbEntry> {
   await ensureKbScaffold();
-  return withFileLock(KB_LOCK_PATH, async () => {
+  return withFileLock(kbLockPath(), async () => {
     const title = opts.title.trim() || "untitled";
     const slug = await uniqueSlug("sources", title);
     const entry: KbEntry = {
@@ -265,7 +265,7 @@ export async function writeWiki(opts: {
   sources?: string[];
 }): Promise<KbEntry> {
   await ensureKbScaffold();
-  return withFileLock(KB_LOCK_PATH, async () => {
+  return withFileLock(kbLockPath(), async () => {
     const slug = opts.slug
       ? assertSafeSlug(opts.slug)
       : normalizeSlug(opts.title) || `page-${Date.now()}`;
@@ -287,7 +287,7 @@ export async function writeWiki(opts: {
 
 /** Delete an entry (user-initiated). Returns false if it didn't exist. */
 export async function removeEntry(layer: KbLayer, slug: string): Promise<boolean> {
-  return withFileLock(KB_LOCK_PATH, async () => {
+  return withFileLock(kbLockPath(), async () => {
     const file = entryFile(layer, slug);
     if (!(await pathExists(file))) return false;
     await fs.rm(file, { force: true });

--- a/src/mail/accounts.ts
+++ b/src/mail/accounts.ts
@@ -4,7 +4,7 @@
  *   ~/.lisa/mail/accounts.json   — the connected mailboxes (no secrets)
  *   ~/.lisa/mail/secrets.json    — per-account secrets, mode 0600
  *
- * LISA_HOME is resolved lazily so tests can point it at a tmp dir. Absence of
+ * lisaHome() is resolved lazily so tests can point it at a tmp dir. Absence of
  * either file means "no accounts" — exactly the pre-feature behavior.
  */
 import fs from "node:fs";

--- a/src/mcp/config.test.ts
+++ b/src/mcp/config.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// CONFIG_PATH (mcp.json) is derived from LISA_HOME at import; set a tmp home
+// CONFIG_PATH (mcp.json) is derived from lisaHome() at import; set a tmp home
 // before importing (dynamic import). Per-file process isolation keeps it local.
 let mod: typeof import("./config.js");
 let home: string;

--- a/src/mcp/config.ts
+++ b/src/mcp/config.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaGlobalHome } from "../paths.js";
 import { pathExists } from "../fs-utils.js";
 
 export interface McpServerSpec {
@@ -16,7 +16,7 @@ export interface McpConfig {
   mcpServers: Record<string, Omit<McpServerSpec, "name">>;
 }
 
-const CONFIG_PATH = path.join(LISA_HOME, "mcp.json");
+const CONFIG_PATH = path.join(lisaGlobalHome(), "mcp.json");
 
 export async function loadMcpConfig(): Promise<McpServerSpec[]> {
   if (!(await pathExists(CONFIG_PATH))) return [];

--- a/src/memory/embedding-cache.test.ts
+++ b/src/memory/embedding-cache.test.ts
@@ -6,7 +6,7 @@ import path from "node:path";
 import type { Embedder } from "./embedding.js";
 
 // Isolate the on-disk cache before importing the module (paths.js reads
-// LISA_HOME at import time).
+// lisaHome() at import time).
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-embcache-"));
 process.env.LISA_HOME = TMP;
 

--- a/src/memory/embedding.test.ts
+++ b/src/memory/embedding.test.ts
@@ -7,8 +7,8 @@ import type { Embedder, PostJson } from "./embedding.js";
 import type { Index, Document } from "./vector.js";
 
 // semanticSearch → ensureEmbeddings now reads/writes the on-disk embedding
-// cache; point it at a throwaway LISA_HOME so the suite never touches the real
-// ~/.lisa. Set before importing the modules (paths.js captures LISA_HOME once).
+// cache; point it at a throwaway lisaHome() so the suite never touches the real
+// ~/.lisa. Set before importing the modules (paths.js captures lisaHome() once).
 process.env.LISA_HOME = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-emb-"));
 
 const { cosineSimilarity, parseOllamaEmbedding, OllamaEmbedder } = await import("./embedding.js");

--- a/src/memory/embedding.ts
+++ b/src/memory/embedding.ts
@@ -11,7 +11,7 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 import { localEndpoint } from "../model/local.js";
 
 export interface Embedder {
@@ -140,9 +140,11 @@ export async function embedWithCache(
   return { vectors, updated, misses: missIdx.length };
 }
 
-const EMBED_CACHE_DIR = path.join(LISA_HOME, "embeddings");
+function embedCacheDir(): string {
+  return path.join(lisaHome(), "embeddings");
+}
 function embedCacheFile(embedderId: string): string {
-  return path.join(EMBED_CACHE_DIR, `${embedderId.replace(/[^a-zA-Z0-9._-]/g, "_")}.json`);
+  return path.join(embedCacheDir(), `${embedderId.replace(/[^a-zA-Z0-9._-]/g, "_")}.json`);
 }
 
 /** Load the on-disk cache for an embedder; {} if missing/corrupt. */
@@ -157,7 +159,7 @@ export async function loadEmbeddingCache(embedderId: string): Promise<EmbeddingC
 /** Persist the cache for an embedder. Best-effort (never throws). */
 export async function saveEmbeddingCache(embedderId: string, cache: EmbeddingCache): Promise<void> {
   try {
-    await fs.mkdir(EMBED_CACHE_DIR, { recursive: true });
+    await fs.mkdir(embedCacheDir(), { recursive: true });
     await fs.writeFile(embedCacheFile(embedderId), JSON.stringify(cache));
   } catch {
     // best-effort; a missing cache just means more re-embedding next time

--- a/src/memory/store.ts
+++ b/src/memory/store.ts
@@ -1,5 +1,5 @@
 import { atomicWrite, ensureDir, readTextOrEmpty } from "../fs-utils.js";
-import { MEMORY_DIR, MEMORY_FILE, USER_FILE } from "../paths.js";
+import { memoryDir, memoryFile, userFile } from "../paths.js";
 
 export type MemoryStore = "memory" | "user";
 
@@ -9,7 +9,7 @@ const MAX_BYTES: Record<MemoryStore, number> = {
 };
 
 function fileFor(store: MemoryStore): string {
-  return store === "memory" ? MEMORY_FILE : USER_FILE;
+  return store === "memory" ? memoryFile() : userFile();
 }
 
 export async function readMemory(store: MemoryStore): Promise<string> {
@@ -20,7 +20,7 @@ export async function writeMemory(
   store: MemoryStore,
   content: string,
 ): Promise<void> {
-  await ensureDir(MEMORY_DIR);
+  await ensureDir(memoryDir());
   const trimmed = content.replace(/\s+$/g, "") + "\n";
   if (Buffer.byteLength(trimmed, "utf8") > MAX_BYTES[store]) {
     throw new Error(

--- a/src/memory/vector.test.ts
+++ b/src/memory/vector.test.ts
@@ -4,8 +4,8 @@ import { mkdtempSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// Point LISA_HOME at an empty temp dir BEFORE importing the module under
-// test, so paths.ts (evaluated at import) resolves SESSIONS_DIR there.
+// Point lisaHome() at an empty temp dir BEFORE importing the module under
+// test, so paths.ts (evaluated at import) resolves sessionsDir() there.
 // node's test runner isolates each test file in its own process, so this
 // env mutation can't leak into other suites.
 const TMP = mkdtempSync(path.join(os.tmpdir(), "lisa-mem-test-"));
@@ -39,7 +39,7 @@ describe("buildIndex — caching", () => {
   test("a new session file invalidates the cache (fingerprint changes)", async () => {
     clearIndexCache();
     const before = await buildIndex();
-    // Write a session jsonl into SESSIONS_DIR (LISA_HOME/sessions). The
+    // Write a session jsonl into sessionsDir() (lisaHome()/sessions). The
     // fingerprint (mtime+size of *.jsonl) changes, so the next build is fresh.
     const sessionsDir = path.join(TMP, "sessions");
     const { mkdirSync, writeFileSync } = await import("node:fs");

--- a/src/memory/vector.ts
+++ b/src/memory/vector.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import fs from "node:fs/promises";
 import { listSessionsOnDisk, loadSessionMessages } from "../sessions/list.js";
-import { SESSIONS_DIR } from "../paths.js";
+import { sessionsDir } from "../paths.js";
 import { extractTextFromContent } from "../agent.js";
 import {
   cosineSimilarity,
@@ -49,7 +49,7 @@ let cachedFingerprint = "";
 async function sessionsFingerprint(): Promise<string> {
   let files: string[];
   try {
-    files = await fs.readdir(SESSIONS_DIR);
+    files = await fs.readdir(sessionsDir());
   } catch {
     // Missing dir and empty dir must fingerprint identically: buildIndex →
     // listSessionsOnDisk → ensureDir CREATES the dir as a side effect, so a
@@ -61,7 +61,7 @@ async function sessionsFingerprint(): Promise<string> {
   for (const f of files.sort()) {
     if (!f.endsWith(".jsonl")) continue;
     try {
-      const st = await fs.stat(path.join(SESSIONS_DIR, f));
+      const st = await fs.stat(path.join(sessionsDir(), f));
       parts.push(`${f}:${st.mtimeMs}:${st.size}`);
     } catch {
       // file vanished between readdir and stat — ignore

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,13 +1,55 @@
 import os from "node:os";
 import path from "node:path";
+import { AsyncLocalStorage } from "node:async_hooks";
 
-export const LISA_HOME =
-  process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+/**
+ * Home resolution — the multi-tenant seam (PLAN_ACCOUNTS_BILLING B2 / C3).
+ *
+ * Two homes exist on purpose:
+ *  - `lisaGlobalHome()` — the operator/process home. Config + provider keys
+ *    (config.env), the account directory (accounts.json), device tokens, the
+ *    session secret. NEVER per-user.
+ *  - `lisaHome()` — the ACTIVE home for identity-bearing state (soul, sessions,
+ *    memory, reflections, autonomy, kb…). On the Mac edition it equals the
+ *    global home. On the cloud edition, a signed-in request runs inside
+ *    `homeScope.run(homeForUid(uid), …)` and everything downstream — including
+ *    awaited work — reads that user's subtree instead.
+ *
+ * Paths are FUNCTIONS, not import-time constants: a constant freezes the home
+ * at module load, which is exactly what made the codebase single-tenant.
+ */
+export const homeScope = new AsyncLocalStorage<string>();
 
-export const SKILLS_DIR = path.join(LISA_HOME, "skills");
-export const MEMORY_DIR = path.join(LISA_HOME, "memory");
-export const SESSIONS_DIR = path.join(LISA_HOME, "sessions");
-export const REFLECTIONS_DIR = path.join(LISA_HOME, "reflections");
+/** The operator/process home (config, keys, accounts, devices). Never per-uid. */
+export function lisaGlobalHome(): string {
+  return process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
+}
 
-export const MEMORY_FILE = path.join(MEMORY_DIR, "MEMORY.md");
-export const USER_FILE = path.join(MEMORY_DIR, "USER.md");
+/** The active home — per-uid inside a cloud request scope, else the global home. */
+export function lisaHome(): string {
+  return homeScope.getStore() ?? lisaGlobalHome();
+}
+
+/** A user's home subtree. uid comes from the account store (server-minted). */
+export function homeForUid(uid: string): string {
+  return path.join(lisaGlobalHome(), "users", uid);
+}
+
+export function skillsDir(): string {
+  return path.join(lisaHome(), "skills");
+}
+export function memoryDir(): string {
+  return path.join(lisaHome(), "memory");
+}
+export function sessionsDir(): string {
+  return path.join(lisaHome(), "sessions");
+}
+export function reflectionsDir(): string {
+  return path.join(lisaHome(), "reflections");
+}
+export function memoryFile(): string {
+  return path.join(memoryDir(), "MEMORY.md");
+}
+export function userFile(): string {
+  return path.join(memoryDir(), "USER.md");
+}

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaGlobalHome } from "../paths.js";
 import { ensureDir, pathExists } from "../fs-utils.js";
 import { parseFrontmatter } from "../skills/frontmatter.js";
 import type { Skill } from "../types.js";
@@ -12,7 +12,7 @@ import type {
   SubagentDefinition,
 } from "./types.js";
 
-const PLUGINS_DIR = path.join(LISA_HOME, "plugins");
+const PLUGINS_DIR = path.join(lisaGlobalHome(), "plugins");
 
 export async function loadAllPlugins(): Promise<LoadedPlugin[]> {
   await ensureDir(PLUGINS_DIR);

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -5,21 +5,21 @@ import { listSkills } from "./skills/manager.js";
 import { readMemory } from "./memory/store.js";
 import { readIndex } from "./kb/store.js";
 import { readSchema } from "./kb/schema.js";
-import { KB_INDEX_FILE, KB_SCHEMA_FILE } from "./kb/paths.js";
-import { LISA_HOME, MEMORY_DIR, SKILLS_DIR } from "./paths.js";
+import { kbIndexFile, kbSchemaFile } from "./kb/paths.js";
+import { lisaHome, memoryDir, skillsDir } from "./paths.js";
 import { pathExists } from "./fs-utils.js";
 import { availableMoodSlugs } from "./tools/set_mood.js";
 import { isBorn, readSoulSummary } from "./soul/store.js";
 import {
-  SOUL_CONSTITUTION,
-  SOUL_DESIRES_DIR,
-  SOUL_DIR,
-  SOUL_EMOTIONS,
-  SOUL_IDENTITY,
-  SOUL_NAME,
-  SOUL_OPINIONS_DIR,
-  SOUL_PURPOSE,
-  SOUL_VALUES_DIR,
+  soulConstitutionFile,
+  soulDesiresDir,
+  soulDir,
+  soulEmotionsFile,
+  soulIdentityFile,
+  soulNameFile,
+  soulOpinionsDir,
+  soulPurposeFile,
+  soulValuesDir,
 } from "./soul/paths.js";
 import type { SoulSummary } from "./soul/types.js";
 
@@ -80,7 +80,7 @@ export async function buildSystemPromptSnapshot(): Promise<PromptSnapshot> {
     `- platform: ${process.platform} (${os.release()})`,
     `- node: ${process.version}`,
     `- home: ${os.homedir()}`,
-    `- lisa data: ${LISA_HOME}`,
+    `- lisa data: ${lisaHome()}`,
   ].join("\n");
 
   const moods = await availableMoodSlugs();
@@ -206,29 +206,29 @@ export async function getPromptFingerprint(): Promise<string> {
   const parts: string[] = [];
   // Single files
   for (const p of [
-    SOUL_NAME,
-    SOUL_IDENTITY,
-    SOUL_PURPOSE,
-    SOUL_CONSTITUTION,
-    SOUL_EMOTIONS,
-    path.join(MEMORY_DIR, "MEMORY.md"),
-    path.join(MEMORY_DIR, "USER.md"),
+    soulNameFile(),
+    soulIdentityFile(),
+    soulPurposeFile(),
+    soulConstitutionFile(),
+    soulEmotionsFile(),
+    path.join(memoryDir(), "MEMORY.md"),
+    path.join(memoryDir(), "USER.md"),
     // KB: index.md is rewritten on every KB mutation (store regenerates it), so
     // its mtime is a cheap proxy for "the KB changed" — plus the schema file for
     // rule edits. Lets KB captures/edits hot-reload into the prompt mid-session.
-    KB_INDEX_FILE,
-    KB_SCHEMA_FILE,
+    kbIndexFile(),
+    kbSchemaFile(),
   ]) {
     parts.push(await mtimeOrZero(p));
   }
   // Directories — concat sorted entry names + per-entry mtime so we catch
   // both content changes AND additions/removals of values/opinions/desires.
-  for (const d of [SOUL_VALUES_DIR, SOUL_OPINIONS_DIR, SOUL_DESIRES_DIR, SKILLS_DIR]) {
+  for (const d of [soulValuesDir(), soulOpinionsDir(), soulDesiresDir(), skillsDir()]) {
     parts.push(await dirFingerprint(d));
   }
   // Soul lock matters too — tampered files shift the prompt's "## Notice"
   // block. Cheap to include.
-  parts.push(await mtimeOrZero(path.join(SOUL_DIR, "soul.lock.json")));
+  parts.push(await mtimeOrZero(path.join(soulDir(), "soul.lock.json")));
   return parts.join("|");
 }
 

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -3,7 +3,7 @@ import { extractTextFromContent } from "./agent.js";
 import { atomicWrite } from "./fs-utils.js";
 import { DEFAULT_MODEL } from "./llm.js";
 import { appendMemory, type MemoryStore } from "./memory/store.js";
-import { REFLECTIONS_DIR } from "./paths.js";
+import { reflectionsDir } from "./paths.js";
 import { providerForModel } from "./providers/registry.js";
 import { createSkill, getSkill, patchSkill } from "./skills/manager.js";
 import { withSoulCaller } from "./soul/git.js";
@@ -222,7 +222,7 @@ async function reflectOnSessionInner(opts: {
       raw = retryRaw;
       parsed = retryParsed;
     } else {
-      const errPath = path.join(REFLECTIONS_DIR, `${opts.sessionId}.error.json`);
+      const errPath = path.join(reflectionsDir(), `${opts.sessionId}.error.json`);
       try {
         await atomicWrite(
           errPath,
@@ -397,7 +397,7 @@ async function reflectOnSessionInner(opts: {
   }
 
   await atomicWrite(
-    path.join(REFLECTIONS_DIR, `${opts.sessionId}.json`),
+    path.join(reflectionsDir(), `${opts.sessionId}.json`),
     JSON.stringify(
       { summary: payload.summary, operations: payload.operations, applied, skipped, underReflected },
       null,

--- a/src/screen_advisor/engine.ts
+++ b/src/screen_advisor/engine.ts
@@ -22,7 +22,7 @@
 
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 
 export interface ScreenAdvisorConfig {
   /** Master switch. Off by default — capture only happens when true. */
@@ -39,7 +39,9 @@ export const DEFAULT_SCREEN_ADVISOR_CONFIG: ScreenAdvisorConfig = {
 export const MIN_INTERVAL_MINUTES = 2;
 export const MAX_INTERVAL_MINUTES = 240;
 
-export const SCREEN_ADVISOR_CONFIG_PATH = path.join(LISA_HOME, "screen-advisor.json");
+export function screenAdvisorConfigPath(): string {
+  return path.join(lisaHome(), "screen-advisor.json");
+}
 
 /** Coerce arbitrary input into a valid config (clamped interval, boolean enabled). */
 export function normalizeConfig(
@@ -55,7 +57,7 @@ export function normalizeConfig(
 }
 
 export async function loadScreenAdvisorConfig(
-  p: string = SCREEN_ADVISOR_CONFIG_PATH,
+  p: string = screenAdvisorConfigPath(),
 ): Promise<ScreenAdvisorConfig> {
   try {
     const raw = JSON.parse(await fsp.readFile(p, "utf8")) as Partial<ScreenAdvisorConfig>;
@@ -67,7 +69,7 @@ export async function loadScreenAdvisorConfig(
 
 export async function saveScreenAdvisorConfig(
   cfg: ScreenAdvisorConfig,
-  p: string = SCREEN_ADVISOR_CONFIG_PATH,
+  p: string = screenAdvisorConfigPath(),
 ): Promise<ScreenAdvisorConfig> {
   const norm = normalizeConfig(cfg);
   await fsp.mkdir(path.dirname(p), { recursive: true });

--- a/src/sessions/active.ts
+++ b/src/sessions/active.ts
@@ -1,17 +1,19 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 
 /**
  * Pointer to the currently-live web session. Written when the web server
  * starts a session (or resumes one), read on next startup so a redeploy
  * (or any restart) keeps the same conversation thread.
  */
-const ACTIVE_WEB_SESSION_FILE = path.join(LISA_HOME, "active-web-session.txt");
+function activeWebSessionFile(): string {
+  return path.join(lisaHome(), "active-web-session.txt");
+}
 
 export async function readActiveWebSession(): Promise<string | null> {
   try {
-    const raw = (await fsp.readFile(ACTIVE_WEB_SESSION_FILE, "utf8")).trim();
+    const raw = (await fsp.readFile(activeWebSessionFile(), "utf8")).trim();
     return raw || null;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
@@ -20,12 +22,12 @@ export async function readActiveWebSession(): Promise<string | null> {
 }
 
 export async function writeActiveWebSession(id: string): Promise<void> {
-  await fsp.writeFile(ACTIVE_WEB_SESSION_FILE, id, "utf8");
+  await fsp.writeFile(activeWebSessionFile(), id, "utf8");
 }
 
 export async function clearActiveWebSession(): Promise<void> {
   try {
-    await fsp.unlink(ACTIVE_WEB_SESSION_FILE);
+    await fsp.unlink(activeWebSessionFile());
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
   }

--- a/src/sessions/list.ts
+++ b/src/sessions/list.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { SESSIONS_DIR } from "../paths.js";
+import { sessionsDir } from "../paths.js";
 import { ensureDir, pathExists } from "../fs-utils.js";
 import type { SessionEntry, SessionHeader, StoredMessage } from "../types.js";
 
@@ -15,12 +15,12 @@ export interface SessionInfo {
 }
 
 export async function listSessionsOnDisk(): Promise<SessionInfo[]> {
-  await ensureDir(SESSIONS_DIR);
-  const files = await fs.readdir(SESSIONS_DIR);
+  await ensureDir(sessionsDir());
+  const files = await fs.readdir(sessionsDir());
   const out: SessionInfo[] = [];
   for (const file of files) {
     if (!file.endsWith(".jsonl")) continue;
-    const full = path.join(SESSIONS_DIR, file);
+    const full = path.join(sessionsDir(), file);
     try {
       const info = await summarize(full);
       if (info) out.push(info);
@@ -71,7 +71,7 @@ export async function loadSessionMessages(id: string): Promise<{
   header: SessionHeader;
   messages: StoredMessage[];
 }> {
-  const file = path.join(SESSIONS_DIR, `${id}.jsonl`);
+  const file = path.join(sessionsDir(), `${id}.jsonl`);
   if (!(await pathExists(file))) {
     throw new Error(`session ${id} not found at ${file}`);
   }

--- a/src/sessions/store.test.ts
+++ b/src/sessions/store.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { StoredMessage } from "../types.js";
 
-// SESSIONS_DIR is resolved from LISA_HOME at import time, so set a tmp home
+// sessionsDir() is resolved from lisaHome() at import time, so set a tmp home
 // BEFORE importing the store (dynamic import). node --test isolates each file in
 // its own process, so this env mutation can't leak to other suites.
 let SessionStore: typeof import("./store.js").SessionStore;

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import crypto from "node:crypto";
-import { SESSIONS_DIR } from "../paths.js";
+import { sessionsDir } from "../paths.js";
 import { appendLine, ensureDir } from "../fs-utils.js";
 import type { SessionEntry, SessionHeader, StoredMessage } from "../types.js";
 
@@ -17,7 +17,7 @@ export class SessionStore {
   }
 
   static async open(id: string): Promise<SessionStore> {
-    const file = path.join(SESSIONS_DIR, `${id}.jsonl`);
+    const file = path.join(sessionsDir(), `${id}.jsonl`);
     const raw = await fs.readFile(file, "utf8");
     const lines = raw.split("\n").filter(Boolean);
     if (lines.length === 0) throw new Error(`session ${id} is empty`);
@@ -29,9 +29,9 @@ export class SessionStore {
     cwd: string;
     model: string;
   }): Promise<SessionStore> {
-    await ensureDir(SESSIONS_DIR);
+    await ensureDir(sessionsDir());
     const id = `${stamp()}-${crypto.randomBytes(3).toString("hex")}`;
-    const file = path.join(SESSIONS_DIR, `${id}.jsonl`);
+    const file = path.join(sessionsDir(), `${id}.jsonl`);
     const header: SessionHeader = {
       type: "session",
       id,

--- a/src/skills/executable.ts
+++ b/src/skills/executable.ts
@@ -30,7 +30,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { pathToFileURL } from "node:url";
 import { atomicWrite, ensureDir, pathExists } from "../fs-utils.js";
-import { SKILLS_DIR } from "../paths.js";
+import { skillsDir } from "../paths.js";
 import type { ToolDefinition } from "../types.js";
 
 const TOOL_JS = "tool.js";
@@ -75,7 +75,7 @@ async function shaOf(p: string): Promise<string | null> {
 }
 
 async function readApproved(slug: string): Promise<ApprovedRecord | null> {
-  const f = path.join(SKILLS_DIR, slug, APPROVED_FILE);
+  const f = path.join(skillsDir(), slug, APPROVED_FILE);
   if (!(await pathExists(f))) return null;
   try {
     return JSON.parse(await fs.readFile(f, "utf8")) as ApprovedRecord;
@@ -85,15 +85,15 @@ async function readApproved(slug: string): Promise<ApprovedRecord | null> {
 }
 
 async function writeApproved(slug: string, rec: ApprovedRecord): Promise<void> {
-  await atomicWrite(path.join(SKILLS_DIR, slug, APPROVED_FILE), JSON.stringify(rec, null, 2));
+  await atomicWrite(path.join(skillsDir(), slug, APPROVED_FILE), JSON.stringify(rec, null, 2));
 }
 
 async function isDisabled(slug: string): Promise<boolean> {
-  return await pathExists(path.join(SKILLS_DIR, slug, DISABLED_FILE));
+  return await pathExists(path.join(skillsDir(), slug, DISABLED_FILE));
 }
 
 async function appendAudit(slug: string, event: string, detail?: string): Promise<void> {
-  const f = path.join(SKILLS_DIR, slug, AUDIT_FILE);
+  const f = path.join(skillsDir(), slug, AUDIT_FILE);
   await ensureDir(path.dirname(f));
   const ts = new Date().toISOString();
   const line = `${ts}\t${event}${detail ? `\t${detail}` : ""}\n`;
@@ -101,7 +101,7 @@ async function appendAudit(slug: string, event: string, detail?: string): Promis
 }
 
 export async function readAudit(slug: string): Promise<string> {
-  const f = path.join(SKILLS_DIR, slug, AUDIT_FILE);
+  const f = path.join(skillsDir(), slug, AUDIT_FILE);
   if (!(await pathExists(f))) return "";
   return await fs.readFile(f, "utf8");
 }
@@ -109,7 +109,7 @@ export async function readAudit(slug: string): Promise<string> {
 export async function readToolSource(slug: string): Promise<string | null> {
   // Prefer .ts if present (more readable); fall back to .js.
   for (const name of ["tool.ts", TOOL_JS]) {
-    const p = path.join(SKILLS_DIR, slug, name);
+    const p = path.join(skillsDir(), slug, name);
     if (await pathExists(p)) {
       return await fs.readFile(p, "utf8");
     }
@@ -119,13 +119,13 @@ export async function readToolSource(slug: string): Promise<string | null> {
 
 /** Discover all candidates with a tool.js, regardless of approval state. */
 export async function discoverExecutableSkills(): Promise<ExecutableCandidate[]> {
-  if (!(await pathExists(SKILLS_DIR))) return [];
-  const entries = await fs.readdir(SKILLS_DIR, { withFileTypes: true });
+  if (!(await pathExists(skillsDir()))) return [];
+  const entries = await fs.readdir(skillsDir(), { withFileTypes: true });
   const out: ExecutableCandidate[] = [];
   for (const e of entries) {
     if (!e.isDirectory() || e.name.startsWith(".")) continue;
     const slug = e.name;
-    const toolJsPath = path.join(SKILLS_DIR, slug, TOOL_JS);
+    const toolJsPath = path.join(skillsDir(), slug, TOOL_JS);
     const currentShaMaybe = await shaOf(toolJsPath);
     if (!currentShaMaybe) continue; // no tool.js — not an executable skill
     const approved = await readApproved(slug);
@@ -187,7 +187,7 @@ export async function approveExecutableSkill(
   slug: string,
   opts: { toolName: string; note?: string },
 ): Promise<ApprovedRecord> {
-  const toolJsPath = path.join(SKILLS_DIR, slug, TOOL_JS);
+  const toolJsPath = path.join(skillsDir(), slug, TOOL_JS);
   const sha = await shaOf(toolJsPath);
   if (!sha) throw new Error(`no tool.js found at ${toolJsPath}`);
   const rec: ApprovedRecord = {
@@ -198,7 +198,7 @@ export async function approveExecutableSkill(
   };
   await writeApproved(slug, rec);
   // Re-enable on approval if a stale .disabled flag is present.
-  const disPath = path.join(SKILLS_DIR, slug, DISABLED_FILE);
+  const disPath = path.join(skillsDir(), slug, DISABLED_FILE);
   if (await pathExists(disPath)) {
     await fs.rm(disPath, { force: true });
     await appendAudit(slug, "re_enabled");
@@ -208,7 +208,7 @@ export async function approveExecutableSkill(
 }
 
 export async function disableExecutableSkill(slug: string, reason?: string): Promise<void> {
-  const dir = path.join(SKILLS_DIR, slug);
+  const dir = path.join(skillsDir(), slug);
   if (!(await pathExists(dir))) throw new Error(`skill "${slug}" not found`);
   await ensureDir(dir);
   await fs.writeFile(path.join(dir, DISABLED_FILE), `${new Date().toISOString()}\n${reason ?? ""}\n`);
@@ -216,7 +216,7 @@ export async function disableExecutableSkill(slug: string, reason?: string): Pro
 }
 
 export async function enableExecutableSkill(slug: string): Promise<void> {
-  const dir = path.join(SKILLS_DIR, slug);
+  const dir = path.join(skillsDir(), slug);
   const f = path.join(dir, DISABLED_FILE);
   if (await pathExists(f)) {
     await fs.rm(f, { force: true });

--- a/src/skills/manager.ts
+++ b/src/skills/manager.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs/promises";
 import path from "node:path";
-import { SKILLS_DIR } from "../paths.js";
+import { skillsDir } from "../paths.js";
 import { atomicWrite, ensureDir, pathExists } from "../fs-utils.js";
 import type { Skill, SkillFrontmatter } from "../types.js";
 import { buildFrontmatter, parseFrontmatter } from "./frontmatter.js";
@@ -8,7 +8,7 @@ import { buildFrontmatter, parseFrontmatter } from "./frontmatter.js";
 const VALID_NAME = /^[a-z0-9][a-z0-9-]{0,62}$/;
 
 function skillDir(name: string): string {
-  return path.join(SKILLS_DIR, name);
+  return path.join(skillsDir(), name);
 }
 
 function skillFile(name: string): string {
@@ -24,8 +24,8 @@ export function validateSkillName(name: string): void {
 }
 
 export async function listSkills(): Promise<Skill[]> {
-  await ensureDir(SKILLS_DIR);
-  const entries = await fs.readdir(SKILLS_DIR, { withFileTypes: true });
+  await ensureDir(skillsDir());
+  const entries = await fs.readdir(skillsDir(), { withFileTypes: true });
   const out: Skill[] = [];
   for (const entry of entries) {
     if (!entry.isDirectory() || entry.name.startsWith(".")) continue;

--- a/src/soul/concurrency.test.ts
+++ b/src/soul/concurrency.test.ts
@@ -10,7 +10,7 @@ import path from "node:path";
 // under concurrency. Without the lock, concurrent RMW would clobber the events
 // array (last-writer-wins) and drop events.
 //
-// SOUL_DIR derives from LISA_HOME at import, so set a tmp home before importing
+// soulDir() derives from lisaHome() at import, so set a tmp home before importing
 // (dynamic import); node --test isolates each file in its own process.
 let store: typeof import("./store.js");
 let home: string;

--- a/src/soul/desire-activity.test.ts
+++ b/src/soul/desire-activity.test.ts
@@ -11,7 +11,7 @@ import type { DesireEntry } from "./types.js";
 // file mtimes off disk and feeding pickCurrentDesire end-to-end. Uses a real
 // temp soul with mtimes pinned via fs.utimes so the assertions are deterministic.
 //
-// SOUL_DIR derives from LISA_HOME at import, so set a tmp home before importing.
+// soulDir() derives from lisaHome() at import, so set a tmp home before importing.
 let store: typeof import("./store.js");
 let paths: typeof import("./paths.js");
 let home: string;

--- a/src/soul/desire-evolve.test.ts
+++ b/src/soul/desire-evolve.test.ts
@@ -8,7 +8,7 @@ import path from "node:path";
 // now evolve desires in place, not just append. These exercise the store
 // primitives that power both paths.
 //
-// SOUL_DIR derives from LISA_HOME at import, so set a tmp home before importing
+// soulDir() derives from lisaHome() at import, so set a tmp home before importing
 // (dynamic import); node --test isolates each file in its own process.
 let store: typeof import("./store.js");
 let home: string;

--- a/src/soul/git.ts
+++ b/src/soul/git.ts
@@ -13,7 +13,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
 import { pathExists } from "../fs-utils.js";
 import { withFileLock } from "./lock.js";
-import { SOUL_DIR } from "./paths.js";
+import { soulDir } from "./paths.js";
 
 /**
  * Cross-process lock around the add→diff→commit sequence. The in-process
@@ -27,7 +27,7 @@ import { SOUL_DIR } from "./paths.js";
  * reusing the same lock here would self-deadlock. Ordering is always
  * write-lock → git-lock, never the reverse, so the two can't deadlock.
  */
-const SOUL_GIT_LOCK_PATH = path.join(SOUL_DIR, ".git-write.lock");
+const SOUL_GIT_LOCK_PATH = path.join(soulDir(), ".git-write.lock");
 
 export type SoulCaller =
   | "birth"
@@ -105,7 +105,7 @@ function runGitRaw(args: string[], cwd: string): Promise<GitResult> {
 }
 
 async function runGit(args: string[]): Promise<GitResult> {
-  return await runGitRaw(args, SOUL_DIR);
+  return await runGitRaw(args, soulDir());
 }
 
 /**
@@ -118,8 +118,8 @@ export async function initSoulRepo(): Promise<void> {
     console.warn("[soul-git] git not available; soul history disabled");
     return;
   }
-  if (!(await pathExists(SOUL_DIR))) return;
-  const dotGit = path.join(SOUL_DIR, ".git");
+  if (!(await pathExists(soulDir()))) return;
+  const dotGit = path.join(soulDir(), ".git");
   if (await pathExists(dotGit)) return;
 
   try {
@@ -135,7 +135,7 @@ export async function initSoulRepo(): Promise<void> {
     await runGit(["config", "core.hooksPath", "/dev/null"]);
     // .gitignore for transient junk.
     const fs = await import("node:fs/promises");
-    const ignorePath = path.join(SOUL_DIR, ".gitignore");
+    const ignorePath = path.join(soulDir(), ".gitignore");
     if (!(await pathExists(ignorePath))) {
       await fs.writeFile(
         ignorePath,
@@ -165,7 +165,7 @@ export async function initSoulRepo(): Promise<void> {
 }
 
 /**
- * Stage the file at `relPath` (relative to SOUL_DIR) and commit if there's a
+ * Stage the file at `relPath` (relative to soulDir()) and commit if there's a
  * real diff. opKind is the high-level operation ("patch", "feel", "journal",
  * etc.). Failures are swallowed with a warn — soul history is best-effort.
  *
@@ -180,7 +180,7 @@ export function commitSoulChange(
   const caller = currentCaller();
   return enqueueCommit(async () => {
     if (!(await checkGitAvailable())) return;
-    const dotGit = path.join(SOUL_DIR, ".git");
+    const dotGit = path.join(soulDir(), ".git");
     if (!(await pathExists(dotGit))) return; // not initialized yet (pre-birth)
     try {
       await withFileLock(
@@ -243,7 +243,7 @@ export async function gitLogOneline(opts: {
   since?: string;
 }): Promise<string> {
   if (!(await checkGitAvailable())) return "(git unavailable)";
-  const dotGit = path.join(SOUL_DIR, ".git");
+  const dotGit = path.join(soulDir(), ".git");
   if (!(await pathExists(dotGit))) return "(soul history not initialized)";
   const args = ["log", "--pretty=format:%h %ad %s", "--date=iso-strict"];
   if (opts.limit) args.push(`-n`, String(opts.limit));
@@ -260,7 +260,7 @@ export async function gitDiffPatch(opts: {
   limit?: number;
 }): Promise<string> {
   if (!(await checkGitAvailable())) return "(git unavailable)";
-  const dotGit = path.join(SOUL_DIR, ".git");
+  const dotGit = path.join(soulDir(), ".git");
   if (!(await pathExists(dotGit))) return "(soul history not initialized)";
   const args = ["log", "-p", "--no-color", "--date=iso-strict"];
   if (opts.limit) args.push(`-n`, String(opts.limit));

--- a/src/soul/lock.ts
+++ b/src/soul/lock.ts
@@ -21,7 +21,7 @@
 import fsp from "node:fs/promises";
 import path from "node:path";
 import { ensureDir } from "../fs-utils.js";
-import { SOUL_DIR } from "./paths.js";
+import { soulDir } from "./paths.js";
 
 export interface FileLockOpts {
   /** Treat a held lock as abandoned after this many ms (crashed holder). */
@@ -132,7 +132,7 @@ export async function withFileLock<T>(
 }
 
 /** The canonical soul write-lock path. */
-export const SOUL_LOCK_PATH = path.join(SOUL_DIR, ".write.lock");
+export const SOUL_LOCK_PATH = path.join(soulDir(), ".write.lock");
 
 /**
  * Run `fn` while holding the soul write-lock. Use this around any

--- a/src/soul/paths.ts
+++ b/src/soul/paths.ts
@@ -1,43 +1,72 @@
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 import { assertSafeSlug } from "./slug.js";
 
-export const SOUL_DIR = path.join(LISA_HOME, "soul");
+// Soul paths are FUNCTIONS of the active home (see ../paths.ts): under the
+// cloud edition's per-uid request scope they resolve into that user's subtree.
 
-export const SOUL_SEED = path.join(SOUL_DIR, "seed.json");
-export const SOUL_NAME = path.join(SOUL_DIR, "name.md");
-export const SOUL_IDENTITY = path.join(SOUL_DIR, "identity.md");
-export const SOUL_PURPOSE = path.join(SOUL_DIR, "purpose.md");
-export const SOUL_CONSTITUTION = path.join(SOUL_DIR, "constitution.md");
-export const SOUL_EMOTIONS = path.join(SOUL_DIR, "emotions.json");
-export const SOUL_LOCK = path.join(SOUL_DIR, "soul.lock.json");
+export function soulDir(): string {
+  return path.join(lisaHome(), "soul");
+}
 
-export const SOUL_VALUES_DIR = path.join(SOUL_DIR, "values");
-export const SOUL_OPINIONS_DIR = path.join(SOUL_DIR, "opinions");
-export const SOUL_DESIRES_DIR = path.join(SOUL_DIR, "desires");
-export const SOUL_JOURNAL_DIR = path.join(SOUL_DIR, "journal");
-export const SOUL_RELATIONSHIPS_DIR = path.join(SOUL_DIR, "relationships");
+export function soulSeedFile(): string {
+  return path.join(soulDir(), "seed.json");
+}
+export function soulNameFile(): string {
+  return path.join(soulDir(), "name.md");
+}
+export function soulIdentityFile(): string {
+  return path.join(soulDir(), "identity.md");
+}
+export function soulPurposeFile(): string {
+  return path.join(soulDir(), "purpose.md");
+}
+export function soulConstitutionFile(): string {
+  return path.join(soulDir(), "constitution.md");
+}
+export function soulEmotionsFile(): string {
+  return path.join(soulDir(), "emotions.json");
+}
+export function soulLockFile(): string {
+  return path.join(soulDir(), "soul.lock.json");
+}
+
+export function soulValuesDir(): string {
+  return path.join(soulDir(), "values");
+}
+export function soulOpinionsDir(): string {
+  return path.join(soulDir(), "opinions");
+}
+export function soulDesiresDir(): string {
+  return path.join(soulDir(), "desires");
+}
+export function soulJournalDir(): string {
+  return path.join(soulDir(), "journal");
+}
+export function soulRelationshipsDir(): string {
+  return path.join(soulDir(), "relationships");
+}
 
 // Every slug-bearing path helper runs the slug through assertSafeSlug first.
 // This is the single chokepoint for path-traversal defense: a slug like
 // "../../../etc/x" or "a/b" throws here rather than escaping the soul dir.
 export function valueFile(slug: string): string {
-  return path.join(SOUL_VALUES_DIR, `${assertSafeSlug(slug)}.md`);
+  return path.join(soulValuesDir(), `${assertSafeSlug(slug)}.md`);
 }
 export function opinionFile(slug: string): string {
-  return path.join(SOUL_OPINIONS_DIR, `${assertSafeSlug(slug)}.md`);
+  return path.join(soulOpinionsDir(), `${assertSafeSlug(slug)}.md`);
 }
 export function desireFile(slug: string): string {
-  return path.join(SOUL_DESIRES_DIR, `${assertSafeSlug(slug)}.md`);
+  return path.join(soulDesiresDir(), `${assertSafeSlug(slug)}.md`);
 }
 export function desireProgressFile(slug: string): string {
-  return path.join(SOUL_DESIRES_DIR, `${assertSafeSlug(slug)}.progress.md`);
+  return path.join(soulDesiresDir(), `${assertSafeSlug(slug)}.progress.md`);
 }
 export function journalFile(date: string): string {
   // Journal keys are dates (YYYY-MM-DD), which assertSafeSlug accepts (no
   // separators/dots-leading), so this guards against a malformed date too.
-  return path.join(SOUL_JOURNAL_DIR, `${assertSafeSlug(date)}.md`);
+  return path.join(soulJournalDir(), `${assertSafeSlug(date)}.md`);
 }
 export function relationshipFile(userKey: string): string {
-  return path.join(SOUL_RELATIONSHIPS_DIR, `${assertSafeSlug(userKey)}.md`);
+  return path.join(soulRelationshipsDir(), `${assertSafeSlug(userKey)}.md`);
 }

--- a/src/soul/store.ts
+++ b/src/soul/store.ts
@@ -5,19 +5,19 @@ import { atomicWrite, ensureDir, pathExists, readTextOrEmpty } from "../fs-utils
 import { commitSoulChange, initSoulRepo } from "./git.js";
 import { withSoulLock } from "./lock.js";
 import {
-  SOUL_DIR,
-  SOUL_SEED,
-  SOUL_NAME,
-  SOUL_IDENTITY,
-  SOUL_PURPOSE,
-  SOUL_CONSTITUTION,
-  SOUL_EMOTIONS,
-  SOUL_LOCK,
-  SOUL_VALUES_DIR,
-  SOUL_OPINIONS_DIR,
-  SOUL_DESIRES_DIR,
-  SOUL_JOURNAL_DIR,
-  SOUL_RELATIONSHIPS_DIR,
+  soulDir,
+  soulSeedFile,
+  soulNameFile,
+  soulIdentityFile,
+  soulPurposeFile,
+  soulConstitutionFile,
+  soulEmotionsFile,
+  soulLockFile,
+  soulValuesDir,
+  soulOpinionsDir,
+  soulDesiresDir,
+  soulJournalDir,
+  soulRelationshipsDir,
   valueFile,
   opinionFile,
   desireFile,
@@ -39,73 +39,73 @@ import {
 export async function ensureSoulDirs(): Promise<void> {
   await Promise.all(
     [
-      SOUL_DIR,
-      SOUL_VALUES_DIR,
-      SOUL_OPINIONS_DIR,
-      SOUL_DESIRES_DIR,
-      SOUL_JOURNAL_DIR,
-      SOUL_RELATIONSHIPS_DIR,
+      soulDir(),
+      soulValuesDir(),
+      soulOpinionsDir(),
+      soulDesiresDir(),
+      soulJournalDir(),
+      soulRelationshipsDir(),
     ].map((d) => ensureDir(d)),
   );
 }
 
 export async function isBorn(): Promise<boolean> {
-  return await pathExists(SOUL_SEED);
+  return await pathExists(soulSeedFile());
 }
 
 export async function readSeed(): Promise<SoulSeed | null> {
-  if (!(await pathExists(SOUL_SEED))) return null;
-  return JSON.parse(await fs.readFile(SOUL_SEED, "utf8")) as SoulSeed;
+  if (!(await pathExists(soulSeedFile()))) return null;
+  return JSON.parse(await fs.readFile(soulSeedFile(), "utf8")) as SoulSeed;
 }
 
 export async function writeSeed(seed: SoulSeed): Promise<void> {
   await ensureSoulDirs();
-  await atomicWrite(SOUL_SEED, JSON.stringify(seed, null, 2));
+  await atomicWrite(soulSeedFile(), JSON.stringify(seed, null, 2));
   await commitSoulChange("seed.json", "seed");
 }
 
 export async function readName(): Promise<string> {
-  const raw = (await readTextOrEmpty(SOUL_NAME)).trim();
+  const raw = (await readTextOrEmpty(soulNameFile())).trim();
   return raw || "Lisa";
 }
 
 export async function writeName(name: string): Promise<void> {
-  await atomicWrite(SOUL_NAME, name.trim() + "\n");
+  await atomicWrite(soulNameFile(), name.trim() + "\n");
   await commitSoulChange("name.md", "patch");
 }
 
 export async function readIdentity(): Promise<string> {
-  return (await readTextOrEmpty(SOUL_IDENTITY)).trim();
+  return (await readTextOrEmpty(soulIdentityFile())).trim();
 }
 export async function writeIdentity(text: string): Promise<void> {
-  await atomicWrite(SOUL_IDENTITY, text.trim() + "\n");
+  await atomicWrite(soulIdentityFile(), text.trim() + "\n");
   await commitSoulChange("identity.md", "patch");
 }
 
 export async function readPurpose(): Promise<string> {
-  return (await readTextOrEmpty(SOUL_PURPOSE)).trim();
+  return (await readTextOrEmpty(soulPurposeFile())).trim();
 }
 export async function writePurpose(text: string): Promise<void> {
-  await atomicWrite(SOUL_PURPOSE, text.trim() + "\n");
+  await atomicWrite(soulPurposeFile(), text.trim() + "\n");
   await commitSoulChange("purpose.md", "patch");
 }
 
 export async function readConstitution(): Promise<string> {
-  return (await readTextOrEmpty(SOUL_CONSTITUTION)).trim();
+  return (await readTextOrEmpty(soulConstitutionFile())).trim();
 }
 export async function writeConstitution(text: string): Promise<void> {
-  await atomicWrite(SOUL_CONSTITUTION, text.trim() + "\n");
+  await atomicWrite(soulConstitutionFile(), text.trim() + "\n");
   await commitSoulChange("constitution.md", "patch");
 }
 
 export async function readEmotions(): Promise<EmotionState> {
   // When the file is missing/corrupt, stamp the defaults with NOW — the
   // catalog default is epoch-0, and decaying "since 1970" zeroes every value.
-  if (!(await pathExists(SOUL_EMOTIONS))) {
+  if (!(await pathExists(soulEmotionsFile()))) {
     return { ...DEFAULT_EMOTIONS, updatedAt: new Date().toISOString() };
   }
   try {
-    const parsed = JSON.parse(await fs.readFile(SOUL_EMOTIONS, "utf8")) as EmotionState;
+    const parsed = JSON.parse(await fs.readFile(soulEmotionsFile(), "utf8")) as EmotionState;
     // Backward-compat: emotions.json predating the event trail had no events
     // field. Treat it as an empty trail rather than throwing.
     return { ...parsed, events: parsed.events ?? [] };
@@ -115,7 +115,7 @@ export async function readEmotions(): Promise<EmotionState> {
 }
 
 export async function writeEmotions(state: EmotionState): Promise<void> {
-  await atomicWrite(SOUL_EMOTIONS, JSON.stringify(state, null, 2));
+  await atomicWrite(soulEmotionsFile(), JSON.stringify(state, null, 2));
   await commitSoulChange("emotions.json", "feel");
 }
 
@@ -191,7 +191,7 @@ export function decayEmotions(
 // ── values ────────────────────────────────────────────────────────────
 
 export async function listValues(): Promise<ValueEntry[]> {
-  return await listMarkdownDir<ValueEntry>(SOUL_VALUES_DIR, parseValueFile);
+  return await listMarkdownDir<ValueEntry>(soulValuesDir(), parseValueFile);
 }
 export async function writeValue(entry: ValueEntry): Promise<void> {
   const body = `# ${entry.title}\n\nbirthed: ${entry.birthedAt}\n\n${entry.body.trim()}\n`;
@@ -214,7 +214,7 @@ function parseValueFile(slug: string, raw: string): ValueEntry {
 // ── opinions ──────────────────────────────────────────────────────────
 
 export async function listOpinions(): Promise<OpinionEntry[]> {
-  return await listMarkdownDir<OpinionEntry>(SOUL_OPINIONS_DIR, parseOpinionFile);
+  return await listMarkdownDir<OpinionEntry>(soulOpinionsDir(), parseOpinionFile);
 }
 
 export async function writeOpinion(entry: OpinionEntry): Promise<void> {
@@ -246,7 +246,7 @@ function parseOpinionFile(slug: string, raw: string): OpinionEntry {
 export async function listDesires(): Promise<DesireEntry[]> {
   // Filter out *.progress.md files — they live in the same directory but
   // belong to their parent desire, not as standalone desires.
-  const all = await listMarkdownDir<DesireEntry>(SOUL_DESIRES_DIR, parseDesireFile);
+  const all = await listMarkdownDir<DesireEntry>(soulDesiresDir(), parseDesireFile);
   return all.filter((d) => !d.slug.endsWith(".progress"));
 }
 
@@ -551,7 +551,7 @@ export async function appendDesireProgress(
 // ── journal ───────────────────────────────────────────────────────────
 
 export async function appendJournal(date: string, entry: string): Promise<void> {
-  await ensureDir(SOUL_JOURNAL_DIR);
+  await ensureDir(soulJournalDir());
   const file = journalFile(date);
   // Read-modify-write under the cross-process soul lock: reflect / soul_journal
   // / idle / heartbeat can all append to the same day's file from different
@@ -570,8 +570,8 @@ export async function readJournal(date: string): Promise<string> {
 }
 
 export async function listJournalDates(): Promise<string[]> {
-  if (!(await pathExists(SOUL_JOURNAL_DIR))) return [];
-  const files = await fs.readdir(SOUL_JOURNAL_DIR);
+  if (!(await pathExists(soulJournalDir()))) return [];
+  const files = await fs.readdir(soulJournalDir());
   return files
     .filter((f) => /^\d{4}-\d{2}-\d{2}\.md$/.test(f))
     .map((f) => f.replace(/\.md$/, ""))
@@ -609,20 +609,20 @@ async function hashFileIfPresent(p: string): Promise<string | null> {
 export async function recomputeLock(): Promise<SoulLock> {
   const hashes: Record<string, string> = {};
   for (const rel of LOCKED_FILES) {
-    const h = await hashFileIfPresent(path.join(SOUL_DIR, rel));
+    const h = await hashFileIfPresent(path.join(soulDir(), rel));
     if (h) hashes[rel] = h;
   }
   return { hashes, savedAt: new Date().toISOString() };
 }
 
 export async function saveLock(lock: SoulLock): Promise<void> {
-  await atomicWrite(SOUL_LOCK, JSON.stringify(lock, null, 2));
+  await atomicWrite(soulLockFile(), JSON.stringify(lock, null, 2));
 }
 
 export async function readLock(): Promise<SoulLock | null> {
-  if (!(await pathExists(SOUL_LOCK))) return null;
+  if (!(await pathExists(soulLockFile()))) return null;
   try {
-    return JSON.parse(await fs.readFile(SOUL_LOCK, "utf8")) as SoulLock;
+    return JSON.parse(await fs.readFile(soulLockFile(), "utf8")) as SoulLock;
   } catch {
     return null;
   }
@@ -633,7 +633,7 @@ export async function detectTampering(): Promise<string[]> {
   if (!lock) return [];
   const tampered: string[] = [];
   for (const rel of LOCKED_FILES) {
-    const cur = await hashFileIfPresent(path.join(SOUL_DIR, rel));
+    const cur = await hashFileIfPresent(path.join(soulDir(), rel));
     if (!cur) {
       // The lock says this file should exist but it's gone — deletion is
       // tampering too, not a pass. (Previously `continue`d, so wiping

--- a/src/tools/compare_agents.ts
+++ b/src/tools/compare_agents.ts
@@ -23,7 +23,7 @@ import {
   getComparison,
   removeComparison,
   newJobId,
-  COMPARE_ROOT,
+  compareRoot,
   type ComparisonJob,
   type ComparisonEntry,
   type CompareAgentKind,
@@ -93,11 +93,11 @@ export const compareAgentsTool: ToolDefinition<CompareInput, string> = {
       if (!repo) return `(not a git repo: ${cwd} — compare_agents isolates each agent in a git worktree)`;
 
       const id = newJobId();
-      await mkdir(path.join(COMPARE_ROOT, id), { recursive: true });
+      await mkdir(path.join(compareRoot(), id), { recursive: true });
       const entries: ComparisonEntry[] = [];
       for (const agent of agents) {
         const branch = `lisa-compare/${id}-${agent}`;
-        const worktree = path.join(COMPARE_ROOT, id, agent);
+        const worktree = path.join(compareRoot(), id, agent);
         const wt = await runIn(repo, "git", ["-C", repo, "worktree", "add", "-b", branch, worktree, "HEAD"], { timeoutMs: 20000, signal: ctx.signal });
         if (wt.code !== 0) {
           entries.push({ agent, worktree, branch, launchError: `worktree add failed: ${wt.stderr.trim().slice(0, 120)}` });

--- a/src/tools/mcp.test.ts
+++ b/src/tools/mcp.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
-// Point LISA_HOME at a temp dir BEFORE importing modules that resolve paths.
+// Point lisaHome() at a temp dir BEFORE importing modules that resolve paths.
 process.env.LISA_HOME = mkdtempSync(path.join(tmpdir(), "lisa-mcp-"));
 const { mcpTool } = await import("./mcp.js");
 

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -2,7 +2,7 @@
  * LISA accounts — the cloud edition's user directory
  * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.1, milestone B1).
  *
- * Two account kinds share one store (`$LISA_HOME/accounts.json`, 0600):
+ * Two account kinds share one store (`$lisaHome()/accounts.json`, 0600):
  *  - **Apple** (`apple-<sub>`): created/updated on every verified Sign in with
  *    Apple. No password material — Apple is the authority.
  *  - **Email** (`em-<random>`): self-serve email+password, scrypt-hashed. This

--- a/src/web/room-music.test.ts
+++ b/src/web/room-music.test.ts
@@ -4,7 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
-// LISA_HOME (→ the ~/.lisa/music user dir) is read at import, so set a tmp home
+// lisaHome() (→ the ~/.lisa/music user dir) is read at import, so set a tmp home
 // before the dynamic import; node --test isolates each file in its own process.
 let mod: typeof import("./room-music.js");
 let home: string;
@@ -67,7 +67,7 @@ describe("listRoomMusic", () => {
   });
 
   test("missing manifest and missing user dir → empty, never throws", async () => {
-    // LISA_HOME is a const fixed at import, so simulate "no user music" by
+    // lisaHome() is a const fixed at import, so simulate "no user music" by
     // removing the dir, and point at a bundled dir with no manifest.json.
     fs.rmSync(mod.userMusicDir(), { recursive: true, force: true });
     const empty = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-music-empty-"));

--- a/src/web/room-music.ts
+++ b/src/web/room-music.ts
@@ -14,7 +14,7 @@
  */
 import fs from "node:fs/promises";
 import path from "node:path";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome } from "../paths.js";
 
 export type MusicMood = "classical" | "light" | "classic" | "mine";
 
@@ -44,7 +44,7 @@ interface BundledManifestEntry {
 }
 
 export function userMusicDir(): string {
-  return path.join(LISA_HOME, "music");
+  return path.join(lisaHome(), "music");
 }
 
 const MOODS: ReadonlySet<string> = new Set(["classical", "light", "classic", "mine"]);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -97,7 +97,7 @@ import {
   type SuggestionProvider,
 } from "../screen_advisor/engine.js";
 import os from "node:os";
-import { LISA_HOME } from "../paths.js";
+import { lisaHome, lisaGlobalHome, homeScope, homeForUid } from "../paths.js";
 import { isCloud, editionInfo } from "../edition.js";
 import {
   verifyAppleIdentityToken,
@@ -261,7 +261,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   const host = opts.host ?? "127.0.0.1";
   const webToken = process.env.LISA_WEB_TOKEN?.trim() || null;
   // Account sessions (PLAN_ACCOUNTS_BILLING B1): the signing secret lives in
-  // $LISA_HOME (auto-created 0600; durable on the cloud's /data mount). Only the
+  // $lisaHome() (auto-created 0600; durable on the cloud's /data mount). Only the
   // cloud edition mints/verifies account sessions today — the Mac edition gains
   // a client-side use in B6 (managed inference).
   const sessionSecret = isCloud() ? loadOrCreateSessionSecret() : null;
@@ -277,14 +277,17 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   const initialFingerprint = await getPromptFingerprint();
   // Per-process hot-reload cache for the web server: same shape as cli's
   // makeHotReloadRebuilder, inlined here so the web server stays standalone.
-  let cachedFp = initialFingerprint;
-  let cachedText = snapshot.text;
+  // Keyed by the ACTIVE home (B2): each cloud account gets its own soul, so the
+  // prompt snapshot must be cached per-uid, not process-wide.
+  const promptCache = new Map<string, { fp: string; text: string }>();
+  promptCache.set(lisaGlobalHome(), { fp: initialFingerprint, text: snapshot.text });
   const rebuildPrompt = async (): Promise<{ text: string; fingerprint: string }> => {
+    const key = lisaHome();
     const fp = await getPromptFingerprint();
-    if (fp === cachedFp) return { text: cachedText, fingerprint: fp };
+    const cached = promptCache.get(key);
+    if (cached && fp === cached.fp) return { text: cached.text, fingerprint: fp };
     const next = await buildSystemPromptSnapshot();
-    cachedFp = fp;
-    cachedText = next.text;
+    promptCache.set(key, { fp, text: next.text });
     return { text: next.text, fingerprint: fp };
   };
   // Resume previous chat across restarts. Three-tier fallback:
@@ -315,7 +318,60 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   // would run two agents against the same history reference and clobber each
   // other's `history.length = 0; history.push(...)` at the end. Same model as
   // the channels router's per-thread busy+queue, with a promise chain.
-  let chatChain: Promise<void> = Promise.resolve();
+  //
+  // ── Per-account conversation contexts (B2 multi-tenant seam) ──────────────
+  // The module-level session/history above serve the Mac edition and legacy
+  // shared-token cloud callers (one shared conversation — unchanged). A
+  // signed-in cloud request runs inside homeScope, and gets its OWN context,
+  // created lazily INSIDE that scope so every path underneath — sessions dir,
+  // active pointer, soul, memory — resolves into the user's subtree. The
+  // background schedulers (idle/reflect) keep operating on the global context
+  // only; per-uid autonomy is gated on per-uid budgets (B4+).
+  interface ChatCtx {
+    session: SessionStore;
+    history: StoredMessage[];
+    chain: Promise<void>;
+  }
+  const globalChat: ChatCtx = { session, history, chain: Promise.resolve() };
+  const uidChats = new Map<string, ChatCtx>();
+  const ctxForRequest = async (): Promise<ChatCtx> => {
+    const scoped = homeScope.getStore();
+    if (!scoped) return globalChat;
+    let ctx = uidChats.get(scoped);
+    if (!ctx) {
+      const s = await resumeOrCreateWebSession(opts.model);
+      await writeActiveWebSession(s.id);
+      const { messages } = await s.readMessagePage(0, 9999);
+      ctx = { session: s, history: [...messages], chain: Promise.resolve() };
+      uidChats.set(scoped, ctx);
+    }
+    return ctx;
+  };
+
+  // Lazy per-user birth (B2): a signed-in user's first request seeds THEIR soul
+  // (the entrypoint's one-shot birth only covers the shared/global home). Runs
+  // in the background inside the caller's home scope; chat before it completes
+  // simply runs with the bare prompt and the soul arrives mid-conversation.
+  const birthsInFlight = new Set<string>();
+  const ensureUserBirth = (uid: string): void => {
+    if (birthsInFlight.has(uid)) return;
+    birthsInFlight.add(uid);
+    void (async () => {
+      try {
+        const { isBorn } = await import("../soul/store.js");
+        if (await isBorn()) return; // reads inside the per-uid scope
+        console.error(`[accounts] birthing a soul for ${uid}…`);
+        const { birth } = await import("../soul/birth.js");
+        await birth({ model: opts.model });
+        promptCache.delete(lisaHome()); // pick the newborn soul up next turn
+        console.error(`[accounts] soul born for ${uid}`);
+      } catch (e) {
+        console.error(`[accounts] birth failed for ${uid}: ${(e as Error).message}`);
+      } finally {
+        birthsInFlight.delete(uid);
+      }
+    })();
+  };
 
   // ── Persistent /events SSE subscribers (mood + idle broadcasts) ─────
   const eventClients = new Set<http.ServerResponse>();
@@ -339,7 +395,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   // normalized stream. Privacy: structural metadata only (see types.ts +
   // each adapter). Replaces the single-purpose ClaudeCodeWatcher wiring.
   const orchestratorCfg = await loadOrchestratorConfig(
-    path.join(LISA_HOME, "agents.json"),
+    path.join(lisaHome(), "agents.json"),
   );
   const hub = new OrchestratorHub(orchestratorCfg, {
     log: (msg) => console.error(msg),
@@ -914,6 +970,16 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           `lisa_token=${encodeURIComponent(presented)}; HttpOnly; SameSite=Strict; Path=/`,
         );
       }
+      // ── Per-uid home scope (B2) ────────────────────────────────────────────
+      // From here on, every path helper — soul, sessions, memory, billing —
+      // resolves into this account's subtree, including across awaits
+      // (AsyncLocalStorage.enterWith sticks to this async chain).
+      if (cloud && accountUid) {
+        const uidHome = homeForUid(accountUid);
+        await fs.mkdir(uidHome, { recursive: true });
+        homeScope.enterWith(uidHome);
+        ensureUserBirth(accountUid);
+      }
     }
 
     // ── Account introspection + deletion (post-gate; PLAN_ACCOUNTS_BILLING B1) ──
@@ -940,16 +1006,17 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         return;
       }
       const removed = deleteAccount(accountUid);
-      // Remove the per-uid home (B2 layout; a no-op before it exists). The
-      // account record going away already killed every session via sv-check.
+      // Remove the per-uid home + in-memory context. The account record going
+      // away already killed every session via the sv-check.
       try {
-        const home = process.env.LISA_HOME ?? path.join(os.homedir(), ".lisa");
-        const userHome = path.join(home, "users", accountUid);
+        const userHome = homeForUid(accountUid);
         // Refuse to follow a surprising path — belt & braces against uid tampering
         // (uids are server-minted, but cheap to double-check).
-        if (userHome.startsWith(path.join(home, "users") + path.sep)) {
+        if (userHome.startsWith(path.join(lisaGlobalHome(), "users") + path.sep)) {
           await fs.rm(userHome, { recursive: true, force: true });
         }
+        uidChats.delete(userHome);
+        promptCache.delete(userHome);
       } catch (e) {
         console.error(`[auth] account home cleanup failed: ${(e as Error).message}`);
       }
@@ -1985,18 +2052,20 @@ self.addEventListener('fetch', (event) => {
     }
 
     if (req.method === "GET" && url === "/session") {
+      const chat = await ctxForRequest();
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ id: session.id, model: opts.model }));
+      res.end(JSON.stringify({ id: chat.session.id, model: opts.model }));
       return;
     }
 
     if (req.method === "GET" && url === "/events") {
+      const chat = await ctxForRequest();
       res.writeHead(200, {
         "content-type": "text/event-stream",
         "cache-control": "no-cache",
         connection: "keep-alive",
       });
-      res.write(`data: ${JSON.stringify({ type: "hello", session: session.id })}\n\n`);
+      res.write(`data: ${JSON.stringify({ type: "hello", session: chat.session.id })}\n\n`);
       // Send current mood right away
       res.write(`data: ${JSON.stringify({ type: "mood", slug: moodBus.current() })}\n\n`);
       eventClients.add(res);
@@ -2008,7 +2077,7 @@ self.addEventListener('fetch', (event) => {
       const qs = new URL(url, "http://localhost").searchParams;
       const page = Math.max(0, parseInt(qs.get("page") ?? "0", 10));
       const pageSize = 20;
-      const { messages, hasMore } = await session.readMessagePage(page, pageSize);
+      const { messages, hasMore } = await (await ctxForRequest()).session.readMessagePage(page, pageSize);
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ messages, hasMore, page }));
       return;
@@ -2396,6 +2465,7 @@ self.addEventListener('fetch', (event) => {
     }
 
     if (req.method === "POST" && url === "/chat") {
+      const chat = await ctxForRequest();
       let body = "";
       for await (const chunk of req) body += chunk.toString("utf8");
       let message: string;
@@ -2466,7 +2536,7 @@ self.addEventListener('fetch', (event) => {
               signal: AbortSignal.any([abort.signal, turnAbort.signal]),
               log: () => {},
             },
-            history,
+            history: chat.history,
             userMessage: message,
             userFiles: files,
             model: opts.model,
@@ -2508,7 +2578,7 @@ self.addEventListener('fetch', (event) => {
               const r = await fireHooks(
                 "PreToolUse",
                 hooks,
-                { TOOL_NAME: name, TOOL_INPUT: JSON.stringify(input), SESSION_ID: session.id, LISA_HOME, CLAUDE_PROJECT_DIR: process.cwd() },
+                { TOOL_NAME: name, TOOL_INPUT: JSON.stringify(input), SESSION_ID: chat.session.id, LISA_HOME: lisaHome(), CLAUDE_PROJECT_DIR: process.cwd() },
                 process.cwd(),
               );
               if (r.blocked.length > 0) return { block: r.blocked.join("; ") };
@@ -2522,22 +2592,22 @@ self.addEventListener('fetch', (event) => {
                   TOOL_INPUT: JSON.stringify(input),
                   TOOL_RESULT: result,
                   TOOL_ERROR: isError ? "1" : "",
-                  SESSION_ID: session.id,
-                  LISA_HOME,
+                  SESSION_ID: chat.session.id,
+                  LISA_HOME: lisaHome(),
                   CLAUDE_PROJECT_DIR: process.cwd(),
                 },
                 process.cwd(),
               );
               if (r.rewriteResult != null) return { rewriteResult: r.rewriteResult };
             },
-            onMessagePersist: (m) => session.appendMessage(m),
+            onMessagePersist: (m) => chat.session.appendMessage(m),
             hotReload: {
               initialFingerprint: fresh.fingerprint,
               rebuild: rebuildPrompt,
             },
           });
-          history.length = 0;
-          history.push(...result.history);
+          chat.history.length = 0;
+          chat.history.push(...result.history);
           if (!anyText && !anyTool && !errorSent) send({ type: "empty" });
           send({ type: "done" });
         } catch (err) {
@@ -2547,10 +2617,11 @@ self.addEventListener('fetch', (event) => {
           res.end();
         }
       };
-      // Queue behind any in-flight turn; the SSE stream stays open while we
-      // wait, so the second tab just sees its reply start a little later.
-      const job = chatChain.then(runTurn, runTurn);
-      chatChain = job.then(
+      // Queue behind any in-flight turn ON THIS CONTEXT (per-uid, so one
+      // account's long turn never blocks another's); the SSE stream stays open
+      // while we wait, so the second tab just sees its reply start later.
+      const job = chat.chain.then(runTurn, runTurn);
+      chat.chain = job.then(
         () => {},
         () => {},
       );
@@ -2559,10 +2630,11 @@ self.addEventListener('fetch', (event) => {
     }
 
     if (req.method === "POST" && url === "/reflect") {
+      const chat = await ctxForRequest();
       try {
         const r = await reflectOnSession({
-          history,
-          sessionId: session.id,
+          history: chat.history,
+          sessionId: chat.session.id,
           model: opts.model,
         });
         res.writeHead(200, { "content-type": "application/json" });

--- a/src/web/sessions-auth.ts
+++ b/src/web/sessions-auth.ts
@@ -11,7 +11,7 @@
  * `sv` is the account's session version: bumping it (or deleting the account)
  * invalidates every outstanding session for that uid without any server-side
  * session store. Stateless by design — the single secret lives next to the
- * other credentials in `$LISA_HOME` (0600), auto-created on first use so the
+ * other credentials in `$lisaHome()` (0600), auto-created on first use so the
  * cloud container needs no extra env to turn accounts on.
  */
 import fs from "node:fs";
@@ -44,7 +44,7 @@ function secretPath(): string {
 
 /**
  * Load the session-signing secret, creating (and persisting, 0600) a random one
- * on first use. On the cloud image `$LISA_HOME` is the durable /data mount, so
+ * on first use. On the cloud image `$lisaHome()` is the durable /data mount, so
  * sessions survive restarts; losing the file merely signs everyone out.
  */
 export function loadOrCreateSessionSecret(): string {

--- a/src/web/tenancy.test.ts
+++ b/src/web/tenancy.test.ts
@@ -1,0 +1,88 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-tenancy-"));
+process.env.LISA_HOME = TMP;
+// Soul git history is irrelevant here and just slows the writes down.
+process.env.LISA_SOUL_NO_GIT = "1";
+
+const { lisaHome, lisaGlobalHome, homeScope, homeForUid, sessionsDir } = await import("../paths.js");
+const soulPaths = await import("../soul/paths.js");
+const soulStore = await import("../soul/store.js");
+
+const HOME_A = homeForUid("apple-001.aaa");
+const HOME_B = homeForUid("em-bbbbbbbbbbbbbbbbbb");
+
+describe("per-uid home scope (B2)", () => {
+  test("outside any scope, lisaHome == the global home", () => {
+    assert.equal(lisaHome(), TMP);
+    assert.equal(lisaGlobalHome(), TMP);
+  });
+
+  test("homeForUid nests under <global>/users/<uid>", () => {
+    assert.equal(HOME_A, path.join(TMP, "users", "apple-001.aaa"));
+  });
+
+  test("inside a scope every path helper resolves into that user's subtree", () => {
+    homeScope.run(HOME_A, () => {
+      assert.equal(lisaHome(), HOME_A);
+      assert.ok(soulPaths.soulDir().startsWith(HOME_A));
+      assert.ok(sessionsDir().startsWith(HOME_A));
+      // The operator home is NOT rescoped — config/accounts stay global.
+      assert.equal(lisaGlobalHome(), TMP);
+    });
+    // Scope does not leak once run() returns.
+    assert.equal(lisaHome(), TMP);
+  });
+
+  test("the scope survives awaits (async continuations keep their home)", async () => {
+    await homeScope.run(HOME_A, async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      assert.equal(lisaHome(), HOME_A);
+      await new Promise((r) => setTimeout(r, 5));
+      assert.ok(soulPaths.soulJournalDir().startsWith(HOME_A));
+    });
+  });
+
+  test("two tenants write souls that land in disjoint subtrees", async () => {
+    await homeScope.run(HOME_A, async () => {
+      await soulStore.ensureSoulDirs();
+      await soulStore.writeName("Aria");
+    });
+    await homeScope.run(HOME_B, async () => {
+      await soulStore.ensureSoulDirs();
+      await soulStore.writeName("Belle");
+    });
+    // On-disk isolation:
+    const nameA = fs.readFileSync(path.join(HOME_A, "soul", "name.md"), "utf8");
+    const nameB = fs.readFileSync(path.join(HOME_B, "soul", "name.md"), "utf8");
+    assert.match(nameA, /Aria/);
+    assert.match(nameB, /Belle/);
+    // Cross-tenant read impossible through the store:
+    await homeScope.run(HOME_A, async () => {
+      assert.equal(await soulStore.readName(), "Aria");
+    });
+    await homeScope.run(HOME_B, async () => {
+      assert.equal(await soulStore.readName(), "Belle");
+    });
+    // The global home saw neither soul.
+    assert.equal(fs.existsSync(path.join(TMP, "soul", "name.md")), false);
+  });
+
+  test("isBorn is scoped: born in A, unborn in B and globally", async () => {
+    await homeScope.run(HOME_A, async () => {
+      await soulStore.writeSeed({
+        bornAt: new Date().toISOString(),
+        bigFive: { openness: 0.5, conscientiousness: 0.5, extraversion: 0.5, agreeableness: 0.5, neuroticism: 0.5 },
+      } as never);
+      assert.equal(await soulStore.isBorn(), true);
+    });
+    await homeScope.run(HOME_B, async () => {
+      assert.equal(await soulStore.isBorn(), false);
+    });
+    assert.equal(await soulStore.isBorn(), false);
+  });
+});


### PR DESCRIPTION
**Stacked on #261.** The multi-tenant core — the gate before any real cloud user beyond a reviewer.

## Design

Two homes, deliberately:
- **`lisaGlobalHome()`** — operator/process home: `config.env`, `accounts.json`, device tokens, session secret. Never per-uid.
- **`lisaHome()`** — the ACTIVE home for identity-bearing state (soul, sessions, memory, reflections, kb, autonomy…). AsyncLocalStorage-scoped: a signed-in cloud request enters `homeScope` with `$LISA_HOME/users/<uid>` and every downstream path — across awaits — resolves there.

Path **constants became functions** (`SESSIONS_DIR` → `sessionsDir()` etc., 65 files) because an import-time constant freezes the home — exactly what made the codebase single-tenant. Module-scope constants that captured the home at import were functionized too (active-session pointer, autonomy dir, embeddings cache, advisor state…).

## Server

- Per-uid **ChatCtx** `{session, history, chain}`: each account gets its own conversation, restore-from-disk, and serialized turn queue — one account's long turn no longer blocks another's.
- Prompt snapshot cache keyed by active home (per-uid souls → per-uid prompts).
- **Lazy per-user birth**: first signed-in request births that user's soul in the background (deduped per uid); chatting before it completes runs on the bare prompt and the soul arrives mid-conversation.
- Account deletion clears the home subtree + in-memory contexts.

## Mac edition: zero change

No scope is ever entered → `lisaHome()` degrades to the global home; the global chat context is byte-for-byte the old code path. Background schedulers (idle/reflect) stay global-only; per-uid autonomy is gated on per-uid budgets (B4+).

## Tests

New tenancy suite: scope resolution, await-survival, **two tenants writing disjoint souls, cross-tenant reads impossible**, isBorn scoping. Full suite **1038 pass / 0 fail**.

## Notes / follow-ups

- Firestore for accounts/balances (multi-instance unlock) is deferred to a follow-up PR — file-backed state stays correct under `min=max=1`, which deploy.sh still pins.
- GCS `/data` needs no change: per-uid is just the `/data/users/<uid>` subtree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)