### PR TITLE
feat(billing): B3 — price table + per-uid usage meter + usage API

### DIFF
--- a/src/autonomy/runs.ts
+++ b/src/autonomy/runs.ts
@@ -21,8 +21,12 @@ import { withFileLock } from "../soul/lock.js";
 export function autonomyDir(): string {
   return path.join(lisaHome(), "autonomy");
 }
-const RUNS_FILE = path.join(autonomyDir(), "runs.jsonl");
-const RUNS_LOCK = path.join(autonomyDir(), "runs.lock");
+function runsFile(): string {
+  return path.join(autonomyDir(), "runs.jsonl");
+}
+function runsLock(): string {
+  return path.join(autonomyDir(), "runs.lock");
+}
 const MAX_RUNS = 2000;
 
 /** Which self-driven mechanism produced the run. */
@@ -56,19 +60,19 @@ export interface AutonomyRun {
 /** Append one run record; trim the ledger opportunistically. Never throws. */
 export async function recordAutonomyRun(run: AutonomyRun): Promise<void> {
   try {
-    await appendLine(RUNS_FILE, JSON.stringify(run));
+    await appendLine(runsFile(), JSON.stringify(run));
   } catch {
     return; // recording is best-effort; never break the autonomy run on it
   }
   try {
-    const lineCount = (await readTextOrEmpty(RUNS_FILE)).split("\n").filter((l) => l.trim()).length;
+    const lineCount = (await readTextOrEmpty(runsFile())).split("\n").filter((l) => l.trim()).length;
     if (lineCount > MAX_RUNS) {
       await withFileLock(
-        RUNS_LOCK,
+        runsLock(),
         async () => {
-          const lines = (await readTextOrEmpty(RUNS_FILE)).split("\n").filter((l) => l.trim());
+          const lines = (await readTextOrEmpty(runsFile())).split("\n").filter((l) => l.trim());
           if (lines.length > MAX_RUNS) {
-            await atomicWrite(RUNS_FILE, lines.slice(lines.length - MAX_RUNS).join("\n") + "\n");
+            await atomicWrite(runsFile(), lines.slice(lines.length - MAX_RUNS).join("\n") + "\n");
           }
         },
         { timeoutMs: 2_000, staleMs: 60_000 },
@@ -81,7 +85,7 @@ export async function recordAutonomyRun(run: AutonomyRun): Promise<void> {
 
 /** Read run records, optionally only those within the last `sinceMs`. */
 export async function readAutonomyRuns(sinceMs?: number): Promise<AutonomyRun[]> {
-  const raw = await readTextOrEmpty(RUNS_FILE);
+  const raw = await readTextOrEmpty(runsFile());
   const cutoff = sinceMs != null ? Date.now() - sinceMs : null;
   const out: AutonomyRun[] = [];
   for (const line of raw.split("\n")) {

--- a/src/billing/meter.test.ts
+++ b/src/billing/meter.test.ts
@@ -1,0 +1,83 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-billing-"));
+process.env.LISA_HOME = TMP;
+
+const { homeScope, homeForUid } = await import("../paths.js");
+const { recordUsage, readUsage, summarizeUsage } = await import("./meter.js");
+const { costMicroUSD, priceForModel, modelTier, formatMicroUSD, MARGIN } = await import("./prices.js");
+
+const U = (i: number, o: number, cr = 0, cw = 0) => ({
+  inputTokens: i,
+  outputTokens: o,
+  cacheReadTokens: cr,
+  cacheWriteTokens: cw,
+});
+
+describe("prices", () => {
+  test("glm is standard tier; claude/gpt/unknown are premium", () => {
+    assert.equal(modelTier("glm-4.6"), "standard");
+    assert.equal(modelTier("claude-sonnet-4-6"), "premium");
+    assert.equal(modelTier("gpt-4o"), "premium");
+    assert.equal(modelTier("totally-unknown-model"), "premium");
+  });
+
+  test("cost math: face = list × margin, exact micro-USD", () => {
+    // 1M output tokens of glm-4.6 at $2.2 list × 1.4 margin = $3.08 face.
+    assert.equal(costMicroUSD("glm-4.6", U(0, 1_000_000)), Math.round(2.2 * MARGIN * 1e6));
+    // Zero usage costs zero; tiny usage rounds UP (never free).
+    assert.equal(costMicroUSD("glm-4.6", U(0, 0)), 0);
+    assert.equal(costMicroUSD("glm-4.6", U(1, 0)) >= 1, true);
+  });
+
+  test("unknown model gets the conservative fallback, not free", () => {
+    const p = priceForModel("mystery-9000");
+    assert.equal(p.tier, "premium");
+    assert.ok(p.outPerM > 0);
+  });
+
+  test("formatMicroUSD renders dollars", () => {
+    assert.equal(formatMicroUSD(3_080_000), "$3.08");
+  });
+});
+
+describe("meter ledger", () => {
+  test("record → read → summarize round-trip", async () => {
+    const rec = await recordUsage("chat", "glm-4.6", U(1000, 2000), new Date("2026-07-22T10:00:00Z"));
+    assert.ok(rec);
+    assert.equal(rec.model, "glm-4.6");
+    assert.ok(rec.microUSD > 0);
+    const rows = await readUsage();
+    assert.equal(rows.length, 1);
+    const sum = await summarizeUsage(Date.parse("2026-07-22T00:00:00Z"));
+    assert.equal(sum.turns, 1);
+    assert.equal(sum.microUSD, rec.microUSD);
+    assert.equal(sum.inputTokens, 1000);
+    // A window starting after the record excludes it.
+    const later = await summarizeUsage(Date.parse("2026-07-23T00:00:00Z"));
+    assert.equal(later.turns, 0);
+  });
+
+  test("ledger is per-home: a scoped uid writes into its own subtree", async () => {
+    const HOME_A = homeForUid("em-metertest");
+    await homeScope.run(HOME_A, async () => {
+      await recordUsage("chat", "glm-4.6", U(10, 10));
+      const scoped = await readUsage();
+      assert.equal(scoped.length, 1);
+    });
+    assert.ok(fs.existsSync(path.join(HOME_A, "billing", "usage.jsonl")));
+    // The global ledger from the previous test still has exactly one row.
+    const globalRows = await readUsage();
+    assert.equal(globalRows.length, 1);
+  });
+
+  test("corrupt lines are skipped, not fatal", async () => {
+    fs.appendFileSync(path.join(TMP, "billing", "usage.jsonl"), "not-json\n");
+    const rows = await readUsage();
+    assert.equal(rows.length, 1);
+  });
+});

--- a/src/billing/meter.ts
+++ b/src/billing/meter.ts
@@ -1,0 +1,134 @@
+/**
+ * Usage meter — the per-user token/cost ledger
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.3, milestone B3).
+ *
+ * Every LLM turn appends one line to `<active home>/billing/usage.jsonl` —
+ * inside a signed-in cloud request that's the user's subtree (B2 home scope),
+ * on the Mac edition it's the local home. The JSONL is the AUDIT SOURCE; the
+ * quota engine (B4) keeps a fast-path `balance.json` beside it that can always
+ * be rebuilt from here.
+ *
+ * Same storage discipline as autonomy/runs.ts: append-only, bounded to
+ * MAX_LINES with an opportunistic trim under a cross-process lock, and
+ * recording NEVER throws (metering must not take chat down).
+ */
+import path from "node:path";
+import { lisaHome } from "../paths.js";
+import { appendLine, readTextOrEmpty, atomicWrite } from "../fs-utils.js";
+import { withFileLock } from "../soul/lock.js";
+import type { ProviderUsage } from "../providers/types.js";
+import { costMicroUSD, PRICES_VERSION } from "./prices.js";
+
+export function billingDir(): string {
+  return path.join(lisaHome(), "billing");
+}
+function usageFile(): string {
+  return path.join(billingDir(), "usage.jsonl");
+}
+function usageLock(): string {
+  return path.join(billingDir(), "usage.lock");
+}
+
+const MAX_LINES = 5000;
+
+/** One metered LLM turn. */
+export interface UsageRecord {
+  /** ISO 8601. */
+  at: string;
+  /** What drove the turn ("chat" today; "gw" for the B6 gateway, etc.). */
+  source: string;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  /** Face cost, micro-USD, priced by prices.ts at PRICES_VERSION. */
+  microUSD: number;
+  pricesVersion: number;
+}
+
+/**
+ * Append one usage line for the ACTIVE home (call inside the request's home
+ * scope). Returns the priced record (or null when recording failed) — the
+ * quota engine consumes the returned cost.
+ */
+export async function recordUsage(
+  source: string,
+  model: string,
+  usage: ProviderUsage,
+  now: Date = new Date(),
+): Promise<UsageRecord | null> {
+  const rec: UsageRecord = {
+    at: now.toISOString(),
+    source,
+    model,
+    inputTokens: usage.inputTokens,
+    outputTokens: usage.outputTokens,
+    cacheReadTokens: usage.cacheReadTokens,
+    cacheWriteTokens: usage.cacheWriteTokens,
+    microUSD: costMicroUSD(model, usage),
+    pricesVersion: PRICES_VERSION,
+  };
+  try {
+    await appendLine(usageFile(), JSON.stringify(rec));
+    void trimIfNeeded();
+    return rec;
+  } catch (err) {
+    console.error(`[billing] usage record failed: ${(err as Error).message}`);
+    return null;
+  }
+}
+
+async function trimIfNeeded(): Promise<void> {
+  try {
+    const text = await readTextOrEmpty(usageFile());
+    const lines = text.split("\n").filter(Boolean);
+    if (lines.length <= MAX_LINES) return;
+    await withFileLock(usageLock(), async () => {
+      const fresh = (await readTextOrEmpty(usageFile())).split("\n").filter(Boolean);
+      if (fresh.length <= MAX_LINES) return;
+      await atomicWrite(usageFile(), fresh.slice(-MAX_LINES).join("\n") + "\n");
+    });
+  } catch {
+    // trim is best-effort
+  }
+}
+
+/** Read the ledger (oldest → newest). Tolerates a corrupt line. */
+export async function readUsage(): Promise<UsageRecord[]> {
+  const text = await readTextOrEmpty(usageFile());
+  const out: UsageRecord[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const rec = JSON.parse(line) as UsageRecord;
+      if (typeof rec.at === "string" && typeof rec.microUSD === "number") out.push(rec);
+    } catch {
+      // skip corrupt line
+    }
+  }
+  return out;
+}
+
+export interface UsageSummary {
+  /** Face micro-USD spent inside the window. */
+  microUSD: number;
+  inputTokens: number;
+  outputTokens: number;
+  turns: number;
+}
+
+/** Aggregate the ledger over [since, now]. */
+export async function summarizeUsage(sinceMs: number): Promise<UsageSummary> {
+  const rows = await readUsage();
+  const out: UsageSummary = { microUSD: 0, inputTokens: 0, outputTokens: 0, turns: 0 };
+  for (const r of rows) {
+    const t = Date.parse(r.at);
+    if (!Number.isFinite(t) || t < sinceMs) continue;
+    out.microUSD += r.microUSD;
+    out.inputTokens += r.inputTokens;
+    out.outputTokens += r.outputTokens;
+    out.turns += 1;
+  }
+  return out;
+}

--- a/src/billing/prices.ts
+++ b/src/billing/prices.ts
@@ -1,0 +1,93 @@
+/**
+ * Model price table — FACE-VALUE pricing for LISA-billed usage
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.3/§7, milestone B3).
+ *
+ * Face price = provider list price × MARGIN. The margin (1.4×) covers Apple's
+ * commission on credit packs, infra, and refund slippage. All amounts are
+ * micro-USD (1e-6 USD, integers) per MILLION tokens, so arithmetic stays exact.
+ *
+ * Keep this table in sync with the providers' official price pages when
+ * onboarding a model — it is versioned with the code on purpose (an audit can
+ * pin any ledger line to the table that priced it via `PRICES_VERSION`).
+ *
+ * Tiers: "standard" models are eligible for the free session window; "premium"
+ * models only ever draw from paid balance (the one hard product constraint —
+ * see §7 of the plan).
+ */
+import type { ProviderUsage } from "../providers/types.js";
+
+export const PRICES_VERSION = 1;
+export const MARGIN = 1.4;
+
+export type ModelTier = "standard" | "premium";
+
+export interface ModelPrice {
+  /** Face price, micro-USD per 1M input tokens. */
+  inPerM: number;
+  /** Face price, micro-USD per 1M output tokens. */
+  outPerM: number;
+  /** Face price, micro-USD per 1M cache-write tokens. */
+  cacheWritePerM: number;
+  /** Face price, micro-USD per 1M cache-read tokens. */
+  cacheReadPerM: number;
+  tier: ModelTier;
+}
+
+/** $/M → micro-USD/M at face value (list × margin). */
+function face(usdPerM: number): number {
+  return Math.round(usdPerM * MARGIN * 1_000_000);
+}
+
+/**
+ * Longest-prefix match table. List prices as of 2026-07 — re-check the
+ * provider price pages before onboarding a new model.
+ */
+const TABLE: Array<{ prefix: string; price: ModelPrice }> = [
+  // GLM (Zhipu, open.bigmodel.cn) — the standard/free-window family.
+  { prefix: "glm-", price: { inPerM: face(0.6), outPerM: face(2.2), cacheWritePerM: face(0.6), cacheReadPerM: face(0.11), tier: "standard" } },
+  { prefix: "chatglm-", price: { inPerM: face(0.6), outPerM: face(2.2), cacheWritePerM: face(0.6), cacheReadPerM: face(0.11), tier: "standard" } },
+  // Anthropic — premium (paid balance only).
+  { prefix: "claude-haiku", price: { inPerM: face(1), outPerM: face(5), cacheWritePerM: face(1.25), cacheReadPerM: face(0.1), tier: "premium" } },
+  { prefix: "claude-sonnet", price: { inPerM: face(3), outPerM: face(15), cacheWritePerM: face(3.75), cacheReadPerM: face(0.3), tier: "premium" } },
+  { prefix: "claude-opus", price: { inPerM: face(5), outPerM: face(25), cacheWritePerM: face(6.25), cacheReadPerM: face(0.5), tier: "premium" } },
+  { prefix: "claude-", price: { inPerM: face(3), outPerM: face(15), cacheWritePerM: face(3.75), cacheReadPerM: face(0.3), tier: "premium" } },
+  // OpenAI — premium.
+  { prefix: "gpt-4o-mini", price: { inPerM: face(0.15), outPerM: face(0.6), cacheWritePerM: face(0.15), cacheReadPerM: face(0.075), tier: "premium" } },
+  { prefix: "gpt-", price: { inPerM: face(2.5), outPerM: face(10), cacheWritePerM: face(2.5), cacheReadPerM: face(1.25), tier: "premium" } },
+];
+
+/**
+ * Conservative fallback for unknown models: priced like a mid premium model so
+ * a table gap can never hand out free inference; tier "premium" keeps it off
+ * the free window.
+ */
+const FALLBACK: ModelPrice = { inPerM: face(3), outPerM: face(15), cacheWritePerM: face(3.75), cacheReadPerM: face(0.3), tier: "premium" };
+
+export function priceForModel(model: string): ModelPrice {
+  const m = model.trim().toLowerCase();
+  for (const { prefix, price } of TABLE) {
+    if (m.startsWith(prefix)) return price;
+  }
+  return FALLBACK;
+}
+
+export function modelTier(model: string): ModelTier {
+  return priceForModel(model).tier;
+}
+
+/** Face cost of one usage sample, micro-USD (integer, rounded up ≥ 0). */
+export function costMicroUSD(model: string, usage: ProviderUsage): number {
+  const p = priceForModel(model);
+  const cost =
+    (usage.inputTokens * p.inPerM +
+      usage.outputTokens * p.outPerM +
+      usage.cacheWriteTokens * p.cacheWritePerM +
+      usage.cacheReadTokens * p.cacheReadPerM) /
+    1_000_000;
+  return Math.max(0, Math.ceil(cost));
+}
+
+/** Render micro-USD as a human dollar string ("$1.23"). */
+export function formatMicroUSD(micro: number): string {
+  return `$${(micro / 1_000_000).toFixed(2)}`;
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -37,6 +37,8 @@ import {
 } from "../soul/desire-focus.js";
 import { ISLAND_HTML } from "./island.js";
 import { LOGIN_HTML } from "./login.js";
+import { recordUsage, summarizeUsage } from "../billing/meter.js";
+import { PRICES_VERSION } from "../billing/prices.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
@@ -994,6 +996,19 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
             : { signedIn: false },
         ),
       );
+      return;
+    }
+
+    if (req.method === "GET" && url === "/api/billing/usage") {
+      // Usage for the ACTIVE home — the signed-in account's ledger on cloud,
+      // the local ledger otherwise. 12h aligns with the quota window (B4).
+      const now = Date.now();
+      const [window12h, today] = await Promise.all([
+        summarizeUsage(now - 12 * 60 * 60 * 1000),
+        summarizeUsage(new Date(new Date(now).setHours(0, 0, 0, 0)).getTime()),
+      ]);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ window12h, today, pricesVersion: PRICES_VERSION }));
       return;
     }
 
@@ -2608,6 +2623,17 @@ self.addEventListener('fetch', (event) => {
           });
           chat.history.length = 0;
           chat.history.push(...result.history);
+          // Metering (B3): price the turn into the ACTIVE home's ledger — the
+          // per-uid subtree for signed-in cloud accounts. Mac edition (BYO key)
+          // is not metered. Never throws.
+          if (cloud) {
+            void recordUsage("chat", opts.model, {
+              inputTokens: result.inputTokens,
+              outputTokens: result.outputTokens,
+              cacheReadTokens: result.cacheReadTokens,
+              cacheWriteTokens: result.cacheWriteTokens,
+            });
+          }
           if (!anyText && !anyTool && !errorSent) send({ type: "empty" });
           send({ type: "done" });
         } catch (err) {


### PR DESCRIPTION
**Stacked on #262.** Milestone B3: metering. Interactive chat was already computing token usage every turn and **discarding it** at the `runAgent` result — this PR catches it, prices it, and ledgers it per user.

## What

- **`prices.ts`** — longest-prefix model table, integer micro-USD per M tokens. Face = provider list × **1.4 margin**. GLM = *standard* tier (free-window eligible in B4); Claude/GPT = *premium* (paid balance only). Unknown models fall back to premium pricing — a table gap can never hand out free inference. `PRICES_VERSION` stamps every ledger line.
- **`meter.ts`** — append-only `billing/usage.jsonl` in the ACTIVE home (per-uid under B2's scope): the audit source the B4 `balance.json` fast-path can always be rebuilt from. Same lock+trim discipline as `autonomy/runs.jsonl`; `recordUsage` never throws.
- **`server.ts`** — `/chat` meters each turn (cloud edition only; Mac/BYO stays unmetered), `GET /api/billing/usage` returns 12h-window + today summaries for the signed-in account.
- Fixed two module-scope paths in `autonomy/runs.ts` that still froze the home at import (missed in B2's sweep).

## Tests

Price tiers / margin math / round-up-never-free / ledger round-trip / per-home scoping / corrupt-line tolerance. Full suite **1045 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)