### PR TITLE
feat(billing): B4 — 12h session window + paid tiers + 402 paywall + budget breaker

### DIFF
--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -155,12 +155,40 @@ struct AccountCard: View {
     @EnvironmentObject var app: AppState
     @State private var showDeleteConfirm = false
     @State private var deleting = false
+    @State private var quota: LisaClient.QuotaStatus?
+
+    private static let tierLabels: [String: String] = [
+        "free": "Free", "free-unverified": "Free (verify email for more)",
+        "tier1": "Tier 1", "tier2": "Tier 2",
+    ]
 
     var body: some View {
         Section("LISA account") {
             if let acct = app.account, acct.signedIn {
                 LabeledContent("Signed in as", value: acct.email ?? acct.uid ?? "—")
-                LabeledContent("Plan", value: (acct.plan ?? "free").capitalized)
+                if let q = quota, q.available, let window = q.windowMicroUSD, window > 0 {
+                    let spent = q.spentMicroUSD ?? 0
+                    let remaining = q.remainingMicroUSD ?? 0
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack {
+                            Text("Session allowance")
+                            Spacer()
+                            Text("\(Self.dollars(remaining)) of \(Self.dollars(window)) left")
+                                .foregroundStyle(.secondary)
+                        }
+                        .font(.subheadline)
+                        ProgressView(value: Double(min(spent, window)), total: Double(window))
+                            .tint(remaining > 0 ? Theme.green : Theme.danger)
+                        if let reset = q.resetAt, remaining <= 0 {
+                            Text("Refreshes \(Date(timeIntervalSince1970: reset / 1000), style: .relative)")
+                                .font(.caption).foregroundStyle(.secondary)
+                        }
+                    }
+                    LabeledContent("Tier", value: Self.tierLabels[q.tier ?? "free"] ?? (q.tier ?? "Free"))
+                    LabeledContent("Credits", value: Self.dollars(max(0, q.paidMicroUSD ?? 0)))
+                } else {
+                    LabeledContent("Plan", value: (acct.plan ?? "free").capitalized)
+                }
                 Button("Sign out") {
                     app.signOutCloud()
                     app.notify("Signed out.")
@@ -172,6 +200,7 @@ struct AccountCard: View {
                 LabeledContent("Signed in", value: "No (token connection)")
             }
         }
+        .task { quota = try? await app.client.billingQuota() }
         .confirmationDialog("Delete your LISA account?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
             Button("Delete account and data", role: .destructive) {
                 deleting = true
@@ -189,5 +218,9 @@ struct AccountCard: View {
         } message: {
             Text("Deletes your account and its cloud data permanently. Purchased credits are handled by Apple's refund process and are not restored by re-registering.")
         }
+    }
+
+    private static func dollars(_ micro: Int) -> String {
+        String(format: "$%.2f", Double(micro) / 1_000_000)
     }
 }

--- a/packaging/ios-companion/Sources/ChatView.swift
+++ b/packaging/ios-companion/Sources/ChatView.swift
@@ -153,6 +153,11 @@ final class ChatModel: ObservableObject {
         if cancelled {
             messages[idx].status = .cancelled
             if messages[idx].text.isEmpty { messages[idx].text = "Stopped." }
+        } else if case LisaError.http(402) = error {
+            // Quota exhausted (B4): the server refused the turn with a clean 402
+            // before streaming. Same copy as the web paywall (strings.ts).
+            messages[idx].status = .error
+            messages[idx].text = "Your free allowance for this session is used up — it refreshes every 12 hours. Add credits in Settings → LISA account to keep going now."
         } else {
             messages[idx].status = .error
             let msg = (error as? LocalizedError)?.errorDescription ?? "Couldn't reach Lisa."

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -119,6 +119,22 @@ final class LisaClient {
         try await decode("/api/auth/me", as: AccountMe.self)
     }
 
+    /// The signed-in account's quota window + balance (`GET /api/billing/quota`).
+    /// `available == false` when the connection isn't an account session.
+    struct QuotaStatus: Decodable, Equatable {
+        var available: Bool
+        var tier: String?
+        var windowMicroUSD: Int?
+        var spentMicroUSD: Int?
+        var remainingMicroUSD: Int?
+        var paidMicroUSD: Int?
+        var resetAt: Double?
+    }
+
+    func billingQuota() async throws -> QuotaStatus {
+        try await decode("/api/billing/quota", as: QuotaStatus.self)
+    }
+
     /// In-app account deletion (App Store 5.1.1(v)) — `DELETE /api/account`.
     /// Only works when the connection uses an account session.
     func deleteAccount() async throws {

--- a/src/billing/prices.ts
+++ b/src/billing/prices.ts
@@ -91,3 +91,15 @@ export function costMicroUSD(model: string, usage: ProviderUsage): number {
 export function formatMicroUSD(micro: number): string {
   return `$${(micro / 1_000_000).toFixed(2)}`;
 }
+
+/**
+ * How many tokens `microUSD` can buy at this model's OUTPUT rate — the
+ * conservative per-turn breaker for the agent loop (every token priced as
+ * output). Clamped to a sane ceiling so a huge paid balance doesn't disable
+ * the breaker entirely.
+ */
+export function tokensAffordable(model: string, microUSD: number): number {
+  const p = priceForModel(model);
+  const tokens = Math.floor((microUSD / p.outPerM) * 1_000_000);
+  return Math.max(1000, Math.min(tokens, 5_000_000));
+}

--- a/src/billing/quota.test.ts
+++ b/src/billing/quota.test.ts
@@ -1,0 +1,112 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-quota-"));
+process.env.LISA_HOME = TMP;
+
+const quota = await import("./quota.js");
+const {
+  precheckTurn, debitTurn, quotaStatus, creditPurchase, clawbackPurchase,
+  WINDOW_MS, FREE_WINDOW_FULL, FREE_WINDOW_UNVERIFIED, TIER1_WINDOW, TIER2_WINDOW,
+} = quota;
+import type { AccountRecord } from "../web/accounts.js";
+
+const T0 = 1_750_000_000_000;
+
+const APPLE: AccountRecord = {
+  uid: "apple-1", kind: "apple", createdAt: T0, lastLoginAt: T0, verified: true, sessionVersion: 0,
+};
+const EMAIL_UNVERIFIED: AccountRecord = {
+  uid: "em-1", kind: "email", email: "a@b.co", createdAt: T0, lastLoginAt: T0, verified: false, sessionVersion: 0,
+};
+
+beforeEach(() => {
+  fs.rmSync(path.join(TMP, "billing"), { recursive: true, force: true });
+});
+
+describe("quota engine", () => {
+  test("first standard turn opens a 12h window with the tier allowance", async () => {
+    const pre = await precheckTurn(APPLE, "glm-4.6", T0);
+    assert.ok(pre.ok);
+    const q = await quotaStatus(APPLE, T0 + 1);
+    assert.equal(q.tier, "free");
+    assert.equal(q.windowMicroUSD, FREE_WINDOW_FULL);
+    assert.equal(q.resetAt, T0 + WINDOW_MS);
+  });
+
+  test("unverified email gets the reduced window", async () => {
+    await precheckTurn(EMAIL_UNVERIFIED, "glm-4.6", T0);
+    const q = await quotaStatus(EMAIL_UNVERIFIED, T0 + 1);
+    assert.equal(q.tier, "free-unverified");
+    assert.equal(q.windowMicroUSD, FREE_WINDOW_UNVERIFIED);
+  });
+
+  test("debit draws free window first, then paid; exhaustion → 402 shape; window reset restores", async () => {
+    await creditPurchase({ at: T0, microUSD: 2_000_000, transactionId: "t1" }, T0);
+    await precheckTurn(APPLE, "glm-4.6", T0);
+    // burn the whole free window + $1 of paid
+    await debitTurn(APPLE, "glm-4.6", FREE_WINDOW_FULL + 1_000_000, T0 + 1000);
+    let q = await quotaStatus(APPLE, T0 + 2000);
+    assert.equal(q.remainingMicroUSD, 0);
+    assert.equal(q.paidMicroUSD, 1_000_000);
+    // still ok: paid remains
+    let pre = await precheckTurn(APPLE, "glm-4.6", T0 + 3000);
+    assert.ok(pre.ok);
+    // burn the paid too → exhausted
+    await debitTurn(APPLE, "glm-4.6", 1_000_000, T0 + 4000);
+    pre = await precheckTurn(APPLE, "glm-4.6", T0 + 5000);
+    assert.ok(!pre.ok && pre.error === "quota_exhausted");
+    assert.equal(pre.ok === false && pre.resetAt, T0 + WINDOW_MS);
+    // window rolls → fresh allowance
+    pre = await precheckTurn(APPLE, "glm-4.6", T0 + WINDOW_MS + 1);
+    assert.ok(pre.ok);
+  });
+
+  test("premium models never touch the free window", async () => {
+    let pre = await precheckTurn(APPLE, "claude-sonnet-4-6", T0);
+    assert.ok(!pre.ok && pre.error === "premium_requires_balance");
+    await creditPurchase({ at: T0, microUSD: 5_000_000, transactionId: "t2" }, T0);
+    pre = await precheckTurn(APPLE, "claude-sonnet-4-6", T0 + 1);
+    assert.ok(pre.ok);
+    await debitTurn(APPLE, "claude-sonnet-4-6", 2_000_000, T0 + 2);
+    const q = await quotaStatus(APPLE, T0 + 3);
+    assert.equal(q.paidMicroUSD, 3_000_000);
+    // free window untouched by the premium debit
+    assert.equal(q.spentMicroUSD, 0);
+  });
+
+  test("30d purchases raise the tier window; old purchases age out", async () => {
+    await creditPurchase({ at: T0, microUSD: 4_990_000, transactionId: "t3" }, T0);
+    let q = await quotaStatus(APPLE, T0 + 1);
+    assert.equal(q.tier, "tier1");
+    assert.equal(q.windowMicroUSD, TIER1_WINDOW);
+    await creditPurchase({ at: T0 + 2, microUSD: 15_000_000, transactionId: "t4" }, T0 + 2);
+    q = await quotaStatus(APPLE, T0 + 3);
+    assert.equal(q.tier, "tier2");
+    assert.equal(q.windowMicroUSD, TIER2_WINDOW);
+    // 31 days later the tier decays (balance itself remains)
+    const later = T0 + 31 * 24 * 60 * 60 * 1000;
+    q = await quotaStatus(APPLE, later);
+    assert.equal(q.tier, "free");
+    assert.equal(q.paidMicroUSD, 19_990_000);
+  });
+
+  test("refund clawback reverses the purchase and can go negative; premium locks, standard window survives", async () => {
+    await creditPurchase({ at: T0, microUSD: 5_000_000, transactionId: "t5" }, T0);
+    await debitTurn(APPLE, "claude-sonnet-4-6", 4_000_000, T0 + 1);
+    assert.equal(await clawbackPurchase("t5"), true);
+    const q = await quotaStatus(APPLE, T0 + 2);
+    assert.equal(q.paidMicroUSD, -4_000_000);
+    // premium locked
+    const prePremium = await precheckTurn(APPLE, "claude-sonnet-4-6", T0 + 3);
+    assert.ok(!prePremium.ok);
+    // standard free window still works
+    const preStd = await precheckTurn(APPLE, "glm-4.6", T0 + 4);
+    assert.ok(preStd.ok);
+    // unknown transaction → false
+    assert.equal(await clawbackPurchase("nope"), false);
+  });
+});

--- a/src/billing/quota.ts
+++ b/src/billing/quota.ts
@@ -1,0 +1,243 @@
+/**
+ * Quota engine — the 12h session window, paid tiers, and debit order
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §5.2/§6.3, milestone B4).
+ *
+ * Model (decisions locked 2026-07-21):
+ *  - A signed-in account's first request opens a 12h WINDOW carrying a free
+ *    face-value allowance. The window expires, the allowance resets — no
+ *    carry-over (Claude Code's session model, 5h→12h).
+ *  - The allowance depends on account standing: Apple / verified email $5;
+ *    unverified email $1. PAYING raises it by tier — 30-day cumulative IAP
+ *    purchases ≥ $4.99 → $10, ≥ $19.99 → $20 (the tier is a perk that decays
+ *    30 days after the purchases stop; the PAID BALANCE itself never expires —
+ *    App Store 3.1.1).
+ *  - Debit order: free window first, then paid balance. PREMIUM models
+ *    (Claude/GPT — prices.ts tier) never touch the free window: paid only.
+ *  - A refund clawback (B5) may push the paid balance negative; standard-model
+ *    free-window use keeps working, premium stays locked until topped up.
+ *
+ * Storage: `<active home>/billing/balance.json` — the fast path beside the
+ * usage.jsonl audit ledger; atomic writes under the billing lock.
+ */
+import path from "node:path";
+import { lisaHome } from "../paths.js";
+import { atomicWrite, readTextOrEmpty, ensureDir } from "../fs-utils.js";
+import { withFileLock } from "../soul/lock.js";
+import type { AccountRecord } from "../web/accounts.js";
+import { modelTier } from "./prices.js";
+import { billingDir } from "./meter.js";
+
+export const WINDOW_MS = 12 * 60 * 60 * 1000;
+export const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+
+// Face-value allowances, micro-USD.
+export const FREE_WINDOW_FULL = 5_000_000; // Apple / verified email
+export const FREE_WINDOW_UNVERIFIED = 1_000_000; // email before verification (B7 levels it)
+export const TIER1_WINDOW = 10_000_000;
+export const TIER2_WINDOW = 20_000_000;
+export const TIER1_THRESHOLD = 4_990_000; // ≥ $4.99 bought in the last 30d
+export const TIER2_THRESHOLD = 19_990_000; // ≥ $19.99
+
+export interface PurchaseEntry {
+  /** ms since epoch. */
+  at: number;
+  /** Face value credited, micro-USD. */
+  microUSD: number;
+  /** StoreKit transactionId (dedup + refund clawback key, B5). */
+  transactionId?: string;
+}
+
+export interface BalanceState {
+  /** Paid balance, micro-USD. Never expires; may go negative after a refund. */
+  paidMicroUSD: number;
+  /** Purchases (for the 30d tier); pruned past 60d. */
+  purchases: PurchaseEntry[];
+  /** The active free window, if one has been opened. */
+  window?: { start: number; spentMicroUSD: number };
+}
+
+function balanceFile(): string {
+  return path.join(billingDir(), "balance.json");
+}
+function balanceLock(): string {
+  return path.join(billingDir(), "balance.lock");
+}
+
+const EMPTY: BalanceState = { paidMicroUSD: 0, purchases: [] };
+
+export async function readBalance(): Promise<BalanceState> {
+  try {
+    const text = await readTextOrEmpty(balanceFile());
+    if (!text.trim()) return { ...EMPTY, purchases: [] };
+    const parsed = JSON.parse(text) as BalanceState;
+    return {
+      paidMicroUSD: typeof parsed.paidMicroUSD === "number" ? parsed.paidMicroUSD : 0,
+      purchases: Array.isArray(parsed.purchases) ? parsed.purchases : [],
+      window: parsed.window,
+    };
+  } catch {
+    return { ...EMPTY, purchases: [] };
+  }
+}
+
+async function writeBalance(state: BalanceState): Promise<void> {
+  await ensureDir(billingDir());
+  await atomicWrite(balanceFile(), JSON.stringify(state, null, 2));
+}
+
+/** Mutate the balance under the cross-process lock. */
+export async function updateBalance<T>(
+  fn: (state: BalanceState) => T,
+): Promise<T> {
+  await ensureDir(billingDir());
+  return withFileLock(balanceLock(), async () => {
+    const state = await readBalance();
+    const out = fn(state);
+    await writeBalance(state);
+    return out;
+  });
+}
+
+/** 30-day cumulative purchase face value, micro-USD. */
+export function purchases30d(state: BalanceState, now: number): number {
+  return state.purchases
+    .filter((p) => now - p.at <= THIRTY_DAYS_MS)
+    .reduce((sum, p) => sum + p.microUSD, 0);
+}
+
+export type QuotaTier = "free" | "free-unverified" | "tier1" | "tier2";
+
+export function tierFor(acct: AccountRecord, state: BalanceState, now: number): QuotaTier {
+  const bought = purchases30d(state, now);
+  if (bought >= TIER2_THRESHOLD) return "tier2";
+  if (bought >= TIER1_THRESHOLD) return "tier1";
+  return acct.verified ? "free" : "free-unverified";
+}
+
+export function windowAllowance(tier: QuotaTier): number {
+  switch (tier) {
+    case "tier2": return TIER2_WINDOW;
+    case "tier1": return TIER1_WINDOW;
+    case "free": return FREE_WINDOW_FULL;
+    case "free-unverified": return FREE_WINDOW_UNVERIFIED;
+  }
+}
+
+export interface QuotaStatus {
+  tier: QuotaTier;
+  /** Face allowance of the current window. */
+  windowMicroUSD: number;
+  /** Spent inside the current window. */
+  spentMicroUSD: number;
+  /** max(0, allowance - spent). */
+  remainingMicroUSD: number;
+  /** Paid balance (may be negative after a refund). */
+  paidMicroUSD: number;
+  /** When the current window resets (ms epoch), or null if none is open. */
+  resetAt: number | null;
+}
+
+/** Roll the window if expired (mutates state); returns the live window. */
+function liveWindow(state: BalanceState, now: number): { start: number; spentMicroUSD: number } {
+  if (!state.window || now - state.window.start >= WINDOW_MS) {
+    state.window = { start: now, spentMicroUSD: 0 };
+  }
+  return state.window;
+}
+
+export async function quotaStatus(acct: AccountRecord, now: number = Date.now()): Promise<QuotaStatus> {
+  const state = await readBalance();
+  const tier = tierFor(acct, state, now);
+  const allowance = windowAllowance(tier);
+  // Read-only view: an expired window shows as fresh (it WILL reset on use).
+  const w = state.window && now - state.window.start < WINDOW_MS ? state.window : null;
+  const spent = w?.spentMicroUSD ?? 0;
+  return {
+    tier,
+    windowMicroUSD: allowance,
+    spentMicroUSD: spent,
+    remainingMicroUSD: Math.max(0, allowance - spent),
+    paidMicroUSD: state.paidMicroUSD,
+    resetAt: w ? w.start + WINDOW_MS : null,
+  };
+}
+
+export type PrecheckResult =
+  | { ok: true; /** budget hint for the agent's token breaker, micro-USD */ budgetMicroUSD: number }
+  | { ok: false; error: "quota_exhausted"; resetAt: number; tier: QuotaTier }
+  | { ok: false; error: "premium_requires_balance"; tier: QuotaTier };
+
+/**
+ * Gate one turn BEFORE it runs. Opens/rolls the window as a side effect (the
+ * window starts at first use, Claude Code-style).
+ */
+export async function precheckTurn(
+  acct: AccountRecord,
+  model: string,
+  now: number = Date.now(),
+): Promise<PrecheckResult> {
+  return updateBalance((state) => {
+    const tier = tierFor(acct, state, now);
+    if (modelTier(model) === "premium") {
+      // Premium never draws on the free window.
+      if (state.paidMicroUSD > 0) return { ok: true, budgetMicroUSD: state.paidMicroUSD };
+      return { ok: false, error: "premium_requires_balance", tier };
+    }
+    const w = liveWindow(state, now);
+    const allowance = windowAllowance(tier);
+    const freeLeft = allowance - w.spentMicroUSD;
+    const paid = Math.max(0, state.paidMicroUSD);
+    if (freeLeft <= 0 && paid <= 0) {
+      return { ok: false, error: "quota_exhausted", resetAt: w.start + WINDOW_MS, tier };
+    }
+    return { ok: true, budgetMicroUSD: Math.max(0, freeLeft) + paid };
+  });
+}
+
+/**
+ * Debit one metered turn AFTER it ran: free window first (standard models),
+ * then paid balance. Premium models bill paid only. A concurrent overshoot may
+ * push paid slightly negative — absorbed by the next purchase.
+ */
+export async function debitTurn(
+  acct: AccountRecord,
+  model: string,
+  microUSD: number,
+  now: number = Date.now(),
+): Promise<void> {
+  if (microUSD <= 0) return;
+  await updateBalance((state) => {
+    if (modelTier(model) === "premium") {
+      state.paidMicroUSD -= microUSD;
+      return;
+    }
+    const tier = tierFor(acct, state, now);
+    const w = liveWindow(state, now);
+    const allowance = windowAllowance(tier);
+    const freeLeft = Math.max(0, allowance - w.spentMicroUSD);
+    const fromFree = Math.min(freeLeft, microUSD);
+    w.spentMicroUSD += fromFree;
+    const rest = microUSD - fromFree;
+    if (rest > 0) state.paidMicroUSD -= rest;
+  });
+}
+
+/** Credit a purchase (B5 IAP calls this) and prune purchases older than 60d. */
+export async function creditPurchase(entry: PurchaseEntry, now: number = Date.now()): Promise<void> {
+  await updateBalance((state) => {
+    state.paidMicroUSD += entry.microUSD;
+    state.purchases.push(entry);
+    state.purchases = state.purchases.filter((p) => now - p.at <= 2 * THIRTY_DAYS_MS);
+  });
+}
+
+/** Reverse a refunded purchase by transactionId (B5 ASN clawback). */
+export async function clawbackPurchase(transactionId: string): Promise<boolean> {
+  return updateBalance((state) => {
+    const idx = state.purchases.findIndex((p) => p.transactionId === transactionId);
+    if (idx < 0) return false;
+    const [gone] = state.purchases.splice(idx, 1);
+    state.paidMicroUSD -= gone!.microUSD;
+    return true;
+  });
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -38,7 +38,8 @@ import {
 import { ISLAND_HTML } from "./island.js";
 import { LOGIN_HTML } from "./login.js";
 import { recordUsage, summarizeUsage } from "../billing/meter.js";
-import { PRICES_VERSION } from "../billing/prices.js";
+import { PRICES_VERSION, tokensAffordable } from "../billing/prices.js";
+import { precheckTurn, debitTurn, quotaStatus } from "../billing/quota.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
@@ -996,6 +997,21 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
             : { signedIn: false },
         ),
       );
+      return;
+    }
+
+    if (req.method === "GET" && url === "/api/billing/quota") {
+      // The signed-in account's window/tier/balance — drives the quota bar +
+      // paywall in every client (same numbers everywhere, §5.5).
+      const acct = accountUid ? getAccount(accountUid) : null;
+      if (!acct) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ available: false }));
+        return;
+      }
+      const q = await quotaStatus(acct);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ available: true, ...q }));
       return;
     }
 
@@ -2502,6 +2518,27 @@ self.addEventListener('fetch', (event) => {
         res.end(JSON.stringify({ error: `bad request: ${(err as Error).message}` }));
         return;
       }
+      // ── Quota gate (B4) — signed-in cloud accounts only; the legacy shared-
+      // token demo stays operator-funded and ungated. Runs BEFORE the SSE
+      // handshake so exhaustion is a clean HTTP 402 the clients can route to
+      // a paywall (structured body: error + resetAt + tier).
+      let quotaBudgetMicroUSD: number | null = null;
+      const quotaAcct = cloud && accountUid ? getAccount(accountUid) : null;
+      if (quotaAcct) {
+        const pre = await precheckTurn(quotaAcct, opts.model);
+        if (!pre.ok) {
+          res.writeHead(402, { "content-type": "application/json" });
+          res.end(
+            JSON.stringify(
+              pre.error === "quota_exhausted"
+                ? { error: pre.error, resetAt: pre.resetAt, tier: pre.tier }
+                : { error: pre.error, tier: pre.tier },
+            ),
+          );
+          return;
+        }
+        quotaBudgetMicroUSD = pre.budgetMicroUSD;
+      }
       // User just talked — reset the idle watcher + stamp focus freshness.
       try { getIdleWatcher(60 * 60_000).tick(); } catch {}
       lastUserMessageAt = Date.now();
@@ -2556,6 +2593,13 @@ self.addEventListener('fetch', (event) => {
             userFiles: files,
             model: opts.model,
             thinking: opts.thinking,
+            // Pre-debit breaker (B4): a single turn can never burn past what
+            // the account could pay for. Conservatively prices every token at
+            // the output rate.
+            budgetTokens:
+              quotaBudgetMicroUSD != null
+                ? tokensAffordable(opts.model, quotaBudgetMicroUSD)
+                : undefined,
             onEvent: (ev) => {
               if (ev.type === "text_delta" && ev.text) {
                 anyText = true;
@@ -2627,12 +2671,14 @@ self.addEventListener('fetch', (event) => {
           // per-uid subtree for signed-in cloud accounts. Mac edition (BYO key)
           // is not metered. Never throws.
           if (cloud) {
-            void recordUsage("chat", opts.model, {
+            const rec = await recordUsage("chat", opts.model, {
               inputTokens: result.inputTokens,
               outputTokens: result.outputTokens,
               cacheReadTokens: result.cacheReadTokens,
               cacheWriteTokens: result.cacheWriteTokens,
             });
+            // Debit order (B4): free window first, then paid balance.
+            if (rec && quotaAcct) await debitTurn(quotaAcct, opts.model, rec.microUSD);
           }
           if (!anyText && !anyTool && !errorSent) send({ type: "empty" });
           send({ type: "done" });


### PR DESCRIPTION
**Stacked on #263.** Milestone B4 — the free-allowance / tier engine, per the locked decisions.

## Engine (`src/billing/quota.ts`)

- First standard-model turn opens a **12h window** with a tier-dependent allowance:

| Tier | Condition (30d cumulative IAP) | Window |
|---|---|---|
| Free | — (Apple / verified email) | $5 |
| Free-unverified | — (email, pre-verification) | $1 |
| Tier 1 | ≥ $4.99 | $10 |
| Tier 2 | ≥ $19.99 | $20 |

- Tier perk decays 30 days after purchases stop; **paid balance never expires** (3.1.1).
- Debit order: free window → paid balance. **Premium models (Claude/GPT) never touch the free window** — the one hard economics constraint from §7.
- Refund clawback may push paid negative: premium locks, standard free window survives (decision #4).

## Server

- `/chat` pre-checks **before** the SSE handshake → clean **HTTP 402** `{error, resetAt, tier}`; granted budget feeds `runAgent`'s `budgetTokens` breaker (every token priced at the output rate) so one turn can't overshoot; actual metered cost debited post-turn.
- `GET /api/billing/quota` — window/tier/balance for all clients (same numbers everywhere).
- Legacy shared-token demo stays ungated (operator-funded).

## iOS

- ChatView maps 402 → paywall copy; AccountCard gains the **session allowance bar** (spent/left + reset countdown), tier + credits rows.

## Tests

Window open/reset, tier math + 30d decay, debit order, premium isolation, clawback semantics. Full suite **1051 pass / 0 fail**; iOS simulator build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)