### PR TITLE
feat(billing): B5 — StoreKit 2 consumable credits + server JWS verify + ASN refunds

### DIFF
--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -156,6 +156,7 @@ struct AccountCard: View {
     @State private var showDeleteConfirm = false
     @State private var deleting = false
     @State private var quota: LisaClient.QuotaStatus?
+    @State private var showPaywall = false
 
     private static let tierLabels: [String: String] = [
         "free": "Free", "free-unverified": "Free (verify email for more)",
@@ -186,6 +187,11 @@ struct AccountCard: View {
                     }
                     LabeledContent("Tier", value: Self.tierLabels[q.tier ?? "free"] ?? (q.tier ?? "Free"))
                     LabeledContent("Credits", value: Self.dollars(max(0, q.paidMicroUSD ?? 0)))
+                    Button {
+                        showPaywall = true
+                    } label: {
+                        Label("Add credits…", systemImage: "plus.circle")
+                    }
                 } else {
                     LabeledContent("Plan", value: (acct.plan ?? "free").capitalized)
                 }
@@ -201,6 +207,11 @@ struct AccountCard: View {
             }
         }
         .task { quota = try? await app.client.billingQuota() }
+        .sheet(isPresented: $showPaywall, onDismiss: {
+            Task { quota = try? await app.client.billingQuota() }
+        }) {
+            PaywallSheet().environmentObject(app)
+        }
         .confirmationDialog("Delete your LISA account?", isPresented: $showDeleteConfirm, titleVisibility: .visible) {
             Button("Delete account and data", role: .destructive) {
                 deleting = true

--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -66,6 +66,9 @@ struct RootView: View {
             }
         }
         .task { await app.refreshWidgetSnapshot() }          // keep the widget fresh off-tab (A5)
+        // Unfinished-purchase listener (B5): StoreKit re-delivers transactions
+        // the server never credited; the server-side dedup makes replays safe.
+        .task { CreditsStore.shared.start(app: app) }
         .onChange(of: scenePhase) { _, phase in
             if phase == .background { app.lockIfEnabled() }  // re-arm when leaving foreground
             if phase == .active { Task { await app.refreshWidgetSnapshot() } }

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -135,6 +135,21 @@ final class LisaClient {
         try await decode("/api/billing/quota", as: QuotaStatus.self)
     }
 
+    /// Submit a StoreKit 2 transaction JWS for crediting (`POST /api/billing/iap`).
+    /// `ok:false` with error "duplicate_transaction" still means the credit
+    /// happened once already — the caller should finish() the transaction.
+    struct IapResult: Decodable {
+        var ok: Bool
+        var creditedMicroUSD: Int?
+        var error: String?
+    }
+
+    func iapSubmit(jws: String) async throws -> IapResult {
+        var r = try await decode("/api/billing/iap", method: "POST", json: ["jws": jws], as: IapResult.self)
+        if r.error == "duplicate_transaction" { r.ok = true }
+        return r
+    }
+
     /// In-app account deletion (App Store 5.1.1(v)) — `DELETE /api/account`.
     /// Only works when the connection uses an account session.
     func deleteAccount() async throws {

--- a/packaging/ios-companion/Sources/StoreView.swift
+++ b/packaging/ios-companion/Sources/StoreView.swift
@@ -1,0 +1,149 @@
+import SwiftUI
+import StoreKit
+
+/// Consumable credit packs (PLAN_ACCOUNTS_BILLING B5).
+///
+/// Flow: StoreKit 2 purchase → send the transaction's JWS to the server
+/// (`POST /api/billing/iap`) → the server verifies the Apple signature chain,
+/// dedupes by transactionId, credits the signed-in account → ONLY THEN
+/// `Transaction.finish()`. If we crash before the server answers, StoreKit
+/// re-delivers the unfinished transaction via `Transaction.updates` and the
+/// server-side dedup makes the replay safe.
+@MainActor
+final class CreditsStore: ObservableObject {
+    static let shared = CreditsStore()
+    static let productIDs = [
+        "ai.meetlisa.main.credits.5",
+        "ai.meetlisa.main.credits.10",
+        "ai.meetlisa.main.credits.20",
+    ]
+
+    @Published var products: [Product] = []
+    @Published var busy = false
+    @Published var message: String?
+    private var updatesTask: Task<Void, Never>?
+
+    /// Start the unfinished-transaction listener once per launch (App.swift).
+    func start(app: AppState) {
+        guard updatesTask == nil else { return }
+        updatesTask = Task { [weak self, weak app] in
+            for await update in StoreKit.Transaction.updates {
+                guard let self, let app else { return }
+                await self.credit(update, app: app)
+            }
+        }
+    }
+
+    func loadProducts() async {
+        guard products.isEmpty else { return }
+        let loaded = (try? await Product.products(for: Self.productIDs)) ?? []
+        products = loaded.sorted { $0.price < $1.price }
+    }
+
+    func purchase(_ product: Product, app: AppState) async {
+        busy = true
+        defer { busy = false }
+        message = nil
+        do {
+            switch try await product.purchase() {
+            case .success(let verification):
+                await credit(verification, app: app)
+            case .userCancelled:
+                break
+            case .pending:
+                message = "Purchase is pending approval."
+            @unknown default:
+                break
+            }
+        } catch {
+            message = "Purchase failed — please try again."
+        }
+    }
+
+    /// Server-credit a verified transaction, then finish it.
+    private func credit(_ verification: VerificationResult<StoreKit.Transaction>, app: AppState) async {
+        guard case .verified(let tx) = verification else { return }
+        do {
+            let r = try await app.client.iapSubmit(jws: verification.jwsRepresentation)
+            if r.ok {
+                await tx.finish()
+                message = "Credits added."
+                await app.refreshAccount()
+            } else {
+                message = "Couldn't credit the purchase (\(r.error ?? "error"))."
+            }
+        } catch {
+            // Leave the transaction unfinished — StoreKit re-delivers it and the
+            // server dedup makes the retry safe.
+            message = "Couldn't reach the server — the purchase will be credited automatically."
+        }
+    }
+
+    func restore() async {
+        try? await AppStore.sync()
+    }
+}
+
+/// The paywall sheet: three packs, restore, and the tier explainer.
+struct PaywallSheet: View {
+    @EnvironmentObject var app: AppState
+    @StateObject private var store = CreditsStore.shared
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    if store.products.isEmpty {
+                        HStack { ProgressView(); Text("Loading packs…").foregroundStyle(.secondary) }
+                    }
+                    ForEach(store.products, id: \.id) { product in
+                        Button {
+                            Task { await store.purchase(product, app: app) }
+                        } label: {
+                            HStack {
+                                VStack(alignment: .leading) {
+                                    Text(product.displayName.isEmpty ? product.id : product.displayName)
+                                    Text(bonusLabel(product.id))
+                                        .font(.caption).foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Text(product.displayPrice).bold()
+                            }
+                        }
+                        .disabled(store.busy)
+                    }
+                } header: {
+                    Text("Credit packs")
+                } footer: {
+                    Text("Credits never expire and roam with your account. Any purchase also raises your free 12-hour session allowance for 30 days ($4.99+ → $10, $19.99+ → $20). Premium models draw on credits only.")
+                }
+
+                Section {
+                    Button("Restore purchases") { Task { await store.restore() } }
+                }
+
+                if let msg = store.message {
+                    Section { Text(msg).font(.caption).foregroundStyle(.secondary) }
+                }
+            }
+            .consoleBackground()
+            .navigationTitle("Add credits")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) { Button("Done") { dismiss() } }
+            }
+            .task { await store.loadProducts() }
+        }
+        .preferredColorScheme(.dark)
+    }
+
+    private func bonusLabel(_ id: String) -> String {
+        switch id {
+        case "ai.meetlisa.main.credits.5": return "$5.00 in credits · Tier 1 boost"
+        case "ai.meetlisa.main.credits.10": return "$10.50 in credits (+5%) · Tier 1 boost"
+        case "ai.meetlisa.main.credits.20": return "$22.00 in credits (+10%) · Tier 2 boost"
+        default: return ""
+        }
+    }
+}

--- a/src/billing/iap.test.ts
+++ b/src/billing/iap.test.ts
@@ -1,0 +1,88 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-iap-"));
+process.env.LISA_HOME = TMP;
+
+const { verifyAppleJWS, validateTransaction, creditTransaction, refundTransaction, PRODUCTS, IapError } =
+  await import("./iap.js");
+const { homeScope, homeForUid } = await import("../paths.js");
+const { readBalance } = await import("./quota.js");
+
+const b64 = (o: object) => Buffer.from(JSON.stringify(o)).toString("base64url");
+
+beforeEach(() => {
+  fs.rmSync(path.join(TMP, "iap-transactions.json"), { force: true });
+  fs.rmSync(path.join(TMP, "users"), { recursive: true, force: true });
+});
+
+describe("JWS shape validation", () => {
+  test("garbage / missing x5c / wrong alg → malformed_jws", async () => {
+    for (const bad of [
+      "not-a-jws",
+      "a.b",
+      `${b64({ alg: "ES256" })}.${b64({})}.sig`, // no x5c
+      `${b64({ alg: "RS256", x5c: ["a", "b"] })}.${b64({})}.sig`, // wrong alg
+    ]) {
+      await assert.rejects(verifyAppleJWS(bad, { now: 0 }), (e: unknown) => (e as InstanceType<typeof IapError>).code === "malformed_jws");
+    }
+  });
+});
+
+describe("transaction payload validation", () => {
+  const good = { transactionId: "1000000123", productId: "ai.meetlisa.main.credits.10", bundleId: "ai.meetlisa.main" };
+
+  test("accepts a known product on our bundle", () => {
+    const tx = validateTransaction(good);
+    assert.equal(tx.productId, "ai.meetlisa.main.credits.10");
+  });
+
+  test("wrong bundle / unknown product / missing id → typed errors", () => {
+    assert.throws(() => validateTransaction({ ...good, bundleId: "com.evil.app" }), (e: unknown) => (e as InstanceType<typeof IapError>).code === "wrong_bundle");
+    assert.throws(() => validateTransaction({ ...good, productId: "ai.meetlisa.main.credits.999" }), (e: unknown) => (e as InstanceType<typeof IapError>).code === "unknown_product");
+    assert.throws(() => validateTransaction({ ...good, transactionId: "" }), (e: unknown) => (e as InstanceType<typeof IapError>).code === "malformed_jws");
+  });
+});
+
+describe("credit + dedup + refund", () => {
+  const tx = validateTransaction({
+    transactionId: "tx-1",
+    productId: "ai.meetlisa.main.credits.10",
+    bundleId: "ai.meetlisa.main",
+  });
+
+  test("credits the uid's balance once; a replay is rejected globally", async () => {
+    const credited = await creditTransaction("em-alpha", tx, 1000);
+    assert.equal(credited, PRODUCTS["ai.meetlisa.main.credits.10"]);
+    await homeScope.run(homeForUid("em-alpha"), async () => {
+      const b = await readBalance();
+      assert.equal(b.paidMicroUSD, 10_500_000);
+      assert.equal(b.purchases[0]!.transactionId, "tx-1");
+    });
+    // Same transaction, same OR different account → duplicate.
+    await assert.rejects(creditTransaction("em-alpha", tx, 2000), (e: unknown) => (e as InstanceType<typeof IapError>).code === "duplicate_transaction");
+    await assert.rejects(creditTransaction("em-beta", tx, 3000), (e: unknown) => (e as InstanceType<typeof IapError>).code === "duplicate_transaction");
+    await homeScope.run(homeForUid("em-beta"), async () => {
+      const b = await readBalance();
+      assert.equal(b.paidMicroUSD, 0);
+    });
+  });
+
+  test("refund claws back from the owning account; unknown tx → null", async () => {
+    await creditTransaction("em-gamma", { ...tx, transactionId: "tx-2" }, 1000);
+    const undone = await refundTransaction("tx-2");
+    assert.equal(undone?.uid, "em-gamma");
+    assert.equal(undone?.microUSD, 10_500_000);
+    await homeScope.run(homeForUid("em-gamma"), async () => {
+      const b = await readBalance();
+      assert.equal(b.paidMicroUSD, 0);
+      assert.equal(b.purchases.length, 0);
+    });
+    assert.equal(await refundTransaction("tx-never"), null);
+    // The index entry survives the refund, so a replayed credit stays deduped.
+    await assert.rejects(creditTransaction("em-gamma", { ...tx, transactionId: "tx-2" }, 2000), (e: unknown) => (e as InstanceType<typeof IapError>).code === "duplicate_transaction");
+  });
+});

--- a/src/billing/iap.ts
+++ b/src/billing/iap.ts
@@ -1,0 +1,240 @@
+/**
+ * Apple In-App Purchase — StoreKit 2 JWS verification + crediting
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.4, milestone B5).
+ *
+ * The iOS app purchases a consumable credit pack and POSTs the transaction's
+ * JWS representation to `/api/billing/iap`. We verify it here — signature
+ * (ES256) by the leaf of the embedded x5c chain, chain rooted in Apple's
+ * Root CA G3 — then validate bundle/product, dedupe by transactionId in a
+ * GLOBAL index (one Apple transaction can never credit two accounts), and
+ * credit the signed-in account's balance. The client calls
+ * `Transaction.finish()` only after we answer OK, so a crash between purchase
+ * and credit is re-delivered by StoreKit, and the dedup makes that safe.
+ *
+ * App Store Server Notifications V2 (`/api/billing/asn`) reuses the same JWS
+ * verification; REFUND/REVOKE claws the credit back from whichever account
+ * the global index says received it.
+ *
+ * No external dependencies: node:crypto's X509Certificate walks the chain and
+ * verifies ES256 (ieee-p1363). The Apple root is fetched once from
+ * apple.com/certificateauthority over TLS and cached under the global home
+ * (override with LISA_APPLE_ROOT_PATH for air-gapped deploys).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import crypto, { X509Certificate } from "node:crypto";
+import { lisaGlobalHome, homeScope, homeForUid } from "../paths.js";
+import { withFileLock } from "../soul/lock.js";
+import { creditPurchase, clawbackPurchase } from "./quota.js";
+
+export class IapError extends Error {
+  constructor(
+    public code:
+      | "malformed_jws"
+      | "bad_chain"
+      | "bad_signature"
+      | "wrong_bundle"
+      | "unknown_product"
+      | "duplicate_transaction"
+      | "root_unavailable"
+      | "unknown_transaction",
+  ) {
+    super(code);
+    this.name = "IapError";
+  }
+}
+
+/** Consumable credit packs: ASC product id → credited face value (micro-USD). */
+export const PRODUCTS: Record<string, number> = {
+  "ai.meetlisa.main.credits.5": 5_000_000,
+  "ai.meetlisa.main.credits.10": 10_500_000, // +5% bonus
+  "ai.meetlisa.main.credits.20": 22_000_000, // +10% bonus
+};
+
+export const EXPECTED_BUNDLE = "ai.meetlisa.main";
+
+const APPLE_ROOT_URL = "https://www.apple.com/certificateauthority/AppleRootCA-G3.cer";
+
+function rootCachePath(): string {
+  return process.env.LISA_APPLE_ROOT_PATH ?? path.join(lisaGlobalHome(), "apple-root-g3.cer");
+}
+
+let rootCert: X509Certificate | null = null;
+
+/** Load (fetch-once + cache) Apple's Root CA G3. */
+export async function appleRootCert(): Promise<X509Certificate> {
+  if (rootCert) return rootCert;
+  const file = rootCachePath();
+  try {
+    rootCert = new X509Certificate(fs.readFileSync(file));
+    return rootCert;
+  } catch {
+    /* fall through to fetch */
+  }
+  const res = await fetch(APPLE_ROOT_URL);
+  if (!res.ok) throw new IapError("root_unavailable");
+  const der = Buffer.from(await res.arrayBuffer());
+  const cert = new X509Certificate(der);
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  fs.writeFileSync(file, der);
+  rootCert = cert;
+  return cert;
+}
+
+/** Test seam. */
+export function _setAppleRootForTests(cert: X509Certificate | null): void {
+  rootCert = cert;
+}
+
+function b64urlJson(segment: string): Record<string, unknown> {
+  try {
+    return JSON.parse(Buffer.from(segment, "base64url").toString("utf8"));
+  } catch {
+    throw new IapError("malformed_jws");
+  }
+}
+
+/** The fields of a decoded StoreKit 2 transaction we act on. */
+export interface AppleTransaction {
+  transactionId: string;
+  productId: string;
+  bundleId: string;
+  /** "Production" | "Sandbox" (Xcode/TestFlight). */
+  environment?: string;
+  purchaseDate?: number;
+}
+
+/**
+ * Verify a StoreKit 2 JWS (transaction or ASN payload) and return its decoded
+ * payload. Checks: x5c chain (leaf←intermediate←root, root pinned to Apple
+ * Root CA G3), validity windows, and the ES256 signature by the leaf.
+ */
+export async function verifyAppleJWS(
+  jws: string,
+  opts: { root?: X509Certificate; now?: number } = {},
+): Promise<Record<string, unknown>> {
+  const parts = jws.split(".");
+  if (parts.length !== 3) throw new IapError("malformed_jws");
+  const [headerB64, payloadB64, sigB64] = parts as [string, string, string];
+  const header = b64urlJson(headerB64);
+  if (header.alg !== "ES256" || !Array.isArray(header.x5c) || header.x5c.length < 2) {
+    throw new IapError("malformed_jws");
+  }
+  const chain = (header.x5c as string[]).map((c) => {
+    try {
+      return new X509Certificate(Buffer.from(c, "base64"));
+    } catch {
+      throw new IapError("malformed_jws");
+    }
+  });
+  const root = opts.root ?? (await appleRootCert());
+  const now = opts.now ?? Date.now();
+  // Each cert must be inside its validity window and signed by the next one;
+  // the last must be signed by (or BE) the pinned root.
+  for (let i = 0; i < chain.length; i++) {
+    const cert = chain[i]!;
+    if (now < Date.parse(cert.validFrom) || now > Date.parse(cert.validTo)) {
+      throw new IapError("bad_chain");
+    }
+    const issuer = i + 1 < chain.length ? chain[i + 1]! : root;
+    if (!cert.verify(issuer.publicKey)) throw new IapError("bad_chain");
+  }
+  const last = chain[chain.length - 1]!;
+  if (last.fingerprint256 !== root.fingerprint256 && !last.verify(root.publicKey)) {
+    throw new IapError("bad_chain");
+  }
+  // ES256 over "header.payload" with the LEAF key, ieee-p1363 (r||s) encoding.
+  const ok = crypto.verify(
+    "sha256",
+    Buffer.from(`${headerB64}.${payloadB64}`, "utf8"),
+    { key: chain[0]!.publicKey, dsaEncoding: "ieee-p1363" },
+    Buffer.from(sigB64, "base64url"),
+  );
+  if (!ok) throw new IapError("bad_signature");
+  return b64urlJson(payloadB64);
+}
+
+/** Validate the decoded transaction payload against bundle + product table. */
+export function validateTransaction(payload: Record<string, unknown>): AppleTransaction {
+  const tx: AppleTransaction = {
+    transactionId: String(payload.transactionId ?? ""),
+    productId: String(payload.productId ?? ""),
+    bundleId: String(payload.bundleId ?? ""),
+    environment: typeof payload.environment === "string" ? payload.environment : undefined,
+    purchaseDate: typeof payload.purchaseDate === "number" ? payload.purchaseDate : undefined,
+  };
+  if (!tx.transactionId) throw new IapError("malformed_jws");
+  if (tx.bundleId !== EXPECTED_BUNDLE) throw new IapError("wrong_bundle");
+  if (!(tx.productId in PRODUCTS)) throw new IapError("unknown_product");
+  return tx;
+}
+
+// ── Global transaction index (one credit per Apple transaction, ever) ───────
+interface TxIndexEntry {
+  transactionId: string;
+  uid: string;
+  productId: string;
+  microUSD: number;
+  at: number;
+}
+
+function txIndexPath(): string {
+  return path.join(lisaGlobalHome(), "iap-transactions.json");
+}
+function txIndexLock(): string {
+  return path.join(lisaGlobalHome(), "iap-transactions.lock");
+}
+
+function readTxIndex(): TxIndexEntry[] {
+  try {
+    const parsed: unknown = JSON.parse(fs.readFileSync(txIndexPath(), "utf8"));
+    return Array.isArray(parsed) ? (parsed as TxIndexEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeTxIndex(list: TxIndexEntry[]): void {
+  const file = txIndexPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify(list, null, 2), { mode: 0o600 });
+  fs.renameSync(tmp, file);
+}
+
+/**
+ * Credit a VERIFIED transaction to `uid`. Dedupes globally; credits the uid's
+ * balance inside that uid's home scope. Returns the credited face value.
+ */
+export async function creditTransaction(uid: string, tx: AppleTransaction, now: number = Date.now()): Promise<number> {
+  const microUSD = PRODUCTS[tx.productId]!;
+  await withFileLock(txIndexLock(), async () => {
+    const index = readTxIndex();
+    if (index.some((e) => e.transactionId === tx.transactionId)) {
+      throw new IapError("duplicate_transaction");
+    }
+    index.push({ transactionId: tx.transactionId, uid, productId: tx.productId, microUSD, at: now });
+    writeTxIndex(index);
+  });
+  await homeScope.run(homeForUid(uid), () =>
+    creditPurchase({ at: now, microUSD, transactionId: tx.transactionId }, now),
+  );
+  return microUSD;
+}
+
+/**
+ * Reverse a refunded transaction (ASN V2 REFUND/REVOKE): find the owning uid
+ * in the global index and claw the credit back from that account's balance.
+ */
+export async function refundTransaction(transactionId: string): Promise<{ uid: string; microUSD: number } | null> {
+  let entry: TxIndexEntry | undefined;
+  await withFileLock(txIndexLock(), async () => {
+    const index = readTxIndex();
+    entry = index.find((e) => e.transactionId === transactionId);
+    // Keep the index entry (marked) so a replayed credit stays deduped.
+  });
+  if (!entry) return null;
+  const uid = entry.uid;
+  await homeScope.run(homeForUid(uid), () => clawbackPurchase(transactionId));
+  return { uid, microUSD: entry.microUSD };
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -40,6 +40,7 @@ import { LOGIN_HTML } from "./login.js";
 import { recordUsage, summarizeUsage } from "../billing/meter.js";
 import { PRICES_VERSION, tokensAffordable } from "../billing/prices.js";
 import { precheckTurn, debitTurn, quotaStatus } from "../billing/quota.js";
+import { verifyAppleJWS, validateTransaction, creditTransaction, refundTransaction, IapError } from "../billing/iap.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
@@ -896,6 +897,46 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // ── App Store Server Notifications V2 (pre-gate: Apple can't present our
+    // tokens; the JWS signature chain IS the authentication). Refunds claw the
+    // credit back from whichever account the global index credited (B5).
+    if (req.method === "POST" && url === "/api/billing/asn") {
+      if (!cloud) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("not available");
+        return;
+      }
+      try {
+        const body = await readJsonBody(req);
+        const signed = typeof body.signedPayload === "string" ? body.signedPayload : "";
+        if (!signed) throw new IapError("malformed_jws");
+        const outer = await verifyAppleJWS(signed);
+        const type = String(outer.notificationType ?? "");
+        if (type === "REFUND" || type === "REVOKE") {
+          const data = (outer.data ?? {}) as Record<string, unknown>;
+          const txJws = typeof data.signedTransactionInfo === "string" ? data.signedTransactionInfo : "";
+          if (!txJws) throw new IapError("malformed_jws");
+          const tx = await verifyAppleJWS(txJws);
+          const transactionId = String(tx.transactionId ?? "");
+          const undone = transactionId ? await refundTransaction(transactionId) : null;
+          console.error(
+            undone
+              ? `[iap] ${type}: clawed back ${undone.microUSD} micro-USD from ${undone.uid} (tx ${transactionId})`
+              : `[iap] ${type}: unknown transaction ${transactionId} — ignored`,
+          );
+        }
+        // Always 200 a verified notification — Apple retries non-2xx.
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (e) {
+        const code = e instanceof IapError ? e.code : "verification_failed";
+        console.error(`[iap] ASN rejected: ${code}`);
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: code }));
+      }
+      return;
+    }
+
     if (req.method === "POST" && url === "/api/auth/logout") {
       // Stateless sessions: logout = drop the credential client-side; here we
       // just expire the cookie for browsers. (Account-wide revocation is the
@@ -997,6 +1038,39 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
             : { signedIn: false },
         ),
       );
+      return;
+    }
+
+    if (req.method === "POST" && url === "/api/billing/iap") {
+      // Credit a StoreKit 2 purchase (B5). Session-authed: the credit lands on
+      // the SIGNED-IN account. The client calls Transaction.finish() only after
+      // this answers ok, and the global transactionId index makes StoreKit's
+      // re-delivery (crash between purchase and credit) safe to replay.
+      if (!accountUid) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "account_session_required" }));
+        return;
+      }
+      try {
+        const body = await readJsonBody(req);
+        const jws = typeof body.jws === "string" ? body.jws : "";
+        if (!jws) throw new IapError("malformed_jws");
+        const payload = await verifyAppleJWS(jws);
+        const tx = validateTransaction(payload);
+        const credited = await creditTransaction(accountUid, tx);
+        const acct = getAccount(accountUid);
+        const q = acct ? await quotaStatus(acct) : null;
+        console.error(`[iap] credited ${credited} micro-USD to ${accountUid} (${tx.productId}, tx ${tx.transactionId}, ${tx.environment ?? "?"})`);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, creditedMicroUSD: credited, quota: q }));
+      } catch (e) {
+        const code = e instanceof IapError ? e.code : "verification_failed";
+        // duplicate_transaction answers 200-ok:false so the client still
+        // finishes the transaction (it WAS credited once already).
+        const status = code === "duplicate_transaction" ? 200 : 400;
+        res.writeHead(status, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: code === "duplicate_transaction", error: code }));
+      }
       return;
     }
 


### PR DESCRIPTION
**Stacked on #264.** Milestone B5 — the money path. Native StoreKit 2 + zero-dependency server verification (no RevenueCat).

## The invariant

**Credit exactly once, then finish.** The client sends the transaction JWS to the server *before* `Transaction.finish()`; the server verifies Apple's signature chain, dedupes by `transactionId` in a **global index** (one Apple transaction can never credit two accounts), credits the signed-in uid's balance, and only then does the client finish. A crash anywhere in between → StoreKit re-delivers → the dedup makes the replay a no-op.

## Server

- `verifyAppleJWS`: ES256 by the x5c **leaf**, chain walked with validity windows, root pinned to **Apple Root CA G3** (fetched once from apple.com over TLS, cached; `LISA_APPLE_ROOT_PATH` for air-gapped).
- `POST /api/billing/iap` (session-authed): validate bundle+product → credit → return fresh quota. Duplicate → `200 {ok:false}` so the client still finishes.
- `POST /api/billing/asn` (pre-gate — the signature chain IS the auth): **REFUND/REVOKE** → claw the credit back from the owning account (balance may go negative → premium locks per B4). Verified notifications always 200.

## iOS

`CreditsStore` (+ `Transaction.updates` listener at launch) and `PaywallSheet` (3 packs / restore / tier explainer); AccountCard gets **Add credits…**.

## Operator actions (before 1.1 review)

1. ASC: sign the **Paid Apps** agreement (banking/tax), create the 3 **consumable** products with the exact ids above, submit them WITH the 1.1 binary.
2. Apply to the **Small Business Program** (15%).
3. ASC → App Information → set the **ASN V2 production URL** to `https://<cloud>/api/billing/asn`.
4. Create + fund the review demo account (`reviewer@meetlisa.ai`) and put user/pass in App Review Information.

## Tests

JWS shape rejection / payload validation / credit + cross-account dedup / refund clawback + post-refund replay. Full suite **1056 pass / 0 fail**; iOS build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)