### PR TITLE
feat(gateway): B6 — inference gateway + key-free signed-in Macs + lisa login/billing

### DIFF
--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -40,7 +40,10 @@ export interface ParsedArgs {
     | "sense"
     | "agents"
     | "pair"
-    | "mail";
+    | "mail"
+    | "login"
+    | "logout"
+    | "billing";
   subargs: string[];
   serveWeb: boolean;
   serveImessage: boolean;
@@ -190,7 +193,10 @@ export function parseArgs(argv: string[]): ParsedArgs {
       first === "sense" ||
       first === "agents" ||
       first === "pair" ||
-      first === "mail"
+      first === "mail" ||
+      first === "login" ||
+      first === "logout" ||
+      first === "billing"
     ) {
       out.subcommand = first;
       out.subargs = positional.slice(1);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -201,6 +201,23 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Managed inference accounts (PLAN_ACCOUNTS_BILLING B6).
+  if (args.subcommand === "login") {
+    const { cmdLogin } = await import("./cli/account.js");
+    await cmdLogin(args.subargs);
+    return;
+  }
+  if (args.subcommand === "logout") {
+    const { cmdLogout } = await import("./cli/account.js");
+    await cmdLogout();
+    return;
+  }
+  if (args.subcommand === "billing") {
+    const { cmdBilling } = await import("./cli/account.js");
+    await cmdBilling(args.subargs);
+    return;
+  }
+
   if (args.subcommand === "soul") {
     const summary = await readSoulSummary();
     if (!summary) {

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -1,0 +1,138 @@
+/**
+ * `lisa login` / `lisa logout` / `lisa billing` — the managed-inference CLI
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.6, milestone B6).
+ *
+ * login: email+password against a LISA Cloud instance → stores the account
+ * session in config.env (LISA_MANAGED_SESSION/_BASE). From then on, any model
+ * WITHOUT its own BYO key routes through the cloud gateway — no API key needed.
+ * BYO keys keep winning; `lisa logout` removes the session.
+ *
+ * The password is read from the TTY with echo off (never from argv — argv
+ * leaks into `ps`). Sign in with Apple isn't possible in a terminal; email
+ * accounts are the CLI path.
+ */
+import readline from "node:readline";
+import { saveConfigEnv } from "../env.js";
+import { managedConfig } from "../providers/registry.js";
+import { formatMicroUSD } from "../billing/prices.js";
+
+function ask(question: string, opts: { hidden?: boolean } = {}): Promise<string> {
+  const rl = readline.createInterface({ input: process.stdin, output: process.stderr, terminal: true });
+  return new Promise((resolve) => {
+    if (opts.hidden) {
+      // Mute the echo: readline writes the prompt, we swallow the keystrokes.
+      const stream = process.stderr;
+      const origWrite = stream.write.bind(stream);
+      let muted = false;
+      (stream as unknown as { write: typeof origWrite }).write = ((chunk: never, ...rest: never[]) => {
+        if (muted) return true;
+        return origWrite(chunk, ...rest);
+      }) as typeof origWrite;
+      rl.question(question, (answer) => {
+        (stream as unknown as { write: typeof origWrite }).write = origWrite;
+        origWrite("\n");
+        rl.close();
+        resolve(answer);
+      });
+      muted = true;
+    } else {
+      rl.question(question, (answer) => {
+        rl.close();
+        resolve(answer);
+      });
+    }
+  });
+}
+
+export async function cmdLogin(subargs: string[]): Promise<void> {
+  const base = (subargs[0] ?? process.env.LISA_MANAGED_BASE ?? "https://cloud.meetlisa.ai").replace(/\/+$/, "");
+  const email = (await ask(`LISA Cloud (${base})\nEmail: `)).trim();
+  const password = await ask("Password: ", { hidden: true });
+  if (!email || !password) {
+    console.error("login cancelled — email and password are both required.");
+    process.exitCode = 1;
+    return;
+  }
+  let res: Response;
+  try {
+    res = await fetch(`${base}/api/auth/login`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ email, password }),
+    });
+  } catch {
+    console.error(`✗ could not reach ${base}`);
+    process.exitCode = 1;
+    return;
+  }
+  if (!res.ok) {
+    let code = "";
+    try { code = ((await res.json()) as { error?: string }).error ?? ""; } catch { /* text body */ }
+    const hint =
+      code === "bad_credentials" ? "wrong email or password"
+      : code === "throttled" ? "too many attempts — wait 15 minutes"
+      : `HTTP ${res.status}`;
+    console.error(`✗ sign-in rejected (${hint}). No account? Create one in the iOS app or on the web page.`);
+    process.exitCode = 1;
+    return;
+  }
+  const body = (await res.json()) as { token?: string; uid?: string };
+  if (!body.token) {
+    console.error("✗ unexpected server response (no session token)");
+    process.exitCode = 1;
+    return;
+  }
+  await saveConfigEnv({ LISA_MANAGED_SESSION: body.token, LISA_MANAGED_BASE: base });
+  console.error(`✓ signed in as ${email} (${body.uid ?? "?"})`);
+  console.error("  Models without a BYO key now route through LISA Cloud — no API key needed.");
+  await cmdBilling([]);
+}
+
+export async function cmdLogout(): Promise<void> {
+  await saveConfigEnv({ LISA_MANAGED_SESSION: "", LISA_MANAGED_BASE: "" });
+  console.error("✓ signed out — managed inference disabled (BYO keys unaffected).");
+}
+
+export async function cmdBilling(_subargs: string[]): Promise<void> {
+  const managed = managedConfig();
+  if (!managed) {
+    console.error("Not signed in. Run `lisa login` first (BYO-key usage isn't metered).");
+    process.exitCode = 1;
+    return;
+  }
+  try {
+    const headers = { authorization: `Bearer ${managed.session}` };
+    const [quotaRes, usageRes] = await Promise.all([
+      fetch(`${managed.base}/api/billing/quota`, { headers }),
+      fetch(`${managed.base}/api/billing/usage`, { headers }),
+    ]);
+    if (quotaRes.status === 401) {
+      console.error("✗ session expired — run `lisa login` again.");
+      process.exitCode = 1;
+      return;
+    }
+    const quota = (await quotaRes.json()) as {
+      available?: boolean; tier?: string; windowMicroUSD?: number;
+      spentMicroUSD?: number; remainingMicroUSD?: number; paidMicroUSD?: number; resetAt?: number;
+    };
+    const usage = (await usageRes.json()) as {
+      window12h?: { microUSD: number; turns: number };
+      today?: { microUSD: number; turns: number };
+    };
+    if (!quota.available) {
+      console.error("Signed in, but this connection isn't an account session — run `lisa login` again.");
+      return;
+    }
+    console.log(`tier:        ${quota.tier}`);
+    console.log(
+      `session:     ${formatMicroUSD(quota.remainingMicroUSD ?? 0)} of ${formatMicroUSD(quota.windowMicroUSD ?? 0)} left` +
+        (quota.resetAt ? ` (resets ${new Date(quota.resetAt).toLocaleTimeString()})` : ""),
+    );
+    console.log(`credits:     ${formatMicroUSD(Math.max(0, quota.paidMicroUSD ?? 0))}`);
+    if (usage.window12h) console.log(`last 12h:    ${formatMicroUSD(usage.window12h.microUSD)} across ${usage.window12h.turns} turns`);
+    if (usage.today) console.log(`today:       ${formatMicroUSD(usage.today.microUSD)} across ${usage.today.turns} turns`);
+  } catch {
+    console.error(`✗ could not reach ${managed.base}`);
+    process.exitCode = 1;
+  }
+}

--- a/src/providers/registry.ts
+++ b/src/providers/registry.ts
@@ -127,7 +127,7 @@ export const OPENAI_COMPAT_PRESETS: OpenAICompatPreset[] = [
  * mixed case (Baichuan2-Turbo, MiniMax-Text-01) and users typing the canonical
  * lowercase form shouldn't have to remember a vendor-specific capitalization.
  */
-function findPreset(model: string): OpenAICompatPreset | null {
+export function findPreset(model: string): OpenAICompatPreset | null {
   const lower = model.toLowerCase();
   for (const p of OPENAI_COMPAT_PRESETS) {
     if (p.modelPrefixes.some((pre) => lower.startsWith(pre.toLowerCase()))) return p;
@@ -180,7 +180,34 @@ export function resolveAnthropicAuth(
  * (detectProvider consults process.env for the LISA_BASE_URL / LISA_PROVIDER
  * routing rules; the per-key lookups below read the passed `env`.)
  */
+/**
+ * Managed inference (PLAN_ACCOUNTS_BILLING B6): a signed-in Mac/CLI with no
+ * provider key of its own routes LLM calls through the LISA cloud gateway
+ * (`/gw/*`), authenticated by the account session. Written to config.env by
+ * `lisa login`; BYO keys always win — managed only engages for a model whose
+ * own credentials are absent.
+ */
+export function managedConfig(
+  env: Record<string, string | undefined> = process.env,
+): { base: string; session: string } | null {
+  const session = env.LISA_MANAGED_SESSION?.trim();
+  if (!session) return null;
+  const base = (env.LISA_MANAGED_BASE?.trim() || "https://cloud.meetlisa.ai").replace(/\/+$/, "");
+  return { base, session };
+}
+
 export function hasCredentialsForModel(
+  model: string,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  // A managed session can drive any gateway-served model (anthropic/openai
+  // faces); gemini has no gateway face yet.
+  if (managedConfig(env) && detectProvider(model) !== "gemini") return true;
+  return hasOwnCredentialsForModel(model, env);
+}
+
+/** BYO credentials only (ignores the managed session). */
+export function hasOwnCredentialsForModel(
   model: string,
   env: Record<string, string | undefined> = process.env,
 ): boolean {
@@ -227,6 +254,26 @@ export function makeProvider(name: ProviderName): Provider {
  */
 function resolveProvider(model: string): Provider {
   const provider = detectProvider(model);
+  // Managed inference (B6): no own key for this model + a signed-in session →
+  // the LISA gateway, with the session token as the credential. The gateway
+  // swaps in the real provider key, meters, and enforces quota (402s surface
+  // through the normal provider error path).
+  const managed = managedConfig();
+  if (managed && !hasOwnCredentialsForModel(model)) {
+    if (provider === "anthropic") {
+      return new AnthropicProvider({
+        authToken: managed.session,
+        baseURL: `${managed.base}/gw/anthropic`,
+      });
+    }
+    if (provider === "openai") {
+      return new OpenAIProvider({
+        apiKey: managed.session,
+        baseURL: `${managed.base}/gw/openai/v1`,
+      });
+    }
+    // gemini: no gateway face yet — fall through to the normal resolution.
+  }
   if (provider === "anthropic") {
     return new AnthropicProvider({
       ...resolveAnthropicAuth(),

--- a/src/web/gateway.test.ts
+++ b/src/web/gateway.test.ts
@@ -1,0 +1,73 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+const { planUpstream, foldUsage, usageFromJson } = await import("./gateway.js");
+const { managedConfig, hasCredentialsForModel } = await import("../providers/registry.js");
+
+const ZERO = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+describe("planUpstream", () => {
+  test("anthropic face swaps in the real key + version passthrough", () => {
+    const plan = planUpstream("anthropic", "/v1/messages", "claude-sonnet-4-6",
+      { "anthropic-version": "2024-01-01" }, { ANTHROPIC_API_KEY: "sk-real" });
+    assert.equal(plan?.url, "https://api.anthropic.com/v1/messages");
+    assert.equal(plan?.headers["x-api-key"], "sk-real");
+    assert.equal(plan?.headers["anthropic-version"], "2024-01-01");
+  });
+
+  test("openai face routes GLM through its preset with the ZHIPU key", () => {
+    const plan = planUpstream("openai", "/chat/completions", "glm-4.6", {}, { ZHIPU_API_KEY: "zk" });
+    assert.ok(plan?.url.includes("bigmodel.cn"));
+    assert.equal(plan?.headers.authorization, "Bearer zk");
+  });
+
+  test("no operator key for the face → null (503 upstream)", () => {
+    assert.equal(planUpstream("anthropic", "/v1/messages", "claude-3", {}, {}), null);
+    assert.equal(planUpstream("openai", "/chat/completions", "glm-4.6", {}, {}), null);
+  });
+});
+
+describe("usage tee-parsing", () => {
+  test("anthropic stream: message_start + message_delta accumulate", () => {
+    let acc = foldUsage("anthropic", {
+      type: "message_start",
+      message: { usage: { input_tokens: 100, cache_read_input_tokens: 40, cache_creation_input_tokens: 10, output_tokens: 1 } },
+    }, ZERO);
+    acc = foldUsage("anthropic", { type: "message_delta", usage: { output_tokens: 250 } }, acc);
+    assert.deepEqual(acc, { inputTokens: 100, outputTokens: 251, cacheReadTokens: 40, cacheWriteTokens: 10 });
+  });
+
+  test("openai stream: only the final usage chunk counts; content chunks are neutral", () => {
+    let acc = foldUsage("openai", { choices: [{ delta: { content: "hi" } }], usage: null }, ZERO);
+    assert.deepEqual(acc, ZERO);
+    acc = foldUsage("openai", { usage: { prompt_tokens: 42, completion_tokens: 88 } }, acc);
+    assert.equal(acc.inputTokens, 42);
+    assert.equal(acc.outputTokens, 88);
+  });
+
+  test("non-streaming JSON bodies for both faces", () => {
+    assert.deepEqual(
+      usageFromJson("anthropic", { usage: { input_tokens: 5, output_tokens: 7 } }),
+      { inputTokens: 5, outputTokens: 7, cacheReadTokens: 0, cacheWriteTokens: 0 },
+    );
+    assert.equal(usageFromJson("openai", { usage: { prompt_tokens: 3, completion_tokens: 4 } }).outputTokens, 4);
+  });
+});
+
+describe("managed mode resolution", () => {
+  test("managedConfig parses env; empty session → null; base normalized", () => {
+    assert.equal(managedConfig({}), null);
+    assert.equal(managedConfig({ LISA_MANAGED_SESSION: "  " }), null);
+    const m = managedConfig({ LISA_MANAGED_SESSION: "s1.x.y", LISA_MANAGED_BASE: "https://cloud.example.com/" });
+    assert.equal(m?.base, "https://cloud.example.com");
+    assert.equal(managedConfig({ LISA_MANAGED_SESSION: "t" })?.base, "https://cloud.meetlisa.ai");
+  });
+
+  test("a managed session satisfies the key gate for gateway-served models", () => {
+    const env = { LISA_MANAGED_SESSION: "s1.x.y" };
+    assert.equal(hasCredentialsForModel("glm-4.6", env), true);
+    assert.equal(hasCredentialsForModel("claude-sonnet-4-6", env), true);
+    assert.equal(hasCredentialsForModel("gemini-2.0-pro", env), false);
+    assert.equal(hasCredentialsForModel("glm-4.6", {}), false);
+  });
+});

--- a/src/web/gateway.ts
+++ b/src/web/gateway.ts
@@ -1,0 +1,259 @@
+/**
+ * LISA inference gateway — key-free managed inference for signed-in clients
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.6, milestone B6).
+ *
+ * A signed-in Mac / CLI / app with NO provider key of its own sends its LLM
+ * calls here instead of to the provider: the uid-authed key-swap descendant of
+ * packaging/gcp-relay. Two upstream protocol faces:
+ *
+ *   POST /gw/anthropic/v1/messages          → api.anthropic.com (x-api-key swap)
+ *   POST /gw/openai/v1/chat/completions     → the model's OpenAI-compatible
+ *                                             preset (GLM → open.bigmodel.cn)
+ *
+ * Per request: session auth (handled by the server gate — accountUid arrives
+ * here non-null), quota precheck (B4; premium models need paid balance),
+ * key-swap, streaming passthrough with a tee-parser that extracts token usage
+ * from the stream itself, then metering + debit into the uid's ledger.
+ *
+ * PRIVACY BOUNDARY (documented in the plan + site): prompts TRANSIT this
+ * process over TLS and are never persisted; the ledger stores token counts
+ * and the model name only.
+ */
+import type http from "node:http";
+import { findPreset } from "../providers/registry.js";
+import type { ProviderUsage } from "../providers/types.js";
+import type { AccountRecord } from "./accounts.js";
+import { precheckTurn, debitTurn } from "../billing/quota.js";
+import { recordUsage } from "../billing/meter.js";
+
+export interface UpstreamPlan {
+  url: string;
+  headers: Record<string, string>;
+}
+
+/**
+ * Where does this gateway call go, and with which swapped-in credentials?
+ * Returns null when the operator has no key for the model's provider.
+ */
+export function planUpstream(
+  face: "anthropic" | "openai",
+  subpath: string,
+  model: string,
+  clientHeaders: http.IncomingHttpHeaders,
+  env: Record<string, string | undefined> = process.env,
+): UpstreamPlan | null {
+  if (face === "anthropic") {
+    const key = env.ANTHROPIC_API_KEY;
+    if (!key) return null;
+    const version = typeof clientHeaders["anthropic-version"] === "string"
+      ? clientHeaders["anthropic-version"]
+      : "2023-06-01";
+    return {
+      url: `https://api.anthropic.com${subpath}`,
+      headers: {
+        "content-type": "application/json",
+        "x-api-key": key,
+        "anthropic-version": version,
+      },
+    };
+  }
+  // OpenAI-compatible face: route by the model's preset (GLM → bigmodel), else
+  // vanilla OpenAI.
+  const preset = findPreset(model);
+  const base = preset ? preset.baseURL : "https://api.openai.com/v1";
+  const key = preset ? env[preset.apiKeyEnv] : env.OPENAI_API_KEY;
+  if (!key) return null;
+  return {
+    url: `${base.replace(/\/$/, "")}${subpath}`,
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${key}`,
+    },
+  };
+}
+
+const ZERO: ProviderUsage = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+/**
+ * Fold one upstream SSE `data:` JSON object into the running usage.
+ * Anthropic: message_start carries input/cache counts, message_delta the
+ * output count. OpenAI-compat: the final chunk (stream_options.include_usage)
+ * carries {usage:{prompt_tokens, completion_tokens}}.
+ */
+export function foldUsage(face: "anthropic" | "openai", obj: Record<string, unknown>, acc: ProviderUsage): ProviderUsage {
+  if (face === "anthropic") {
+    if (obj.type === "message_start") {
+      const usage = ((obj.message as Record<string, unknown> | undefined)?.usage ?? {}) as Record<string, unknown>;
+      return {
+        ...acc,
+        inputTokens: acc.inputTokens + num(usage.input_tokens),
+        cacheReadTokens: acc.cacheReadTokens + num(usage.cache_read_input_tokens),
+        cacheWriteTokens: acc.cacheWriteTokens + num(usage.cache_creation_input_tokens),
+        outputTokens: acc.outputTokens + num(usage.output_tokens),
+      };
+    }
+    if (obj.type === "message_delta") {
+      const usage = (obj.usage ?? {}) as Record<string, unknown>;
+      return { ...acc, outputTokens: acc.outputTokens + num(usage.output_tokens) };
+    }
+    return acc;
+  }
+  const usage = obj.usage as Record<string, unknown> | undefined | null;
+  if (usage && typeof usage === "object") {
+    return {
+      ...acc,
+      inputTokens: acc.inputTokens + num(usage.prompt_tokens),
+      outputTokens: acc.outputTokens + num(usage.completion_tokens),
+    };
+  }
+  return acc;
+}
+
+function num(v: unknown): number {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+/** Extract usage from a NON-streaming upstream JSON response body. */
+export function usageFromJson(face: "anthropic" | "openai", body: Record<string, unknown>): ProviderUsage {
+  if (face === "anthropic") {
+    const usage = (body.usage ?? {}) as Record<string, unknown>;
+    return {
+      inputTokens: num(usage.input_tokens),
+      outputTokens: num(usage.output_tokens),
+      cacheReadTokens: num(usage.cache_read_input_tokens),
+      cacheWriteTokens: num(usage.cache_creation_input_tokens),
+    };
+  }
+  return foldUsage("openai", body, ZERO);
+}
+
+/**
+ * Handle one gateway request (server.ts routes /gw/* here AFTER the auth gate
+ * has established the account session + entered the per-uid home scope).
+ */
+export async function handleGateway(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  url: string,
+  acct: AccountRecord,
+): Promise<void> {
+  const face: "anthropic" | "openai" = url.startsWith("/gw/anthropic/") ? "anthropic" : "openai";
+  const subpath = url.slice(face === "anthropic" ? "/gw/anthropic".length : "/gw/openai".length);
+
+  let raw = "";
+  for await (const chunk of req) raw += chunk.toString("utf8");
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(raw) as Record<string, unknown>;
+  } catch {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "bad_json" }));
+    return;
+  }
+  const model = typeof body.model === "string" ? body.model : "";
+  if (!model) {
+    res.writeHead(400, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "model_required" }));
+    return;
+  }
+
+  // Quota gate (same engine as /chat): tier decides model access; exhaustion
+  // is a structured 402 the local providers surface verbatim.
+  const pre = await precheckTurn(acct, model);
+  if (!pre.ok) {
+    res.writeHead(402, { "content-type": "application/json" });
+    res.end(
+      JSON.stringify(
+        pre.error === "quota_exhausted"
+          ? { error: pre.error, resetAt: pre.resetAt, tier: pre.tier }
+          : { error: pre.error, tier: pre.tier },
+      ),
+    );
+    return;
+  }
+
+  const stream = body.stream === true;
+  if (stream && face === "openai") {
+    // Ask the upstream to append the usage chunk so the tee-parser can meter.
+    body.stream_options = { ...(body.stream_options as object ?? {}), include_usage: true };
+  }
+
+  const plan = planUpstream(face, subpath, model, req.headers);
+  if (!plan) {
+    res.writeHead(503, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "model_not_available" }));
+    return;
+  }
+
+  let upstream: Response;
+  try {
+    upstream = await fetch(plan.url, {
+      method: "POST",
+      headers: plan.headers,
+      body: JSON.stringify(body),
+    });
+  } catch {
+    res.writeHead(502, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "upstream_unreachable" }));
+    return;
+  }
+
+  let usage: ProviderUsage = { ...ZERO };
+  const settle = async () => {
+    const rec = await recordUsage("gw", model, usage);
+    if (rec) await debitTurn(acct, model, rec.microUSD);
+  };
+
+  const contentType = upstream.headers.get("content-type") ?? "application/json";
+  if (!upstream.body || !contentType.includes("text/event-stream")) {
+    // Non-streaming (or error) response: buffer, meter, forward as-is.
+    const text = await upstream.text();
+    if (upstream.ok) {
+      try {
+        usage = usageFromJson(face, JSON.parse(text) as Record<string, unknown>);
+      } catch {
+        /* unmeterable body — forward anyway */
+      }
+      await settle();
+    }
+    res.writeHead(upstream.status, { "content-type": contentType });
+    res.end(text);
+    return;
+  }
+
+  // Streaming: byte-for-byte passthrough + tee-parse `data:` lines for usage.
+  res.writeHead(upstream.status, {
+    "content-type": contentType,
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+  const reader = upstream.body.getReader();
+  const decoder = new TextDecoder();
+  let carry = "";
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      res.write(Buffer.from(value));
+      carry += decoder.decode(value, { stream: true });
+      let nl: number;
+      while ((nl = carry.indexOf("\n")) >= 0) {
+        const line = carry.slice(0, nl).trim();
+        carry = carry.slice(nl + 1);
+        if (!line.startsWith("data:")) continue;
+        const payload = line.slice(5).trim();
+        if (!payload || payload === "[DONE]") continue;
+        try {
+          usage = foldUsage(face, JSON.parse(payload) as Record<string, unknown>, usage);
+        } catch {
+          /* non-JSON data line */
+        }
+      }
+    }
+  } catch {
+    // client or upstream dropped — meter what we saw
+  } finally {
+    await settle();
+    res.end();
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -41,6 +41,7 @@ import { recordUsage, summarizeUsage } from "../billing/meter.js";
 import { PRICES_VERSION, tokensAffordable } from "../billing/prices.js";
 import { precheckTurn, debitTurn, quotaStatus } from "../billing/quota.js";
 import { verifyAppleJWS, validateTransaction, creditTransaction, refundTransaction, IapError } from "../billing/iap.js";
+import { handleGateway } from "./gateway.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
@@ -1038,6 +1039,19 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
             : { signedIn: false },
         ),
       );
+      return;
+    }
+
+    // ── Inference gateway (B6): key-free managed LLM calls from signed-in
+    // Macs/CLIs. Account sessions only — never the shared demo token.
+    if (req.method === "POST" && (url.startsWith("/gw/anthropic/") || url.startsWith("/gw/openai/"))) {
+      const acct = cloud && accountUid ? getAccount(accountUid) : null;
+      if (!acct) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "account_session_required" }));
+        return;
+      }
+      await handleGateway(req, res, url, acct);
       return;
     }
 


### PR DESCRIPTION
**Stacked on #265.** Milestone B6 — decision #3: **a signed-in local Mac needs no API key.**

## Gateway (`src/web/gateway.ts`)

Two protocol faces, both `POST`-only and account-session-only (the shared demo token is refused):

- `/gw/anthropic/v1/messages` → api.anthropic.com (x-api-key swap)
- `/gw/openai/v1/chat/completions` → the model's OpenAI-compat preset (GLM → open.bigmodel.cn)

Per request: **B4 quota precheck** (premium models need paid balance; exhaustion = structured 402) → key-swap → **streaming passthrough** with a tee-parser that reads token usage out of the stream itself (anthropic `message_start`/`message_delta`; openai via injected `stream_options.include_usage`) → metering + debit into the uid's ledger.

**Privacy boundary** (documented): prompts transit the gateway over TLS and are never persisted — the ledger stores token counts + model name only. Users who don't accept that keep the BYO-key path, unchanged.

## Managed mode (providers/registry.ts)

`lisa login` writes `LISA_MANAGED_SESSION`/`_BASE` to config.env; any model **without its own BYO key** resolves to the gateway (Anthropic face via `authToken`, OpenAI face via bearer). **BYO keys always win.** `hasCredentialsForModel` accepts a managed session so birth/run gates pass key-free. (Gemini has no gateway face yet.)

## CLI

- `lisa login [base]` — email+password (echo-off TTY; never argv), stores the session, prints the quota.
- `lisa logout` — removes it (BYO keys unaffected).
- `lisa billing` — tier / session window / credits / last-12h usage.

## Follow-ups noted

- Mac menu-bar app "Sign in" UI that fronts `lisa login` (the backend plumbing this PR adds is what it needs).
- Gemini gateway face if demand appears.

## Tests

Upstream planning + key swap, stream usage folding (both faces), non-stream usage, managed resolution + key gate. **1064 pass / 0 fail.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)