### PR TITLE
feat(accounts): B8a — email verification (Resend); verified levels $1 → $5

### DIFF
--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -157,6 +157,7 @@ struct AccountCard: View {
     @State private var deleting = false
     @State private var quota: LisaClient.QuotaStatus?
     @State private var showPaywall = false
+    @State private var resendMessage: String?
 
     private static let tierLabels: [String: String] = [
         "free": "Free", "free-unverified": "Free (verify email for more)",
@@ -167,6 +168,22 @@ struct AccountCard: View {
         Section("LISA account") {
             if let acct = app.account, acct.signedIn {
                 LabeledContent("Signed in as", value: acct.email ?? acct.uid ?? "—")
+                // Unverified email = reduced ($1) session window (B8a).
+                if acct.kind == "email" && acct.verified == false {
+                    VStack(alignment: .leading, spacing: 6) {
+                        Label("Email not verified — your free allowance is limited to $1 per session.",
+                              systemImage: "envelope.badge")
+                            .font(.caption).foregroundStyle(Theme.waiting)
+                        Button(resendMessage ?? "Resend verification email") {
+                            Task {
+                                let sent = (try? await app.client.resendVerification()) ?? false
+                                resendMessage = sent ? "Sent — check your inbox." : "Couldn't send — try again later."
+                            }
+                        }
+                        .font(.caption)
+                        .disabled(resendMessage == "Sent — check your inbox.")
+                    }
+                }
                 if let q = quota, q.available, let window = q.windowMicroUSD, window > 0 {
                     let spent = q.spentMicroUSD ?? 0
                     let remaining = q.remainingMicroUSD ?? 0

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -157,6 +157,14 @@ final class LisaClient {
         _ = try await decode("/api/account", method: "DELETE", as: R.self)
     }
 
+    /// Re-send the email-verification mail (`POST /api/auth/verify/resend`).
+    /// Returns true when a mail actually went out.
+    func resendVerification() async throws -> Bool {
+        struct R: Decodable { let ok: Bool; let sent: Bool?; let alreadyVerified: Bool? }
+        let r = try await decode("/api/auth/verify/resend", method: "POST", as: R.self)
+        return r.sent ?? (r.alreadyVerified ?? false)
+    }
+
     /// URL for a server asset (e.g. a mood portrait at /assets/lisa/<slug>.png),
     /// carrying the token as a query param so AsyncImage — which can't set an
     /// Authorization header — still authenticates against a non-loopback server.

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -41,10 +41,14 @@ export interface AccountRecord {
   scrypt?: ScryptParams;
   createdAt: number;
   lastLoginAt: number;
-  /** Email ownership verified (B7 wires actual mail); Apple counts as verified. */
+  /** Email ownership verified (B8a wires the mail); Apple counts as verified. */
   verified: boolean;
   /** Bump to invalidate every outstanding session for this uid. */
   sessionVersion: number;
+  /** SHA-256 of the outstanding verification token (email kind, unverified). */
+  verifyTokenHash?: string;
+  /** Verification-token expiry, ms epoch. */
+  verifyExpiresAt?: number;
 }
 
 export class AccountError extends Error {
@@ -297,27 +301,60 @@ export function sessionAccountValid(uid: string, sv: number): boolean {
  * password. Returns the record.
  */
 export function ensureSeededAccount(email: string, password: string, now: number = Date.now()): AccountRecord {
-  const existing = getAccountByEmail(email);
-  if (existing) {
-    if (!existing.verified) {
-      const list = loadAccounts();
-      const live = list.find((a) => a.uid === existing.uid);
-      if (live) {
-        live.verified = true;
-        saveAccounts(list);
-        live.scrypt = existing.scrypt;
-        return live;
-      }
-    }
-    return existing;
-  }
-  const rec = createEmailAccount(email, password, now);
+  const existing = getAccountByEmail(email) ?? createEmailAccount(email, password, now);
   const list = loadAccounts();
-  const live = list.find((a) => a.uid === rec.uid);
-  if (live) {
+  const live = list.find((a) => a.uid === existing.uid);
+  if (live && !live.verified) {
     live.verified = true;
     saveAccounts(list);
     return live;
   }
-  return rec;
+  return live ?? existing;
+}
+
+// ── email-ownership verification (B8a) ──────────────────────────────────────
+const VERIFY_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Mint (and store the hash of) a fresh verification token for an unverified
+ * email account. Returns the RAW token once — it goes into the mailed link —
+ * or null when the uid isn't an unverified email account.
+ */
+export function beginEmailVerification(uid: string, now: number = Date.now()): string | null {
+  const list = loadAccounts();
+  const acct = list.find((a) => a.uid === uid);
+  if (!acct || acct.kind !== "email" || acct.verified) return null;
+  const token = crypto.randomBytes(24).toString("hex");
+  acct.verifyTokenHash = crypto.createHash("sha256").update(token).digest("hex");
+  acct.verifyExpiresAt = now + VERIFY_TTL_MS;
+  saveAccounts(list);
+  return token;
+}
+
+/**
+ * Confirm a verification link. Constant-time hash compare; expiry enforced.
+ * On success the account is marked verified (free window levels $1 → $5) and
+ * the token is cleared. Returns the account or null.
+ */
+export function confirmEmailVerification(rawToken: string, now: number = Date.now()): AccountRecord | null {
+  if (!rawToken) return null;
+  const presented = crypto.createHash("sha256").update(rawToken).digest();
+  const list = loadAccounts();
+  for (const acct of list) {
+    if (!acct.verifyTokenHash || acct.verified) continue;
+    let stored: Buffer;
+    try {
+      stored = Buffer.from(acct.verifyTokenHash, "hex");
+    } catch {
+      continue;
+    }
+    if (stored.length !== presented.length || !crypto.timingSafeEqual(stored, presented)) continue;
+    if (!acct.verifyExpiresAt || acct.verifyExpiresAt < now) return null; // matched but stale
+    acct.verified = true;
+    delete acct.verifyTokenHash;
+    delete acct.verifyExpiresAt;
+    saveAccounts(list);
+    return acct;
+  }
+  return null;
 }

--- a/src/web/mailer.ts
+++ b/src/web/mailer.ts
@@ -1,0 +1,76 @@
+/**
+ * Outbound mail — email-ownership verification for LISA accounts
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md B7 follow-up, milestone B8a).
+ *
+ * One provider, one purpose: Resend's REST API (zero deps) sends the
+ * verification link that levels an email account's free window from $1 to $5.
+ * Without RESEND_API_KEY the mailer degrades loudly-but-safely: the link is
+ * printed to the server log so an operator can forward it by hand (and dev
+ * setups keep working offline).
+ *
+ * Env: RESEND_API_KEY, LISA_MAIL_FROM (default "LISA <no-reply@meetlisa.ai>";
+ * the domain must be verified in Resend before real sends succeed).
+ */
+
+export interface MailResult {
+  sent: boolean;
+  /** Provider id or the reason it wasn't sent. */
+  detail: string;
+}
+
+export interface MailerConfig {
+  apiKey: string | null;
+  from: string;
+}
+
+export function mailerConfig(env: Record<string, string | undefined> = process.env): MailerConfig {
+  return {
+    apiKey: env.RESEND_API_KEY?.trim() || null,
+    from: env.LISA_MAIL_FROM?.trim() || "LISA <no-reply@meetlisa.ai>",
+  };
+}
+
+/** Compose the verification mail (pure — unit-testable). */
+export function verificationEmail(link: string): { subject: string; text: string } {
+  return {
+    subject: "Verify your LISA account email",
+    text:
+      `Confirm this email address for your LISA account by opening the link below:\n\n` +
+      `${link}\n\n` +
+      `Verifying raises your free session allowance to the full amount. The link ` +
+      `expires in 24 hours. If you didn't create a LISA account, ignore this mail.`,
+  };
+}
+
+export async function sendVerificationEmail(
+  to: string,
+  link: string,
+  cfg: MailerConfig = mailerConfig(),
+  fetchFn: typeof fetch = fetch,
+): Promise<MailResult> {
+  const mail = verificationEmail(link);
+  if (!cfg.apiKey) {
+    console.error(`[mail] RESEND_API_KEY unset — verification link for ${to}: ${link}`);
+    return { sent: false, detail: "no_api_key" };
+  }
+  try {
+    const res = await fetchFn("https://api.resend.com/emails", {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${cfg.apiKey}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ from: cfg.from, to: [to], subject: mail.subject, text: mail.text }),
+    });
+    if (!res.ok) {
+      const body = await res.text().catch(() => "");
+      console.error(`[mail] resend rejected (${res.status}): ${body.slice(0, 200)}`);
+      return { sent: false, detail: `http_${res.status}` };
+    }
+    const parsed = (await res.json().catch(() => ({}))) as { id?: string };
+    return { sent: true, detail: parsed.id ?? "sent" };
+  } catch (e) {
+    console.error(`[mail] send failed: ${(e as Error).message}`);
+    return { sent: false, detail: "network_error" };
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -88,7 +88,10 @@ import {
   getAccount,
   sessionAccountValid,
   ensureSeededAccount,
+  beginEmailVerification,
+  confirmEmailVerification,
 } from "./accounts.js";
+import { sendVerificationEmail } from "./mailer.js";
 import { readBalance, creditPurchase } from "../billing/quota.js";
 import { PushBridge, listPush, registerPush, unregisterPush, setPushPrefs, registerLiveActivity, unregisterLiveActivity, type PushPrefs } from "./push.js";
 import { SenseService } from "../sense/service.js";
@@ -214,6 +217,13 @@ function presentedToken(req: http.IncomingMessage, url: string): string | null {
     /* fall through */
   }
   return null;
+}
+
+/** The absolute /verify link for a raw token, derived from the request host. */
+function verifyLinkFor(req: http.IncomingMessage, rawToken: string): string {
+  const host = req.headers.host ?? "cloud.meetlisa.ai";
+  const proto = (req.headers["x-forwarded-proto"] as string | undefined) ?? "https";
+  return `${proto}://${host}/verify?token=${rawToken}`;
 }
 
 /** Read and JSON-parse a request body (tolerant: bad/empty JSON ⇒ {}). */
@@ -902,6 +912,12 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           res.end(JSON.stringify({ error: "bad_credentials" }));
           return;
         }
+        // First registration: kick off email verification (B8a) — verifying
+        // levels the free window from $1 to the full $5. Fire-and-forget.
+        if (url === "/api/auth/register") {
+          const raw = beginEmailVerification(acct.uid);
+          if (raw) void sendVerificationEmail(acct.email!, verifyLinkFor(req, raw));
+        }
         const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
         res.writeHead(200, {
           "content-type": "application/json",
@@ -959,6 +975,27 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.writeHead(401, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: code }));
       }
+      return;
+    }
+
+    // Email-verification landing (pre-gate: the token IS the credential; the
+    // user clicks it from their mail client, no session cookie there).
+    if (req.method === "GET" && url.startsWith("/verify")) {
+      let token = "";
+      try {
+        token = new URL(url, "http://localhost").searchParams.get("token")?.trim() ?? "";
+      } catch {
+        /* fall through */
+      }
+      const acct = cloud && token ? confirmEmailVerification(token) : null;
+      res.writeHead(acct ? 200 : 400, { "content-type": "text/html; charset=utf-8" });
+      res.end(
+        `<!doctype html><meta name="viewport" content="width=device-width, initial-scale=1">` +
+          `<body style="font: 16px -apple-system, sans-serif; background:#0b0e13; color:#e6e9ef; display:grid; place-items:center; min-height:95vh">` +
+          (acct
+            ? `<div style="text-align:center"><h2>✓ Email verified</h2><p>Your free session allowance is now the full amount.<br>You can close this page and return to LISA.</p></div>`
+            : `<div style="text-align:center"><h2>Link invalid or expired</h2><p>Request a fresh verification email from Settings in the app.</p></div>`),
+      );
       return;
     }
 
@@ -1137,6 +1174,26 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       ]);
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ window12h, today, pricesVersion: PRICES_VERSION }));
+      return;
+    }
+
+    if (req.method === "POST" && url === "/api/auth/verify/resend") {
+      // Re-send the verification mail for the signed-in unverified email account.
+      const acct = accountUid ? getAccount(accountUid) : null;
+      if (!acct || acct.kind !== "email" || !acct.email) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "email_account_required" }));
+        return;
+      }
+      if (acct.verified) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, alreadyVerified: true }));
+        return;
+      }
+      const raw = beginEmailVerification(acct.uid);
+      const mail = raw ? await sendVerificationEmail(acct.email, verifyLinkFor(req, raw)) : null;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, sent: mail?.sent ?? false }));
       return;
     }
 

--- a/src/web/verification.test.ts
+++ b/src/web/verification.test.ts
@@ -1,0 +1,89 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-verify-"));
+process.env.LISA_HOME = TMP;
+const FILE = path.join(TMP, "accounts.json");
+
+const { createEmailAccount, beginEmailVerification, confirmEmailVerification, upsertAppleAccount, getAccount } =
+  await import("./accounts.js");
+const { verificationEmail, mailerConfig, sendVerificationEmail } = await import("./mailer.js");
+
+beforeEach(() => {
+  fs.rmSync(FILE, { force: true });
+});
+
+describe("email verification", () => {
+  test("begin → confirm levels the account to verified and clears the token", () => {
+    const rec = createEmailAccount("a@b.co", "password-123");
+    assert.equal(rec.verified, false);
+    const raw = beginEmailVerification(rec.uid, 1000);
+    assert.ok(raw && raw.length >= 32);
+    // raw token never persisted, only its hash
+    assert.equal(fs.readFileSync(FILE, "utf8").includes(raw!), false);
+    const confirmed = confirmEmailVerification(raw!, 2000);
+    assert.equal(confirmed?.uid, rec.uid);
+    const after = getAccount(rec.uid);
+    assert.equal(after?.verified, true);
+    assert.equal(after?.verifyTokenHash, undefined);
+    // replay of the used token fails
+    assert.equal(confirmEmailVerification(raw!, 3000), null);
+  });
+
+  test("expired / wrong tokens fail; re-begin rotates the token", () => {
+    const rec = createEmailAccount("c@d.co", "password-123");
+    const raw1 = beginEmailVerification(rec.uid, 1000)!;
+    // expired (25h later)
+    assert.equal(confirmEmailVerification(raw1, 1000 + 25 * 60 * 60 * 1000), null);
+    // fresh token supersedes the old one
+    const raw2 = beginEmailVerification(rec.uid, 2000)!;
+    assert.notEqual(raw1, raw2);
+    assert.equal(confirmEmailVerification(raw1, 3000), null);
+    assert.ok(confirmEmailVerification(raw2, 3000));
+  });
+
+  test("apple accounts and already-verified accounts can't begin verification", () => {
+    const apple = upsertAppleAccount("001.xyz", undefined);
+    assert.equal(beginEmailVerification(apple.uid), null);
+    const rec = createEmailAccount("e@f.co", "password-123");
+    const raw = beginEmailVerification(rec.uid)!;
+    confirmEmailVerification(raw);
+    assert.equal(beginEmailVerification(rec.uid), null);
+  });
+});
+
+describe("mailer", () => {
+  test("compose includes the link; config defaults are sane", () => {
+    const mail = verificationEmail("https://x/verify?token=t");
+    assert.match(mail.text, /https:\/\/x\/verify\?token=t/);
+    const cfg = mailerConfig({});
+    assert.equal(cfg.apiKey, null);
+    assert.match(cfg.from, /meetlisa\.ai/);
+  });
+
+  test("no api key → degrades to logged link, sent:false", async () => {
+    const r = await sendVerificationEmail("a@b.co", "https://x/verify?token=t", mailerConfig({}));
+    assert.deepEqual(r, { sent: false, detail: "no_api_key" });
+  });
+
+  test("sends through the injected fetch and reports the provider id", async () => {
+    const calls: Array<{ url: string; init: RequestInit }> = [];
+    const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      calls.push({ url: String(url), init: init! });
+      return new Response(JSON.stringify({ id: "email_123" }), { status: 200 });
+    }) as typeof fetch;
+    const r = await sendVerificationEmail(
+      "a@b.co",
+      "https://x/verify?token=t",
+      { apiKey: "re_key", from: "LISA <no-reply@meetlisa.ai>" },
+      fakeFetch,
+    );
+    assert.deepEqual(r, { sent: true, detail: "email_123" });
+    assert.equal(calls.length, 1);
+    assert.match(calls[0]!.url, /api\.resend\.com/);
+    assert.match(String(calls[0]!.init.body), /a@b\.co/);
+  });
+});


### PR DESCRIPTION
**Stacked on #267.** First of the code-leftover finishers from PLAN §10.

- **`mailer.ts`** — Resend REST (no deps). No `RESEND_API_KEY` → the link is logged instead of sent (dev/offline safe).
- **`accounts.ts`** — `beginEmailVerification` (token hash only on disk, 24h TTL, rotation) / `confirmEmailVerification` (constant-time, replay-dead). Seed helper dead-code cleanup.
- **`server.ts`** — register sends the mail; `GET /verify?token=` pre-gate landing page; `POST /api/auth/verify/resend`.
- **iOS** — unverified banner + resend button in AccountCard.
- Quota: no change needed — `tierFor` already keys off `verified`, so confirming levels the window $1 → $5 automatically.

**Operator env (when ready):** `RESEND_API_KEY` + verify `meetlisa.ai` as a sending domain in Resend; optionally `LISA_MAIL_FROM`. Until then registration still works — links appear in the Cloud Run log.

Tests: 6 new (round-trip/replay/expiry/rotation/kind-gating/mailer). **1075 pass / 0 fail**; iOS build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)