### PR TITLE
feat(auth): B8b — Sign in with Apple on the web login page

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -58,6 +58,9 @@ ENVS="^##^LISA_EDITION=cloud##LISA_WEB_TOKEN=${LISA_WEB_TOKEN}"
 [ -n "${LISA_CLOUD_APPLE_SIGNIN:-}" ] && ENVS="${ENVS}##LISA_CLOUD_APPLE_SIGNIN=${LISA_CLOUD_APPLE_SIGNIN}"
 [ -n "${LISA_CLOUD_APPLE_SUBS:-}" ]   && ENVS="${ENVS}##LISA_CLOUD_APPLE_SUBS=${LISA_CLOUD_APPLE_SUBS}"
 [ -n "${LISA_CLOUD_APPLE_AUD:-}" ]    && ENVS="${ENVS}##LISA_CLOUD_APPLE_AUD=${LISA_CLOUD_APPLE_AUD}"
+# Sign in with Apple on the WEB login page (B8b): the Services ID registered in
+# the Apple portal for cloud.meetlisa.ai (needs domain verification there).
+[ -n "${LISA_CLOUD_APPLE_WEB_SID:-}" ] && ENVS="${ENVS}##LISA_CLOUD_APPLE_WEB_SID=${LISA_CLOUD_APPLE_WEB_SID}"
 # Accounts & billing era (PLAN_ACCOUNTS_BILLING B1–B7), all optional:
 #   LISA_REVIEWER_SEED="email:password"  idempotent App-Review demo account (verified, $20/Tier-2)
 #   LISA_RPM_LIMIT / LISA_DAILY_CAP_USD  abuse guards (defaults 20 rpm / $200 per day)

--- a/src/web/cloudAuth.test.ts
+++ b/src/web/cloudAuth.test.ts
@@ -5,6 +5,7 @@ import {
   verifyAppleIdentityToken,
   AppleAuthError,
   appleSignInConfig,
+  audienceForClient,
   subAllowed,
   type AppleJWK,
 } from "./cloudAuth.js";
@@ -118,4 +119,18 @@ test("subAllowed: empty allowlist admits anyone; non-empty restricts", () => {
   assert.equal(subAllowed("x", { enabled: true, audience: AUD, allowedSubs: [] }), true);
   assert.equal(subAllowed("x", { enabled: true, audience: AUD, allowedSubs: ["y"] }), false);
   assert.equal(subAllowed("y", { enabled: true, audience: AUD, allowedSubs: ["y"] }), true);
+});
+
+test("webServicesId parses from env; absent → null (B8b)", () => {
+  const on = appleSignInConfig({ LISA_CLOUD_APPLE_WEB_SID: " ai.meetlisa.web " } as NodeJS.ProcessEnv);
+  assert.equal(on.webServicesId, "ai.meetlisa.web");
+  assert.equal(appleSignInConfig({} as NodeJS.ProcessEnv).webServicesId, null);
+});
+
+test("audienceForClient picks the surface's aud and rejects unconfigured web (B8b)", () => {
+  const cfg = appleSignInConfig({ LISA_CLOUD_APPLE_WEB_SID: "ai.meetlisa.web" } as NodeJS.ProcessEnv);
+  assert.equal(audienceForClient(cfg, "native"), "ai.meetlisa.main");
+  assert.equal(audienceForClient(cfg, "web"), "ai.meetlisa.web");
+  const bare = appleSignInConfig({} as NodeJS.ProcessEnv);
+  assert.equal(audienceForClient(bare, "web"), null);
 });

--- a/src/web/cloudAuth.ts
+++ b/src/web/cloudAuth.ts
@@ -155,6 +155,12 @@ export interface AppleSignInConfig {
   enabled: boolean;
   /** Expected token audience — the app bundle id. */
   audience: string;
+  /**
+   * Sign in with Apple on the WEB (B8b): the Services ID that Apple's JS flow
+   * mints tokens for (`aud` differs from the native bundle id). Unset ⇒ the
+   * web button stays hidden and web-audience tokens are rejected.
+   */
+  webServicesId: string | null;
   /** Optional allowlist of Apple `sub`s; empty = any verified Apple ID may sign in. */
   allowedSubs: string[];
 }
@@ -176,11 +182,21 @@ export function appleSignInConfig(env: NodeJS.ProcessEnv = process.env): AppleSi
   return {
     enabled: truthy(env.LISA_CLOUD_APPLE_SIGNIN),
     audience: env.LISA_CLOUD_APPLE_AUD?.trim() || "ai.meetlisa.main",
+    webServicesId: env.LISA_CLOUD_APPLE_WEB_SID?.trim() || null,
     allowedSubs: (env.LISA_CLOUD_APPLE_SUBS ?? "")
       .split(",")
       .map((s) => s.trim())
       .filter(Boolean),
   };
+}
+
+/**
+ * Pick the expected `aud` for a sign-in request: web-client tokens carry the
+ * Services ID, native ones the bundle id. Returns null when that surface
+ * isn't configured (⇒ reject).
+ */
+export function audienceForClient(cfg: AppleSignInConfig, client: "native" | "web"): string | null {
+  return client === "web" ? cfg.webServicesId : cfg.audience;
 }
 
 /** True when `sub` is permitted by the (possibly empty) allowlist. */

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -42,6 +42,13 @@ export const LOGIN_HTML = `<!doctype html>
   }
   button.secondary { background: transparent; color: #8a93a5; font-weight: 500; margin-top: 8px; }
   button:disabled { opacity: .5; cursor: default; }
+  #apple-wrap { display: none; margin-bottom: 18px; }
+  #apple-btn {
+    width: 100%; padding: 12px; border: 0; border-radius: 10px; cursor: pointer;
+    background: #fff; color: #000; font-size: 16px; font-weight: 600;
+  }
+  .divider { display: none; align-items: center; gap: 10px; color: #5d6575; font-size: 12px; margin-bottom: 4px; }
+  .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: #232a36; }
   .err { color: #ff7a7a; font-size: 13px; margin-top: 12px; min-height: 1.2em; }
   .hint { color: #5d6575; font-size: 12px; margin-top: 18px; }
 </style>
@@ -50,6 +57,10 @@ export const LOGIN_HTML = `<!doctype html>
 <div class="card">
   <h1>LISA Cloud</h1>
   <p class="sub">Sign in to reach your Lisa. A free usage allowance refreshes every 12 hours.</p>
+  <div id="apple-wrap">
+    <button id="apple-btn" type="button"> Sign in with Apple</button>
+  </div>
+  <div class="divider" id="divider">or use email</div>
   <form id="f">
     <label for="email">Email</label>
     <input id="email" type="email" autocomplete="username" required>
@@ -90,6 +101,46 @@ export const LOGIN_HTML = `<!doctype html>
   document.getElementById("register").addEventListener("click", () => {
     if (f.reportValidity()) auth("/api/auth/register");
   });
+
+  // Sign in with Apple on the web (B8b): drawn only when the instance has a
+  // Services ID configured (GET /api/auth/config). Apple's JS runs a popup and
+  // hands back an id_token; the server verifies it against the web audience.
+  fetch("/api/auth/config").then((r) => r.json()).then((cfg) => {
+    if (!cfg || !cfg.appleWeb || !cfg.appleWeb.servicesId) return;
+    const s = document.createElement("script");
+    s.src = "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
+    s.onload = () => {
+      window.AppleID.auth.init({
+        clientId: cfg.appleWeb.servicesId,
+        scope: "name email",
+        redirectURI: location.origin,
+        usePopup: true,
+      });
+      document.getElementById("apple-wrap").style.display = "block";
+      document.getElementById("divider").style.display = "flex";
+      document.getElementById("apple-btn").addEventListener("click", async () => {
+        err.textContent = "";
+        try {
+          const auth = await window.AppleID.auth.signIn();
+          const idToken = auth && auth.authorization && auth.authorization.id_token;
+          if (!idToken) { err.textContent = "Apple didn't return a token."; return; }
+          const res = await fetch("/api/auth/apple", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ identityToken: idToken, client: "web" }),
+          });
+          if (res.ok) { location.replace("/"); return; }
+          err.textContent = "Apple sign-in was rejected (" + res.status + ").";
+        } catch (e) {
+          // popup_closed_by_user etc. — silent unless a real failure
+          if (e && e.error && e.error !== "popup_closed_by_user") {
+            err.textContent = "Apple sign-in failed.";
+          }
+        }
+      });
+    };
+    document.head.appendChild(s);
+  }).catch(() => {});
 </script>
 </body>
 </html>

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -116,6 +116,7 @@ import {
   appleSignInConfig,
   subAllowed,
   AppleAuthError,
+  audienceForClient,
 } from "./cloudAuth.js";
 import { detectLanHost, buildPairUrl } from "./pairing.js";
 import { qrSvg } from "./qr-svg.js";
@@ -866,9 +867,19 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end("identityToken required");
         return;
       }
+      // Web tokens (Apple JS popup on the login page, B8b) carry the Services
+      // ID as `aud`, native ones the bundle id. Reject a surface that isn't
+      // configured rather than verifying against the wrong audience.
+      const client = payload.client === "web" ? "web" as const : "native" as const;
+      const audience = audienceForClient(cfg, client);
+      if (!audience) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("apple sign-in not available for this client");
+        return;
+      }
       try {
         const id = await verifyAppleIdentityToken(idToken, {
-          audience: cfg.audience,
+          audience,
           fetchKeys: fetchAppleKeys,
         });
         if (!subAllowed(id.sub, cfg)) {
@@ -880,13 +891,33 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         // The uid keys per-user isolation (B2) and billing (B3+).
         const acct = upsertAppleAccount(id.sub, id.email);
         const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
-        res.writeHead(200, { "content-type": "application/json" });
+        res.writeHead(200, {
+          "content-type": "application/json",
+          // Web clients continue via cookie; Bearer clients ignore it.
+          "set-cookie": `lisa_token=${encodeURIComponent(session)}; HttpOnly; SameSite=Strict; Path=/`,
+        });
         res.end(JSON.stringify({ ok: true, token: session, uid: acct.uid }));
       } catch (e) {
         const msg = e instanceof AppleAuthError ? e.message : "verification failed";
         res.writeHead(401, { "content-type": "text/plain" });
         res.end(`apple sign-in rejected: ${msg}`);
       }
+      return;
+    }
+
+    // Public sign-in surface config (pre-gate): the login page asks which
+    // buttons to draw. Never exposes secrets — just feature flags + ids.
+    if (req.method === "GET" && url === "/api/auth/config") {
+      const cfg = appleSignInConfig();
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          accounts: cloud && !!sessionSecret,
+          appleWeb: cloud && cfg.enabled && !!cfg.webServicesId
+            ? { servicesId: cfg.webServicesId }
+            : null,
+        }),
+      );
       return;
     }
 


### PR DESCRIPTION
**Stacked on #268.** Second code-leftover finisher.

- **`cloudAuth.ts`**: `LISA_CLOUD_APPLE_WEB_SID` + `audienceForClient` — web tokens carry the **Services ID** as `aud`, native ones the bundle id; an unconfigured surface is rejected, never mis-verified.
- **`server.ts`**: `/api/auth/apple` accepts `{client:"web"}`; success now also pins the session cookie. New pre-gate `GET /api/auth/config` (feature flags + ids only) tells the login page what to draw.
- **`login.ts`**: Apple button appears only when configured; Apple JS popup → id_token → POST → reload into the authed island.

## Operator (to enable, optional)

1. Apple portal → Identifiers → **Services ID** (e.g. `ai.meetlisa.web`) → enable *Sign in with Apple*, group under primary App ID `ai.meetlisa.main`, verify domain `cloud.meetlisa.ai`, return URL `https://cloud.meetlisa.ai`.
2. Deploy with `LISA_CLOUD_APPLE_WEB_SID=ai.meetlisa.web`.

Until then the page shows email-only — no behavior change.

Tests: config parsing + audience selection. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)