### PR TITLE
feat(billing): B8c — Stripe top-up (desktop/web) + /account page

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -66,6 +66,12 @@ ENVS="^##^LISA_EDITION=cloud##LISA_WEB_TOKEN=${LISA_WEB_TOKEN}"
 #   LISA_RPM_LIMIT / LISA_DAILY_CAP_USD  abuse guards (defaults 20 rpm / $200 per day)
 #   LISA_BILLING_KILL=1                  pause ALL metered inference immediately
 [ -n "${LISA_REVIEWER_SEED:-}" ]  && ENVS="${ENVS}##LISA_REVIEWER_SEED=${LISA_REVIEWER_SEED}"
+#   RESEND_API_KEY / LISA_MAIL_FROM  email verification (B8a; domain verified in Resend)
+#   STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET  desktop/web top-up (B8c)
+[ -n "${RESEND_API_KEY:-}" ]        && ENVS="${ENVS}##RESEND_API_KEY=${RESEND_API_KEY}"
+[ -n "${LISA_MAIL_FROM:-}" ]        && ENVS="${ENVS}##LISA_MAIL_FROM=${LISA_MAIL_FROM}"
+[ -n "${STRIPE_SECRET_KEY:-}" ]     && ENVS="${ENVS}##STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}"
+[ -n "${STRIPE_WEBHOOK_SECRET:-}" ] && ENVS="${ENVS}##STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}"
 [ -n "${LISA_RPM_LIMIT:-}" ]      && ENVS="${ENVS}##LISA_RPM_LIMIT=${LISA_RPM_LIMIT}"
 [ -n "${LISA_DAILY_CAP_USD:-}" ]  && ENVS="${ENVS}##LISA_DAILY_CAP_USD=${LISA_DAILY_CAP_USD}"
 [ -n "${LISA_BILLING_KILL:-}" ]   && ENVS="${ENVS}##LISA_BILLING_KILL=${LISA_BILLING_KILL}"

--- a/src/billing/iap.ts
+++ b/src/billing/iap.ts
@@ -203,23 +203,35 @@ function writeTxIndex(list: TxIndexEntry[]): void {
 }
 
 /**
- * Credit a VERIFIED transaction to `uid`. Dedupes globally; credits the uid's
- * balance inside that uid's home scope. Returns the credited face value.
+ * Credit ANY external payment (Apple IAP, Stripe, operator grant) to `uid`
+ * exactly once: global transactionId dedup, then the uid's balance inside its
+ * home scope. Shared by the IAP and Stripe paths so cross-channel replay is
+ * impossible by construction. Returns the credited face value.
  */
-export async function creditTransaction(uid: string, tx: AppleTransaction, now: number = Date.now()): Promise<number> {
-  const microUSD = PRODUCTS[tx.productId]!;
+export async function creditExternalTransaction(
+  uid: string,
+  transactionId: string,
+  productId: string,
+  microUSD: number,
+  now: number = Date.now(),
+): Promise<number> {
   await withFileLock(txIndexLock(), async () => {
     const index = readTxIndex();
-    if (index.some((e) => e.transactionId === tx.transactionId)) {
+    if (index.some((e) => e.transactionId === transactionId)) {
       throw new IapError("duplicate_transaction");
     }
-    index.push({ transactionId: tx.transactionId, uid, productId: tx.productId, microUSD, at: now });
+    index.push({ transactionId, uid, productId, microUSD, at: now });
     writeTxIndex(index);
   });
   await homeScope.run(homeForUid(uid), () =>
-    creditPurchase({ at: now, microUSD, transactionId: tx.transactionId }, now),
+    creditPurchase({ at: now, microUSD, transactionId }, now),
   );
   return microUSD;
+}
+
+/** Credit a VERIFIED Apple transaction to `uid` (IAP flavor of the above). */
+export async function creditTransaction(uid: string, tx: AppleTransaction, now: number = Date.now()): Promise<number> {
+  return creditExternalTransaction(uid, tx.transactionId, tx.productId, PRODUCTS[tx.productId]!, now);
 }
 
 /**

--- a/src/billing/stripe.test.ts
+++ b/src/billing/stripe.test.ts
@@ -1,0 +1,76 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+
+const { stripeConfig, STRIPE_PACKS, createCheckoutSession, verifyStripeSignature, classifyStripeEvent } =
+  await import("./stripe.js");
+
+describe("stripe config + packs", () => {
+  test("unset env → nulls; packs mirror the IAP face economics", () => {
+    assert.deepEqual(stripeConfig({}), { secretKey: null, webhookSecret: null });
+    assert.equal(STRIPE_PACKS["5"]!.faceMicroUSD, 5_000_000);
+    assert.equal(STRIPE_PACKS["10"]!.faceMicroUSD, 10_500_000);
+    assert.equal(STRIPE_PACKS["20"]!.faceMicroUSD, 22_000_000);
+  });
+});
+
+describe("checkout session creation", () => {
+  test("builds the form-encoded request with metadata + ad-hoc price", async () => {
+    let captured: { url: string; body: string } | null = null;
+    const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
+      captured = { url: String(url), body: String(init?.body) };
+      return new Response(JSON.stringify({ id: "cs_123", url: "https://checkout.stripe.com/x" }), { status: 200 });
+    }) as typeof fetch;
+    const s = await createCheckoutSession("em-abc", "10", "https://cloud.meetlisa.ai",
+      { secretKey: "sk_test", webhookSecret: null }, fakeFetch);
+    assert.equal(s?.id, "cs_123");
+    const body = new URLSearchParams(captured!.body);
+    assert.equal(body.get("metadata[uid]"), "em-abc");
+    assert.equal(body.get("metadata[pack]"), "10");
+    assert.equal(body.get("line_items[0][price_data][unit_amount]"), "999");
+    assert.match(body.get("success_url")!, /\/account\?paid=1/);
+  });
+
+  test("unknown pack or missing key → null, no network call", async () => {
+    const boom = (async () => { throw new Error("no"); }) as unknown as typeof fetch;
+    assert.equal(await createCheckoutSession("u", "99", "https://x", { secretKey: "sk", webhookSecret: null }, boom), null);
+    assert.equal(await createCheckoutSession("u", "5", "https://x", { secretKey: null, webhookSecret: null }, boom), null);
+  });
+});
+
+describe("webhook signature", () => {
+  const secret = "whsec_test";
+  const sign = (payload: string, t: number) =>
+    `t=${t},v1=${crypto.createHmac("sha256", secret).update(`${t}.${payload}`).digest("hex")}`;
+
+  test("valid signature within tolerance passes; wrong secret fails", () => {
+    const payload = JSON.stringify({ type: "checkout.session.completed" });
+    const t = 1_753_000_000;
+    const header = sign(payload, t);
+    assert.equal(verifyStripeSignature(payload, header, secret, t * 1000), true);
+    assert.equal(verifyStripeSignature(payload, header, "whsec_other", t * 1000), false);
+    assert.equal(verifyStripeSignature(payload + "x", header, secret, t * 1000), false);
+  });
+
+  test("stale timestamp / malformed header fail", () => {
+    const payload = "{}";
+    const t = 1_753_000_000;
+    assert.equal(verifyStripeSignature(payload, sign(payload, t), secret, (t + 600) * 1000), false);
+    assert.equal(verifyStripeSignature(payload, "v1=deadbeef", secret, t * 1000), false);
+    assert.equal(verifyStripeSignature(payload, "", secret, t * 1000), false);
+  });
+});
+
+describe("event classification", () => {
+  test("completed checkout → credit with uid/pack; refund → payment_intent; else ignore", () => {
+    const credit = classifyStripeEvent({
+      type: "checkout.session.completed",
+      data: { object: { id: "cs_1", metadata: { uid: "em-x", pack: "20" } } },
+    });
+    assert.deepEqual(credit, { kind: "credit", id: "cs_1", uid: "em-x", pack: "20" });
+    const refund = classifyStripeEvent({ type: "charge.refunded", data: { object: { payment_intent: "pi_9" } } });
+    assert.equal(refund.kind, "refund");
+    assert.equal(refund.id, "pi_9");
+    assert.equal(classifyStripeEvent({ type: "invoice.paid", data: { object: {} } }).kind, "ignore");
+  });
+});

--- a/src/billing/stripe.ts
+++ b/src/billing/stripe.ts
@@ -1,0 +1,160 @@
+/**
+ * Stripe top-up — the DESKTOP/WEB purchase path
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §8 B7 follow-up, milestone B8c).
+ *
+ * Same packs and face values as the IAP consumables, sold through Stripe
+ * Checkout with zero Apple involvement. The iOS app NEVER links here (App
+ * Store 3.1.1 anti-steering hygiene outside the US); entry points are the web
+ * /account page and the website.
+ *
+ * Flow: POST /api/billing/stripe/checkout (account session) → hosted Checkout
+ * → Stripe webhook `checkout.session.completed` → credit through the SAME
+ * global transaction index the IAP path uses (`stripe-<sessionId>`), so
+ * replays and cross-account double-credits are impossible by construction.
+ * `charge.refunded` claws back via a session lookup.
+ *
+ * Zero deps: Checkout sessions via form-encoded REST; webhook signatures are
+ * HMAC-SHA256 over `${t}.${payload}` (Stripe-Signature v1 scheme).
+ *
+ * Env: STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET.
+ */
+import crypto from "node:crypto";
+
+export interface StripeConfig {
+  secretKey: string | null;
+  webhookSecret: string | null;
+}
+
+export function stripeConfig(env: Record<string, string | undefined> = process.env): StripeConfig {
+  return {
+    secretKey: env.STRIPE_SECRET_KEY?.trim() || null,
+    webhookSecret: env.STRIPE_WEBHOOK_SECRET?.trim() || null,
+  };
+}
+
+/** Same face economics as the IAP packs (see billing/iap.ts PRODUCTS). */
+export const STRIPE_PACKS: Record<string, { usdCents: number; faceMicroUSD: number; name: string }> = {
+  "5": { usdCents: 499, faceMicroUSD: 5_000_000, name: "LISA Credits — $5.00" },
+  "10": { usdCents: 999, faceMicroUSD: 10_500_000, name: "LISA Credits — $10.50 (+5%)" },
+  "20": { usdCents: 1999, faceMicroUSD: 22_000_000, name: "LISA Credits — $22.00 (+10%)" },
+};
+
+/**
+ * Create a hosted Checkout session for `uid`/`pack`. Returns the redirect URL.
+ * Ad-hoc price_data — no dashboard products to maintain.
+ */
+export async function createCheckoutSession(
+  uid: string,
+  pack: string,
+  baseUrl: string,
+  cfg: StripeConfig = stripeConfig(),
+  fetchFn: typeof fetch = fetch,
+): Promise<{ id: string; url: string } | null> {
+  const p = STRIPE_PACKS[pack];
+  if (!p || !cfg.secretKey) return null;
+  const form = new URLSearchParams({
+    mode: "payment",
+    success_url: `${baseUrl}/account?paid=1`,
+    cancel_url: `${baseUrl}/account`,
+    client_reference_id: uid,
+    "metadata[uid]": uid,
+    "metadata[pack]": pack,
+    "line_items[0][quantity]": "1",
+    "line_items[0][price_data][currency]": "usd",
+    "line_items[0][price_data][unit_amount]": String(p.usdCents),
+    "line_items[0][price_data][product_data][name]": p.name,
+  });
+  const res = await fetchFn("https://api.stripe.com/v1/checkout/sessions", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${cfg.secretKey}`,
+      "content-type": "application/x-www-form-urlencoded",
+    },
+    body: form.toString(),
+  });
+  if (!res.ok) {
+    console.error(`[stripe] checkout create failed (${res.status}): ${(await res.text()).slice(0, 200)}`);
+    return null;
+  }
+  const body = (await res.json()) as { id?: string; url?: string };
+  if (!body.id || !body.url) return null;
+  return { id: body.id, url: body.url };
+}
+
+/**
+ * Verify a Stripe-Signature header over the RAW request payload. v1 scheme:
+ * HMAC-SHA256(`${t}.${payload}`, webhookSecret), 5-minute default tolerance.
+ */
+export function verifyStripeSignature(
+  payload: string,
+  header: string,
+  secret: string,
+  now: number = Date.now(),
+  toleranceSec = 300,
+): boolean {
+  let t = "";
+  const v1s: string[] = [];
+  for (const part of header.split(",")) {
+    const [k, v] = part.split("=", 2);
+    if (k?.trim() === "t" && v) t = v.trim();
+    if (k?.trim() === "v1" && v) v1s.push(v.trim());
+  }
+  if (!t || v1s.length === 0) return false;
+  const ts = Number(t);
+  if (!Number.isFinite(ts) || Math.abs(now / 1000 - ts) > toleranceSec) return false;
+  const expected = crypto.createHmac("sha256", secret).update(`${t}.${payload}`).digest();
+  for (const v1 of v1s) {
+    let presented: Buffer;
+    try {
+      presented = Buffer.from(v1, "hex");
+    } catch {
+      continue;
+    }
+    if (presented.length === expected.length && crypto.timingSafeEqual(presented, expected)) return true;
+  }
+  return false;
+}
+
+/** The bits of a webhook event we act on. */
+export interface StripeEventSummary {
+  kind: "credit" | "refund" | "ignore";
+  /** checkout session id (credit) or payment_intent id (refund). */
+  id: string;
+  uid?: string;
+  pack?: string;
+}
+
+/** Classify a parsed webhook event (pure). */
+export function classifyStripeEvent(evt: Record<string, unknown>): StripeEventSummary {
+  const type = String(evt.type ?? "");
+  const object = ((evt.data as Record<string, unknown> | undefined)?.object ?? {}) as Record<string, unknown>;
+  if (type === "checkout.session.completed") {
+    const meta = (object.metadata ?? {}) as Record<string, unknown>;
+    return {
+      kind: "credit",
+      id: String(object.id ?? ""),
+      uid: typeof meta.uid === "string" ? meta.uid : undefined,
+      pack: typeof meta.pack === "string" ? meta.pack : undefined,
+    };
+  }
+  if (type === "charge.refunded") {
+    return { kind: "refund", id: String(object.payment_intent ?? "") };
+  }
+  return { kind: "ignore", id: "" };
+}
+
+/** Find the checkout session id behind a payment_intent (refund clawback). */
+export async function sessionIdForPaymentIntent(
+  paymentIntent: string,
+  cfg: StripeConfig = stripeConfig(),
+  fetchFn: typeof fetch = fetch,
+): Promise<string | null> {
+  if (!cfg.secretKey || !paymentIntent) return null;
+  const res = await fetchFn(
+    `https://api.stripe.com/v1/checkout/sessions?payment_intent=${encodeURIComponent(paymentIntent)}&limit=1`,
+    { headers: { authorization: `Bearer ${cfg.secretKey}` } },
+  );
+  if (!res.ok) return null;
+  const body = (await res.json()) as { data?: Array<{ id?: string }> };
+  return body.data?.[0]?.id ?? null;
+}

--- a/src/web/account-page.ts
+++ b/src/web/account-page.ts
@@ -1,0 +1,105 @@
+/**
+ * /account — the signed-in self-service page for DESKTOP/WEB users
+ * (PLAN_ACCOUNTS_BILLING B8c): session window, credits, Stripe top-up,
+ * sign-out. Served post-gate, so an unauthenticated browser lands on the
+ * login page instead. The iOS app never links here (3.1.1 hygiene) — its
+ * purchases go through StoreKit.
+ *
+ * NOTE: one template literal — NO backticks inside (island.ts trap).
+ */
+export const ACCOUNT_HTML = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>LISA — Account</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; margin: 0; }
+  body {
+    min-height: 100vh; display: grid; place-items: center;
+    background: #0b0e13; color: #e6e9ef;
+    font: 16px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  }
+  .card {
+    width: min(92vw, 430px); padding: 32px 28px; border-radius: 16px;
+    background: #12161e; border: 1px solid #232a36;
+  }
+  h1 { font-size: 22px; margin-bottom: 18px; }
+  .row { display: flex; justify-content: space-between; margin: 8px 0; font-size: 15px; }
+  .row .k { color: #8a93a5; }
+  .bar { height: 8px; border-radius: 4px; background: #232a36; overflow: hidden; margin: 10px 0 18px; }
+  .bar > div { height: 100%; background: #58d68d; }
+  h2 { font-size: 14px; color: #8a93a5; margin: 22px 0 8px; }
+  button {
+    width: 100%; margin-top: 8px; padding: 11px; border: 0; border-radius: 10px;
+    background: #1b2330; color: #e6e9ef; font-size: 15px; cursor: pointer;
+    border: 1px solid #2a3342; text-align: left; display: flex; justify-content: space-between;
+  }
+  button:hover { border-color: #5b8cff; }
+  button.quiet { background: transparent; border: 0; color: #8a93a5; text-align: center; display: block; }
+  .note { color: #5d6575; font-size: 12px; margin-top: 14px; }
+  .ok { color: #58d68d; font-size: 13px; margin-bottom: 10px; display: none; }
+</style>
+</head>
+<body>
+<div class="card">
+  <h1>Your LISA account</h1>
+  <div class="ok" id="paid-ok">✓ Payment received — credits are being applied.</div>
+  <div class="row"><span class="k">Signed in as</span><span id="who">…</span></div>
+  <div class="row"><span class="k">Tier</span><span id="tier">…</span></div>
+  <div class="row"><span class="k">Session allowance</span><span id="allow">…</span></div>
+  <div class="bar"><div id="barfill" style="width:0%"></div></div>
+  <div class="row"><span class="k">Credits</span><span id="credits">…</span></div>
+
+  <div id="topup" style="display:none">
+    <h2>Add credits (never expire; also raise your daily session for 30 days)</h2>
+    <button data-pack="5"><span>$5.00 credits · Tier 1</span><b>$4.99</b></button>
+    <button data-pack="10"><span>$10.50 credits (+5%) · Tier 1</span><b>$9.99</b></button>
+    <button data-pack="20"><span>$22.00 credits (+10%) · Tier 2</span><b>$19.99</b></button>
+  </div>
+
+  <button class="quiet" id="logout">Sign out</button>
+  <div class="note">Buying in the iOS app works too — credits roam with the account either way.</div>
+</div>
+<script>
+  const $ = (id) => document.getElementById(id);
+  if (location.search.includes("paid=1")) $("paid-ok").style.display = "block";
+  const dollars = (m) => "$" + (Math.max(0, m || 0) / 1e6).toFixed(2);
+  async function refresh() {
+    const me = await fetch("/api/auth/me").then((r) => r.json()).catch(() => null);
+    if (me && me.signedIn) $("who").textContent = me.email || me.uid;
+    const q = await fetch("/api/billing/quota").then((r) => r.json()).catch(() => null);
+    if (q && q.available) {
+      $("tier").textContent = q.tier;
+      $("allow").textContent = dollars(q.remainingMicroUSD) + " of " + dollars(q.windowMicroUSD) + " left";
+      $("credits").textContent = dollars(q.paidMicroUSD);
+      const pct = q.windowMicroUSD ? Math.min(100, 100 * (q.remainingMicroUSD / q.windowMicroUSD)) : 0;
+      $("barfill").style.width = pct + "%";
+    }
+    const cfg = await fetch("/api/auth/config").then((r) => r.json()).catch(() => null);
+    if (cfg && cfg.stripe) $("topup").style.display = "block";
+  }
+  refresh();
+  document.querySelectorAll("#topup button").forEach((btn) => {
+    btn.addEventListener("click", async () => {
+      btn.disabled = true;
+      const res = await fetch("/api/billing/stripe/checkout", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ pack: btn.dataset.pack }),
+      }).catch(() => null);
+      btn.disabled = false;
+      if (!res || !res.ok) return;
+      const body = await res.json();
+      if (body.url) location.href = body.url;
+    });
+  });
+  $("logout").addEventListener("click", async () => {
+    await fetch("/api/auth/logout", { method: "POST" });
+    location.replace("/");
+  });
+</script>
+</body>
+</html>
+`;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -40,7 +40,9 @@ import { LOGIN_HTML } from "./login.js";
 import { recordUsage, summarizeUsage } from "../billing/meter.js";
 import { PRICES_VERSION, tokensAffordable } from "../billing/prices.js";
 import { precheckTurn, debitTurn, quotaStatus } from "../billing/quota.js";
-import { verifyAppleJWS, validateTransaction, creditTransaction, refundTransaction, IapError } from "../billing/iap.js";
+import { verifyAppleJWS, validateTransaction, creditTransaction, creditExternalTransaction, refundTransaction, IapError } from "../billing/iap.js";
+import { stripeConfig, verifyStripeSignature, classifyStripeEvent, createCheckoutSession, sessionIdForPaymentIntent, STRIPE_PACKS } from "../billing/stripe.js";
+import { ACCOUNT_HTML } from "./account-page.js";
 import { handleGateway } from "./gateway.js";
 import { preflightLimits } from "../billing/limits.js";
 import { ROOM_HTML } from "./room.js";
@@ -916,8 +918,61 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           appleWeb: cloud && cfg.enabled && !!cfg.webServicesId
             ? { servicesId: cfg.webServicesId }
             : null,
+          stripe: cloud && !!stripeConfig().secretKey,
         }),
       );
+      return;
+    }
+
+    // ── Stripe webhook (pre-gate: the signature over the RAW body is the
+    // authentication; B8c). Credits reuse the IAP global dedup index.
+    if (req.method === "POST" && url === "/api/billing/stripe/webhook") {
+      const scfg = stripeConfig();
+      if (!cloud || !scfg.webhookSecret) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("not available");
+        return;
+      }
+      let raw = "";
+      for await (const chunk of req) raw += chunk.toString("utf8");
+      const sig = typeof req.headers["stripe-signature"] === "string" ? req.headers["stripe-signature"] : "";
+      if (!verifyStripeSignature(raw, sig, scfg.webhookSecret)) {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "bad_signature" }));
+        return;
+      }
+      try {
+        const summary = classifyStripeEvent(JSON.parse(raw) as Record<string, unknown>);
+        if (summary.kind === "credit" && summary.uid && summary.pack && STRIPE_PACKS[summary.pack]) {
+          try {
+            const credited = await creditExternalTransaction(
+              summary.uid,
+              `stripe-${summary.id}`,
+              `stripe.pack.${summary.pack}`,
+              STRIPE_PACKS[summary.pack]!.faceMicroUSD,
+            );
+            console.error(`[stripe] credited ${credited} micro-USD to ${summary.uid} (session ${summary.id})`);
+          } catch (e) {
+            if (!(e instanceof IapError && e.code === "duplicate_transaction")) throw e;
+            // replayed webhook — already credited, fine
+          }
+        } else if (summary.kind === "refund" && summary.id) {
+          const sessionId = await sessionIdForPaymentIntent(summary.id, scfg);
+          const undone = sessionId ? await refundTransaction(`stripe-${sessionId}`) : null;
+          console.error(
+            undone
+              ? `[stripe] refund: clawed back ${undone.microUSD} micro-USD from ${undone.uid}`
+              : `[stripe] refund for unknown payment ${summary.id} — ignored`,
+          );
+        }
+        // Verified events always 200 so Stripe stops retrying.
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true }));
+      } catch (e) {
+        console.error(`[stripe] webhook handling failed: ${(e as Error).message}`);
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "handling_failed" }));
+      }
       return;
     }
 
@@ -1177,6 +1232,42 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.writeHead(status, { "content-type": "application/json" });
         res.end(JSON.stringify({ ok: code === "duplicate_transaction", error: code }));
       }
+      return;
+    }
+
+    // ── /account: desktop/web self-service page (post-gate; unauthenticated
+    // browsers land on the login page). iOS never links here (3.1.1).
+    if (req.method === "GET" && (url === "/account" || url.startsWith("/account?"))) {
+      res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+      res.end(ACCOUNT_HTML);
+      return;
+    }
+
+    if (req.method === "POST" && url === "/api/billing/stripe/checkout") {
+      // Start a hosted Checkout for the signed-in account (B8c).
+      const scfg = stripeConfig();
+      if (!cloud || !scfg.secretKey) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "stripe_not_configured" }));
+        return;
+      }
+      if (!accountUid) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "account_session_required" }));
+        return;
+      }
+      const body = await readJsonBody(req);
+      const pack = typeof body.pack === "string" ? body.pack : "";
+      const proto = (req.headers["x-forwarded-proto"] as string | undefined) ?? "https";
+      const base = `${proto}://${req.headers.host ?? "cloud.meetlisa.ai"}`;
+      const session = await createCheckoutSession(accountUid, pack, base, scfg);
+      if (!session) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "checkout_failed" }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, url: session.url }));
       return;
     }
 


### PR DESCRIPTION
**Stacked on #269.** Third code-leftover finisher — the desktop/web money path.

- **`stripe.ts`** (zero deps): hosted Checkout via form-encoded REST, ad-hoc `price_data` (same face economics as the IAP packs), `uid`/`pack` in metadata; **Stripe-Signature v1** verification (timing-safe, 5-min tolerance); refund → session lookup by payment_intent.
- **`iap.ts`**: `creditExternalTransaction` — the global-dedup + scoped-credit core is now channel-agnostic; one transaction can never credit twice **across channels** either.
- **`server.ts`**: `POST /api/billing/stripe/checkout` (account session) · `POST /api/billing/stripe/webhook` (pre-gate, raw-body signature auth; replay-tolerant credit, refund clawback) · **`GET /account`** — signed-in self-service page (quota bar, credits, top-up, sign-out). Top-up buttons render only when Stripe is configured; **iOS never links here** (3.1.1).
- `deploy.sh`: passes `STRIPE_SECRET_KEY`/`STRIPE_WEBHOOK_SECRET` + the B8a mail envs that were missing.

## Operator (to enable, optional)

1. Stripe account → copy the secret key.
2. Dashboard → Webhooks → add `https://cloud.meetlisa.ai/api/billing/stripe/webhook`, events `checkout.session.completed` + `charge.refunded` → copy the signing secret.
3. Deploy with both envs. Until then `/account` simply hides the top-up section.

Tests: pack economics / checkout body / signature valid+tampered+stale / classification. Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)