### PR TITLE
feat(mac): B8d — menu-bar Sign in to LISA Cloud + anomaly push alerts

### DIFF
--- a/packaging/mac-client/Sources/Lisa/AccountWindow.swift
+++ b/packaging/mac-client/Sources/Lisa/AccountWindow.swift
@@ -1,0 +1,161 @@
+//
+//  AccountWindow.swift
+//  Lisa
+//
+//  "Sign in to LISA Cloud" (PLAN_ACCOUNTS_BILLING B8d): email+password against
+//  the hosted cloud; on success the account session is written to
+//  ~/.lisa/config.env (LISA_MANAGED_SESSION/_BASE) and the local backend runs
+//  KEY-FREE — its LLM calls route through the LISA inference gateway, metered
+//  against the account's allowance. BYO keys in config.env always win; signing
+//  out simply clears the session. The backend reads config.env at start, so
+//  apply = restart (offered in-window).
+//
+
+import AppKit
+
+final class AccountWindowController: NSWindowController {
+    static let shared = AccountWindowController()
+
+    private let baseField = NSTextField(string: "")
+    private let emailField = NSTextField(string: "")
+    private let passwordField = NSSecureTextField(string: "")
+    private let statusLabel = NSTextField(wrappingLabelWithString: "")
+    private lazy var signInButton = NSButton(title: "Sign in", target: self, action: #selector(signIn))
+    private lazy var signOutButton = NSButton(title: "Sign out", target: self, action: #selector(signOut))
+    private lazy var restartButton = NSButton(title: "Restart backend to apply", target: self, action: #selector(restartBackend))
+
+    private convenience init() {
+        let win = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 320),
+            styleMask: [.titled, .closable, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        win.titleVisibility = .hidden
+        win.titlebarAppearsTransparent = true
+        win.isMovableByWindowBackground = true
+        win.isReleasedWhenClosed = false
+        self.init(window: win)
+        win.contentView = buildContent()
+        win.center()
+    }
+
+    func show() {
+        refreshState()
+        window?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    private func buildContent() -> NSView {
+        let title = NSTextField(labelWithString: "LISA Cloud account")
+        title.font = .boldSystemFont(ofSize: 16)
+        let blurb = NSTextField(wrappingLabelWithString:
+            "Sign in and this Mac runs key-free: models without your own API key route " +
+            "through LISA Cloud, using your account's daily allowance and credits. " +
+            "Your soul and data stay on this Mac.")
+        blurb.font = .systemFont(ofSize: 12)
+        blurb.textColor = .secondaryLabelColor
+
+        baseField.placeholderString = "https://cloud.meetlisa.ai"
+        emailField.placeholderString = "Email"
+        passwordField.placeholderString = "Password"
+        statusLabel.font = .systemFont(ofSize: 12)
+
+        signInButton.bezelStyle = .rounded
+        signInButton.keyEquivalent = "\r"
+        signOutButton.bezelStyle = .rounded
+        restartButton.bezelStyle = .rounded
+        restartButton.isHidden = true
+
+        let buttonRow = NSStackView(views: [signInButton, signOutButton, restartButton])
+        buttonRow.spacing = 8
+
+        let stack = NSStackView(views: [title, blurb, baseField, emailField, passwordField, buttonRow, statusLabel])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 10
+        stack.edgeInsets = NSEdgeInsets(top: 36, left: 24, bottom: 24, right: 24)
+        for f in [baseField, emailField, passwordField] {
+            f.translatesAutoresizingMaskIntoConstraints = false
+            f.widthAnchor.constraint(equalToConstant: 352).isActive = true
+        }
+        statusLabel.translatesAutoresizingMaskIntoConstraints = false
+        statusLabel.widthAnchor.constraint(equalToConstant: 352).isActive = true
+        return stack
+    }
+
+    private func refreshState() {
+        let base = BackendController.shared.configEnvValue("LISA_MANAGED_BASE") ?? ""
+        baseField.stringValue = base.isEmpty ? "https://cloud.meetlisa.ai" : base
+        let signedIn = !(BackendController.shared.configEnvValue("LISA_MANAGED_SESSION") ?? "").isEmpty
+        signOutButton.isHidden = !signedIn
+        statusLabel.textColor = .secondaryLabelColor
+        statusLabel.stringValue = signedIn
+            ? "Signed in — managed inference is on. BYO API keys in config.env still take priority."
+            : ""
+    }
+
+    @objc private func signIn() {
+        let base = baseField.stringValue.trimmingCharacters(in: .whitespaces)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let email = emailField.stringValue.trimmingCharacters(in: .whitespaces)
+        let password = passwordField.stringValue
+        guard let url = URL(string: "\(base)/api/auth/login"), !email.isEmpty, !password.isEmpty else {
+            setStatus("Enter the cloud URL, email, and password.", error: true)
+            return
+        }
+        signInButton.isEnabled = false
+        setStatus("Signing in…", error: false)
+        var req = URLRequest(url: url, timeoutInterval: 15)
+        req.httpMethod = "POST"
+        req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        req.httpBody = try? JSONSerialization.data(withJSONObject: ["email": email, "password": password])
+        URLSession.shared.dataTask(with: req) { data, resp, _ in
+            DispatchQueue.main.async { [weak self] in
+                guard let self else { return }
+                self.signInButton.isEnabled = true
+                let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+                guard code == 200, let data,
+                      let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                      let token = obj["token"] as? String, !token.isEmpty else {
+                    let hint = code == 401 ? "wrong email or password"
+                        : code == 429 ? "too many attempts — wait 15 minutes"
+                        : code == 404 ? "this instance doesn't offer accounts"
+                        : code == -1 ? "couldn't reach the server" : "HTTP \(code)"
+                    self.setStatus("Sign-in failed (\(hint)).", error: true)
+                    return
+                }
+                BackendController.shared.upsertConfigEnv("LISA_MANAGED_SESSION", value: token)
+                BackendController.shared.upsertConfigEnv("LISA_MANAGED_BASE", value: base)
+                self.passwordField.stringValue = ""
+                self.refreshState()
+                self.setStatus("Signed in. Restart the backend so it picks up the session.", error: false)
+                self.restartButton.isHidden = false
+            }
+        }.resume()
+    }
+
+    @objc private func signOut() {
+        BackendController.shared.upsertConfigEnv("LISA_MANAGED_SESSION", value: "")
+        refreshState()
+        setStatus("Signed out. Restart the backend to apply.", error: false)
+        restartButton.isHidden = false
+    }
+
+    @objc private func restartBackend() {
+        restartButton.isEnabled = false
+        setStatus("Restarting the backend…", error: false)
+        BackendController.shared.restart { [weak self] up in
+            guard let self else { return }
+            self.restartButton.isEnabled = true
+            self.restartButton.isHidden = up
+            self.setStatus(up ? "Backend restarted — you're all set." : "Backend didn't come back — check ~/.lisa/backend.log.",
+                           error: !up)
+        }
+    }
+
+    private func setStatus(_ text: String, error: Bool) {
+        statusLabel.stringValue = text
+        statusLabel.textColor = error ? .systemRed : .secondaryLabelColor
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/AppDelegate.swift
+++ b/packaging/mac-client/Sources/Lisa/AppDelegate.swift
@@ -146,6 +146,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - About / Updates
 
+    @objc func showAccount(_ sender: Any?) {
+        AccountWindowController.shared.show()
+    }
+
     @objc func showAbout(_ sender: Any?) {
         AboutWindowController.shared.show()
     }
@@ -212,6 +216,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         settingsItem.target = self
         appMenu.addItem(settingsItem)
+        // Managed inference (B8d): sign in once, run key-free via LISA Cloud.
+        let accountItem = NSMenuItem(
+            title: "Sign in to LISA Cloud…",
+            action: #selector(showAccount(_:)),
+            keyEquivalent: ""
+        )
+        accountItem.target = self
+        appMenu.addItem(accountItem)
         appMenu.addItem(.separator())
         appMenu.addItem(NSMenuItem(
             title: "Hide Lisa",

--- a/packaging/mac-client/Sources/Lisa/BackendController.swift
+++ b/packaging/mac-client/Sources/Lisa/BackendController.swift
@@ -52,6 +52,63 @@ final class BackendController {
         }
     }
 
+    // MARK: - Account (managed inference, B8d)
+
+    /// Public read of a ~/.lisa/config.env value (AccountWindow uses it).
+    func configEnvValue(_ key: String) -> String? {
+        readEnvValue(key, from: lisaPath("config.env"))
+    }
+
+    /// Upsert KEY=value in ~/.lisa/config.env (replace the existing line or
+    /// append; empty value keeps the line — the backend treats "" as unset).
+    func upsertConfigEnv(_ key: String, value: String) {
+        let path = lisaPath("config.env")
+        var lines = ((try? String(contentsOfFile: path, encoding: .utf8)) ?? "")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        if let last = lines.last, last.isEmpty { lines.removeLast() }
+        var replaced = false
+        for i in lines.indices {
+            let stripped = lines[i].trimmingCharacters(in: .whitespaces)
+            let body = stripped.hasPrefix("export ") ? String(stripped.dropFirst(7)) : stripped
+            if body.hasPrefix("\(key)=") {
+                lines[i] = "\(key)=\(value)"
+                replaced = true
+                break
+            }
+        }
+        if !replaced { lines.append("\(key)=\(value)") }
+        let dir = (path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        try? (lines.joined(separator: "\n") + "\n").write(toFile: path, atomically: true, encoding: .utf8)
+        try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
+    }
+
+    /// Stop the (detached) backend and start a fresh one so config.env changes
+    /// apply. The backend was launched with nohup, so we match its command line;
+    /// killing only `lisa serve --web` variants keeps unrelated processes safe.
+    func restart(_ completion: @escaping (Bool) -> Void) {
+        let kill = Process()
+        kill.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
+        kill.arguments = ["-f", "serve --web"]
+        kill.terminationHandler = { _ in
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+                guard let self else { return }
+                self.start()
+                // Report through the existing status notification once, then hand
+                // the outcome to the caller.
+                var observer: NSObjectProtocol?
+                observer = NotificationCenter.default.addObserver(
+                    forName: BackendController.statusChanged, object: nil, queue: .main
+                ) { note in
+                    if let observer { NotificationCenter.default.removeObserver(observer) }
+                    completion((note.userInfo?["up"] as? Bool) ?? false)
+                }
+            }
+        }
+        try? kill.run()
+    }
+
     // MARK: - Probe
 
     func probe(_ completion: @escaping (Bool) -> Void) {

--- a/src/billing/meter.ts
+++ b/src/billing/meter.ts
@@ -87,6 +87,13 @@ export async function recordUsage(
 // day is worth an operator's eyes (PLAN §6.5).
 const ALERT_THRESHOLD_MICRO = 10_000_000;
 const alerted = new Set<string>();
+
+/** Where anomaly alerts go besides the log (B8d: the server wires the push bridge). */
+let anomalySink: ((text: string) => void) | null = null;
+export function setAnomalySink(sink: ((text: string) => void) | null): void {
+  anomalySink = sink;
+}
+
 async function alertIfAnomalous(now: Date): Promise<void> {
   try {
     const key = `${lisaHome()}:${now.toISOString().slice(0, 10)}`;
@@ -94,9 +101,13 @@ async function alertIfAnomalous(now: Date): Promise<void> {
     const today = await summarizeUsage(new Date(now).setUTCHours(0, 0, 0, 0));
     if (today.microUSD > ALERT_THRESHOLD_MICRO) {
       alerted.add(key);
-      console.error(
-        `[billing] ⚠ anomaly: ${lisaHome()} spent ${(today.microUSD / 1e6).toFixed(2)} USD face today (${today.turns} turns)`,
-      );
+      const text = `${lisaHome()} spent ${(today.microUSD / 1e6).toFixed(2)} USD face today (${today.turns} turns)`;
+      console.error(`[billing] ⚠ anomaly: ${text}`);
+      try {
+        anomalySink?.(text);
+      } catch {
+        /* alerting must never break metering */
+      }
     }
   } catch {
     /* observability only */

--- a/src/web/push.ts
+++ b/src/web/push.ts
@@ -501,6 +501,14 @@ export class PushBridge {
     );
   }
 
+  /** Billing anomaly (B8d): a single account crossed the daily face threshold. */
+  onBillingAnomaly(text: string): void {
+    this.fire(
+      { pref: "error", title: "LISA billing anomaly", body: text.slice(0, 240), priority: "high", tag: "billing-anomaly" },
+      "billing#anomaly",
+    );
+  }
+
   private fire(ev: PushEvent, throttleKey: string): void {
     const subs = this.subs().filter((s) => s.prefs[ev.pref]);
     if (subs.length === 0) return;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -37,7 +37,7 @@ import {
 } from "../soul/desire-focus.js";
 import { ISLAND_HTML } from "./island.js";
 import { LOGIN_HTML } from "./login.js";
-import { recordUsage, summarizeUsage } from "../billing/meter.js";
+import { recordUsage, summarizeUsage, setAnomalySink } from "../billing/meter.js";
 import { PRICES_VERSION, tokensAffordable } from "../billing/prices.js";
 import { precheckTurn, debitTurn, quotaStatus } from "../billing/quota.js";
 import { verifyAppleJWS, validateTransaction, creditTransaction, creditExternalTransaction, refundTransaction, IapError } from "../billing/iap.js";
@@ -445,6 +445,9 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   // Operational push: notify subscribed phones on agent done/error/permission +
   // Reve idle messages. Opt-in, ntfy by default (apns is a stub). See push.ts.
   const pushBridge = new PushBridge({ log: (m) => console.error(m) });
+  // Billing anomalies reach the operator's phone through the same channel as
+  // agent errors (B8d) — pref "error", throttled inside the bridge.
+  setAnomalySink((text) => pushBridge.onBillingAnomaly(text));
   hub.on("update", (session: AgentSession) => {
     // L6 — record the transition in the orchestrator journal so the
     // cross-agent recap can answer "what happened while I was away?" even for


### PR DESCRIPTION
**Stacked on #270.** Fourth code-leftover finisher.

## Mac menu-bar app

- **`AccountWindow`** (Lisa ▸ *Sign in to LISA Cloud…*): email+password → session written to `~/.lisa/config.env` (`LISA_MANAGED_SESSION`/`_BASE`) → this Mac runs **key-free** through the B6 gateway. BYO keys always win; Sign out clears the session. In-window **Restart backend to apply** (pkill the detached `serve --web`, fresh start, outcome via the existing status notification).
- `BackendController` gains public `configEnvValue`/`upsertConfigEnv` (replace-or-append, 0600 kept) + `restart()`.

## Server

- `meter.setAnomalySink` + `PushBridge.onBillingAnomaly`: the **$10/day per-account anomaly** now reaches the operator's phone via the existing push channel (pref "error", bridge-throttled) instead of only the Cloud Run log.

Verified: mac-client `build.sh` green; typecheck + full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)