### PR TITLE
fix(web): isolate SSE fan-out and mood state per tenant (B2)

### DIFF
--- a/src/mood-bus.test.ts
+++ b/src/mood-bus.test.ts
@@ -1,0 +1,59 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+
+// Give the path helpers a throwaway global home before anything imports them,
+// matching src/web/tenancy.test.ts.
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-mood-"));
+process.env.LISA_HOME = TMP;
+
+const { homeScope, homeForUid } = await import("./paths.js");
+const { moodBus } = await import("./mood-bus.js");
+
+const HOME_A = homeForUid("apple-001.aaa");
+const HOME_B = homeForUid("em-bbbbbbbbbbbbbbbbbb");
+
+describe("moodBus — per-tenant mood state (B2)", () => {
+  test("current() defaults to neutral outside any scope", () => {
+    assert.equal(moodBus.current(), "neutral");
+  });
+
+  test("a mood set in scope A is NOT visible in scope B or globally", () => {
+    homeScope.run(HOME_A, () => moodBus.set("happy"));
+    homeScope.run(HOME_B, () => moodBus.set("gloomy"));
+
+    // Each tenant reads back only its own mood…
+    homeScope.run(HOME_A, () => assert.equal(moodBus.current(), "happy"));
+    homeScope.run(HOME_B, () => assert.equal(moodBus.current(), "gloomy"));
+    // …and neither leaked into the global (Mac / background) scope.
+    assert.equal(moodBus.current(), "neutral");
+  });
+
+  test("the global scope is independent of any tenant", () => {
+    moodBus.set("focused"); // no scope → global
+    assert.equal(moodBus.current(), "focused");
+    // Tenants set earlier are unchanged by a global set.
+    homeScope.run(HOME_A, () => assert.equal(moodBus.current(), "happy"));
+  });
+
+  test("current() reads the CALLER's scope, so a fresh connection sees its own mood", () => {
+    // Simulates the /events + /chat + island-ping connect frames, which call
+    // moodBus.current() while already inside the subscriber's home scope.
+    const seenByA = homeScope.run(HOME_A, () => moodBus.current());
+    const seenByB = homeScope.run(HOME_B, () => moodBus.current());
+    assert.equal(seenByA, "happy");
+    assert.equal(seenByB, "gloomy");
+    assert.notEqual(seenByA, seenByB);
+  });
+
+  test("forget(uid) drops a deleted account's mood back to neutral", () => {
+    homeScope.run(HOME_A, () => assert.equal(moodBus.current(), "happy"));
+    moodBus.forget("apple-001.aaa");
+    homeScope.run(HOME_A, () => assert.equal(moodBus.current(), "neutral"));
+    // Forgetting A never touches B or the global mood.
+    homeScope.run(HOME_B, () => assert.equal(moodBus.current(), "gloomy"));
+    assert.equal(moodBus.current(), "focused");
+  });
+});

--- a/src/mood-bus.ts
+++ b/src/mood-bus.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from "node:events";
+import { scopedUid } from "./paths.js";
 
 /**
  * Process-wide mood bus + a few lightweight agent-state pulses.
@@ -11,17 +12,37 @@ import { EventEmitter } from "node:events";
  *
  * Decoupled from the agent loop so non-agent code (scheduled tasks,
  * heartbeats, channels) can also nudge the avatar.
+ *
+ * ── Mood STATE is per-tenant (B2) ────────────────────────────────────────
+ * set_mood runs inside the caller's home scope, so the "current" slug is
+ * stored under that scope's uid (scopedUid()). A signed-in cloud account gets
+ * its own current mood; the Mac edition and all background/global work share
+ * the one null scope. current() returns the mood of the CALLER's scope, so a
+ * fresh /events, /chat or island-ping connection is served ITS OWN account's
+ * mood on connect — never whatever another tenant last set. The `mood` EVENT
+ * is still a single process-wide emit; the web server's tenant-aware fan-out
+ * (web/event-bus.ts) is what filters who receives it.
  */
 class MoodBus extends EventEmitter {
-  private currentSlug = "neutral";
+  private globalMood = "neutral"; // Mac edition / background / shared token
+  private readonly moodByUid = new Map<string, string>(); // signed-in accounts
 
   set(slug: string): void {
-    this.currentSlug = slug;
+    const uid = scopedUid();
+    if (uid) this.moodByUid.set(uid, slug);
+    else this.globalMood = slug;
     this.emit("mood", slug);
   }
 
+  /** The current mood of the CALLER's home scope (defaults to "neutral"). */
   current(): string {
-    return this.currentSlug;
+    const uid = scopedUid();
+    return uid ? this.moodByUid.get(uid) ?? "neutral" : this.globalMood;
+  }
+
+  /** Drop a tenant's stored mood — called when its account is deleted (B2). */
+  forget(uid: string): void {
+    this.moodByUid.delete(uid);
   }
 
   /** Agent loop entered a turn — surfaces switch to "thinking" indicator. */

--- a/src/web/event-bus.test.ts
+++ b/src/web/event-bus.test.ts
@@ -1,0 +1,160 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { TenantEventBus, sameTenant, type EventSink } from "./event-bus.js";
+
+// Two uids in the same shape the account store mints (Apple / email accounts),
+// mirroring src/web/tenancy.test.ts's HOME_A / HOME_B.
+const UID_A = "apple-001.aaa";
+const UID_B = "em-bbbbbbbbbbbbbbbbbb";
+
+/** A fake SSE sink that records every frame written to it. */
+class FakeSink implements EventSink {
+  readonly frames: string[] = [];
+  write(chunk: string): void {
+    this.frames.push(chunk);
+  }
+  /** The `type` field of each event delivered, in order. */
+  types(): string[] {
+    return this.frames.map(
+      (f) => JSON.parse(f.replace(/^data: /, "").trim()).type as string,
+    );
+  }
+  /** Everything ever written, joined — for "did any byte leak?" assertions. */
+  raw(): string {
+    return this.frames.join("");
+  }
+}
+
+describe("TenantEventBus — cross-tenant isolation (B2)", () => {
+  test("a uid-A event is never delivered to a uid-B subscriber", () => {
+    const bus = new TenantEventBus<FakeSink>();
+    const a = new FakeSink();
+    const b = new FakeSink();
+    bus.add(a, UID_A);
+    bus.add(b, UID_B);
+
+    // The kind of event that carries private message TEXT.
+    bus.broadcast(
+      { type: "idle_message", text: "A's private musing", source: "advisor" },
+      UID_A,
+    );
+
+    assert.deepEqual(a.types(), ["idle_message"]);
+    assert.deepEqual(b.frames, []); // B received nothing at all
+    assert.equal(b.raw().includes("private"), false); // not even a byte leaked
+  });
+
+  test("each tenant receives only its own stream of events", () => {
+    const bus = new TenantEventBus<FakeSink>();
+    const a = new FakeSink();
+    const b = new FakeSink();
+    bus.add(a, UID_A);
+    bus.add(b, UID_B);
+
+    bus.broadcast({ type: "mood", slug: "happy" }, UID_A);
+    bus.broadcast({ type: "chat_start" }, UID_A);
+    bus.broadcast({ type: "mood", slug: "sad" }, UID_B);
+    bus.broadcast({ type: "chat_end" }, UID_A);
+
+    assert.deepEqual(a.types(), ["mood", "chat_start", "chat_end"]);
+    assert.deepEqual(b.types(), ["mood"]);
+  });
+
+  test("single-tenant (Mac): null origin + null subscriber → delivered", () => {
+    const bus = new TenantEventBus<FakeSink>();
+    const only = new FakeSink();
+    bus.add(only, null);
+
+    bus.broadcast({ type: "idle_message", text: "hello" }, null);
+    bus.broadcast({ type: "mood", slug: "neutral" }, null);
+
+    // Unchanged from the pre-B2 behavior: the one implicit user sees everything.
+    assert.deepEqual(only.types(), ["idle_message", "mood"]);
+  });
+
+  test("a signed-in cloud tenant does NOT receive global/background (null-origin) events", () => {
+    const bus = new TenantEventBus<FakeSink>();
+    const signedIn = new FakeSink();
+    const shared = new FakeSink(); // legacy shared-token demo caller (null uid)
+    bus.add(signedIn, UID_A);
+    bus.add(shared, null);
+
+    // The global idle scheduler runs outside any per-uid scope → origin null.
+    bus.broadcast({ type: "idle_message", text: "global soul musing" }, null);
+
+    assert.deepEqual(signedIn.frames, []); // the global soul never leaks to a tenant
+    assert.deepEqual(shared.types(), ["idle_message"]);
+  });
+
+  test("two subscribers for the SAME tenant (e.g. two tabs) both receive it", () => {
+    const bus = new TenantEventBus<FakeSink>();
+    const tab1 = new FakeSink();
+    const tab2 = new FakeSink();
+    const otherTenant = new FakeSink();
+    bus.add(tab1, UID_A);
+    bus.add(tab2, UID_A);
+    bus.add(otherTenant, UID_B);
+
+    bus.broadcast({ type: "mood", slug: "curious" }, UID_A);
+
+    assert.deepEqual(tab1.types(), ["mood"]);
+    assert.deepEqual(tab2.types(), ["mood"]);
+    assert.deepEqual(otherTenant.frames, []);
+  });
+
+  test("unsubscribe stops delivery and frees the slot", () => {
+    const bus = new TenantEventBus<FakeSink>();
+    const a = new FakeSink();
+    const off = bus.add(a, UID_A);
+    assert.equal(bus.size, 1);
+
+    bus.broadcast({ type: "mood", slug: "happy" }, UID_A);
+    off();
+    bus.broadcast({ type: "mood", slug: "sad" }, UID_A);
+
+    assert.deepEqual(a.types(), ["mood"]); // only the pre-unsubscribe frame
+    assert.equal(bus.size, 0);
+  });
+
+  test("the same sink can register twice and each slot is removed independently", () => {
+    const bus = new TenantEventBus<FakeSink>();
+    const sink = new FakeSink();
+    const off1 = bus.add(sink, UID_A);
+    bus.add(sink, UID_A);
+    assert.equal(bus.size, 2);
+
+    off1();
+    assert.equal(bus.size, 1); // only the first registration went away
+
+    bus.broadcast({ type: "mood", slug: "happy" }, UID_A);
+    assert.deepEqual(sink.types(), ["mood"]); // delivered once, via the surviving slot
+  });
+
+  test("a dead sink (throwing write) doesn't block delivery to its tenant-mates", () => {
+    const bus = new TenantEventBus();
+    const dead: EventSink = {
+      write() {
+        throw new Error("EPIPE: connection gone");
+      },
+    };
+    const live = new FakeSink();
+    bus.add(dead, UID_A);
+    bus.add(live, UID_A);
+
+    assert.doesNotThrow(() =>
+      bus.broadcast({ type: "mood", slug: "happy" }, UID_A),
+    );
+    assert.deepEqual(live.types(), ["mood"]);
+  });
+});
+
+describe("sameTenant predicate", () => {
+  test("exact uid match, including null === null", () => {
+    assert.equal(sameTenant(null, null), true); // Mac / shared-token
+    assert.equal(sameTenant(UID_A, UID_A), true);
+    assert.equal(sameTenant(UID_A, UID_B), false); // the leak this closes
+    assert.equal(sameTenant(null, UID_A), false); // tenant event ↛ shared sub
+    assert.equal(sameTenant(UID_A, null), false); // global event ↛ tenant sub
+  });
+});

--- a/src/web/event-bus.ts
+++ b/src/web/event-bus.ts
@@ -1,0 +1,98 @@
+/**
+ * Tenant-aware SSE fan-out for the web server's persistent `/events` stream.
+ *
+ * The problem this solves (PLAN_ACCOUNTS_BILLING B2): the `/events` stream is a
+ * single process-wide broadcast. It carries `mood`, `chat_start`/`chat_end` and
+ * `idle_message` events — the last of which contains message TEXT. Fanning every
+ * event to every open connection is fine on the Mac edition (one implicit user)
+ * but in the multi-tenant cloud edition it leaks one signed-in account's
+ * activity — and idle-message content — to every other signed-in account.
+ *
+ * The fix is a uid match on both ends:
+ *  - every subscriber is pinned to the uid it authenticated as, and
+ *  - every event carries the uid of the home scope it originated in
+ *    (`scopedUid()` at broadcast time; null for global/background work).
+ * A subscriber receives an event only when the two uids are equal. The Mac
+ * edition uses null for both, so the match is always true and delivery is
+ * unchanged. The legacy shared-token cloud demo caller is also null-uid, so it
+ * keeps seeing the global soul's background activity exactly as before.
+ *
+ * Kept as a standalone unit (not a closure inside `startWebServer`) so the
+ * isolation rule is unit-testable without standing up an HTTP server — see
+ * event-bus.test.ts.
+ */
+
+/** Anything we can push an SSE frame into. `http.ServerResponse` satisfies it. */
+export interface EventSink {
+  write(chunk: string): unknown;
+}
+
+/**
+ * Deliver an event to a subscriber iff the two share a tenant.
+ *
+ * A plain uid equality, but named so both the persistent `/events` fan-out
+ * (via {@link TenantEventBus}) and the `/chat` per-turn mood stream — which is
+ * not a bus subscriber — enforce the *same* rule from one place. `null === null`
+ * is intentional: it is how the single-tenant Mac edition and the shared-token
+ * demo (one implicit, unscoped user) keep receiving everything.
+ */
+export function sameTenant(
+  subscriberUid: string | null,
+  originUid: string | null,
+): boolean {
+  return subscriberUid === originUid;
+}
+
+interface Subscriber<S extends EventSink> {
+  sink: S;
+  uid: string | null;
+}
+
+/**
+ * A set of SSE subscribers, each pinned to a uid, with a fan-out that only
+ * reaches subscribers in the originating event's tenant.
+ */
+export class TenantEventBus<S extends EventSink = EventSink> {
+  private readonly subscribers = new Set<Subscriber<S>>();
+
+  /**
+   * Register `sink` as a subscriber for tenant `uid` (null on the Mac edition /
+   * shared-token demo). Returns an unsubscribe function to call on disconnect —
+   * identity is per-entry, so the same sink may register more than once and
+   * each registration is removed independently.
+   */
+  add(sink: S, uid: string | null): () => void {
+    const entry: Subscriber<S> = { sink, uid };
+    this.subscribers.add(entry);
+    return () => {
+      this.subscribers.delete(entry);
+    };
+  }
+
+  /** Live subscriber count (diagnostics / tests). */
+  get size(): number {
+    return this.subscribers.size;
+  }
+
+  /**
+   * Fan `event` out to every subscriber in `origin`'s tenant.
+   *
+   * `origin` is the uid of the home scope the event came from: a signed-in
+   * cloud account's uid when the event was produced inside that account's
+   * request/turn scope, or null when it came from the global/background scope
+   * (idle/reflect schedulers, orchestrator hub) or the single-tenant Mac
+   * edition. A dead connection that throws on write is skipped, not fatal —
+   * it is removed by its own close handler.
+   */
+  broadcast(event: unknown, origin: string | null): void {
+    const data = `data: ${JSON.stringify(event)}\n\n`;
+    for (const sub of this.subscribers) {
+      if (!sameTenant(sub.uid, origin)) continue;
+      try {
+        sub.sink.write(data);
+      } catch {
+        /* dead conn — dropped when its close handler fires */
+      }
+    }
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -111,7 +111,7 @@ import {
   type SuggestionProvider,
 } from "../screen_advisor/engine.js";
 import os from "node:os";
-import { lisaHome, lisaGlobalHome, homeScope, homeForUid } from "../paths.js";
+import { lisaHome, lisaGlobalHome, homeScope, homeForUid, scopedUid } from "../paths.js";
 import { isCloud, editionInfo } from "../edition.js";
 import {
   verifyAppleIdentityToken,
@@ -122,6 +122,7 @@ import {
   audienceForClient,
 } from "./cloudAuth.js";
 import { detectLanHost, buildPairUrl } from "./pairing.js";
+import { TenantEventBus, sameTenant } from "./event-bus.js";
 import { qrSvg } from "./qr-svg.js";
 import type { ToolDefinition, StoredMessage } from "../types.js";
 
@@ -417,13 +418,20 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   };
 
   // ── Persistent /events SSE subscribers (mood + idle broadcasts) ─────
-  const eventClients = new Set<http.ServerResponse>();
-  const broadcast = (event: object) => {
-    const data = `data: ${JSON.stringify(event)}\n\n`;
-    for (const c of eventClients) {
-      try { c.write(data); } catch { /* dead conn */ }
-    }
-  };
+  // Tenant-aware fan-out (B2): each subscriber is pinned to the account it
+  // authenticated as, and every event carries the uid of the home scope it
+  // originated in. A subscriber only receives events from its own tenant, so
+  // one cloud account's mood / thinking / idle-message TEXT never leaks to
+  // another signed-in account. Mac edition + shared-token demo are null-uid on
+  // both ends, so delivery is unchanged (one implicit user sees everything).
+  // See event-bus.ts for the isolation rule and its unit tests.
+  const eventClients = new TenantEventBus<http.ServerResponse>();
+  // Origin defaults to the CURRENT home scope: a broadcast made inside a
+  // signed-in request/turn scope carries that uid; one from the global /
+  // background scope (schedulers, orchestrator hub) carries null. So the many
+  // `broadcast({...})` call sites below need no per-site change.
+  const broadcast = (event: object, origin: string | null = scopedUid()) =>
+    eventClients.broadcast(event, origin);
   moodBus.on("mood", (slug) => broadcast({ type: "mood", slug }));
   // Surface "thinking" to long-lived viewers (web GUI, island widget). Each
   // event is one tick — surfaces toggle their own indicator. Multiple
@@ -1375,6 +1383,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         }
         uidChats.delete(userHome);
         promptCache.delete(userHome);
+        moodBus.forget(accountUid); // keyed by uid, not home path
       } catch (e) {
         console.error(`[auth] account home cleanup failed: ${(e as Error).message}`);
       }
@@ -2426,8 +2435,10 @@ self.addEventListener('fetch', (event) => {
       res.write(`data: ${JSON.stringify({ type: "hello", session: chat.session.id })}\n\n`);
       // Send current mood right away
       res.write(`data: ${JSON.stringify({ type: "mood", slug: moodBus.current() })}\n\n`);
-      eventClients.add(res);
-      req.on("close", () => eventClients.delete(res));
+      // Pin this subscriber to the account it authenticated as (B2). null on the
+      // Mac edition and the shared-token demo → one implicit user, sees all.
+      const unsubscribe = eventClients.add(res, cloud ? accountUid : null);
+      req.on("close", unsubscribe);
       return;
     }
 
@@ -2901,7 +2912,14 @@ self.addEventListener('fetch', (event) => {
       // queued turn isn't stuck behind an abandoned run.
       const turnAbort = new AbortController();
       req.on("close", () => turnAbort.abort());
-      const onMood = (slug: string) => send({ type: "mood", slug });
+      // The moodBus is process-wide: another tenant's concurrent turn emits on
+      // it too. Only forward mood ticks that originate in THIS caller's home
+      // scope (B2), so a cloud account never sees another account's mood. Mac /
+      // shared-token: ownUid is null and so is the emitting scope → always on.
+      const ownUid = cloud ? accountUid : null;
+      const onMood = (slug: string) => {
+        if (sameTenant(ownUid, scopedUid())) send({ type: "mood", slug });
+      };
       moodBus.on("mood", onMood);
       // Send the current mood immediately so a fresh tab knows where to start.
       send({ type: "mood", slug: moodBus.current() });


### PR DESCRIPTION
## The leak

The process-wide `moodBus`/SSE broadcast fanned **every event to all signed-in accounts regardless of uid**: mood ticks, `chat_start`/`chat_end`, and `idle_message` — *including its text body*. Found while reviewing the accounts/billing epic (#259–#272). Pre-existing, and **not** covered by B2's isolation, which scoped the filesystem but never the event stream.

Impact is bounded to the cloud edition with more than one account signed in at once — i.e. exactly the configuration that multi-user launch requires.

## The fix

**Tenant-aware fan-out.** New `src/web/event-bus.ts`:

- `TenantEventBus` — every subscriber is pinned to the account it authenticated as at `add()` time.
- `sameTenant(subUid, originUid)` — exact equality, with `null === null` preserved on purpose.

Wiring in `server.ts`:

- `/events` subscribes as `cloud ? accountUid : null`, and unsubscribes on `req.on("close")`.
- `broadcast(event, origin = scopedUid())` defaults each event's origin to the home scope it was emitted from — schedulers and background work carry `null`, in-request broadcasts carry that uid. **The ~20 existing `broadcast({...})` call sites needed no change.**
- Delivery happens iff `subscriber.uid === origin`.
- The same predicate guards the `/chat` per-turn `onMood` handler, which had the sibling leak.

**Mood state is per-tenant too.** `mood-bus.ts` now keeps a `globalMood` field for the null scope and a `moodByUid` Map for signed-in accounts, both keyed off `scopedUid()`. A fresh `/events`, `/chat` or island-ping connection is served *its own* account's mood on connect rather than whatever another tenant last set. `forget(uid)` drops it on account deletion, next to the existing `uidChats.delete`/`promptCache.delete`.

The three `moodBus.current()` call sites are untouched: they already run downstream of the auth gate's `homeScope.enterWith()` (server.ts ~1181), which sticks to the request's async chain — so `current()` became scope-aware for free. Verified rather than assumed; the write side (`set_mood.ts`) runs inside the same chain.

## Mac edition / shared-token demo

Unchanged. Both ends are `null`, `null === null` holds, so the one implicit user still sees everything.

## Tests

- `src/web/event-bus.test.ts` — 10 assertions, including *"a uid-A event is never delivered to uid-B"*, independent removal of a double-registered sink, and a dead (throwing) sink not blocking its tenant-mates.
- `src/mood-bus.test.ts` — 5 per-scope isolation assertions, including that a fresh connection reads its own scope and that `forget()` doesn't touch other tenants.

`npm run typecheck` clean; full suite **1103 pass / 0 fail / 1 skipped** (the skip is pre-existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)