### PR TITLE
fix(lock): O_EXCL fallback when link() is unsupported (gcsfuse /data)

### DIFF
--- a/src/soul/lock.test.ts
+++ b/src/soul/lock.test.ts
@@ -121,4 +121,46 @@ describe("withFileLock", () => {
     const out = await withFileLock(lp, async () => "recovered", { timeoutMs: 1000 });
     assert.equal(out, "recovered");
   });
+
+  // gcsfuse (Cloud Run's /data volume) has no hard links: link() → ENOSYS.
+  // The O_EXCL fallback must keep both acquisition and mutual exclusion.
+  describe("link() unsupported (gcsfuse)", () => {
+    const realLink = fsp.link;
+    before(() => {
+      fsp.link = async () => {
+        const err = new Error("ENOSYS: function not implemented, link") as NodeJS.ErrnoException;
+        err.code = "ENOSYS";
+        throw err;
+      };
+    });
+    after(() => {
+      fsp.link = realLink;
+    });
+
+    test("acquires and releases via the O_EXCL fallback", async () => {
+      const lp = lockPath();
+      const out = await withFileLock(lp, async () => "fallback", { timeoutMs: 1000 });
+      assert.equal(out, "fallback");
+      await assert.rejects(() => fsp.stat(lp), /ENOENT/, "lock file should be gone");
+    });
+
+    test("still mutually excludes a second acquirer", async () => {
+      const lp = lockPath();
+      let release!: () => void;
+      const held = new Promise<void>((r) => (release = r));
+      let acquired!: () => void;
+      const inside = new Promise<void>((r) => (acquired = r));
+      const holder = withFileLock(lp, async () => {
+        acquired();
+        await held;
+      }, { staleMs: 60_000 });
+      await inside;
+      await assert.rejects(
+        () => withFileLock(lp, async () => "never", { timeoutMs: 300, pollMs: 10, staleMs: 60_000 }),
+        /timed out acquiring lock/,
+      );
+      release();
+      await holder;
+    });
+  });
 });

--- a/src/soul/lock.ts
+++ b/src/soul/lock.ts
@@ -94,9 +94,27 @@ export async function withFileLock<T>(
     // concurrent acquirers in the *same* process don't clobber each other.
     const tmp = `${lockPath}.${process.pid}.${Math.random().toString(36).slice(2)}.tmp`;
     try {
-      await fsp.writeFile(tmp, JSON.stringify({ pid: process.pid, ts: Date.now() } satisfies LockBody));
+      const body = JSON.stringify({ pid: process.pid, ts: Date.now() } satisfies LockBody);
+      await fsp.writeFile(tmp, body);
       try {
-        await fsp.link(tmp, lockPath);
+        try {
+          await fsp.link(tmp, lockPath);
+        } catch (e) {
+          const code = (e as NodeJS.ErrnoException).code;
+          if (code !== "ENOSYS" && code !== "ENOTSUP" && code !== "EPERM") throw e;
+          // Filesystems without hard links — gcsfuse behind Cloud Run's /data
+          // volume returns ENOSYS — fall back to O_EXCL creation. Weaker than
+          // link() (content lands just after creation, not with it), but
+          // isStale() already treats an unreadable body as stale, so the worst
+          // case is a contender briefly reading a half-written lock and
+          // stealing it — acceptable on the single-instance cloud edition.
+          const fh = await fsp.open(lockPath, "wx");
+          try {
+            await fh.writeFile(body);
+          } finally {
+            await fh.close();
+          }
+        }
       } finally {
         await fsp.rm(tmp, { force: true }).catch(() => {});
       }


### PR DESCRIPTION
## Bug (found live during the accounts-launch deploy)

Cloud Run mounts the durable `/data` volume via **gcsfuse, which does not implement hard links** — `fsp.link()` throws `ENOSYS`. `withFileLock` acquires its lock exclusively via `link(tmp, lockPath)`, so on the cloud edition **every locked billing write fails**:

- the B7 reviewer seed's $20 credit (observed in the live logs: `[accounts] reviewer seed failed: ENOSYS: function not implemented, link '…/billing/balance.lock.….tmp' -> '…/billing/balance.lock'`)
- IAP / Stripe credit ingestion (`creditPurchase` → `balance.lock`)
- the per-uid usage meter (`usage.lock`)
- autonomy `runs.jsonl` appends

Mac edition is unaffected (APFS has hard links) — which is why the whole suite was green while the cloud path was broken.

## Fix

When `link()` fails with `ENOSYS`/`ENOTSUP`/`EPERM`, fall back to `fsp.open(lockPath, "wx")` (O_CREAT|O_EXCL) and write the body through the handle. Weaker than link() — content lands just after creation instead of atomically with it — but `isStale()` already treats an unreadable body as stale, so the worst case is a contender stealing a half-written lock; acceptable on the single-instance cloud edition (multi-instance uses the Firestore turn lease from #272 instead).

## Tests

Two new cases under a monkeypatched `fsp.link` that always throws ENOSYS: acquisition+release via the fallback, and mutual exclusion still holding. `npm run typecheck` clean; lock suite 9/9, billing quota+meter 13/13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)