### PR TITLE
fix(billing): 7 accounts/billing review follow-ups

### DIFF
--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -1,5 +1,8 @@
 import SwiftUI
 import AuthenticationServices
+#if LISA_ENABLE_SIWA
+import CryptoKit
+#endif
 
 /// Shared cloud sign-in form (PLAN_ACCOUNTS_BILLING B1) — the PRIMARY flow:
 /// Sign in with Apple first, email+password second, and the legacy paste-a-token
@@ -19,6 +22,13 @@ struct CloudSignInForm: View {
     @State private var pasteText = ""
     @State private var busy = false
     @State private var error: String?
+    #if LISA_ENABLE_SIWA
+    /// Raw (un-hashed) nonce for the in-flight Apple request (#261). We send
+    /// sha256(raw) to Apple and the raw value to our server, which re-hashes it
+    /// and matches it against the token's `nonce` claim — so a token minted for
+    /// some other request can't be replayed at our sign-in endpoint.
+    @State private var appleRawNonce: String?
+    #endif
 
     var body: some View {
         Section {
@@ -26,7 +36,12 @@ struct CloudSignInForm: View {
                 .autocorrectionDisabled().textInputAutocapitalization(.never).keyboardType(.URL)
             #if LISA_ENABLE_SIWA
             SignInWithAppleButton(.continue,
-                onRequest: { req in req.requestedScopes = [.fullName, .email] },
+                onRequest: { req in
+                    req.requestedScopes = [.fullName, .email]
+                    let raw = Self.randomNonce()
+                    appleRawNonce = raw
+                    req.nonce = Self.sha256Hex(raw)
+                },
                 onCompletion: handleApple)
                 .signInWithAppleButtonStyle(.white)
                 .frame(height: 46)
@@ -116,6 +131,18 @@ struct CloudSignInForm: View {
     }
 
     #if LISA_ENABLE_SIWA
+    /// 32 hex chars of randomness — the raw nonce (#261). `SystemRandomNumber-
+    /// Generator` is arc4random_buf on Apple platforms, so no Security import.
+    private static func randomNonce() -> String {
+        var rng = SystemRandomNumberGenerator()
+        return (0..<16).map { _ in String(format: "%02x", UInt8.random(in: 0...255, using: &rng)) }.joined()
+    }
+
+    /// SHA-256 as lowercase hex — the form Apple echoes into the `nonce` claim.
+    private static func sha256Hex(_ s: String) -> String {
+        SHA256.hash(data: Data(s.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
     private func handleApple(_ result: Result<ASAuthorization, Error>) {
         error = nil
         switch result {
@@ -129,9 +156,13 @@ struct CloudSignInForm: View {
                 return
             }
             busy = true
+            // One nonce per request: consume it so a second sign-in can't reuse it.
+            let raw = appleRawNonce
+            appleRawNonce = nil
             Task {
                 do {
-                    try await app.connectCloudWithApple(baseURL: cloudURL, identityToken: idToken)
+                    try await app.connectCloudWithApple(baseURL: cloudURL, identityToken: idToken,
+                                                        rawNonce: raw)
                     await verifyThenReport()
                 } catch LisaError.http(404) {
                     busy = false

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -217,9 +217,10 @@ final class AppState: ObservableObject {
     /// session token, then save the cloud connection. Throws on a bad cloud URL,
     /// an instance that hasn't enabled Sign in with Apple (404), or a rejected
     /// token (401). On success the connection is configured for `verifyConnection`.
-    func connectCloudWithApple(baseURL raw: String, identityToken: String) async throws {
+    func connectCloudWithApple(baseURL raw: String, identityToken: String, rawNonce: String? = nil) async throws {
         guard let base = AppState.parseCloudBase(raw) else { throw LisaError.notConfigured }
-        let token = try await LisaClient.exchangeAppleToken(base: base, identityToken: identityToken)
+        let token = try await LisaClient.exchangeAppleToken(base: base, identityToken: identityToken,
+                                                            rawNonce: rawNonce)
         update(host: base.host, port: base.port, token: token, scheme: base.scheme)
         await refreshAccount()
     }

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -57,7 +57,10 @@ final class LisaClient {
     /// is the call that *mints* the token — so it's a static helper that takes the
     /// bare cloud base (host/scheme/port, no token). Throws `LisaError.http` for a
     /// disabled instance (404) or a rejected sign-in (401/403).
-    static func exchangeAppleToken(base: ServerConfig, identityToken: String,
+    /// `rawNonce` is the un-hashed nonce this sign-in minted (#261); the server
+    /// hashes it and compares against the token's `nonce` claim, which proves
+    /// the token was issued for THIS request. nil ⇒ omitted (older instances).
+    static func exchangeAppleToken(base: ServerConfig, identityToken: String, rawNonce: String? = nil,
                                    session: URLSession = .shared) async throws -> String {
         guard let baseURL = base.baseURL, let url = URL(string: "/api/auth/apple", relativeTo: baseURL) else {
             throw LisaError.notConfigured
@@ -65,7 +68,9 @@ final class LisaClient {
         var req = URLRequest(url: url)
         req.httpMethod = "POST"
         req.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        req.httpBody = try JSONSerialization.data(withJSONObject: ["identityToken": identityToken])
+        var payload: [String: String] = ["identityToken": identityToken]
+        if let rawNonce { payload["nonce"] = rawNonce }
+        req.httpBody = try JSONSerialization.data(withJSONObject: payload)
         let (data, resp) = try await session.data(for: req)
         let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
         guard (200..<300).contains(code) else { throw LisaError.http(code) }

--- a/src/billing/iap.test.ts
+++ b/src/billing/iap.test.ts
@@ -7,7 +7,7 @@ import path from "node:path";
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-iap-"));
 process.env.LISA_HOME = TMP;
 
-const { verifyAppleJWS, validateTransaction, creditTransaction, refundTransaction, PRODUCTS, IapError } =
+const { verifyAppleJWS, validateTransaction, creditTransaction, refundTransaction, PRODUCTS, IapError, oidToDer } =
   await import("./iap.js");
 const { homeScope, homeForUid } = await import("../paths.js");
 const { readBalance } = await import("./quota.js");
@@ -29,6 +29,18 @@ describe("JWS shape validation", () => {
     ]) {
       await assert.rejects(verifyAppleJWS(bad, { now: 0 }), (e: unknown) => (e as InstanceType<typeof IapError>).code === "malformed_jws");
     }
+  });
+});
+
+describe("OID DER encoding (#265)", () => {
+  test("encodes Apple's marker OIDs to the bytes the chain walk looks for", () => {
+    // Verified against real Apple certs: these exact TLVs appear in the leaf
+    // and the WWDR intermediate respectively.
+    assert.equal(oidToDer("1.2.840.113635.100.6.11.1").toString("hex"), "060a2a864886f76364060b01");
+    assert.equal(oidToDer("1.2.840.113635.100.6.2.1").toString("hex"), "060a2a864886f76364060201");
+    // multi-byte base-128 arcs and the packed first two arcs
+    assert.equal(oidToDer("2.5.29.19").toString("hex"), "0603551d13"); // basicConstraints
+    assert.equal(oidToDer("1.2.840.113549").toString("hex"), "06062a864886f70d"); // RSADSI
   });
 });
 

--- a/src/billing/iap.test.ts
+++ b/src/billing/iap.test.ts
@@ -42,6 +42,17 @@ describe("OID DER encoding (#265)", () => {
     assert.equal(oidToDer("2.5.29.19").toString("hex"), "0603551d13"); // basicConstraints
     assert.equal(oidToDer("1.2.840.113549").toString("hex"), "06062a864886f70d"); // RSADSI
   });
+
+  test("refuses an OID needing long-form DER length instead of emitting invalid DER", () => {
+    // >127 content bytes. Emitting the length byte unchecked would produce DER
+    // that parses as something else entirely, so the needle would never match
+    // and the role check would silently always fail — refuse loudly instead.
+    const huge = "1.2." + Array.from({ length: 40 }, () => "268435456").join(".");
+    assert.throws(() => oidToDer(huge), IapError);
+    // and malformed input is still rejected
+    assert.throws(() => oidToDer("1"), IapError);
+    assert.throws(() => oidToDer("1.x.3"), IapError);
+  });
 });
 
 describe("transaction payload validation", () => {

--- a/src/billing/iap.ts
+++ b/src/billing/iap.ts
@@ -136,10 +136,25 @@ export function oidToDer(oid: string): Buffer {
     for (let v = arc >>> 7; v > 0; v >>>= 7) groups.unshift((v & 0x7f) | 0x80);
     content.push(...groups);
   }
+  // Short-form length only. Every OID we encode is a dozen bytes, but emitting
+  // `content.length` unchecked past 127 would silently produce INVALID DER
+  // (>127 needs the long form), and the resulting needle would never match —
+  // i.e. a role check that quietly always fails. Refuse instead of lying.
+  if (content.length > 127) throw new IapError("bad_chain");
   return Buffer.from([0x06, content.length, ...content]);
 }
 
-/** Does this cert carry `oid` anywhere in its DER (i.e. as an extension id)? */
+/**
+ * Does this cert carry `oid` anywhere in its DER?
+ *
+ * Deliberately a substring search over the raw certificate, not an extension
+ * walk: Node's X509Certificate exposes no extension getter, and its `keyUsage`
+ * reads back undefined on Apple's certs. So this asserts the OID's TLV is
+ * PRESENT somewhere, not that it is a given extension's `extnID` — a cert
+ * carrying those bytes in another field would also pass. That is weaker than a
+ * real extension check; it is used here only as a role hint on top of a fully
+ * verified, pinned-root chain, never as the sole gate.
+ */
 export function certHasOid(cert: X509Certificate, oid: string): boolean {
   return cert.raw.includes(oidToDer(oid));
 }

--- a/src/billing/iap.ts
+++ b/src/billing/iap.ts
@@ -56,19 +56,56 @@ export const EXPECTED_BUNDLE = "ai.meetlisa.main";
 
 const APPLE_ROOT_URL = "https://www.apple.com/certificateauthority/AppleRootCA-G3.cer";
 
+/**
+ * Apple Root CA G3, pinned by SHA-256 (#265). Without this the "pinned" root
+ * was whatever apple.com served over TLS and then whatever sat in the cache
+ * file — so a TLS compromise or a writable cache dir substituted the trust
+ * anchor and every downstream chain check became theatre. Node's
+ * `fingerprint256` format: uppercase hex, colon-separated.
+ */
+const APPLE_ROOT_G3_SHA256 =
+  "63:34:3A:BF:B8:9A:6A:03:EB:B5:7E:9B:3F:5F:A7:BE:7C:4F:5C:75:6F:30:17:B3:A8:C4:88:C3:65:3E:91:79";
+
+/**
+ * Apple's certificate marker extensions. Presence is asserted on the DER, which
+ * is enough to keep an unrelated (even Apple-issued) cert from standing in for
+ * a receipt-signing one — Node's X509Certificate exposes no extension getter,
+ * and its `keyUsage` reads back undefined on these certs.
+ */
+const OID_LEAF_RECEIPT_SIGNING = "1.2.840.113635.100.6.11.1";
+const OID_INTERMEDIATE_WWDR = "1.2.840.113635.100.6.2.1";
+
+/** Whether the root came from an explicit operator override (not fingerprint-pinned). */
+function rootPathOverridden(): boolean {
+  return !!process.env.LISA_APPLE_ROOT_PATH;
+}
+
 function rootCachePath(): string {
   return process.env.LISA_APPLE_ROOT_PATH ?? path.join(lisaGlobalHome(), "apple-root-g3.cer");
 }
 
 let rootCert: X509Certificate | null = null;
 
-/** Load (fetch-once + cache) Apple's Root CA G3. */
+/**
+ * Load (fetch-once + cache) Apple's Root CA G3, pinned to `APPLE_ROOT_G3_SHA256`.
+ *
+ * A cache file that doesn't match the pin is treated as absent (poisoned or
+ * stale ⇒ re-fetch), and a fetch that doesn't match is a hard failure — so the
+ * anchor is the real G3 no matter which path it arrived by. An EXISTING file at
+ * `LISA_APPLE_ROOT_PATH` skips the pin: that's the documented air-gapped/test
+ * escape hatch, where the operator has chosen the anchor themselves.
+ */
 export async function appleRootCert(): Promise<X509Certificate> {
   if (rootCert) return rootCert;
   const file = rootCachePath();
+  const overridden = rootPathOverridden();
   try {
-    rootCert = new X509Certificate(fs.readFileSync(file));
-    return rootCert;
+    const cached = new X509Certificate(fs.readFileSync(file));
+    if (overridden || cached.fingerprint256 === APPLE_ROOT_G3_SHA256) {
+      rootCert = cached;
+      return rootCert;
+    }
+    console.error(`[iap] cached Apple root at ${file} failed the G3 pin — refetching`);
   } catch {
     /* fall through to fetch */
   }
@@ -76,10 +113,35 @@ export async function appleRootCert(): Promise<X509Certificate> {
   if (!res.ok) throw new IapError("root_unavailable");
   const der = Buffer.from(await res.arrayBuffer());
   const cert = new X509Certificate(der);
+  if (cert.fingerprint256 !== APPLE_ROOT_G3_SHA256) throw new IapError("root_unavailable");
   fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
   fs.writeFileSync(file, der);
   rootCert = cert;
   return cert;
+}
+
+/**
+ * Encode a dotted OID as its DER TLV (tag 0x06). Pure + deterministic — e.g.
+ * `1.2.840.113635.100.6.11.1` → `060a2a864886f76364060b01`.
+ */
+export function oidToDer(oid: string): Buffer {
+  const arcs = oid.split(".").map(Number);
+  if (arcs.length < 2 || arcs.some((n) => !Number.isInteger(n) || n < 0)) {
+    throw new IapError("bad_chain");
+  }
+  const content: number[] = [arcs[0]! * 40 + arcs[1]!];
+  for (const arc of arcs.slice(2)) {
+    // base-128, most-significant group first, continuation bit on all but last
+    const groups = [arc & 0x7f];
+    for (let v = arc >>> 7; v > 0; v >>>= 7) groups.unshift((v & 0x7f) | 0x80);
+    content.push(...groups);
+  }
+  return Buffer.from([0x06, content.length, ...content]);
+}
+
+/** Does this cert carry `oid` anywhere in its DER (i.e. as an extension id)? */
+export function certHasOid(cert: X509Certificate, oid: string): boolean {
+  return cert.raw.includes(oidToDer(oid));
 }
 
 /** Test seam. */
@@ -130,6 +192,17 @@ export async function verifyAppleJWS(
   });
   const root = opts.root ?? (await appleRootCert());
   const now = opts.now ?? Date.now();
+  // Role checks (#265). A signature chain alone doesn't say what each cert is
+  // FOR: without these, any leaf Apple ever issued — or any leaf presented as
+  // its own issuer — could sign transactions. `.ca` is basicConstraints CA
+  // (reliable here; `.keyUsage` reads back undefined on Apple certs), and the
+  // marker OIDs identify the receipt-signing leaf and the WWDR intermediate.
+  if (chain[0]!.ca) throw new IapError("bad_chain"); // a CA must not sign receipts
+  if (!certHasOid(chain[0]!, OID_LEAF_RECEIPT_SIGNING)) throw new IapError("bad_chain");
+  if (!certHasOid(chain[1]!, OID_INTERMEDIATE_WWDR)) throw new IapError("bad_chain");
+  for (let i = 1; i < chain.length; i++) {
+    if (!chain[i]!.ca) throw new IapError("bad_chain"); // non-CA can't issue
+  }
   // Each cert must be inside its validity window and signed by the next one;
   // the last must be signed by (or BE) the pinned root.
   for (let i = 0; i < chain.length; i++) {

--- a/src/billing/limits.test.ts
+++ b/src/billing/limits.test.ts
@@ -7,13 +7,16 @@ import path from "node:path";
 const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-limits-"));
 process.env.LISA_HOME = TMP;
 
-const { rpmOk, resetRpm, globalSpendAdd, globalSpendExceeded, preflightLimits, killSwitchOn, dailyCapMicroUSD } =
-  await import("./limits.js");
+const {
+  rpmOk, resetRpm, globalSpendAdd, globalSpendExceeded, preflightLimits, killSwitchOn, dailyCapMicroUSD,
+  ipRateOk, resetIpRate,
+} = await import("./limits.js");
 
 const T0 = Date.parse("2026-07-22T08:00:00Z");
 
 beforeEach(() => {
   resetRpm();
+  resetIpRate();
   fs.rmSync(path.join(TMP, "billing-global.json"), { force: true });
   delete process.env.LISA_BILLING_KILL;
   delete process.env.LISA_RPM_LIMIT;
@@ -34,6 +37,18 @@ describe("per-uid rpm", () => {
   });
 });
 
+describe("per-key sliding window (#260)", () => {
+  test("caps a key, isolates other keys, slides with the window", () => {
+    assert.ok(ipRateOk("auth:1.2.3.4", 2, 600_000, T0));
+    assert.ok(ipRateOk("auth:1.2.3.4", 2, 600_000, T0 + 1));
+    assert.equal(ipRateOk("auth:1.2.3.4", 2, 600_000, T0 + 2), false);
+    // a different IP is unaffected
+    assert.ok(ipRateOk("auth:5.6.7.8", 2, 600_000, T0 + 2));
+    // past the window the bucket has slid
+    assert.ok(ipRateOk("auth:1.2.3.4", 2, 600_000, T0 + 600_001));
+  });
+});
+
 describe("global daily cap", () => {
   test("accumulates within a UTC day, resets across days, persists on disk", () => {
     process.env.LISA_DAILY_CAP_USD = "1"; // $1 cap for the test
@@ -49,6 +64,28 @@ describe("global daily cap", () => {
 
   test("default cap is $200", () => {
     assert.equal(dailyCapMicroUSD({}), 200_000_000);
+  });
+
+  test("an unreadable counter fails CLOSED, and doesn't get clobbered (#267)", () => {
+    const file = path.join(TMP, "billing-global.json");
+    // A directory in the counter's place reads as EISDIR — an I/O error, not
+    // ENOENT. Previously that read as $0 spent and disabled the cap silently.
+    fs.mkdirSync(file, { recursive: true });
+    try {
+      assert.equal(globalSpendExceeded(T0), true);
+      const v = preflightLimits("u1", T0);
+      assert.ok(!v.ok && v.status === 402 && v.body.error === "service_paused");
+      // the write path must not replace the unreadable counter with a fresh 0
+      globalSpendAdd(1_000, T0);
+      assert.ok(fs.statSync(file).isDirectory());
+    } finally {
+      fs.rmSync(file, { recursive: true, force: true });
+    }
+  });
+
+  test("a corrupt counter file also fails closed (#267)", () => {
+    fs.writeFileSync(path.join(TMP, "billing-global.json"), "{not json");
+    assert.equal(globalSpendExceeded(T0), true);
   });
 });
 

--- a/src/billing/limits.test.ts
+++ b/src/billing/limits.test.ts
@@ -47,6 +47,17 @@ describe("per-key sliding window (#260)", () => {
     // past the window the bucket has slid
     assert.ok(ipRateOk("auth:1.2.3.4", 2, 600_000, T0 + 600_001));
   });
+
+  test("saturation fails OPEN — one client can't lock every new IP out (#260)", () => {
+    // The key space is attacker-controlled (spoofable XFF), so flooding it must
+    // not become a lockout: filling the map is exactly the cheap attack.
+    for (let i = 0; i < 10_000; i++) assert.ok(ipRateOk(`auth:flood-${i}`, 20, 600_000, T0));
+    // A brand-new legitimate IP still gets through rather than being refused.
+    assert.equal(ipRateOk("auth:legit", 20, 600_000, T0), true);
+    // ...while a key already in the map is still capped normally.
+    for (let i = 1; i < 20; i++) ipRateOk("auth:flood-0", 20, 600_000, T0);
+    assert.equal(ipRateOk("auth:flood-0", 20, 600_000, T0), false);
+  });
 });
 
 describe("global daily cap", () => {

--- a/src/billing/limits.ts
+++ b/src/billing/limits.ts
@@ -54,6 +54,45 @@ export function resetRpm(): void {
   rpmBuckets.clear();
 }
 
+// ── generic per-key sliding window (unauthenticated endpoints) ──────────────
+// Separate from rpmBuckets: that one is keyed by uid AFTER auth, this one is
+// keyed by client IP BEFORE it, so an attacker controls the key space. (#260)
+const genericBuckets = new Map<string, number[]>();
+const GENERIC_MAX_KEYS = 10_000;
+
+/**
+ * Record + check one hit for `key` in a sliding `windowMs`. False ⇒ over limit.
+ *
+ * In-memory and per-instance, and the IP behind Cloud Run comes from a header a
+ * client can spoof — so this is a coarse backstop against a single naive
+ * attacker, NOT a security boundary. The real guards on /register and /login
+ * are scrypt's cost, email uniqueness, and the per-email login throttle.
+ */
+export function ipRateOk(key: string, limit: number, windowMs: number, now: number = Date.now()): boolean {
+  const windowStart = now - windowMs;
+  if (genericBuckets.size >= GENERIC_MAX_KEYS) {
+    // Prune fully-expired keys so IP rotation can't grow the map without bound.
+    for (const [k, hits] of genericBuckets) {
+      if (hits.length === 0 || hits[hits.length - 1]! <= windowStart) genericBuckets.delete(k);
+    }
+    // Still full ⇒ everything in it is live. Refuse rather than keep growing.
+    if (genericBuckets.size >= GENERIC_MAX_KEYS && !genericBuckets.has(key)) return false;
+  }
+  const bucket = (genericBuckets.get(key) ?? []).filter((t) => t > windowStart);
+  if (bucket.length >= limit) {
+    genericBuckets.set(key, bucket);
+    return false;
+  }
+  bucket.push(now);
+  genericBuckets.set(key, bucket);
+  return true;
+}
+
+/** Test seam. */
+export function resetIpRate(): void {
+  genericBuckets.clear();
+}
+
 // ── global daily spend cap (persisted; survives restarts) ───────────────────
 interface DayCounter {
   /** UTC day, "YYYY-MM-DD". */
@@ -69,14 +108,44 @@ function utcDay(now: number): string {
   return new Date(now).toISOString().slice(0, 10);
 }
 
-function readCounter(now: number): DayCounter {
+/**
+ * Read today's counter. A MISSING file (ENOENT) or yesterday's stale file is
+ * the normal "no spend yet today" case and reads as 0. A genuine read/parse
+ * FAILURE (permission error, GCS-mount hiccup, corrupt JSON) is reported as
+ * `ok:false` so the cap check can fail CLOSED instead of silently zeroing the
+ * $200/day hard cap. (#267)
+ */
+type CounterRead = { ok: true; counter: DayCounter } | { ok: false };
+
+function readCounter(now: number): CounterRead {
+  let raw: string;
   try {
-    const parsed = JSON.parse(fs.readFileSync(counterPath(), "utf8")) as DayCounter;
-    if (parsed.day === utcDay(now) && typeof parsed.microUSD === "number") return parsed;
-  } catch {
-    /* fresh day / missing file */
+    raw = fs.readFileSync(counterPath(), "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { ok: true, counter: { day: utcDay(now), microUSD: 0 } }; // fresh day
+    }
+    return { ok: false }; // I/O error — the counter is UNKNOWN, not zero
   }
-  return { day: utcDay(now), microUSD: 0 };
+  try {
+    const parsed = JSON.parse(raw) as DayCounter;
+    if (typeof parsed.microUSD !== "number") return { ok: false }; // malformed shape
+    if (parsed.day !== utcDay(now)) return { ok: true, counter: { day: utcDay(now), microUSD: 0 } }; // day rolled
+    return { ok: true, counter: parsed };
+  } catch {
+    return { ok: false }; // corrupt JSON — don't silently disable the cap
+  }
+}
+
+// Throttle the fail-closed log so a persistent storage fault doesn't spam every
+// request; one line per minute is enough for an operator to notice.
+let lastCapReadWarnAt = 0;
+function warnCapReadFailure(now: number): void {
+  if (now - lastCapReadWarnAt < 60_000) return;
+  lastCapReadWarnAt = now;
+  console.error(
+    "[billing] ⚠ global daily-cap counter unreadable — failing CLOSED (service_paused) until the store recovers",
+  );
 }
 
 // B9: with Firestore on, the day counter is a shared doc
@@ -99,7 +168,13 @@ export function globalSpendAdd(microUSD: number, now: number = Date.now()): void
     return;
   }
   try {
-    const c = readCounter(now);
+    const r = readCounter(now);
+    // If the counter is unreadable (not merely absent), DON'T overwrite it with
+    // a fresh 0 — that would clobber a temporarily-unreadable-but-valid file and
+    // undercount the day. Skip the increment; accounting is best-effort and the
+    // audit ledger remains authoritative.
+    if (!r.ok) return;
+    const c = r.counter;
     c.microUSD += microUSD;
     const file = counterPath();
     fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
@@ -130,7 +205,14 @@ export function globalSpendExceeded(now: number = Date.now(), env: Record<string
     }
     return (fsCounterCache?.day === day ? fsCounterCache.microUSD : 0) >= dailyCapMicroUSD(env);
   }
-  return readCounter(now).microUSD >= dailyCapMicroUSD(env);
+  const r = readCounter(now);
+  if (!r.ok) {
+    // The counter is unreadable — fail CLOSED so a storage fault can't silently
+    // disable the hard cap (#267). Reported as "exceeded" ⇒ preflight 402s.
+    warnCapReadFailure(now);
+    return true;
+  }
+  return r.counter.microUSD >= dailyCapMicroUSD(env);
 }
 
 // ── the combined preflight the request paths call ───────────────────────────

--- a/src/billing/limits.ts
+++ b/src/billing/limits.ts
@@ -75,8 +75,15 @@ export function ipRateOk(key: string, limit: number, windowMs: number, now: numb
     for (const [k, hits] of genericBuckets) {
       if (hits.length === 0 || hits[hits.length - 1]! <= windowStart) genericBuckets.delete(k);
     }
-    // Still full ⇒ everything in it is live. Refuse rather than keep growing.
-    if (genericBuckets.size >= GENERIC_MAX_KEYS && !genericBuckets.has(key)) return false;
+    // Still full ⇒ everything in it is live. Fail OPEN, deliberately: the key
+    // space is attacker-controlled (the IP comes from a spoofable XFF header),
+    // so refusing here would let one client fill the map with 10k junk keys and
+    // lock every *new* IP out of /register + /login. This is a coarse backstop,
+    // not a security boundary — scrypt's cost, email uniqueness and the
+    // per-email login throttle are the guards that must not fail open, and none
+    // of them depends on this map. Admitting the overflow is strictly safer
+    // than denying real users.
+    if (genericBuckets.size >= GENERIC_MAX_KEYS && !genericBuckets.has(key)) return true;
   }
   const bucket = (genericBuckets.get(key) ?? []).filter((t) => t > windowStart);
   if (bucket.length >= limit) {

--- a/src/billing/meter.test.ts
+++ b/src/billing/meter.test.ts
@@ -75,6 +75,19 @@ describe("meter ledger", () => {
     assert.equal(globalRows.length, 1);
   });
 
+  test("a failed audit append still returns a priced record (#264)", async () => {
+    // A turn whose ledger line can't land must NOT come back unpriced — the
+    // caller debits `microUSD`, so a null/zero here ships free inference.
+    const HOME_B = homeForUid("em-appendfail");
+    fs.mkdirSync(path.join(HOME_B, "billing", "usage.jsonl"), { recursive: true }); // append → EISDIR
+    await homeScope.run(HOME_B, async () => {
+      const rec = await recordUsage("chat", "glm-4.6", U(1000, 2000));
+      assert.ok(rec, "recordUsage must not return null when the append fails");
+      assert.ok(rec.microUSD > 0);
+      assert.equal(rec.microUSD, costMicroUSD("glm-4.6", U(1000, 2000)));
+    });
+  });
+
   test("corrupt lines are skipped, not fatal", async () => {
     fs.appendFileSync(path.join(TMP, "billing", "usage.jsonl"), "not-json\n");
     const rows = await readUsage();

--- a/src/billing/meter.ts
+++ b/src/billing/meter.ts
@@ -49,16 +49,24 @@ export interface UsageRecord {
 }
 
 /**
- * Append one usage line for the ACTIVE home (call inside the request's home
- * scope). Returns the priced record (or null when recording failed) — the
- * quota engine consumes the returned cost.
+ * Price one metered turn for the ACTIVE home (call inside the request's home
+ * scope) and append it to the audit ledger. ALWAYS returns the priced record —
+ * the quota engine consumes `microUSD` and MUST debit it regardless of whether
+ * the audit line landed.
+ *
+ * The price is computed independently of the append (#264): a full disk
+ * (ENOSPC/EDQUOT) or fd exhaustion (EMFILE) on the local usage.jsonl must lose
+ * at most the audit line, never the debit — otherwise the turn ships free and
+ * the spend is unrecoverable. In the cloud the authoritative balance ledger
+ * lives in Firestore, so a local-FS append failure never blocks the debit.
+ * Never throws (metering must not take chat down).
  */
 export async function recordUsage(
   source: string,
   model: string,
   usage: ProviderUsage,
   now: Date = new Date(),
-): Promise<UsageRecord | null> {
+): Promise<UsageRecord> {
   const rec: UsageRecord = {
     at: now.toISOString(),
     source,
@@ -70,17 +78,18 @@ export async function recordUsage(
     microUSD: costMicroUSD(model, usage),
     pricesVersion: PRICES_VERSION,
   };
+  // Audit-log append is best-effort and DECOUPLED from pricing/debit.
   try {
     await appendLine(usageFile(), JSON.stringify(rec));
     void trimIfNeeded();
-    // Global daily cap accounting + anomaly alert (B7). Best-effort.
-    globalSpendAdd(rec.microUSD, now.getTime());
-    void alertIfAnomalous(now);
-    return rec;
   } catch (err) {
-    console.error(`[billing] usage record failed: ${(err as Error).message}`);
-    return null;
+    console.error(`[billing] usage audit append failed (turn still priced + debited): ${(err as Error).message}`);
   }
+  // Global daily cap accounting + anomaly alert (B7). Best-effort, and run
+  // whether or not the audit line landed.
+  globalSpendAdd(rec.microUSD, now.getTime());
+  void alertIfAnomalous(now);
+  return rec;
 }
 
 // One alert per home per process-day: a single account burning > $10 face in a

--- a/src/cloud/firestore.test.ts
+++ b/src/cloud/firestore.test.ts
@@ -5,7 +5,7 @@ process.env.LISA_FIRESTORE_PROJECT = "test-project";
 
 const {
   toFsFields, fromFsFields, toFsValue, fromFsValue,
-  getDoc, setDoc, casUpdate, acquireLease, releaseLease,
+  getDoc, setDoc, casUpdate, acquireLease, releaseLease, renewLease,
   FirestoreError, _resetFirestoreCachesForTests,
 } = await import("./firestore.js");
 
@@ -141,5 +141,21 @@ describe("turn lease", () => {
     assert.ok(await acquireLease("turn-u1", "owner-b", 10_000, t0 + 3000, fetchFn));
     // expiry → takeover without release
     assert.ok(await acquireLease("turn-u1", "owner-c", 10_000, t0 + 20_000, fetchFn));
+  });
+
+  test("renewal keeps a peer out past the original TTL; non-owners can't renew (#272)", async () => {
+    const { fetchFn } = fakeFirestore();
+    const t0 = 1_700_000_000_000;
+    const a = await acquireLease("turn-u2", "owner-a", 10_000, t0, fetchFn);
+    assert.ok(a);
+    // heartbeat before expiry pushes the deadline out
+    assert.equal(await renewLease(a, 10_000, t0 + 5_000, fetchFn), true);
+    // ...so at t0+12s — past the ORIGINAL expiry — a peer is still locked out
+    assert.equal(await acquireLease("turn-u2", "owner-b", 10_000, t0 + 12_000, fetchFn), null);
+    // a non-owner can't renew someone else's lease
+    assert.equal(await renewLease({ path: a.path, owner: "owner-b" }, 10_000, t0 + 13_000, fetchFn), false);
+    // once it really expires the peer takes over, and the old owner stops renewing
+    assert.ok(await acquireLease("turn-u2", "owner-b", 10_000, t0 + 16_000, fetchFn));
+    assert.equal(await renewLease(a, 10_000, t0 + 17_000, fetchFn), false);
   });
 });

--- a/src/cloud/firestore.ts
+++ b/src/cloud/firestore.ts
@@ -253,6 +253,35 @@ export async function acquireLease(
   }
 }
 
+/**
+ * Push a held lease's expiry out by `ttlMs` (#272). A turn can legitimately run
+ * far longer than one TTL (chat SSE runs under `--timeout 3600`), so the holder
+ * heartbeats instead of the TTL being raised to cover the worst case — a
+ * crashed holder still frees the lease within one TTL. Returns false when we no
+ * longer own it (took too long, someone else took over): the caller stops
+ * renewing rather than stealing it back.
+ */
+export async function renewLease(
+  handle: LeaseHandle,
+  ttlMs: number,
+  now: number = Date.now(),
+  fetchFn: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    return await casUpdate<boolean>(
+      handle.path,
+      (current) => {
+        if (!current || current.owner !== handle.owner) return { next: null, result: false };
+        return { next: { owner: handle.owner, expiresAt: now + ttlMs }, result: true };
+      },
+      fetchFn,
+      2,
+    );
+  } catch {
+    return false; // next heartbeat retries; expiry is the backstop
+  }
+}
+
 /** Release a held lease (best-effort; expiry is the backstop). */
 export async function releaseLease(handle: LeaseHandle, fetchFn: typeof fetch = fetch): Promise<void> {
   try {

--- a/src/cloud/turn-lease.ts
+++ b/src/cloud/turn-lease.ts
@@ -13,7 +13,7 @@
  * preserving today's single-instance behavior byte for byte.
  */
 import crypto from "node:crypto";
-import { firestoreEnabled, acquireLease, releaseLease, type LeaseHandle } from "./firestore.js";
+import { firestoreEnabled, acquireLease, releaseLease, renewLease, type LeaseHandle } from "./firestore.js";
 
 const OWNER = `${process.pid}-${crypto.randomBytes(4).toString("hex")}`;
 const TURN_TTL_MS = 180_000;
@@ -33,6 +33,35 @@ export async function acquireTurnLease(uid: string, waitMs = 15_000): Promise<Tu
     if (Date.now() >= deadline) return null;
     await new Promise((r) => setTimeout(r, 750));
   }
+}
+
+/**
+ * Heartbeat a held lease so a long turn keeps it (#272). Chat SSE runs under
+ * `--timeout 3600` — 20× the TTL — so without this the lease expires mid-turn
+ * and a peer instance happily starts a second run of the same account. Renews
+ * at TTL/3 (two missed beats still leave a full renewal of slack), and stops
+ * renewing if ownership is ever lost. Returns a stop fn for the `finally`.
+ */
+export function startLeaseRenewal(lease: TurnLease | null): () => void {
+  if (!lease || lease === "off") return () => {};
+  let stopped = false;
+  const timer = setInterval(() => {
+    void (async () => {
+      if (stopped) return;
+      const held = await renewLease(lease, TURN_TTL_MS);
+      if (!held && !stopped) {
+        // Someone else owns it now; keeping the beat going would steal it back.
+        stopped = true;
+        clearInterval(timer);
+        console.error(`[lease] lost ${lease.path} mid-turn — renewal stopped`);
+      }
+    })();
+  }, Math.floor(TURN_TTL_MS / 3));
+  timer.unref?.(); // never hold the process open on a heartbeat
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
 }
 
 export async function releaseTurnLease(lease: TurnLease | null): Promise<void> {

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -142,24 +142,40 @@ export function validPassword(pw: string): boolean {
   return pw.length >= 8 && pw.length <= 256;
 }
 
-function hashPassword(pw: string): ScryptParams {
+/**
+ * Async scrypt (#260). `scryptSync` ran the whole KDF on the event loop, so a
+ * handful of concurrent unauthenticated /register or /login calls stalled every
+ * other request — a cheap DoS. The callback form runs on the libuv threadpool.
+ */
+function scryptAsync(pw: string, salt: Buffer, keyLen: number, opts: crypto.ScryptOptions): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    crypto.scrypt(pw, salt, keyLen, opts, (err, key) => (err ? reject(err) : resolve(key)));
+  });
+}
+
+async function hashPassword(pw: string): Promise<ScryptParams> {
   const salt = crypto.randomBytes(16);
-  const key = crypto.scryptSync(pw, salt, SCRYPT.keyLen, SCRYPT);
+  const key = await scryptAsync(pw, salt, SCRYPT.keyLen, SCRYPT);
   return { saltHex: salt.toString("hex"), keyHex: key.toString("hex"), N: SCRYPT.N, r: SCRYPT.r, p: SCRYPT.p };
 }
 
-function passwordMatches(pw: string, p: ScryptParams): boolean {
+async function passwordMatches(pw: string, p: ScryptParams): Promise<boolean> {
   let stored: Buffer;
   try {
     stored = Buffer.from(p.keyHex, "hex");
   } catch {
     return false;
   }
-  const derived = crypto.scryptSync(pw, Buffer.from(p.saltHex, "hex"), stored.length, {
-    N: p.N,
-    r: p.r,
-    p: p.p,
-  });
+  let derived: Buffer;
+  try {
+    derived = await scryptAsync(pw, Buffer.from(p.saltHex, "hex"), stored.length, {
+      N: p.N,
+      r: p.r,
+      p: p.p,
+    });
+  } catch {
+    return false; // corrupt stored params (bad N/r/p) — not a match
+  }
   return derived.length === stored.length && crypto.timingSafeEqual(derived, stored);
 }
 
@@ -226,7 +242,7 @@ export async function createEmailAccount(
   const email = normalizeEmail(emailRaw);
   if (!validEmail(email)) throw new AccountError("invalid_email");
   if (!validPassword(password)) throw new AccountError("weak_password");
-  const scrypt = hashPassword(password); // CPU work outside the CAS loop
+  const scrypt = await hashPassword(password); // CPU work outside the CAS loop
   const rec: AccountRecord = {
     uid: `em-${crypto.randomBytes(9).toString("hex")}`,
     kind: "email",
@@ -265,7 +281,7 @@ export async function verifyEmailLogin(
     r: SCRYPT.r,
     p: SCRYPT.p,
   };
-  const ok = passwordMatches(password, params) && !!acct;
+  const ok = (await passwordMatches(password, params)) && !!acct;
   if (!ok) {
     noteLoginFailure(email, now);
     return null;

--- a/src/web/cloudAuth.test.ts
+++ b/src/web/cloudAuth.test.ts
@@ -7,6 +7,8 @@ import {
   appleSignInConfig,
   audienceForClient,
   subAllowed,
+  sha256hex,
+  appleRequireNonce,
   type AppleJWK,
 } from "./cloudAuth.js";
 
@@ -60,6 +62,39 @@ test("verifies a well-formed Apple identity token", async () => {
 test("accepts aud given as an array", async () => {
   const id = await verifyAppleIdentityToken(mintToken({ ...baseClaims, aud: ["other", AUD] }), opts);
   assert.equal(id.sub, "001234.abcd");
+});
+
+test("nonce: accepts the raw nonce whose hash Apple echoed back (#261)", async () => {
+  const tok = mintToken({ ...baseClaims, nonce: sha256hex("n-abc") });
+  const id = await verifyAppleIdentityToken(tok, { ...opts, expectedNonce: "n-abc" });
+  assert.equal(id.sub, "001234.abcd");
+});
+
+test("nonce: rejects a wrong, absent, or unhashed nonce (#261)", async () => {
+  // token minted for a DIFFERENT sign-in attempt — the replay this blocks
+  const other = mintToken({ ...baseClaims, nonce: sha256hex("n-other") });
+  await assert.rejects(
+    () => verifyAppleIdentityToken(other, { ...opts, expectedNonce: "n-abc" }),
+    (e: Error) => e instanceof AppleAuthError && /nonce mismatch/.test(e.message),
+  );
+  // a token with no nonce claim at all can't satisfy an expected one
+  await assert.rejects(
+    () => verifyAppleIdentityToken(mintToken(baseClaims), { ...opts, expectedNonce: "n-abc" }),
+    AppleAuthError,
+  );
+  // the claim is the HASH, not the raw value — an echoed raw nonce is rejected
+  await assert.rejects(
+    () => verifyAppleIdentityToken(mintToken({ ...baseClaims, nonce: "n-abc" }), { ...opts, expectedNonce: "n-abc" }),
+    AppleAuthError,
+  );
+});
+
+test("nonce: unchecked when the caller expects none (pre-nonce clients)", async () => {
+  const id = await verifyAppleIdentityToken(mintToken({ ...baseClaims, nonce: "whatever" }), opts);
+  assert.equal(id.sub, "001234.abcd");
+  // and the requirement flag is default-OFF so those clients still sign in
+  assert.equal(appleRequireNonce({}), false);
+  assert.equal(appleRequireNonce({ LISA_CLOUD_APPLE_REQUIRE_NONCE: "1" }), true);
 });
 
 test("rejects a tampered payload (signature mismatch)", async () => {

--- a/src/web/cloudAuth.ts
+++ b/src/web/cloudAuth.ts
@@ -50,6 +50,13 @@ export interface VerifyAppleOptions {
   now?: () => number;
   /** Leeway for clock skew, seconds (default 60). */
   clockToleranceSec?: number;
+  /**
+   * Raw nonce this request minted (#261). Apple echoes SHA-256(rawNonce) into
+   * the token's `nonce` claim, so matching it proves the token was minted for
+   * THIS sign-in attempt and isn't a replayed one lifted from elsewhere.
+   * Omitted ⇒ no nonce check (pre-nonce clients).
+   */
+  expectedNonce?: string;
 }
 
 export class AppleAuthError extends Error {
@@ -64,6 +71,18 @@ const APPLE_KEYS_URL = "https://appleid.apple.com/auth/keys";
 
 function b64urlToBuffer(s: string): Buffer {
   return Buffer.from(s, "base64url");
+}
+
+/** SHA-256 as lowercase hex — the form Apple echoes back in the nonce claim. */
+export function sha256hex(s: string): string {
+  return crypto.createHash("sha256").update(s, "utf8").digest("hex");
+}
+
+/** Length-safe constant-time compare of two hex strings. */
+function timingSafeEqualHex(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  return ab.length === bb.length && crypto.timingSafeEqual(ab, bb);
 }
 
 function decodeJson(segment: string): Record<string, unknown> {
@@ -119,6 +138,16 @@ export async function verifyAppleIdentityToken(
   if (exp + tolerance < nowSec) throw new AppleAuthError("token expired");
   const iat = typeof claims.iat === "number" ? claims.iat : 0;
   if (iat - tolerance > nowSec) throw new AppleAuthError("token not yet valid");
+
+  // Replay guard (#261): the client hashes its raw nonce into the auth request,
+  // Apple copies that hash into the token. Compare against our own hash of the
+  // raw nonce the client just sent us.
+  if (opts.expectedNonce !== undefined) {
+    const got = typeof claims.nonce === "string" ? claims.nonce : "";
+    if (!got || !timingSafeEqualHex(got, sha256hex(opts.expectedNonce))) {
+      throw new AppleAuthError("nonce mismatch");
+    }
+  }
 
   const sub = typeof claims.sub === "string" ? claims.sub : "";
   if (!sub) throw new AppleAuthError("missing subject");
@@ -188,6 +217,16 @@ export function appleSignInConfig(env: NodeJS.ProcessEnv = process.env): AppleSi
       .map((s) => s.trim())
       .filter(Boolean),
   };
+}
+
+/**
+ * Should a sign-in without a nonce be rejected outright (#261)? Default OFF so
+ * already-shipped clients (TestFlight builds predating nonce support) keep
+ * working; flip `LISA_CLOUD_APPLE_REQUIRE_NONCE=1` once they've all updated.
+ * When a nonce IS sent it is always verified, flag or no flag.
+ */
+export function appleRequireNonce(env: NodeJS.ProcessEnv = process.env): boolean {
+  return truthy(env.LISA_CLOUD_APPLE_REQUIRE_NONCE);
 }
 
 /**

--- a/src/web/gateway.test.ts
+++ b/src/web/gateway.test.ts
@@ -1,8 +1,9 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
 
-const { planUpstream, foldUsage, usageFromJson } = await import("./gateway.js");
+const { planUpstream, foldUsage, usageFromJson, estimateUsageFromBytes } = await import("./gateway.js");
 const { managedConfig, hasCredentialsForModel } = await import("../providers/registry.js");
+const { costMicroUSD } = await import("../billing/prices.js");
 
 const ZERO = { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 };
 
@@ -51,6 +52,25 @@ describe("usage tee-parsing", () => {
       { inputTokens: 5, outputTokens: 7, cacheReadTokens: 0, cacheWriteTokens: 0 },
     );
     assert.equal(usageFromJson("openai", { usage: { prompt_tokens: 3, completion_tokens: 4 } }).outputTokens, 4);
+  });
+});
+
+describe("missing-usage debit floor (#264)", () => {
+  test("estimates tokens from bytes so a 2xx with no usage is never free", () => {
+    const u = estimateUsageFromBytes(4000, 800);
+    assert.equal(u.inputTokens, 1000);
+    assert.equal(u.outputTokens, 200);
+    assert.equal(u.cacheReadTokens, 0);
+    assert.equal(u.cacheWriteTokens, 0);
+    // a partial token still costs one — never round a real turn down to free
+    const tiny = estimateUsageFromBytes(1, 1);
+    assert.equal(tiny.inputTokens, 1);
+    assert.equal(tiny.outputTokens, 1);
+    // and the priced result is strictly positive
+    assert.ok(costMicroUSD("glm-4.6", tiny) > 0);
+    // degenerate inputs don't produce NaN or negative usage
+    assert.deepEqual(estimateUsageFromBytes(0, 0), ZERO);
+    assert.deepEqual(estimateUsageFromBytes(-5, -5), ZERO);
   });
 });
 

--- a/src/web/gateway.ts
+++ b/src/web/gateway.ts
@@ -26,6 +26,17 @@ import type { AccountRecord } from "./accounts.js";
 import { precheckTurn, debitTurn } from "../billing/quota.js";
 import { recordUsage } from "../billing/meter.js";
 import { preflightLimits } from "../billing/limits.js";
+import { readCappedText, BodyTooLargeError } from "./http-body.js";
+
+/**
+ * Gateway body cap (#266). Far larger than the control-plane cap: LLM payloads
+ * legitimately carry base64 images and long transcripts. Bounded all the same —
+ * an unbounded read OOMs the instance before any quota gate runs.
+ */
+const GW_BODY_LIMIT = Number(process.env.LISA_GW_MAX_BODY_MB || 20) * 1_048_576;
+
+/** Chars-per-token used only for the missing-usage debit floor (#264). */
+const BYTES_PER_TOKEN_EST = 4;
 
 export interface UpstreamPlan {
   url: string;
@@ -114,6 +125,27 @@ function num(v: unknown): number {
   return typeof v === "number" && Number.isFinite(v) ? v : 0;
 }
 
+/**
+ * Debit floor for an upstream that answered 2xx but reported no usage (#264).
+ * Without it a provider that omits the usage block — or an SSE stream the
+ * client cut before the usage chunk — bills 0, i.e. free inference. A coarse
+ * bytes/4 estimate is wrong in the user's favour on cache-heavy turns and in
+ * ours on nothing, which is the right direction to be wrong in.
+ */
+export function estimateUsageFromBytes(requestBytes: number, responseBytes: number): ProviderUsage {
+  return {
+    inputTokens: Math.ceil(Math.max(0, requestBytes) / BYTES_PER_TOKEN_EST),
+    outputTokens: Math.ceil(Math.max(0, responseBytes) / BYTES_PER_TOKEN_EST),
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+  };
+}
+
+/** True when the upstream reported nothing billable at all. */
+function usageIsEmpty(u: ProviderUsage): boolean {
+  return u.inputTokens === 0 && u.outputTokens === 0 && u.cacheReadTokens === 0 && u.cacheWriteTokens === 0;
+}
+
 /** Extract usage from a NON-streaming upstream JSON response body. */
 export function usageFromJson(face: "anthropic" | "openai", body: Record<string, unknown>): ProviderUsage {
   if (face === "anthropic") {
@@ -141,8 +173,20 @@ export async function handleGateway(
   const face: "anthropic" | "openai" = url.startsWith("/gw/anthropic/") ? "anthropic" : "openai";
   const subpath = url.slice(face === "anthropic" ? "/gw/anthropic".length : "/gw/openai".length);
 
-  let raw = "";
-  for await (const chunk of req) raw += chunk.toString("utf8");
+  let raw: string;
+  try {
+    raw = await readCappedText(req, GW_BODY_LIMIT);
+  } catch (err) {
+    if (err instanceof BodyTooLargeError) {
+      res.writeHead(413, { "content-type": "application/json", connection: "close" });
+      res.end(JSON.stringify({ error: "payload_too_large", limitBytes: err.limitBytes }));
+    } else {
+      res.writeHead(400, { "content-type": "application/json" });
+      res.end(JSON.stringify({ error: "read_failed" }));
+    }
+    return;
+  }
+  const requestBytes = Buffer.byteLength(raw, "utf8");
   let body: Record<string, unknown>;
   try {
     body = JSON.parse(raw) as Record<string, unknown>;
@@ -207,15 +251,21 @@ export async function handleGateway(
   }
 
   let usage: ProviderUsage = { ...ZERO };
+  let responseBytes = 0;
   const settle = async () => {
-    const rec = await recordUsage("gw", model, usage);
-    if (rec) await debitTurn(acct, model, rec.microUSD);
+    // A 2xx with no usage at all is a billing hole, not a free turn (#264):
+    // fall back to a byte estimate. Non-2xx settles at whatever we parsed
+    // (normally zero) — the user shouldn't pay for an upstream error.
+    const u = upstream.ok && usageIsEmpty(usage) ? estimateUsageFromBytes(requestBytes, responseBytes) : usage;
+    const rec = await recordUsage("gw", model, u);
+    await debitTurn(acct, model, rec.microUSD);
   };
 
   const contentType = upstream.headers.get("content-type") ?? "application/json";
   if (!upstream.body || !contentType.includes("text/event-stream")) {
     // Non-streaming (or error) response: buffer, meter, forward as-is.
     const text = await upstream.text();
+    responseBytes = Buffer.byteLength(text, "utf8");
     if (upstream.ok) {
       try {
         usage = usageFromJson(face, JSON.parse(text) as Record<string, unknown>);
@@ -242,6 +292,7 @@ export async function handleGateway(
     for (;;) {
       const { done, value } = await reader.read();
       if (done) break;
+      responseBytes += value.length;
       res.write(Buffer.from(value));
       carry += decoder.decode(value, { stream: true });
       let nl: number;

--- a/src/web/http-body.test.ts
+++ b/src/web/http-body.test.ts
@@ -1,0 +1,49 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { Readable } from "node:stream";
+import type http from "node:http";
+
+const { readCappedText, BodyTooLargeError, CTRL_BODY_LIMIT } = await import("./http-body.js");
+
+/** A fake IncomingMessage: just the readable-stream surface the reader uses. */
+function fakeReq(chunks: (string | Buffer)[]): http.IncomingMessage {
+  return Readable.from(chunks.map((c) => (Buffer.isBuffer(c) ? c : Buffer.from(c, "utf8")))) as
+    unknown as http.IncomingMessage;
+}
+
+describe("readCappedText (#260/#264/#266)", () => {
+  test("reads a body under the cap, joining chunks and decoding utf8", async () => {
+    // split a multi-byte char across chunks — a naive per-chunk toString mangles it
+    const euro = Buffer.from("€", "utf8");
+    const body = await readCappedText(
+      fakeReq(["hello ", euro.subarray(0, 1), euro.subarray(1), " world"]),
+      CTRL_BODY_LIMIT,
+    );
+    assert.equal(body, "hello € world");
+  });
+
+  test("rejects past the cap with BodyTooLargeError carrying the limit", async () => {
+    const req = fakeReq(["x".repeat(64), "y".repeat(64)]);
+    await assert.rejects(
+      () => readCappedText(req, 100),
+      (e: unknown) => e instanceof BodyTooLargeError && e.limitBytes === 100,
+    );
+  });
+
+  test("a body exactly at the cap is accepted (boundary is inclusive)", async () => {
+    assert.equal((await readCappedText(fakeReq(["x".repeat(100)]), 100)).length, 100);
+  });
+
+  test("an empty body reads as the empty string", async () => {
+    assert.equal(await readCappedText(fakeReq([]), CTRL_BODY_LIMIT), "");
+  });
+
+  test("a stream error propagates instead of hanging", async () => {
+    const req = new Readable({
+      read() {
+        this.destroy(new Error("socket reset"));
+      },
+    }) as unknown as http.IncomingMessage;
+    await assert.rejects(() => readCappedText(req, CTRL_BODY_LIMIT), /socket reset/);
+  });
+});

--- a/src/web/http-body.ts
+++ b/src/web/http-body.ts
@@ -1,0 +1,64 @@
+/**
+ * Bounded request-body reader (PLAN_ACCOUNTS_BILLING hardening, #260/#264/#266).
+ *
+ * Every pre-auth / pre-quota entrypoint that slurps a whole request body used a
+ * `for await (const chunk of req) body += chunk` loop with NO ceiling — a client
+ * could stream an endless body and OOM the instance before any gate ran. This
+ * reads with a hard byte cap and rejects past it with `BodyTooLargeError`; the
+ * caller answers 413.
+ *
+ * It deliberately does NOT destroy the socket on overflow — it just stops
+ * consuming, so the remaining bytes stay in the kernel buffer under TCP
+ * backpressure (bounded) while the caller writes a 413 with `Connection: close`.
+ */
+import type http from "node:http";
+
+export class BodyTooLargeError extends Error {
+  constructor(public readonly limitBytes: number) {
+    super("body_too_large");
+    this.name = "BodyTooLargeError";
+  }
+}
+
+/** Default cap for control-plane JSON (auth, IAP JWS, checkout, webhooks). */
+export const CTRL_BODY_LIMIT = 1_048_576; // 1 MiB
+
+/**
+ * Read a request body as UTF-8 text, aborting past `limitBytes` with a
+ * `BodyTooLargeError`. Uses explicit listeners (not `for await`) so overflow
+ * neither auto-destroys the socket nor loses the ability to answer 413.
+ */
+export function readCappedText(req: http.IncomingMessage, limitBytes: number): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let total = 0;
+    const chunks: Buffer[] = [];
+    let settled = false;
+    const cleanup = () => {
+      req.off("data", onData);
+      req.off("end", onEnd);
+      req.off("error", onErr);
+    };
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      fn();
+    };
+    const onData = (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > limitBytes) {
+        // Stop consuming; removing the listener returns the stream to paused
+        // mode so the rest of the body backs up in the kernel buffer instead of
+        // our heap. The caller closes the connection.
+        settle(() => reject(new BodyTooLargeError(limitBytes)));
+        return;
+      }
+      chunks.push(chunk);
+    };
+    const onEnd = () => settle(() => resolve(Buffer.concat(chunks).toString("utf8")));
+    const onErr = (err: Error) => settle(() => reject(err));
+    req.on("data", onData);
+    req.on("end", onEnd);
+    req.on("error", onErr);
+  });
+}

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -83,6 +83,7 @@ export const LOGIN_HTML = `<!doctype html>
     weak_password: "Use at least 8 characters.",
     invalid_email: "That doesn't look like an email address.",
     throttled: "Too many attempts — wait 15 minutes.",
+    rate_limited: "Too many attempts from this network — try again later.",
   };
   async function auth(path) {
     err.textContent = "";
@@ -102,6 +103,18 @@ export const LOGIN_HTML = `<!doctype html>
     if (f.reportValidity()) auth("/api/auth/register");
   });
 
+  // Fresh random nonce, or null when this context can't hash one (#261).
+  function mintNonce() {
+    if (!window.crypto || !window.crypto.subtle || !window.crypto.getRandomValues) return null;
+    const b = new Uint8Array(16);
+    window.crypto.getRandomValues(b);
+    return Array.from(b, (x) => x.toString(16).padStart(2, "0")).join("");
+  }
+  async function sha256hex(s) {
+    const d = await window.crypto.subtle.digest("SHA-256", new TextEncoder().encode(s));
+    return Array.from(new Uint8Array(d), (x) => x.toString(16).padStart(2, "0")).join("");
+  }
+
   // Sign in with Apple on the web (B8b): drawn only when the instance has a
   // Services ID configured (GET /api/auth/config). Apple's JS runs a popup and
   // hands back an id_token; the server verifies it against the web audience.
@@ -110,24 +123,31 @@ export const LOGIN_HTML = `<!doctype html>
     const s = document.createElement("script");
     s.src = "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
     s.onload = () => {
-      window.AppleID.auth.init({
+      const appleCfg = {
         clientId: cfg.appleWeb.servicesId,
         scope: "name email",
         redirectURI: location.origin,
         usePopup: true,
-      });
+      };
+      window.AppleID.auth.init(appleCfg);
       document.getElementById("apple-wrap").style.display = "block";
       document.getElementById("divider").style.display = "flex";
       document.getElementById("apple-btn").addEventListener("click", async () => {
         err.textContent = "";
         try {
+          // Per-attempt nonce (#261): Apple echoes sha256(raw) into the token's
+          // nonce claim, so the server can tell a token minted for THIS click
+          // from a replayed one. crypto.subtle needs a secure context — over
+          // plain http we just skip it (the server treats it as optional).
+          const rawNonce = mintNonce();
+          if (rawNonce) window.AppleID.auth.init({ ...appleCfg, nonce: await sha256hex(rawNonce) });
           const auth = await window.AppleID.auth.signIn();
           const idToken = auth && auth.authorization && auth.authorization.id_token;
           if (!idToken) { err.textContent = "Apple didn't return a token."; return; }
           const res = await fetch("/api/auth/apple", {
             method: "POST",
             headers: { "content-type": "application/json" },
-            body: JSON.stringify({ identityToken: idToken, client: "web" }),
+            body: JSON.stringify({ identityToken: idToken, client: "web", ...(rawNonce ? { nonce: rawNonce } : {}) }),
           });
           if (res.ok) { location.replace("/"); return; }
           err.textContent = "Apple sign-in was rejected (" + res.status + ").";

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -44,8 +44,9 @@ import { verifyAppleJWS, validateTransaction, creditTransaction, creditExternalT
 import { stripeConfig, verifyStripeSignature, classifyStripeEvent, createCheckoutSession, sessionIdForPaymentIntent, STRIPE_PACKS } from "../billing/stripe.js";
 import { ACCOUNT_HTML } from "./account-page.js";
 import { handleGateway } from "./gateway.js";
-import { preflightLimits } from "../billing/limits.js";
-import { acquireTurnLease, releaseTurnLease } from "../cloud/turn-lease.js";
+import { readCappedText, BodyTooLargeError, CTRL_BODY_LIMIT } from "./http-body.js";
+import { preflightLimits, ipRateOk } from "../billing/limits.js";
+import { acquireTurnLease, releaseTurnLease, startLeaseRenewal } from "../cloud/turn-lease.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
@@ -120,6 +121,7 @@ import {
   subAllowed,
   AppleAuthError,
   audienceForClient,
+  appleRequireNonce,
 } from "./cloudAuth.js";
 import { detectLanHost, buildPairUrl } from "./pairing.js";
 import { qrSvg } from "./qr-svg.js";
@@ -223,6 +225,22 @@ function presentedToken(req: http.IncomingMessage, url: string): string | null {
   return null;
 }
 
+// Per-IP cap on the unauthenticated account endpoints (#260). Generous enough
+// for a shared NAT / office egress IP doing normal signups + retries.
+const AUTH_IP_LIMIT = 20;
+const AUTH_IP_WINDOW_MS = 10 * 60_000;
+
+/**
+ * Best-effort client IP. Behind Cloud Run the socket peer is the front end, so
+ * the first `x-forwarded-for` hop is the client — and a client can put anything
+ * there. Only used for coarse rate-limit keying, never for authorization.
+ */
+function clientIp(req: http.IncomingMessage, remoteAddr: string): string {
+  const xff = req.headers["x-forwarded-for"];
+  const first = (Array.isArray(xff) ? xff[0] : xff)?.split(",")[0]?.trim();
+  return first || remoteAddr || "unknown";
+}
+
 /** The absolute /verify link for a raw token, derived from the request host. */
 function verifyLinkFor(req: http.IncomingMessage, rawToken: string): string {
   const host = req.headers.host ?? "cloud.meetlisa.ai";
@@ -230,10 +248,27 @@ function verifyLinkFor(req: http.IncomingMessage, rawToken: string): string {
   return `${proto}://${host}/verify?token=${rawToken}`;
 }
 
-/** Read and JSON-parse a request body (tolerant: bad/empty JSON ⇒ {}). */
-async function readJsonBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
-  let body = "";
-  for await (const chunk of req) body += chunk.toString("utf8");
+/**
+ * Read and JSON-parse a request body (tolerant: bad/empty JSON ⇒ {}). Bounded
+ * at `limitBytes` (#260/#264): past the cap it answers 413 itself and returns
+ * null, so callers just `if (!body) return;`. A mid-body client abort ⇒ {}.
+ */
+async function readJsonBody(
+  req: http.IncomingMessage,
+  res: http.ServerResponse,
+  limitBytes: number = CTRL_BODY_LIMIT,
+): Promise<Record<string, unknown> | null> {
+  let body: string;
+  try {
+    body = await readCappedText(req, limitBytes);
+  } catch (err) {
+    if (err instanceof BodyTooLargeError) {
+      res.writeHead(413, { "content-type": "application/json", connection: "close" });
+      res.end(JSON.stringify({ error: "payload_too_large", limitBytes: err.limitBytes }));
+      return null;
+    }
+    return {}; // client aborted mid-body — treat as empty, same as a short body
+  }
   try {
     const parsed: unknown = body ? JSON.parse(body) : {};
     return parsed && typeof parsed === "object" ? (parsed as Record<string, unknown>) : {};
@@ -866,7 +901,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end("cloud sign-in misconfigured (no session secret)");
         return;
       }
-      const payload = await readJsonBody(req);
+      const payload = await readJsonBody(req, res);
+      if (!payload) return; // 413 already sent
       const idToken = typeof payload.identityToken === "string" ? payload.identityToken : "";
       if (!idToken) {
         res.writeHead(400, { "content-type": "text/plain" });
@@ -883,10 +919,21 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end("apple sign-in not available for this client");
         return;
       }
+      // Replay guard (#261): the client mints a raw nonce, sends SHA-256 of it
+      // to Apple and the raw value here. Optional by default so TestFlight
+      // builds shipped before nonce support keep signing in; set
+      // LISA_CLOUD_APPLE_REQUIRE_NONCE=1 to make it mandatory once they update.
+      const nonce = typeof payload.nonce === "string" ? payload.nonce : "";
+      if (!nonce && appleRequireNonce()) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "nonce_required" }));
+        return;
+      }
       try {
         const id = await verifyAppleIdentityToken(idToken, {
           audience,
           fetchKeys: fetchAppleKeys,
+          ...(nonce ? { expectedNonce: nonce } : {}),
         });
         if (!subAllowed(id.sub, cfg)) {
           res.writeHead(403, { "content-type": "text/plain" });
@@ -937,8 +984,21 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end("not available");
         return;
       }
-      let raw = "";
-      for await (const chunk of req) raw += chunk.toString("utf8");
+      // Raw body, capped (#266) — the signature is computed over the raw string,
+      // so this can't go through readJsonBody's parse.
+      let raw: string;
+      try {
+        raw = await readCappedText(req, CTRL_BODY_LIMIT);
+      } catch (err) {
+        if (err instanceof BodyTooLargeError) {
+          res.writeHead(413, { "content-type": "application/json", connection: "close" });
+          res.end(JSON.stringify({ error: "payload_too_large", limitBytes: err.limitBytes }));
+        } else {
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "read_failed" }));
+        }
+        return;
+      }
       const sig = typeof req.headers["stripe-signature"] === "string" ? req.headers["stripe-signature"] : "";
       if (!verifyStripeSignature(raw, sig, scfg.webhookSecret)) {
         res.writeHead(401, { "content-type": "application/json" });
@@ -989,7 +1049,17 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end("accounts not available on this edition");
         return;
       }
-      const body = await readJsonBody(req);
+      // Per-IP cap (#260). /register had no throttle at all — the per-email one
+      // only covers login — so a single client could mint accounts (and scrypt
+      // work) in a loop. Coarse backstop only: behind Cloud Run the IP comes
+      // from a spoofable header. See ipRateOk's note.
+      if (!ipRateOk(`auth:${clientIp(req, remoteAddr)}`, AUTH_IP_LIMIT, AUTH_IP_WINDOW_MS)) {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "rate_limited", retryAfterSec: Math.ceil(AUTH_IP_WINDOW_MS / 1000) }));
+        return;
+      }
+      const body = await readJsonBody(req, res);
+      if (!body) return; // 413 already sent
       const email = typeof body.email === "string" ? body.email : "";
       const password = typeof body.password === "string" ? body.password : "";
       try {
@@ -1038,7 +1108,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         return;
       }
       try {
-        const body = await readJsonBody(req);
+        const body = await readJsonBody(req, res);
+        if (!body) return; // 413 already sent
         const signed = typeof body.signedPayload === "string" ? body.signedPayload : "";
         if (!signed) throw new IapError("malformed_jws");
         const outer = await verifyAppleJWS(signed);
@@ -1208,9 +1279,11 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end(JSON.stringify({ error: "turn_in_progress", retryAfterSec: 15 }));
         return;
       }
+      const stopGwRenewal = startLeaseRenewal(gwLease);
       try {
         await handleGateway(req, res, url, acct);
       } finally {
+        stopGwRenewal();
         await releaseTurnLease(gwLease);
       }
       return;
@@ -1227,7 +1300,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         return;
       }
       try {
-        const body = await readJsonBody(req);
+        const body = await readJsonBody(req, res);
+        if (!body) return; // 413 already sent
         const jws = typeof body.jws === "string" ? body.jws : "";
         if (!jws) throw new IapError("malformed_jws");
         const payload = await verifyAppleJWS(jws);
@@ -1284,7 +1358,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         res.end(JSON.stringify({ error: "account_session_required" }));
         return;
       }
-      const body = await readJsonBody(req);
+      const body = await readJsonBody(req, res);
+      if (!body) return; // 413 already sent
       const pack = typeof body.pack === "string" ? body.pack : "";
       const proto = (req.headers["x-forwarded-proto"] as string | undefined) ?? "https";
       const base = `${proto}://${req.headers.host ?? "cloud.meetlisa.ai"}`;
@@ -2851,6 +2926,7 @@ self.addEventListener('fetch', (event) => {
       // a paywall (structured body: error + resetAt + tier).
       let quotaBudgetMicroUSD: number | null = null;
       let turnLease: import("../cloud/turn-lease.js").TurnLease | null = "off";
+      let stopTurnRenewal: () => void = () => {};
       const quotaAcct = cloud && accountUid ? await getAccount(accountUid) : null;
       if (quotaAcct) {
         // Non-quota guards first (B7): kill switch, global daily cap, per-uid RPM.
@@ -2881,6 +2957,9 @@ self.addEventListener('fetch', (event) => {
           res.end(JSON.stringify({ error: "turn_in_progress", retryAfterSec: 15 }));
           return;
         }
+        // Chat SSE runs under --timeout 3600, far past the lease TTL — heartbeat
+        // it for the life of the turn so it can't expire under us (#272).
+        stopTurnRenewal = startLeaseRenewal(turnLease);
       }
       // User just talked — reset the idle watcher + stamp focus freshness.
       try { getIdleWatcher(60 * 60_000).tick(); } catch {}
@@ -3014,6 +3093,9 @@ self.addEventListener('fetch', (event) => {
           // per-uid subtree for signed-in cloud accounts. Mac edition (BYO key)
           // is not metered. Never throws.
           if (cloud) {
+            // Price + debit are INDEPENDENT of the audit-log append (#264):
+            // recordUsage always returns the priced record even if usage.jsonl
+            // couldn't be written, so a full disk can't ship a free turn.
             const rec = await recordUsage("chat", opts.model, {
               inputTokens: result.inputTokens,
               outputTokens: result.outputTokens,
@@ -3021,7 +3103,7 @@ self.addEventListener('fetch', (event) => {
               cacheWriteTokens: result.cacheWriteTokens,
             });
             // Debit order (B4): free window first, then paid balance.
-            if (rec && quotaAcct) await debitTurn(quotaAcct, opts.model, rec.microUSD);
+            if (quotaAcct) await debitTurn(quotaAcct, opts.model, rec.microUSD);
           }
           if (!anyText && !anyTool && !errorSent) send({ type: "empty" });
           send({ type: "done" });
@@ -3043,6 +3125,7 @@ self.addEventListener('fetch', (event) => {
       try {
         await job;
       } finally {
+        stopTurnRenewal();
         await releaseTurnLease(turnLease);
       }
       return;


### PR DESCRIPTION
Hardening pass over the B0–B9 accounts/billing stack — the seven review follow-ups from #260/#261/#264/#265/#266/#267/#272. Each was a way for the merged stack to lose money, stay up under load, or trust something it shouldn't.

## Billing correctness — a metered turn can no longer ship free

| | before | after |
|---|---|---|
| **meter** (#264) | `recordUsage` returned null when the audit append failed ⇒ debit skipped ⇒ free, unrecoverable turn | pricing is decoupled from the append; the record always comes back priced, and a full disk loses the audit line only |
| **limits** (#267) | `readCounter` returned `{microUSD:0}` on *any* read error ⇒ the $200/day cap failed **open** | ENOENT/stale-day ⇒ 0 (normal); I/O or parse failure ⇒ `ok:false`, cap fails **closed**, and the write path won't clobber an unreadable-but-valid counter |
| **gateway** (#264) | 2xx upstream with no usage block ⇒ `debitTurn(0)` = free inference | falls back to `estimateUsageFromBytes` (bytes/4). Non-2xx still settles at 0 — an upstream error isn't the user's bill |

## Availability + abuse

- **Bounded body reads** (#260/#264/#266) — every pre-auth entrypoint used an unbounded `for await` accumulate. New `readCappedText` caps `readJsonBody`, the Stripe webhook raw read (signature is over the raw string, so it can't go through the JSON path), and the gateway (`LISA_GW_MAX_BODY_MB`, default 20 MiB — LLM payloads carry base64 images). Past the cap: 413 + `Connection: close`, without destroying the socket.
- **scrypt off the event loop + per-IP cap** (#260) — `scryptSync` on unauthenticated `/register`+`/login` stalled every other request. Now async; `/register` (which had no throttle at all — the existing one is per-email, login-only) gets 20 / 10 min per IP. Documented in-code as a coarse backstop: behind Cloud Run the IP comes from a spoofable header, and scrypt cost + email uniqueness remain the real guards.

## Multi-instance + replay

- **turn-lease renewal** (#272) — `TURN_TTL_MS` is 180s but chat SSE runs under `--timeout 3600`, so with `LISA_FIRESTORE=1` and `MAX_INSTANCES>1` the lease expired mid-turn and a peer double-ran the account. Added `renewLease` (CAS) + a TTL/3 heartbeat that stops itself if ownership is lost, wired into both the chat and gateway paths.
- **SIWA nonce** (#261) — there was no nonce anywhere: iOS never set `req.nonce`, the server verified none. Now end-to-end (server, web, iOS), timing-safe against `sha256(rawNonce)`. `LISA_CLOUD_APPLE_REQUIRE_NONCE` is **default-OFF** so already-shipped TestFlight builds keep signing in; a nonce that *is* sent is always verified. Flip it on once clients update.
- **IAP cert chain** (#265) — the "pinned" G3 root was whatever apple.com served over TLS and then whatever sat in the cache file, and the walk asserted no CA constraint or leaf OID: a signature chain alone never said what each cert was *for*. Now the G3 SHA-256 is hardcoded and asserted on both the cached and fetched paths, issuers must be `ca === true`, and Apple's marker OIDs are asserted on the leaf and the WWDR intermediate. `.ca` is used rather than `keyUsage`, which reads back `undefined` on Apple certs. The `opts.root` seam is preserved; an *existing* file at `LISA_APPLE_ROOT_PATH` still skips the pin (documented air-gapped escape hatch).

## Verification

`npm run typecheck` + `npm run build` clean. **1104 tests pass, 0 fail** — 15 new: `renewLease`, cloudAuth nonce (accept / wrong / absent / unhashed), the IP window, cap fail-closed (unreadable + corrupt), meter append-failure, `estimateUsageFromBytes`, `oidToDer` against the two DER byte strings verified on real Apple certs, and a new `http-body.test.ts` (cap boundary, split multi-byte chars, stream error).

The iOS companion type-checks against the iPhoneSimulator SDK with `LISA_ENABLE_SIWA` both on and off. That's compile-verified only — **the nonce path has not been exercised against a real Apple sign-in**, so the first TestFlight build wants a manual sign-in check before `LISA_CLOUD_APPLE_REQUIRE_NONCE` goes on.

Independent of #274 (per-tenant SSE isolation); both branch from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
