### PR TITLE
chore(ios): bump MARKETING_VERSION to 1.1 for the accounts/IAP release

### DIFF
--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -14,7 +14,7 @@ settings:
     # Must be >= the app's App Store version (currently 1.0, PREPARE_FOR_SUBMISSION).
     # A lower CFBundleShortVersionString (this was "0.1.0") is silently REJECTED by
     # App Store Connect at ingestion — upload "succeeds" but no build ever appears.
-    MARKETING_VERSION: "1.0"
+    MARKETING_VERSION: "1.1"
     CURRENT_PROJECT_VERSION: "1"
     TARGETED_DEVICE_FAMILY: "1,2"
     # Automatic signing for device archives (testflight.sh): Xcode picks the


### PR DESCRIPTION
Version 1.1 carries the B1–B9 accounts/billing stack + the three consumable IAPs (created in ASC today). ASC app version 1.1 will be created via API and this build attached once processed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)