### PR TITLE
feat(auth): A3 — Sign in with Google (server)

### DIFF
--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -19,6 +19,8 @@ const {
   resetLoginThrottles,
   appleUid,
   ensureOtpAccount,
+  upsertGoogleAccount,
+  googleUid,
   AccountError,
 } = await import("./accounts.js");
 
@@ -109,6 +111,71 @@ describe("code-only (OTP) accounts", () => {
 
   test("a malformed address is refused", async () => {
     await assert.rejects(ensureOtpAccount("not-an-email", 1000), isCode("invalid_email"));
+  });
+});
+
+describe("google accounts", () => {
+  test("first sign-in creates a verified google account", async () => {
+    const a = await upsertGoogleAccount("108123", "User@Example.com", 1000);
+    assert.equal(a.uid, googleUid("108123"));
+    assert.equal(a.kind, "google");
+    assert.equal(a.email, "user@example.com");
+    assert.equal(a.verified, true);
+    assert.equal(a.googleSub, "108123");
+  });
+
+  test("the sub is the anchor: a changed address keeps the same account", async () => {
+    const first = await upsertGoogleAccount("108123", "old@example.com", 1000);
+    const second = await upsertGoogleAccount("108123", "new@example.com", 2000);
+    assert.equal(second.uid, first.uid);
+    assert.equal(second.email, "new@example.com");
+    assert.equal(second.lastLoginAt, 2000);
+  });
+
+  test("binds to an existing email account instead of splitting the balance", async () => {
+    const made = await createEmailAccount("a@b.co", "password-123");
+    assert.equal(made.verified, false);
+    const g = await upsertGoogleAccount("108123", "a@b.co", 2000);
+    assert.equal(g.uid, made.uid, "same account — same uid, same balance");
+    assert.equal(g.kind, "email", "the original kind is kept; Google is now also an entrance");
+    assert.equal(g.googleSub, "108123");
+    assert.equal(g.verified, true, "Google vouched for the inbox");
+    // Both doors now open the same account.
+    assert.equal((await verifyEmailLogin("a@b.co", "password-123", 3000))?.uid, made.uid);
+    assert.equal((await ensureOtpAccount("a@b.co", 3000)).acct.uid, made.uid);
+  });
+
+  test("a mailed code signs into a google-owned address rather than forking", async () => {
+    const g = await upsertGoogleAccount("108123", "a@b.co", 1000);
+    const viaCode = await ensureOtpAccount("a@b.co", 2000);
+    assert.equal(viaCode.created, false);
+    assert.equal(viaCode.acct.uid, g.uid);
+  });
+
+  test("registering a password over a google-owned address is refused", async () => {
+    await upsertGoogleAccount("108123", "a@b.co", 1000);
+    await assert.rejects(createEmailAccount("a@b.co", "password-123"), isCode("email_taken"));
+  });
+
+  test("a google account cannot be password-authenticated", async () => {
+    await upsertGoogleAccount("108123", "a@b.co", 1000);
+    assert.equal(await verifyEmailLogin("a@b.co", "password-123", 2000), null);
+  });
+
+  test("apple accounts do not bind by address (private relay aliases)", async () => {
+    const apple = await upsertAppleAccount("001.abc", "a@b.co", 1000);
+    const g = await upsertGoogleAccount("108123", "a@b.co", 2000);
+    assert.notEqual(g.uid, apple.uid);
+    assert.equal(g.kind, "google");
+  });
+
+  test("googleUid sanitizes hostile subs", () => {
+    assert.ok(!googleUid("a/b").includes("/"));
+    assert.ok(!googleUid("../../etc").includes("/"));
+  });
+
+  test("a malformed address is refused", async () => {
+    await assert.rejects(upsertGoogleAccount("108123", "not-an-email", 1000), isCode("invalid_email"));
   });
 });
 

--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -152,17 +152,30 @@ describe("google accounts", () => {
     assert.equal(second.lastLoginAt, 2000);
   });
 
-  test("binds to an existing email account instead of splitting the balance", async () => {
+  test("binds to an existing (unverified) email account, dropping the pre-verification password", async () => {
     const made = await createEmailAccount("a@b.co", "password-123");
     assert.equal(made.verified, false);
+    assert.equal(made.sessionVersion, 0);
     const g = await upsertGoogleAccount("108123", "a@b.co", 2000);
     assert.equal(g.uid, made.uid, "same account — same uid, same balance");
     assert.equal(g.kind, "email", "the original kind is kept; Google is now also an entrance");
     assert.equal(g.googleSub, "108123");
     assert.equal(g.verified, true, "Google vouched for the inbox");
-    // Both doors now open the same account.
-    assert.equal((await verifyEmailLogin("a@b.co", "password-123", 3000))?.uid, made.uid);
+    // The pre-verification password can't be trusted (register is open), so it is
+    // dropped and sessionVersion rotated — no longer authenticates (anti pre-hijacking).
+    assert.equal(g.scrypt, undefined, "pre-verification password dropped");
+    assert.equal(g.sessionVersion, 1, "sessionVersion rotated");
+    assert.equal(await verifyEmailLogin("a@b.co", "password-123", 3000), null, "the pre-set password no longer works");
+    // Google + code both still open the same account.
     assert.equal((await ensureOtpAccount("a@b.co", 3000)).acct.uid, made.uid);
+  });
+
+  test("a Google email change is refused when it collides with another account", async () => {
+    await createEmailAccount("b@x.co", "password-123"); // a separate account owns b@x.co
+    await upsertGoogleAccount("108123", "a@x.co", 1000);
+    // Google now reports this sub's email is b@x.co — overwriting would split the
+    // balance / break one-address-one-account, so it is refused.
+    await assert.rejects(upsertGoogleAccount("108123", "b@x.co", 2000), isCode("email_taken"));
   });
 
   test("a mailed code signs into a google-owned address rather than forking", async () => {

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -2,7 +2,7 @@
  * LISA accounts — the cloud edition's user directory
  * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md §6.1, milestone B1).
  *
- * Two account kinds share one store (`$lisaHome()/accounts.json`, 0600):
+ * Three account kinds share one store (`$lisaHome()/accounts.json`, 0600):
  *  - **Apple** (`apple-<sub>`): created/updated on every verified Sign in with
  *    Apple. No password material — Apple is the authority.
  *  - **Email** (`em-<random>`): self-serve, keyed by the address. Password
@@ -10,6 +10,13 @@
  *    (src/web/otp.ts) carry no scrypt params at all, and the password path
  *    rejects them constant-time like any other bad credential. App Review's
  *    demo account is the password kind (ASC insists on user/pass).
+ *  - **Google** (`g-<sub>`): created on the first verified Google sign-in.
+ *
+ * **One address, one account.** Email and Google accounts both *claim* their
+ * address (`EMAIL_OWNER_KINDS`), so every lookup spans both kinds and a person
+ * who signs in by Google today and by mailed code tomorrow lands on the same
+ * uid — and therefore the same balance. Apple is excluded on purpose: its
+ * private-relay addresses are per-app aliases, not a claim on a real inbox.
  *
  * Every account carries a `sessionVersion`; session tokens embed it and the
  *  gate rejects a mismatch — so deleting an account (App Store 5.1.1(v)) or a
@@ -25,7 +32,17 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { firestoreEnabled, getDoc, casUpdate } from "../cloud/firestore.js";
 
-export type AccountKind = "apple" | "email";
+export type AccountKind = "apple" | "email" | "google";
+
+/**
+ * Kinds whose `email` is an ownership claim on that inbox, and so must be
+ * unique across the directory. Apple is absent deliberately (see the header).
+ */
+const EMAIL_OWNER_KINDS: readonly AccountKind[] = ["email", "google"];
+
+function ownsEmail(a: AccountRecord, normalizedEmail: string): boolean {
+  return EMAIL_OWNER_KINDS.includes(a.kind) && a.email === normalizedEmail;
+}
 
 export interface ScryptParams {
   saltHex: string;
@@ -52,6 +69,8 @@ export interface AccountRecord {
   verified: boolean;
   /** Bump to invalidate every outstanding session for this uid. */
   sessionVersion: number;
+  /** Google's stable account id — set on any account a Google sign-in owns. */
+  googleSub?: string;
   /** SHA-256 of the outstanding verification token (email kind, unverified). */
   verifyTokenHash?: string;
   /** Verification-token expiry, ms epoch. */
@@ -230,9 +249,10 @@ export async function getAccount(uid: string): Promise<AccountRecord | null> {
   return (await loadAccounts()).find((a) => a.uid === uid) ?? null;
 }
 
+/** The account that owns this address, of whichever email-owning kind. */
 export async function getAccountByEmail(email: string): Promise<AccountRecord | null> {
   const norm = normalizeEmail(email);
-  return (await loadAccounts()).find((a) => a.kind === "email" && a.email === norm) ?? null;
+  return (await loadAccounts()).find((a) => ownsEmail(a, norm)) ?? null;
 }
 
 /**
@@ -260,7 +280,9 @@ export async function createEmailAccount(
     sessionVersion: 0,
   };
   return mutateAccounts((list) => {
-    if (list.some((a) => a.kind === "email" && a.email === email)) throw new AccountError("email_taken");
+    // Spans Google too: the address is already spoken for, and a second record
+    // would split the person's balance across two uids.
+    if (list.some((a) => ownsEmail(a, email))) throw new AccountError("email_taken");
     list.push(rec);
     return rec;
   });
@@ -287,7 +309,9 @@ export async function ensureOtpAccount(
   if (!validEmail(email)) throw new AccountError("invalid_email");
   const uid = `em-${crypto.randomBytes(9).toString("hex")}`;
   return mutateAccounts((list) => {
-    const existing = list.find((a) => a.kind === "email" && a.email === email);
+    // A Google-owned address counts: proving the inbox signs you into that same
+    // account rather than forking a second one.
+    const existing = list.find((a) => ownsEmail(a, email));
     if (existing) {
       existing.lastLoginAt = now;
       existing.verified = true;
@@ -364,6 +388,62 @@ export async function upsertAppleAccount(
       uid,
       kind: "apple",
       email: email ? normalizeEmail(email) : undefined,
+      createdAt: now,
+      lastLoginAt: now,
+      verified: true,
+      sessionVersion: 0,
+    };
+    list.push(rec);
+    return rec;
+  });
+}
+
+/** Stable uid for a Google `sub` (filesystem-safe; Google subs are digits). */
+export function googleUid(sub: string): string {
+  return `g-${sub.replace(/[^A-Za-z0-9._-]/g, "_")}`;
+}
+
+/**
+ * Upsert the account for a verified Google identity (A3). Resolution order:
+ *
+ *  1. **by `sub`** — the identity anchor, so a Google user who changes the
+ *     address on their Google account keeps their LISA account and balance;
+ *  2. **by address** — binds to the email account already using it, which is
+ *     the whole point of the one-address-one-account rule. Safe because the
+ *     caller only reaches here with `email_verified` from Google;
+ *  3. otherwise create `g-<sub>`.
+ *
+ * Binding marks the account verified: Google vouched for the inbox.
+ */
+export async function upsertGoogleAccount(
+  sub: string,
+  emailRaw: string,
+  now: number = Date.now(),
+): Promise<AccountRecord> {
+  const email = normalizeEmail(emailRaw);
+  if (!validEmail(email)) throw new AccountError("invalid_email");
+  const uid = googleUid(sub);
+  return mutateAccounts((list) => {
+    const bySub = list.find((a) => a.googleSub === sub);
+    if (bySub) {
+      bySub.lastLoginAt = now;
+      bySub.email = email;
+      return bySub;
+    }
+    const byEmail = list.find((a) => ownsEmail(a, email));
+    if (byEmail) {
+      byEmail.googleSub = sub;
+      byEmail.lastLoginAt = now;
+      byEmail.verified = true;
+      delete byEmail.verifyTokenHash;
+      delete byEmail.verifyExpiresAt;
+      return byEmail;
+    }
+    const rec: AccountRecord = {
+      uid,
+      kind: "google",
+      email,
+      googleSub: sub,
       createdAt: now,
       lastLoginAt: now,
       verified: true,

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -451,16 +451,25 @@ export async function upsertGoogleAccount(
     const bySub = list.find((a) => a.googleSub === sub);
     if (bySub) {
       bySub.lastLoginAt = now;
-      bySub.email = email;
+      if (bySub.email !== email) {
+        // Google changed this account's address. Don't overwrite it onto an
+        // address a *different* local account already owns — that would break
+        // one-address-one-account and make getAccountByEmail order-dependent
+        // (split balance). Refuse rather than silently merge.
+        const conflict = list.find((a) => a !== bySub && ownsEmail(a, email));
+        if (conflict) throw new AccountError("email_taken");
+        bySub.email = email;
+      }
       return bySub;
     }
     const byEmail = list.find((a) => ownsEmail(a, email));
     if (byEmail) {
       byEmail.googleSub = sub;
       byEmail.lastLoginAt = now;
-      byEmail.verified = true;
-      delete byEmail.verifyTokenHash;
-      delete byEmail.verifyExpiresAt;
+      // Google verified this inbox → ownership proof: drop any password set before
+      // verification and rotate sessionVersion (anti account-pre-hijacking, same
+      // as the OTP path). A password the owner set AFTER verifying is kept.
+      markVerifiedByOwnershipProof(byEmail);
       return byEmail;
     }
     const rec: AccountRecord = {

--- a/src/web/googleAuth.test.ts
+++ b/src/web/googleAuth.test.ts
@@ -1,0 +1,188 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import {
+  verifyGoogleIdToken,
+  GoogleAuthError,
+  googleSignInConfig,
+  googleAudiences,
+  type GoogleJWK,
+} from "./googleAuth.js";
+
+// A throwaway RSA key standing in for Google's signing key, exported as a JWK so
+// the verifier imports it exactly as it would Google's real JWKS entry.
+const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+const jwk = publicKey.export({ format: "jwk" }) as unknown as GoogleJWK;
+jwk.kid = "test-kid";
+jwk.kty = "RSA";
+jwk.alg = "RS256";
+
+const WEB_AUD = "123-web.apps.googleusercontent.com";
+const IOS_AUD = "123-ios.apps.googleusercontent.com";
+const FIXED_NOW = 1_700_000_000_000;
+const nowSec = Math.floor(FIXED_NOW / 1000);
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+function mintToken(claims: Record<string, unknown>, opts: { kid?: string; alg?: string } = {}): string {
+  const header = { alg: opts.alg ?? "RS256", kid: opts.kid ?? "test-kid", typ: "JWT" };
+  const signingInput = `${b64url(header)}.${b64url(claims)}`;
+  const sig = crypto.sign("RSA-SHA256", Buffer.from(signingInput), privateKey).toString("base64url");
+  return `${signingInput}.${sig}`;
+}
+
+const baseClaims = {
+  iss: "https://accounts.google.com",
+  aud: WEB_AUD,
+  sub: "108123456789",
+  iat: nowSec - 10,
+  exp: nowSec + 3600,
+  email: "user@example.com",
+  email_verified: true,
+};
+
+const opts = {
+  audiences: [WEB_AUD, IOS_AUD],
+  fetchKeys: async () => [jwk],
+  now: () => FIXED_NOW,
+};
+
+const isGoogleError = (msg: RegExp) => (e: unknown) =>
+  e instanceof GoogleAuthError && msg.test(e.message);
+
+describe("google id-token verification", () => {
+  test("accepts a well-formed token", async () => {
+    const id = await verifyGoogleIdToken(mintToken(baseClaims), opts);
+    assert.equal(id.sub, "108123456789");
+    assert.equal(id.email, "user@example.com");
+  });
+
+  test("accepts both issuer spellings", async () => {
+    const id = await verifyGoogleIdToken(mintToken({ ...baseClaims, iss: "accounts.google.com" }), opts);
+    assert.equal(id.sub, "108123456789");
+  });
+
+  test("accepts either configured client id", async () => {
+    const id = await verifyGoogleIdToken(mintToken({ ...baseClaims, aud: IOS_AUD }), opts);
+    assert.equal(id.sub, "108123456789");
+  });
+
+  test("rejects a tampered payload", async () => {
+    const token = mintToken(baseClaims);
+    const [h, , s] = token.split(".");
+    const forged = `${h}.${b64url({ ...baseClaims, sub: "999" })}.${s}`;
+    await assert.rejects(verifyGoogleIdToken(forged, opts), isGoogleError(/bad signature/));
+  });
+
+  test("rejects a foreign issuer", async () => {
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken({ ...baseClaims, iss: "https://evil.example" }), opts),
+      isGoogleError(/wrong issuer/),
+    );
+  });
+
+  test("rejects an audience we don't run", async () => {
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken({ ...baseClaims, aud: "someone-else.apps.googleusercontent.com" }), opts),
+      isGoogleError(/wrong audience/),
+    );
+  });
+
+  test("rejects everything when no audience is configured", async () => {
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken(baseClaims), { ...opts, audiences: [] }),
+      isGoogleError(/wrong audience/),
+    );
+  });
+
+  test("rejects an expired token, honouring the skew allowance", async () => {
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken({ ...baseClaims, exp: nowSec - 120 }), opts),
+      isGoogleError(/expired/),
+    );
+    // Inside the 60s tolerance it still passes.
+    const id = await verifyGoogleIdToken(mintToken({ ...baseClaims, exp: nowSec - 30 }), opts);
+    assert.equal(id.sub, "108123456789");
+  });
+
+  test("rejects alg confusion (alg: none)", async () => {
+    const header = b64url({ alg: "none", kid: "test-kid", typ: "JWT" });
+    const unsigned = `${header}.${b64url(baseClaims)}.`;
+    await assert.rejects(verifyGoogleIdToken(unsigned, opts), isGoogleError(/unexpected alg/));
+  });
+
+  test("rejects an unknown key id", async () => {
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken(baseClaims, { kid: "other-kid" }), opts),
+      isGoogleError(/no matching Google signing key/),
+    );
+  });
+
+  test("an unverified address is refused — it would be a takeover primitive", async () => {
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken({ ...baseClaims, email_verified: false }), opts),
+      isGoogleError(/not verified/),
+    );
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken({ ...baseClaims, email_verified: undefined }), opts),
+      isGoogleError(/not verified/),
+    );
+  });
+
+  test("accepts the legacy string form of email_verified", async () => {
+    const id = await verifyGoogleIdToken(mintToken({ ...baseClaims, email_verified: "true" }), opts);
+    assert.equal(id.email, "user@example.com");
+  });
+
+  test("rejects a token with no email at all", async () => {
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken({ ...baseClaims, email: undefined }), opts),
+      isGoogleError(/missing email/),
+    );
+  });
+
+  test("nonce is checked when supplied (raw, not hashed)", async () => {
+    const claims = { ...baseClaims, nonce: "raw-nonce-value" };
+    const id = await verifyGoogleIdToken(mintToken(claims), { ...opts, expectedNonce: "raw-nonce-value" });
+    assert.equal(id.sub, "108123456789");
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken(claims), { ...opts, expectedNonce: "different" }),
+      isGoogleError(/nonce mismatch/),
+    );
+    // A client that claims a nonce but gets a token without one is rejected.
+    await assert.rejects(
+      verifyGoogleIdToken(mintToken(baseClaims), { ...opts, expectedNonce: "raw-nonce-value" }),
+      isGoogleError(/nonce mismatch/),
+    );
+  });
+
+  test("rejects malformed input", async () => {
+    await assert.rejects(verifyGoogleIdToken("not-a-jwt", opts), isGoogleError(/not a JWT/));
+  });
+});
+
+describe("google config", () => {
+  test("disabled with no client ids", () => {
+    const cfg = googleSignInConfig({});
+    assert.equal(cfg.enabled, false);
+    assert.deepEqual(googleAudiences(cfg), []);
+  });
+
+  test("either id alone enables it; audiences list only what's configured", () => {
+    const webOnly = googleSignInConfig({ LISA_GOOGLE_WEB_CLIENT_ID: WEB_AUD });
+    assert.equal(webOnly.enabled, true);
+    assert.deepEqual(googleAudiences(webOnly), [WEB_AUD]);
+
+    const iosOnly = googleSignInConfig({ LISA_GOOGLE_IOS_CLIENT_ID: IOS_AUD });
+    assert.equal(iosOnly.enabled, true);
+    assert.equal(iosOnly.webClientId, null);
+    assert.deepEqual(googleAudiences(iosOnly), [IOS_AUD]);
+  });
+
+  test("blank env values are treated as unset", () => {
+    const cfg = googleSignInConfig({ LISA_GOOGLE_WEB_CLIENT_ID: "   " });
+    assert.equal(cfg.enabled, false);
+  });
+});

--- a/src/web/googleAuth.ts
+++ b/src/web/googleAuth.ts
@@ -1,0 +1,197 @@
+/**
+ * Sign in with Google — ID-token verification
+ * (docs/PLAN_AUTH_OTP_GOOGLE_v1.0.md §2.2, milestone A3).
+ *
+ * The sibling of cloudAuth.ts, and deliberately the same shape: Google signs its
+ * ID tokens with RS256, which Node verifies natively from a JWK, so this stays
+ * zero-dependency and unit-testable offline (JWKS fetch + clock injected).
+ *
+ * Two client surfaces mint tokens with different audiences — the web page's
+ * Google Identity Services button (`aud` = the Web client id) and the iOS app's
+ * PKCE flow (`aud` = the iOS client id). Both are accepted only when the
+ * matching id is configured, so an unconfigured surface can't slip a token past
+ * the wrong audience check.
+ *
+ * `email_verified` is REQUIRED, not advisory: the address is what binds a Google
+ * identity to an existing LISA account (accounts.ts), so an unproven address
+ * would be an account-takeover primitive.
+ *
+ * Env: LISA_GOOGLE_WEB_CLIENT_ID, LISA_GOOGLE_IOS_CLIENT_ID. With neither set
+ * the endpoint reports disabled and rejects everything.
+ */
+import crypto from "node:crypto";
+
+/** A single JSON Web Key from Google's JWKS (the RSA fields we use). */
+export interface GoogleJWK {
+  kty: string;
+  kid: string;
+  use?: string;
+  alg?: string;
+  n: string;
+  e: string;
+}
+
+/** The verified subset of a Google ID token we act on. */
+export interface GoogleIdentity {
+  /** Stable Google account id (`sub`) — the identity anchor. */
+  sub: string;
+  /** Always present and always verified (we reject the token otherwise). */
+  email: string;
+}
+
+export interface VerifyGoogleOptions {
+  /** Accepted `aud` values — the configured client ids for the live surfaces. */
+  audiences: string[];
+  /** Returns Google's current signing keys. Injected so tests run offline. */
+  fetchKeys: () => Promise<GoogleJWK[]>;
+  /** Clock seam for tests (ms since epoch). Defaults to Date.now(). */
+  now?: () => number;
+  /** Leeway for clock skew, seconds (default 60). */
+  clockToleranceSec?: number;
+  /**
+   * Raw nonce this sign-in minted. Google echoes it back verbatim (unlike
+   * Apple, which echoes SHA-256 of it). Omitted ⇒ no nonce check.
+   */
+  expectedNonce?: string;
+}
+
+export class GoogleAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GoogleAuthError";
+  }
+}
+
+// Google has issued tokens under both spellings for years; both are canonical.
+const GOOGLE_ISSUERS = ["accounts.google.com", "https://accounts.google.com"];
+const GOOGLE_KEYS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+
+function b64urlToBuffer(s: string): Buffer {
+  return Buffer.from(s, "base64url");
+}
+
+function timingSafeEqualStr(a: string, b: string): boolean {
+  const ab = Buffer.from(a, "utf8");
+  const bb = Buffer.from(b, "utf8");
+  return ab.length === bb.length && crypto.timingSafeEqual(ab, bb);
+}
+
+function decodeJson(segment: string): Record<string, unknown> {
+  try {
+    return JSON.parse(b64urlToBuffer(segment).toString("utf8"));
+  } catch {
+    throw new GoogleAuthError("malformed token segment");
+  }
+}
+
+/**
+ * Verify a Google ID-token JWT. Throws `GoogleAuthError` on any failure (bad
+ * signature, wrong issuer/audience, expired, unverified email). Returns the
+ * identity on success.
+ */
+export async function verifyGoogleIdToken(idToken: string, opts: VerifyGoogleOptions): Promise<GoogleIdentity> {
+  const now = opts.now ?? Date.now;
+  const tolerance = opts.clockToleranceSec ?? 60;
+
+  const parts = idToken.split(".");
+  if (parts.length !== 3) throw new GoogleAuthError("not a JWT");
+  const headerB64 = parts[0] as string;
+  const payloadB64 = parts[1] as string;
+  const sigB64 = parts[2] as string;
+
+  const header = decodeJson(headerB64);
+  if (header.alg !== "RS256") throw new GoogleAuthError(`unexpected alg ${String(header.alg)}`);
+  const kid = typeof header.kid === "string" ? header.kid : null;
+  if (!kid) throw new GoogleAuthError("missing key id");
+
+  const keys = await opts.fetchKeys();
+  const jwk = keys.find((k) => k.kid === kid && k.kty === "RSA");
+  if (!jwk) throw new GoogleAuthError("no matching Google signing key");
+
+  const pubKey = crypto.createPublicKey({ key: jwk as unknown as crypto.JsonWebKey, format: "jwk" });
+  const signingInput = Buffer.from(`${headerB64}.${payloadB64}`, "utf8");
+  if (!crypto.verify("RSA-SHA256", signingInput, pubKey, b64urlToBuffer(sigB64))) {
+    throw new GoogleAuthError("bad signature");
+  }
+
+  const claims = decodeJson(payloadB64);
+  if (typeof claims.iss !== "string" || !GOOGLE_ISSUERS.includes(claims.iss)) {
+    throw new GoogleAuthError("wrong issuer");
+  }
+
+  // An empty audience list means nothing is configured — reject rather than
+  // vacuously pass.
+  const aud = claims.aud;
+  const audOk = opts.audiences.length > 0 && typeof aud === "string" && opts.audiences.includes(aud);
+  if (!audOk) throw new GoogleAuthError("wrong audience");
+
+  const nowSec = Math.floor(now() / 1000);
+  const exp = typeof claims.exp === "number" ? claims.exp : 0;
+  if (exp + tolerance < nowSec) throw new GoogleAuthError("token expired");
+  const iat = typeof claims.iat === "number" ? claims.iat : 0;
+  if (iat - tolerance > nowSec) throw new GoogleAuthError("token not yet valid");
+
+  if (opts.expectedNonce !== undefined) {
+    const got = typeof claims.nonce === "string" ? claims.nonce : "";
+    if (!got || !timingSafeEqualStr(got, opts.expectedNonce)) throw new GoogleAuthError("nonce mismatch");
+  }
+
+  const sub = typeof claims.sub === "string" ? claims.sub : "";
+  if (!sub) throw new GoogleAuthError("missing subject");
+
+  const email = typeof claims.email === "string" ? claims.email : "";
+  if (!email) throw new GoogleAuthError("missing email");
+  // The address is what binds this identity to an existing LISA account, so an
+  // unverified one would be a takeover primitive. Google sends a real boolean;
+  // some older paths sent the string. Anything else ⇒ reject.
+  const verified = claims.email_verified === true || claims.email_verified === "true";
+  if (!verified) throw new GoogleAuthError("email not verified by Google");
+
+  return { sub, email };
+}
+
+// ── Google JWKS fetch (cached) ──────────────────────────────────────────────
+let keyCache: { keys: GoogleJWK[]; at: number } | null = null;
+const KEY_TTL_MS = 60 * 60 * 1000;
+
+/** Fetch Google's signing keys, cached for an hour. The default `fetchKeys`. */
+export async function fetchGoogleKeys(now: () => number = Date.now): Promise<GoogleJWK[]> {
+  if (keyCache && now() - keyCache.at < KEY_TTL_MS) return keyCache.keys;
+  const res = await fetch(GOOGLE_KEYS_URL);
+  if (!res.ok) throw new GoogleAuthError(`Google JWKS fetch failed (${res.status})`);
+  const body = (await res.json()) as { keys?: GoogleJWK[] };
+  const keys = Array.isArray(body.keys) ? body.keys : [];
+  if (keys.length === 0) throw new GoogleAuthError("Google JWKS empty");
+  keyCache = { keys, at: now() };
+  return keys;
+}
+
+/** Test seam. */
+export function _resetGoogleKeyCacheForTests(): void {
+  keyCache = null;
+}
+
+// ── Endpoint configuration (env) ────────────────────────────────────────────
+
+export interface GoogleSignInConfig {
+  /** Live when at least one client id is configured. */
+  enabled: boolean;
+  /** GIS button on the login page; null ⇒ the button stays hidden. */
+  webClientId: string | null;
+  /** The iOS app's PKCE flow. */
+  iosClientId: string | null;
+}
+
+export function googleSignInConfig(env: NodeJS.ProcessEnv = process.env): GoogleSignInConfig {
+  const webClientId = env.LISA_GOOGLE_WEB_CLIENT_ID?.trim() || null;
+  const iosClientId = env.LISA_GOOGLE_IOS_CLIENT_ID?.trim() || null;
+  return { enabled: !!(webClientId || iosClientId), webClientId, iosClientId };
+}
+
+/**
+ * Audiences a token may legitimately carry. Only configured surfaces are
+ * accepted, so a token minted for a client id we don't run is rejected.
+ */
+export function googleAudiences(cfg: GoogleSignInConfig): string[] {
+  return [cfg.webClientId, cfg.iosClientId].filter((v): v is string => !!v);
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -95,9 +95,17 @@ import {
   beginEmailVerification,
   confirmEmailVerification,
   ensureOtpAccount,
+  upsertGoogleAccount,
   validEmail,
   normalizeEmail,
 } from "./accounts.js";
+import {
+  verifyGoogleIdToken,
+  fetchGoogleKeys,
+  googleSignInConfig,
+  googleAudiences,
+  GoogleAuthError,
+} from "./googleAuth.js";
 import { requestEmailOtp, verifyEmailOtp, OTP_TTL_MS } from "./otp.js";
 import { sendVerificationEmail, sendSignInCodeEmail } from "./mailer.js";
 import { readBalance, creditPurchase } from "../billing/quota.js";
@@ -970,10 +978,70 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // ── Sign in with Google (cloud edition; A3) ─────────────────────────────
+    // Pre-gate, same posture as /api/auth/apple: it mints access. The client
+    // (GIS on the web, PKCE in the app) hands us the ID token; we verify it
+    // against Google's keys and sign the person into the account that owns the
+    // address — creating one only if nobody does.
+    if (req.method === "POST" && url === "/api/auth/google") {
+      const gcfg = googleSignInConfig();
+      if (!cloud || !gcfg.enabled) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("google sign-in not available");
+        return;
+      }
+      if (!sessionSecret) {
+        res.writeHead(503, { "content-type": "text/plain" });
+        res.end("cloud sign-in misconfigured (no session secret)");
+        return;
+      }
+      if (!ipRateOk(`auth:${clientIp(req, remoteAddr)}`, AUTH_IP_LIMIT, AUTH_IP_WINDOW_MS)) {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "rate_limited", retryAfterSec: Math.ceil(AUTH_IP_WINDOW_MS / 1000) }));
+        return;
+      }
+      const payload = await readJsonBody(req, res);
+      if (!payload) return; // 413 already sent
+      const idToken = typeof payload.idToken === "string" ? payload.idToken : "";
+      if (!idToken) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "id_token_required" }));
+        return;
+      }
+      // Verified when present (the iOS PKCE flow sends one); Google echoes the
+      // raw value rather than a hash of it.
+      const nonce = typeof payload.nonce === "string" ? payload.nonce : "";
+      try {
+        const id = await verifyGoogleIdToken(idToken, {
+          audiences: googleAudiences(gcfg),
+          fetchKeys: fetchGoogleKeys,
+          ...(nonce ? { expectedNonce: nonce } : {}),
+        });
+        const acct = await upsertGoogleAccount(id.sub, id.email);
+        const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "set-cookie": `lisa_token=${encodeURIComponent(session)}; HttpOnly; SameSite=Strict; Path=/${isCloud() ? "; Secure" : ""}`,
+        });
+        res.end(JSON.stringify({ ok: true, token: session, uid: acct.uid, verified: acct.verified }));
+      } catch (e) {
+        if (e instanceof AccountError) {
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: e.code }));
+          return;
+        }
+        const msg = e instanceof GoogleAuthError ? e.message : "verification failed";
+        res.writeHead(401, { "content-type": "text/plain" });
+        res.end(`google sign-in rejected: ${msg}`);
+      }
+      return;
+    }
+
     // Public sign-in surface config (pre-gate): the login page asks which
     // buttons to draw. Never exposes secrets — just feature flags + ids.
     if (req.method === "GET" && url === "/api/auth/config") {
       const cfg = appleSignInConfig();
+      const gcfg = googleSignInConfig();
       res.writeHead(200, { "content-type": "application/json" });
       res.end(
         JSON.stringify({
@@ -981,6 +1049,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           appleWeb: cloud && cfg.enabled && !!cfg.webServicesId
             ? { servicesId: cfg.webServicesId }
             : null,
+          // Only the WEB client id — the button can't be drawn without it.
+          google: cloud && gcfg.webClientId ? { webClientId: gcfg.webClientId } : null,
           stripe: cloud && !!stripeConfig().secretKey,
         }),
       );


### PR DESCRIPTION
Stacked on #289. Adds **Sign in with Google** server-side, and the account rule that keeps one person on one balance no matter which door they use.

> Note: this reverses the "don't add Google" call in `PLAN_ACCOUNTS_BILLING_v1.0.md` §4. That call was about Guideline 4.8 — adding a third-party login obliges you to offer Sign in with Apple too. SIWA is now live and holds first position on every surface, so the obligation is already satisfied and the reason no longer applies.

## Pieces

- **`src/web/googleAuth.ts`** — the sibling of `cloudAuth.ts`: RS256 over Google's JWKS, zero dependencies, JWKS fetch and clock injected so it tests offline.
- **`accounts.ts`** — the one-address-one-account rule (see below).
- **`POST /api/auth/google`** — pre-gate like `/api/auth/apple`, behind the same per-IP backstop. `/api/auth/config` now advertises the web client id so the login page knows whether to draw the button.

Off unless `LISA_GOOGLE_WEB_CLIENT_ID` / `LISA_GOOGLE_IOS_CLIENT_ID` are set.

## One address, one account

The thing worth reviewing closely. Email and Google accounts both *claim* their address (`EMAIL_OWNER_KINDS`), so every lookup spans both kinds:

- Google sign-in onto an address that already has an email account **binds to it** — same uid, same balance — instead of forking a second account;
- a mailed code onto a Google-owned address signs into that same account;
- registering a password over a Google-owned address is `email_taken`.

Resolution is **sub-first**, so someone who changes the address on their Google account keeps their LISA account. **Apple is excluded on purpose**: private-relay addresses are per-app aliases, not a claim on an inbox.

## Security notes for review

- `email_verified` is **required**, not advisory — the address is what binds an identity to an existing account, so an unproven one would be an account-takeover primitive. Both the boolean and the legacy string form are accepted; anything else is rejected.
- Audience must be a client id we actually run, and an **empty config rejects** rather than vacuously passing.
- Both canonical issuer spellings accepted; nonce verified when present (Google echoes the raw value, unlike Apple's SHA-256).
- A Google account can never be password-authenticated (no scrypt params ⇒ decoy path).
- Covered: tampered payload, alg-confusion (`alg: none`), unknown kid, foreign issuer, wrong/unconfigured audience, expiry incl. skew allowance.

## Tests

`npm test` → **1172 tests green** (+27: 18 verifier/config, 9 account binding). Typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)