### PR TITLE
feat(auth): A4 — Sign in with Google on the web and in the app

### DIFF
--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -27,6 +27,8 @@ struct CloudSignInForm: View {
     @State private var busy = false
     @State private var error: String?
     @State private var note: String?
+    /// This instance's Google iOS client id, or nil when it doesn't run Google.
+    @State private var googleClientId: String?
     #if LISA_ENABLE_SIWA
     /// Raw (un-hashed) nonce for the in-flight Apple request (#261). We send
     /// sha256(raw) to Apple and the raw value to our server, which re-hashes it
@@ -54,6 +56,22 @@ struct CloudSignInForm: View {
                 .disabled(busy || AppState.parseCloudBase(cloudURL) == nil)
                 .opacity(busy ? 0.5 : 1)
             #endif
+            // Google sits BELOW Apple: Guideline 4.8 wants Sign in with Apple
+            // offered with equal prominence wherever a third-party login is.
+            // Drawn only when this instance runs an iOS Google client.
+            if let googleClientId {
+                Button { signInWithGoogle(clientId: googleClientId) } label: {
+                    Text("Sign in with Google")
+                        .font(.system(size: 17, weight: .semibold))
+                        .frame(maxWidth: .infinity, minHeight: 46)
+                        .background(Color.white)
+                        .foregroundStyle(.black)
+                        .cornerRadius(Theme.cardRadius)
+                }
+                .buttonStyle(.plain)
+                .disabled(busy || AppState.parseCloudBase(cloudURL) == nil)
+                .opacity(busy ? 0.5 : 1)
+            }
             TextField("Email", text: $email)
                 .autocorrectionDisabled().textInputAutocapitalization(.never)
                 .keyboardType(.emailAddress).textContentType(.username)
@@ -110,6 +128,11 @@ struct CloudSignInForm: View {
         if let error {
             Section { Text(error).font(.caption).foregroundStyle(Theme.danger) }
         }
+        // Re-asked whenever the URL changes: two instances can offer different
+        // sign-in surfaces.
+        Section {} .task(id: cloudURL) {
+            googleClientId = await app.authConfig(baseURL: cloudURL)?.google?.iosClientId
+        }
     }
 
     private var addressReady: Bool {
@@ -125,6 +148,36 @@ struct CloudSignInForm: View {
         let outcome = await app.verifyConnection()
         busy = false
         onResult(outcome)
+    }
+
+    private func signInWithGoogle(clientId: String) {
+        error = nil
+        note = nil
+        busy = true
+        Task {
+            do {
+                let outcome = try await GoogleSignIn.shared.signIn(iosClientId: clientId)
+                try await app.connectCloudWithGoogle(baseURL: cloudURL, idToken: outcome.idToken,
+                                                     nonce: outcome.nonce)
+                await verifyThenReport()
+            } catch GoogleSignInError.cancelled {
+                busy = false // the person backed out — not an error worth shouting about
+            } catch GoogleSignInError.failed(let why) {
+                busy = false
+                error = "Google sign-in failed: \(why)"
+            } catch GoogleSignInError.notConfigured {
+                busy = false
+                error = "This instance's Google client id looks wrong."
+            } catch let err as LisaClient.SignInCodeError {
+                busy = false
+                error = err.status == 404
+                    ? "This instance hasn't enabled Google sign-in."
+                    : "Google sign-in was rejected by this instance (\(err.status))."
+            } catch {
+                busy = false
+                self.error = "Couldn't reach that LISA Cloud URL."
+            }
+        }
     }
 
     /// Human-readable reason for a refused code request/redemption.

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -246,6 +246,22 @@ final class AppState: ObservableObject {
         await refreshAccount()
     }
 
+    /// Which sign-in surfaces this instance offers (drives which buttons to
+    /// draw). Returns nil when the URL doesn't parse or the instance is mute.
+    func authConfig(baseURL raw: String) async -> LisaClient.AuthConfig? {
+        guard let base = AppState.parseCloudBase(raw) else { return nil }
+        return try? await LisaClient.authConfig(base: base)
+    }
+
+    /// Finish a Google sign-in: hand the ID token to the instance for
+    /// verification and keep the session it returns.
+    func connectCloudWithGoogle(baseURL raw: String, idToken: String, nonce: String?) async throws {
+        guard let base = AppState.parseCloudBase(raw) else { throw LisaError.notConfigured }
+        let token = try await LisaClient.exchangeGoogleToken(base: base, idToken: idToken, nonce: nonce)
+        update(host: base.host, port: base.port, token: token, scheme: base.scheme)
+        await refreshAccount()
+    }
+
     /// Ask the instance to mail a one-time sign-in code. Returns false when the
     /// instance accepted the request but couldn't send the mail.
     func requestSignInCode(baseURL raw: String, email: String) async throws -> Bool {

--- a/packaging/ios-companion/Sources/GoogleSignIn.swift
+++ b/packaging/ios-companion/Sources/GoogleSignIn.swift
@@ -1,0 +1,161 @@
+import AuthenticationServices
+import CryptoKit
+import Foundation
+
+/// Sign in with Google, without Google's SDK (PLAN_AUTH_OTP_GOOGLE A4).
+///
+/// The whole flow is ~100 lines of OAuth, so we run it ourselves rather than
+/// take a dependency — the same call the server side makes in `googleAuth.ts`
+/// (verify Apple/Google JWTs with `node:crypto` instead of a library).
+///
+/// It's the standard **authorization code + PKCE** flow for a native app:
+///
+///  1. mint a `code_verifier`, send only its SHA-256 (`code_challenge`) to the
+///     authorize endpoint — so intercepting the redirect gains nothing without
+///     the verifier, which never leaves the device;
+///  2. `ASWebAuthenticationSession` shows Google's page in a sandboxed browser
+///     the app cannot read, and intercepts the redirect itself (which is why no
+///     URL scheme has to be registered in `project.yml`);
+///  3. exchange the code for an `id_token` directly with Google over TLS. iOS
+///     OAuth clients are public clients — there is no client secret to leak.
+///
+/// The `nonce` travels with the request and comes back inside the token, so the
+/// server can tell a token minted for THIS sign-in from a replayed one.
+enum GoogleSignInError: Error {
+    case notConfigured
+    case cancelled
+    case failed(String)
+}
+
+@MainActor
+final class GoogleSignIn: NSObject, ASWebAuthenticationPresentationContextProviding {
+    static let shared = GoogleSignIn()
+
+    struct Outcome {
+        let idToken: String
+        /// The raw nonce, echoed verbatim by Google inside the token.
+        let nonce: String
+    }
+
+    private var live: ASWebAuthenticationSession?
+
+    /// The redirect scheme Google assigns an iOS OAuth client: its id, reversed.
+    /// `123-abc.apps.googleusercontent.com` ⇒ `com.googleusercontent.apps.123-abc`.
+    static func redirectScheme(clientId: String) -> String? {
+        let suffix = ".apps.googleusercontent.com"
+        guard clientId.hasSuffix(suffix) else { return nil }
+        return "com.googleusercontent.apps." + String(clientId.dropLast(suffix.count))
+    }
+
+    func signIn(iosClientId: String) async throws -> Outcome {
+        guard let scheme = Self.redirectScheme(clientId: iosClientId) else {
+            throw GoogleSignInError.notConfigured
+        }
+        let verifier = Self.randomURLSafe(64)
+        let challenge = Self.sha256Base64URL(verifier)
+        let state = Self.randomURLSafe(16)
+        let nonce = Self.randomURLSafe(16)
+        let redirectURI = scheme + ":/oauth2redirect"
+
+        var comps = URLComponents(string: "https://accounts.google.com/o/oauth2/v2/auth")!
+        comps.queryItems = [
+            URLQueryItem(name: "client_id", value: iosClientId),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "scope", value: "openid email"),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "nonce", value: nonce),
+        ]
+        guard let authURL = comps.url else { throw GoogleSignInError.notConfigured }
+
+        let callback = try await present(authURL: authURL, scheme: scheme)
+        let items = URLComponents(url: callback, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        func value(_ name: String) -> String? { items.first { $0.name == name }?.value }
+
+        if let denied = value("error") {
+            throw denied == "access_denied" ? GoogleSignInError.cancelled : GoogleSignInError.failed(denied)
+        }
+        // Guards against a redirect we didn't start (CSRF).
+        guard value("state") == state else { throw GoogleSignInError.failed("state mismatch") }
+        guard let code = value("code") else { throw GoogleSignInError.failed("no authorization code") }
+
+        let idToken = try await exchange(code: code, verifier: verifier,
+                                        clientId: iosClientId, redirectURI: redirectURI)
+        return Outcome(idToken: idToken, nonce: nonce)
+    }
+
+    private func present(authURL: URL, scheme: String) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(url: authURL, callbackURLScheme: scheme) { url, error in
+                if let url {
+                    continuation.resume(returning: url)
+                } else if let error = error as? ASWebAuthenticationSessionError, error.code == .canceledLogin {
+                    continuation.resume(throwing: GoogleSignInError.cancelled)
+                } else {
+                    continuation.resume(throwing: GoogleSignInError.failed(
+                        error?.localizedDescription ?? "the sign-in window closed unexpectedly"))
+                }
+            }
+            session.presentationContextProvider = self
+            // A fresh session every time: signing out of LISA shouldn't leave the
+            // next person silently signed in as the last one.
+            session.prefersEphemeralWebBrowserSession = true
+            live = session
+            if !session.start() {
+                continuation.resume(throwing: GoogleSignInError.failed("couldn't open the sign-in window"))
+            }
+        }
+    }
+
+    /// Swap the one-time code for an id_token. Public client: no secret.
+    private func exchange(code: String, verifier: String, clientId: String, redirectURI: String) async throws -> String {
+        var req = URLRequest(url: URL(string: "https://oauth2.googleapis.com/token")!, timeoutInterval: 20)
+        req.httpMethod = "POST"
+        req.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        var form = URLComponents()
+        form.queryItems = [
+            URLQueryItem(name: "client_id", value: clientId),
+            URLQueryItem(name: "code", value: code),
+            URLQueryItem(name: "code_verifier", value: verifier),
+            URLQueryItem(name: "grant_type", value: "authorization_code"),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+        ]
+        req.httpBody = form.percentEncodedQuery.map { Data($0.utf8) }
+        let (data, resp) = try await URLSession.shared.data(for: req)
+        let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
+        struct TokenResponse: Decodable {
+            let id_token: String?
+            let error_description: String?
+        }
+        let parsed = try? JSONDecoder().decode(TokenResponse.self, from: data)
+        guard status == 200, let idToken = parsed?.id_token, !idToken.isEmpty else {
+            throw GoogleSignInError.failed(parsed?.error_description ?? "Google refused the code exchange (\(status)).")
+        }
+        return idToken
+    }
+
+    // ── PKCE primitives ─────────────────────────────────────────────────────
+    /// `bytes` of randomness as unreserved characters (RFC 7636 §4.1).
+    private static func randomURLSafe(_ bytes: Int) -> String {
+        var rng = SystemRandomNumberGenerator()
+        let alphabet = Array("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+        return String((0..<bytes).map { _ in alphabet[Int.random(in: 0..<alphabet.count, using: &rng)] })
+    }
+
+    private static func sha256Base64URL(_ s: String) -> String {
+        Data(SHA256.hash(data: Data(s.utf8)))
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    func presentationAnchor(for _: ASWebAuthenticationSession) -> ASPresentationAnchor {
+        let scenes = UIApplication.shared.connectedScenes.compactMap { $0 as? UIWindowScene }
+        let window = scenes.first { $0.activationState == .foregroundActive }?.keyWindow
+            ?? scenes.first?.keyWindow
+        return window ?? ASPresentationAnchor()
+    }
+}

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -108,6 +108,45 @@ final class LisaClient {
         return r.token
     }
 
+    /// Which sign-in surfaces an instance offers (`GET /api/auth/config`).
+    /// Public, unauthenticated, and free of secrets — OAuth client ids identify
+    /// the app rather than authorize it.
+    struct AuthConfig: Decodable {
+        struct Google: Decodable {
+            let webClientId: String?
+            let iosClientId: String?
+        }
+        let accounts: Bool?
+        let google: Google?
+    }
+
+    static func authConfig(base: ServerConfig, session: URLSession = .shared) async throws -> AuthConfig {
+        guard let baseURL = base.baseURL, let url = URL(string: "/api/auth/config", relativeTo: baseURL) else {
+            throw LisaError.notConfigured
+        }
+        var req = URLRequest(url: url, timeoutInterval: 10)
+        req.httpMethod = "GET"
+        let (data, resp) = try await session.data(for: req)
+        let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
+        guard (200..<300).contains(status) else { throw LisaError.http(status) }
+        guard let cfg = try? JSONDecoder().decode(AuthConfig.self, from: data) else { throw LisaError.decode }
+        return cfg
+    }
+
+    /// Exchange a Google ID token for the instance's session token
+    /// (`POST /api/auth/google`). Mints access, so it takes the bare cloud base.
+    static func exchangeGoogleToken(base: ServerConfig, idToken: String, nonce: String?,
+                                    session: URLSession = .shared) async throws -> String {
+        var payload = ["idToken": idToken]
+        if let nonce { payload["nonce"] = nonce }
+        let data = try await postAuth(base: base, path: "/api/auth/google", payload: payload, session: session)
+        struct R: Decodable { let token: String }
+        guard let r = try? JSONDecoder().decode(R.self, from: data), !r.token.isEmpty else {
+            throw LisaError.decode
+        }
+        return r.token
+    }
+
     /// A refusal from the sign-in-by-code endpoints, carrying the server's typed
     /// reason. The status alone can't tell "a code just went out" from "you've
     /// asked too many times today", and those need different words.

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -216,4 +216,16 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertTrue(VerifyOutcome.ok.recovery.isEmpty)
         XCTAssertEqual(RecoveryAction.rescan.label, "Scan a fresh code")
     }
+
+    // ── A4: the Google redirect scheme is the client id, reversed ──
+    @MainActor
+    func testGoogleRedirectScheme() {
+        XCTAssertEqual(
+            GoogleSignIn.redirectScheme(clientId: "123-abc.apps.googleusercontent.com"),
+            "com.googleusercontent.apps.123-abc")
+        // A web client id (or anything else) has no reversed form — refuse it
+        // rather than build a redirect Google will reject.
+        XCTAssertNil(GoogleSignIn.redirectScheme(clientId: "123-abc.example.com"))
+        XCTAssertNil(GoogleSignIn.redirectScheme(clientId: ""))
+    }
 }

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -51,7 +51,8 @@ export const LOGIN_HTML = `<!doctype html>
   input#code { letter-spacing: .35em; font-size: 20px; text-align: center; }
   .note { color: #7fd6a3; font-size: 13px; margin-top: 12px; min-height: 1.2em; }
   [hidden] { display: none !important; }
-  #apple-wrap { display: none; margin-bottom: 18px; }
+  #apple-wrap { display: none; margin-bottom: 10px; }
+  #google-wrap { display: none; margin-bottom: 18px; }
   #apple-btn {
     width: 100%; padding: 12px; border: 0; border-radius: 10px; cursor: pointer;
     background: #fff; color: #000; font-size: 16px; font-weight: 600;
@@ -69,6 +70,7 @@ export const LOGIN_HTML = `<!doctype html>
   <div id="apple-wrap">
     <button id="apple-btn" type="button"> Sign in with Apple</button>
   </div>
+  <div id="google-wrap"></div>
   <div class="divider" id="divider">or use email</div>
   <form id="f">
     <label for="email">Email</label>
@@ -245,11 +247,60 @@ export const LOGIN_HTML = `<!doctype html>
     return Array.from(new Uint8Array(d), (x) => x.toString(16).padStart(2, "0")).join("");
   }
 
-  // Sign in with Apple on the web (B8b): drawn only when the instance has a
-  // Services ID configured (GET /api/auth/config). Apple's JS runs a popup and
-  // hands back an id_token; the server verifies it against the web audience.
+  // Federated buttons are drawn only for the surfaces this instance actually
+  // has configured (GET /api/auth/config) — no dead buttons, and the divider
+  // appears only when there is something above it.
   fetch("/api/auth/config").then((r) => r.json()).then((cfg) => {
-    if (!cfg || !cfg.appleWeb || !cfg.appleWeb.servicesId) return;
+    if (!cfg) return;
+    if (cfg.appleWeb && cfg.appleWeb.servicesId) drawApple(cfg);
+    // iosClientId may be set without webClientId — that instance runs Google on
+    // the app only, and the web button must stay away.
+    if (cfg.google && cfg.google.webClientId) drawGoogle(cfg);
+  }).catch(() => {});
+
+  function showDivider() { document.getElementById("divider").style.display = "flex"; }
+
+  // Sign in with Google (A4): Google Identity Services renders its own button
+  // and hands back an id_token, which the server verifies against the web
+  // client id. The nonce is echoed back RAW (Apple echoes a hash of it).
+  function drawGoogle(cfg) {
+    const rawNonce = mintNonce();
+    const s = document.createElement("script");
+    s.src = "https://accounts.google.com/gsi/client";
+    s.async = true;
+    s.onload = () => {
+      if (!window.google || !window.google.accounts || !window.google.accounts.id) return;
+      window.google.accounts.id.initialize({
+        client_id: cfg.google.webClientId,
+        ...(rawNonce ? { nonce: rawNonce } : {}),
+        callback: async (resp) => {
+          err.textContent = "";
+          const idToken = resp && resp.credential;
+          if (!idToken) { err.textContent = "Google didn't return a token."; return; }
+          const res = await fetch("/api/auth/google", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ idToken: idToken, ...(rawNonce ? { nonce: rawNonce } : {}) }),
+          }).catch(() => null);
+          if (res && res.ok) { location.replace("/"); return; }
+          err.textContent = res
+            ? "Google sign-in was rejected (" + res.status + ")."
+            : "Network error — try again.";
+        },
+      });
+      const wrap = document.getElementById("google-wrap");
+      wrap.style.display = "block";
+      showDivider();
+      window.google.accounts.id.renderButton(wrap, {
+        theme: "filled_black", size: "large", width: 324, text: "signin_with", shape: "rectangular",
+      });
+    };
+    document.head.appendChild(s);
+  }
+
+  // Sign in with Apple on the web (B8b): Apple's JS runs a popup and hands back
+  // an id_token; the server verifies it against the web audience.
+  function drawApple(cfg) {
     const s = document.createElement("script");
     s.src = "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
     s.onload = () => {
@@ -261,7 +312,7 @@ export const LOGIN_HTML = `<!doctype html>
       };
       window.AppleID.auth.init(appleCfg);
       document.getElementById("apple-wrap").style.display = "block";
-      document.getElementById("divider").style.display = "flex";
+      showDivider();
       document.getElementById("apple-btn").addEventListener("click", async () => {
         err.textContent = "";
         try {
@@ -290,7 +341,7 @@ export const LOGIN_HTML = `<!doctype html>
       });
     };
     document.head.appendChild(s);
-  }).catch(() => {});
+  }
 </script>
 </body>
 </html>

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -1049,8 +1049,12 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           appleWeb: cloud && cfg.enabled && !!cfg.webServicesId
             ? { servicesId: cfg.webServicesId }
             : null,
-          // Only the WEB client id — the button can't be drawn without it.
-          google: cloud && gcfg.webClientId ? { webClientId: gcfg.webClientId } : null,
+          // Client ids are public by design (they identify the app, they don't
+          // authorize it); each client draws its button only if its own id is
+          // present. The iOS app also needs it to build the PKCE request.
+          google: cloud && gcfg.enabled
+            ? { webClientId: gcfg.webClientId, iosClientId: gcfg.iosClientId }
+            : null,
           stripe: cloud && !!stripeConfig().secretKey,
         }),
       );


### PR DESCRIPTION
Stacked on #291. The client half of Google sign-in.

## Web

Google Identity Services renders its own button, drawn only when the instance advertises a web client id. The same nonce goes to Google and to our server (Google echoes it raw, unlike Apple's hash). The `/api/auth/config` fetch now feeds both providers, and the "or use email" divider appears only when something sits above it.

## iOS — authorization code + PKCE, no SDK

The flow is ~100 lines of OAuth, so we run it ourselves rather than take a dependency — the same call the server side makes (verify Apple/Google JWTs with `node:crypto` instead of a library, and no RevenueCat for IAP).

- The **verifier never leaves the device** — only its SHA-256 goes to the authorize endpoint, so intercepting the redirect gains nothing.
- **`state` is checked** on the way back, guarding against a redirect we didn't start.
- The session is **ephemeral**, so signing out of LISA doesn't leave the next person silently signed in as the last one.
- `ASWebAuthenticationSession` intercepts the callback itself, so **no URL scheme has to be registered in `project.yml`** — which also means the client id doesn't need to be known at build time.
- iOS OAuth clients are public clients: there is no client secret to leak.
- The button sits **below Sign in with Apple** — Guideline 4.8 wants SIWA offered with equal prominence wherever a third-party login is.

## Config

`/api/auth/config` now advertises both client ids, and each client draws its button only if *its own* id is present — so an instance can run Google on the app and not the web, or vice versa. Client ids are public by design: they identify the app, they don't authorize it.

## Verification

- **Web**: driven in a browser against a stub that serves a fake GIS script — the button renders in the right place, `initialize` receives the configured client id and a nonce, and clicking it posts the token **plus the matching nonce** to `/api/auth/google` and lands signed in. Server log confirms the nonce round-trips identically. Screenshot in the thread.
- **iOS**: full `swiftc -typecheck` against the iOS 17 simulator SDK, clean. Added an XCTest for the redirect-scheme derivation, and verified the same logic standalone under `swift` (correct reversal; nil for a non-Google id and for empty input, rather than building a redirect Google would reject).
- The live OAuth round-trip can't be exercised until the GCP client ids exist — see the operator steps in A5.
- `npm test` → **1173 green**, typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)