### PR TITLE
ios: StoreKit config for IAP review screenshots

### DIFF
--- a/packaging/ios-companion/LisaPocket.storekit
+++ b/packaging/ios-companion/LisaPocket.storekit
@@ -1,0 +1,62 @@
+{
+  "identifier" : "3F1A9C7E",
+  "nonRenewingSubscriptions" : [],
+  "products" : [
+    {
+      "displayPrice" : "4.99",
+      "familyShareable" : false,
+      "internalID" : "60000005",
+      "localizations" : [
+        {
+          "description" : "$5.00 in credits · Tier 1 boost",
+          "displayName" : "$5 Credit Pack",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "ai.meetlisa.main.credits.5",
+      "referenceName" : "credits.5",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "9.99",
+      "familyShareable" : false,
+      "internalID" : "60000010",
+      "localizations" : [
+        {
+          "description" : "$10.50 in credits (+5%) · Tier 1 boost",
+          "displayName" : "$10 Credit Pack",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "ai.meetlisa.main.credits.10",
+      "referenceName" : "credits.10",
+      "type" : "Consumable"
+    },
+    {
+      "displayPrice" : "19.99",
+      "familyShareable" : false,
+      "internalID" : "60000020",
+      "localizations" : [
+        {
+          "description" : "$22.00 in credits (+10%) · Tier 2 boost",
+          "displayName" : "$20 Credit Pack",
+          "locale" : "en_US"
+        }
+      ],
+      "productID" : "ai.meetlisa.main.credits.20",
+      "referenceName" : "credits.20",
+      "type" : "Consumable"
+    }
+  ],
+  "settings" : {
+    "_applicationInternalID" : "6784690058",
+    "_developerTeamID" : "9LH9NBX7P4",
+    "_failTransactionsEnabled" : false,
+    "_storeKitErrors" : []
+  },
+  "subscriptionGroups" : [],
+  "version" : {
+    "major" : 3,
+    "minor" : 0
+  }
+}

--- a/packaging/ios-companion/project.yml
+++ b/packaging/ios-companion/project.yml
@@ -121,6 +121,12 @@ schemes:
     build:
       targets:
         LisaPocket: all
+    run:
+      # Local StoreKit config so the simulator renders the credits paywall with
+      # real prices WITHOUT App Store Connect — needed to capture the IAP review
+      # screenshots (the 3 consumables sit at MISSING_METADATA until they have
+      # one). Simulator/dev only; a real StoreKit env ignores this file.
+      storeKitConfiguration: LisaPocket.storekit
     test:
       targets:
         - LisaPocketTests


### PR DESCRIPTION
Unblocks the 3 consumables stuck at **MISSING_METADATA** (each needs a Review Screenshot).

With no local StoreKit config the simulator paywall renders "Loading packs…" — nothing to screenshot. `LisaPocket.storekit` defines `credits.5/10/20` at their real prices ($4.99/$9.99/$19.99), wired into the run scheme via `storeKitConfiguration`, so the simulator renders the paywall with prices and the review screenshots can be captured without ASC.

Simulator/dev only; a real StoreKit env ignores the file. `.xcodeproj` is generated (xcodegen), so only the config + `project.yml` scheme change are committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)