### PR TITLE
feat(auth): Sign in with Google on the web login page (S1)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -61,6 +61,12 @@ ENVS="^##^LISA_EDITION=cloud##LISA_WEB_TOKEN=${LISA_WEB_TOKEN}"
 # Sign in with Apple on the WEB login page (B8b): the Services ID registered in
 # the Apple portal for cloud.meetlisa.ai (needs domain verification there).
 [ -n "${LISA_CLOUD_APPLE_WEB_SID:-}" ] && ENVS="${ENVS}##LISA_CLOUD_APPLE_WEB_SID=${LISA_CLOUD_APPLE_WEB_SID}"
+# Sign in with Google on the WEB login page (S1, PLAN_WEB_SIGNUP):
+#   LISA_CLOUD_GOOGLE_SIGNIN=1     enable POST /api/auth/google
+#   LISA_CLOUD_GOOGLE_CLIENT_ID=…  OAuth web client id (…apps.googleusercontent.com;
+#                                  authorized JS origin = https://cloud.meetlisa.ai)
+[ -n "${LISA_CLOUD_GOOGLE_SIGNIN:-}" ]    && ENVS="${ENVS}##LISA_CLOUD_GOOGLE_SIGNIN=${LISA_CLOUD_GOOGLE_SIGNIN}"
+[ -n "${LISA_CLOUD_GOOGLE_CLIENT_ID:-}" ] && ENVS="${ENVS}##LISA_CLOUD_GOOGLE_CLIENT_ID=${LISA_CLOUD_GOOGLE_CLIENT_ID}"
 # Accounts & billing era (PLAN_ACCOUNTS_BILLING B1–B7), all optional:
 #   LISA_REVIEWER_SEED="email:password"  idempotent App-Review demo account (verified, $20/Tier-2)
 #   LISA_RPM_LIMIT / LISA_DAILY_CAP_USD  abuse guards (defaults 20 rpm / $200 per day)

--- a/src/web/accounts.test.ts
+++ b/src/web/accounts.test.ts
@@ -12,12 +12,14 @@ const {
   createEmailAccount,
   verifyEmailLogin,
   upsertAppleAccount,
+  upsertGoogleAccount,
   deleteAccount,
   getAccount,
   getAccountByEmail,
   sessionAccountValid,
   resetLoginThrottles,
   appleUid,
+  googleUid,
   AccountError,
 } = await import("./accounts.js");
 
@@ -84,6 +86,55 @@ describe("apple accounts", () => {
   test("appleUid sanitizes hostile subs", () => {
     assert.ok(!appleUid("a/b").includes("/"));
     assert.ok(!appleUid("../../etc").includes("/"));
+  });
+});
+
+describe("google accounts (S1)", () => {
+  test("first sign-in creates a verified google account; second reuses it", async () => {
+    const a = await upsertGoogleAccount("110169484474386276334", "user@gmail.com", true, 1000);
+    assert.equal(a.uid, "google-110169484474386276334");
+    assert.equal(a.kind, "google");
+    assert.equal(a.verified, true);
+    assert.equal(a.googleSub, "110169484474386276334");
+    const b = await upsertGoogleAccount("110169484474386276334", "user@gmail.com", true, 2000);
+    assert.equal(b.uid, a.uid);
+    assert.equal(b.lastLoginAt, 2000);
+  });
+
+  test("merges into an existing VERIFIED same-email account — one uid, one Lisa", async () => {
+    const email = await createEmailAccount("user@gmail.com", "password-123");
+    // level the account to verified (as the B8a mail flow would)
+    const seeded = await upsertGoogleAccount("42", "other@gmail.com", true, 500); // unrelated
+    assert.notEqual(seeded.uid, email.uid);
+    // mark verified by simulating the verification outcome
+    const { beginEmailVerification, confirmEmailVerification } = await import("./accounts.js");
+    const raw = await beginEmailVerification(email.uid);
+    assert.ok(raw);
+    await confirmEmailVerification(raw!);
+    const merged = await upsertGoogleAccount("110169484474386276334", "User@Gmail.com", true, 3000);
+    assert.equal(merged.uid, email.uid); // linked, not a new account
+    assert.equal(merged.googleSub, "110169484474386276334");
+    // subsequent Google sign-ins land on the merged uid
+    const again = await upsertGoogleAccount("110169484474386276334", "user@gmail.com", true, 4000);
+    assert.equal(again.uid, email.uid);
+  });
+
+  test("never merges into an UNVERIFIED same-email account (squatter defense)", async () => {
+    const squatter = await createEmailAccount("victim@gmail.com", "password-123");
+    assert.equal(squatter.verified, false);
+    const g = await upsertGoogleAccount("777", "victim@gmail.com", true, 1000);
+    assert.notEqual(g.uid, squatter.uid);
+    assert.equal(g.uid, googleUid("777"));
+  });
+
+  test("no merge without Google's email_verified assertion", async () => {
+    const email = await createEmailAccount("user2@gmail.com", "password-123");
+    const { beginEmailVerification, confirmEmailVerification } = await import("./accounts.js");
+    const raw = await beginEmailVerification(email.uid);
+    await confirmEmailVerification(raw!);
+    const g = await upsertGoogleAccount("888", "user2@gmail.com", false, 1000);
+    assert.notEqual(g.uid, email.uid);
+    assert.equal(g.verified, false); // email_verified: false carries through
   });
 });
 

--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -23,7 +23,7 @@ import path from "node:path";
 import crypto from "node:crypto";
 import { firestoreEnabled, getDoc, casUpdate } from "../cloud/firestore.js";
 
-export type AccountKind = "apple" | "email";
+export type AccountKind = "apple" | "email" | "google";
 
 export interface ScryptParams {
   saltHex: string;
@@ -50,6 +50,12 @@ export interface AccountRecord {
   verifyTokenHash?: string;
   /** Verification-token expiry, ms epoch. */
   verifyExpiresAt?: number;
+  /**
+   * Google `sub` linked to this account (S1). Set on a pure Google account AND
+   * on an email/apple account a verified-email Google sign-in merged into — so
+   * the user keeps one uid (one Lisa) across providers.
+   */
+  googleSub?: string;
 }
 
 export class AccountError extends Error {
@@ -182,6 +188,11 @@ async function passwordMatches(pw: string, p: ScryptParams): Promise<boolean> {
 /** Stable uid for an Apple `sub` (filesystem-safe: sub is digits/dots/dashes). */
 export function appleUid(sub: string): string {
   return `apple-${sub.replace(/[^A-Za-z0-9._-]/g, "_")}`;
+}
+
+/** Stable uid for a Google `sub` (a decimal string; sanitized the same way). */
+export function googleUid(sub: string): string {
+  return `google-${sub.replace(/[^A-Za-z0-9._-]/g, "_")}`;
 }
 
 // ── login throttle (in-memory; single-instance cloud) ───────────────────────
@@ -318,6 +329,60 @@ export async function upsertAppleAccount(
       createdAt: now,
       lastLoginAt: now,
       verified: true,
+      sessionVersion: 0,
+    };
+    list.push(rec);
+    return rec;
+  });
+}
+
+/**
+ * Upsert the account record for a verified Google identity (S1). Called on
+ * every successful Sign in with Google.
+ *
+ * Merge policy (PLAN_WEB_SIGNUP §3 / D2 verdict): if Google asserts the email
+ * is verified AND an existing **verified** account carries the same normalized
+ * email, the Google identity is linked onto that account (`googleSub`) instead
+ * of minting a new uid — same person, same Lisa. Both sides being verified is
+ * what closes the account-takeover door: an unverified email squatter never
+ * inherits a Google identity, and Google's `email_verified` is its ownership
+ * proof. Otherwise a fresh `google-<sub>` account is created.
+ */
+export async function upsertGoogleAccount(
+  sub: string,
+  email: string | undefined,
+  emailVerified: boolean | undefined,
+  now: number = Date.now(),
+): Promise<AccountRecord> {
+  const uid = googleUid(sub);
+  const norm = email ? normalizeEmail(email) : undefined;
+  return mutateAccounts((list) => {
+    // Returning user: linked via a previous merge, or a pure Google account.
+    const existing = list.find((a) => a.googleSub === sub || a.uid === uid);
+    if (existing) {
+      existing.lastLoginAt = now;
+      if (norm && !existing.email) existing.email = norm;
+      return existing;
+    }
+    // First Google sign-in: merge into a verified same-email account if any.
+    if (norm && emailVerified) {
+      const match = list.find((a) => a.email === norm && a.verified);
+      if (match) {
+        match.googleSub = sub;
+        match.lastLoginAt = now;
+        return match;
+      }
+    }
+    const rec: AccountRecord = {
+      uid,
+      kind: "google",
+      email: norm,
+      googleSub: sub,
+      createdAt: now,
+      lastLoginAt: now,
+      // Google accounts count as verified only when Google says the email is
+      // (in practice always true for Google-account emails).
+      verified: emailVerified !== false,
       sessionVersion: 0,
     };
     list.push(rec);

--- a/src/web/googleAuth.test.ts
+++ b/src/web/googleAuth.test.ts
@@ -1,0 +1,143 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import crypto from "node:crypto";
+import {
+  verifyGoogleIdToken,
+  GoogleAuthError,
+  googleSignInConfig,
+  type GoogleJWK,
+} from "./googleAuth.js";
+
+// A throwaway RSA key standing in for Google's signing key, exported as a JWK
+// so the verifier imports it exactly as it would Google's real JWKS entry.
+const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", { modulusLength: 2048 });
+const jwk = publicKey.export({ format: "jwk" }) as unknown as GoogleJWK;
+jwk.kid = "test-kid";
+jwk.kty = "RSA";
+jwk.alg = "RS256";
+
+const AUD = "1234-abcd.apps.googleusercontent.com";
+const FIXED_NOW = 1_700_000_000_000; // fixed clock so exp/iat are deterministic
+const nowSec = Math.floor(FIXED_NOW / 1000);
+
+function b64url(obj: unknown): string {
+  return Buffer.from(JSON.stringify(obj)).toString("base64url");
+}
+
+/** Mint a signed Google-style ID token for tests. */
+function mintToken(claims: Record<string, unknown>, opts: { kid?: string; alg?: string } = {}): string {
+  const header = { alg: opts.alg ?? "RS256", kid: opts.kid ?? "test-kid", typ: "JWT" };
+  const signingInput = `${b64url(header)}.${b64url(claims)}`;
+  const sig = crypto.sign("RSA-SHA256", Buffer.from(signingInput), privateKey).toString("base64url");
+  return `${signingInput}.${sig}`;
+}
+
+const baseClaims = {
+  iss: "https://accounts.google.com",
+  aud: AUD,
+  sub: "110169484474386276334",
+  iat: nowSec - 10,
+  exp: nowSec + 3600,
+  email: "user@gmail.com",
+  email_verified: true,
+};
+
+const opts = {
+  audience: AUD,
+  fetchKeys: async () => [jwk],
+  now: () => FIXED_NOW,
+};
+
+describe("verifyGoogleIdToken", () => {
+  test("verifies a well-formed Google ID token", async () => {
+    const id = await verifyGoogleIdToken(mintToken(baseClaims), opts);
+    assert.equal(id.sub, "110169484474386276334");
+    assert.equal(id.email, "user@gmail.com");
+    assert.equal(id.emailVerified, true);
+  });
+
+  test("accepts both issuer spellings", async () => {
+    const bare = await verifyGoogleIdToken(mintToken({ ...baseClaims, iss: "accounts.google.com" }), opts);
+    assert.equal(bare.sub, baseClaims.sub);
+  });
+
+  test("email_verified arrives as a string in some flows", async () => {
+    const id = await verifyGoogleIdToken(mintToken({ ...baseClaims, email_verified: "true" }), opts);
+    assert.equal(id.emailVerified, true);
+    const off = await verifyGoogleIdToken(mintToken({ ...baseClaims, email_verified: "false" }), opts);
+    assert.equal(off.emailVerified, false);
+  });
+
+  test("rejects a foreign issuer", async () => {
+    await assert.rejects(
+      () => verifyGoogleIdToken(mintToken({ ...baseClaims, iss: "https://appleid.apple.com" }), opts),
+      (e: Error) => e instanceof GoogleAuthError && /wrong issuer/.test(e.message),
+    );
+  });
+
+  test("rejects a wrong audience (token minted for another app)", async () => {
+    await assert.rejects(
+      () => verifyGoogleIdToken(mintToken({ ...baseClaims, aud: "evil.apps.googleusercontent.com" }), opts),
+      (e: Error) => e instanceof GoogleAuthError && /wrong audience/.test(e.message),
+    );
+  });
+
+  test("rejects an expired token (beyond clock tolerance)", async () => {
+    await assert.rejects(
+      () => verifyGoogleIdToken(mintToken({ ...baseClaims, exp: nowSec - 120 }), opts),
+      (e: Error) => e instanceof GoogleAuthError && /expired/.test(e.message),
+    );
+  });
+
+  test("rejects a tampered payload (signature over original bytes)", async () => {
+    const good = mintToken(baseClaims);
+    const parts = good.split(".");
+    const forged = `${parts[0]}.${b64url({ ...baseClaims, sub: "999" })}.${parts[2]}`;
+    await assert.rejects(
+      () => verifyGoogleIdToken(forged, opts),
+      (e: Error) => e instanceof GoogleAuthError && /bad signature/.test(e.message),
+    );
+  });
+
+  test("rejects unknown kid and non-RS256 alg", async () => {
+    await assert.rejects(
+      () => verifyGoogleIdToken(mintToken(baseClaims, { kid: "other-kid" }), opts),
+      (e: Error) => e instanceof GoogleAuthError && /no matching/.test(e.message),
+    );
+    // alg confusion (e.g. HS256 with the public key as HMAC secret) must never verify
+    const header = { alg: "HS256", kid: "test-kid", typ: "JWT" };
+    const signingInput = `${b64url(header)}.${b64url(baseClaims)}`;
+    const mac = crypto
+      .createHmac("sha256", publicKey.export({ type: "spki", format: "pem" }))
+      .update(signingInput)
+      .digest("base64url");
+    await assert.rejects(
+      () => verifyGoogleIdToken(`${signingInput}.${mac}`, opts),
+      (e: Error) => e instanceof GoogleAuthError && /unexpected alg/.test(e.message),
+    );
+  });
+
+  test("rejects garbage that isn't a JWT", async () => {
+    await assert.rejects(() => verifyGoogleIdToken("not-a-jwt", opts), GoogleAuthError);
+  });
+});
+
+describe("googleSignInConfig", () => {
+  test("default-OFF; flag alone is not enough — the client id is the audience", () => {
+    assert.equal(googleSignInConfig({}).enabled, false);
+    assert.equal(googleSignInConfig({ LISA_CLOUD_GOOGLE_SIGNIN: "1" }).enabled, false);
+    assert.equal(
+      googleSignInConfig({ LISA_CLOUD_GOOGLE_CLIENT_ID: AUD }).enabled,
+      false,
+    );
+  });
+
+  test("on when flag + client id are both set", () => {
+    const cfg = googleSignInConfig({
+      LISA_CLOUD_GOOGLE_SIGNIN: "1",
+      LISA_CLOUD_GOOGLE_CLIENT_ID: ` ${AUD} `,
+    });
+    assert.equal(cfg.enabled, true);
+    assert.equal(cfg.clientId, AUD);
+  });
+});

--- a/src/web/googleAuth.ts
+++ b/src/web/googleAuth.ts
@@ -1,0 +1,183 @@
+/**
+ * Sign in with Google — ID-token verification for the hosted LISA Cloud
+ * edition (docs/PLAN_WEB_SIGNUP_v1.0.md S1).
+ *
+ * The login page runs Google Identity Services (GIS); its callback hands the
+ * browser a **ID token** (a JWT signed by Google) which the page POSTs to
+ * `POST /api/auth/google`. We verify it here against Google's published JWKS
+ * and, on success, the server upserts the account and mints a per-uid session
+ * — the exact posture of the Apple channel (src/web/cloudAuth.ts).
+ *
+ * Deliberately mirrors cloudAuth.ts rather than abstracting over it: the two
+ * issuers differ in issuer set (Google uses two `iss` values), audience
+ * semantics (OAuth client id, not a bundle id), and replay posture (GIS
+ * tokens are minted per page-load by Google's own script and live ~1h; there
+ * is no client-mintable raw nonce in the button flow, so we accept the token
+ * lifetime as the replay window — the same stance as pre-nonce Apple clients).
+ *
+ * No external dependencies: RS256 verifies natively from a JWK via
+ * `node:crypto`. The verifier is pure (JWKS fetch + clock injected) so it
+ * unit-tests offline — see googleAuth.test.ts.
+ */
+import crypto from "node:crypto";
+
+/** A single JSON Web Key from Google's JWKS (the RSA fields we use). */
+export interface GoogleJWK {
+  kty: string;
+  kid: string;
+  use?: string;
+  alg?: string;
+  n: string;
+  e: string;
+}
+
+/** The verified subset of a Google ID token we act on. */
+export interface GoogleIdentity {
+  /** Stable Google account id (`sub`, a decimal string). The account key. */
+  sub: string;
+  /** The account's email. Google includes it when the `email` scope is granted. */
+  email?: string;
+  /** Google's own assertion that it verified ownership of that email. */
+  emailVerified?: boolean;
+}
+
+export interface VerifyGoogleOptions {
+  /** Expected `aud` — the OAuth 2.0 web client id (…apps.googleusercontent.com). */
+  audience: string;
+  /** Returns Google's current signing keys. Injected so tests run offline. */
+  fetchKeys: () => Promise<GoogleJWK[]>;
+  /** Clock seam for tests (ms since epoch). Defaults to Date.now(). */
+  now?: () => number;
+  /** Leeway for clock skew, seconds (default 60). */
+  clockToleranceSec?: number;
+}
+
+export class GoogleAuthError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "GoogleAuthError";
+  }
+}
+
+// Google mints `iss` in both bare and https forms depending on the flow.
+const GOOGLE_ISSUERS = ["accounts.google.com", "https://accounts.google.com"];
+const GOOGLE_KEYS_URL = "https://www.googleapis.com/oauth2/v3/certs";
+
+function b64urlToBuffer(s: string): Buffer {
+  return Buffer.from(s, "base64url");
+}
+
+function decodeJson(segment: string): Record<string, unknown> {
+  try {
+    return JSON.parse(b64urlToBuffer(segment).toString("utf8"));
+  } catch {
+    throw new GoogleAuthError("malformed token segment");
+  }
+}
+
+/**
+ * Verify a Google ID-token JWT. Throws `GoogleAuthError` on any failure
+ * (bad signature, wrong issuer/audience, expired). Returns the identity on success.
+ */
+export async function verifyGoogleIdToken(
+  idToken: string,
+  opts: VerifyGoogleOptions,
+): Promise<GoogleIdentity> {
+  const now = opts.now ?? Date.now;
+  const tolerance = opts.clockToleranceSec ?? 60;
+
+  const parts = idToken.split(".");
+  if (parts.length !== 3) throw new GoogleAuthError("not a JWT");
+  const headerB64 = parts[0] as string;
+  const payloadB64 = parts[1] as string;
+  const sigB64 = parts[2] as string;
+
+  const header = decodeJson(headerB64);
+  if (header.alg !== "RS256") throw new GoogleAuthError(`unexpected alg ${String(header.alg)}`);
+  const kid = typeof header.kid === "string" ? header.kid : null;
+  if (!kid) throw new GoogleAuthError("missing key id");
+
+  const keys = await opts.fetchKeys();
+  const jwk = keys.find((k) => k.kid === kid && k.kty === "RSA");
+  if (!jwk) throw new GoogleAuthError("no matching Google signing key");
+
+  // RS256 = RSASSA-PKCS1-v1_5 over SHA-256. Node imports the JWK directly.
+  const pubKey = crypto.createPublicKey({ key: jwk as unknown as crypto.JsonWebKey, format: "jwk" });
+  const signingInput = Buffer.from(`${headerB64}.${payloadB64}`, "utf8");
+  const ok = crypto.verify("RSA-SHA256", signingInput, pubKey, b64urlToBuffer(sigB64));
+  if (!ok) throw new GoogleAuthError("bad signature");
+
+  const claims = decodeJson(payloadB64);
+  if (typeof claims.iss !== "string" || !GOOGLE_ISSUERS.includes(claims.iss)) {
+    throw new GoogleAuthError("wrong issuer");
+  }
+
+  // `aud` may be a string or array.
+  const aud = claims.aud;
+  const audOk = Array.isArray(aud) ? aud.includes(opts.audience) : aud === opts.audience;
+  if (!audOk) throw new GoogleAuthError("wrong audience");
+
+  const nowSec = Math.floor(now() / 1000);
+  const exp = typeof claims.exp === "number" ? claims.exp : 0;
+  if (exp + tolerance < nowSec) throw new GoogleAuthError("token expired");
+  const iat = typeof claims.iat === "number" ? claims.iat : 0;
+  if (iat - tolerance > nowSec) throw new GoogleAuthError("token not yet valid");
+
+  const sub = typeof claims.sub === "string" ? claims.sub : "";
+  if (!sub) throw new GoogleAuthError("missing subject");
+
+  const email = typeof claims.email === "string" ? claims.email : undefined;
+  const emailVerified =
+    claims.email_verified === true || claims.email_verified === "true" ? true
+    : claims.email_verified === false || claims.email_verified === "false" ? false
+    : undefined;
+
+  return { sub, email, emailVerified };
+}
+
+// ── Google JWKS fetch (cached) ──────────────────────────────────────────────
+let keyCache: { keys: GoogleJWK[]; at: number } | null = null;
+// Google rotates roughly daily and old keys stay valid past rotation; an hour
+// of caching (matching the Apple channel) never strands a fresh token.
+const KEY_TTL_MS = 60 * 60 * 1000;
+
+/** Fetch Google's signing keys, cached for an hour. The default `fetchKeys`. */
+export async function fetchGoogleKeys(now: () => number = Date.now): Promise<GoogleJWK[]> {
+  if (keyCache && now() - keyCache.at < KEY_TTL_MS) return keyCache.keys;
+  const res = await fetch(GOOGLE_KEYS_URL);
+  if (!res.ok) throw new GoogleAuthError(`Google JWKS fetch failed (${res.status})`);
+  const body = (await res.json()) as { keys?: GoogleJWK[] };
+  const keys = Array.isArray(body.keys) ? body.keys : [];
+  if (keys.length === 0) throw new GoogleAuthError("Google JWKS empty");
+  keyCache = { keys, at: now() };
+  return keys;
+}
+
+// ── Endpoint configuration (env) ────────────────────────────────────────────
+
+export interface GoogleSignInConfig {
+  /** Whether the endpoint is live. Off unless BOTH the flag and client id are set. */
+  enabled: boolean;
+  /** The OAuth web client id — the expected token audience. Null ⇒ disabled. */
+  clientId: string | null;
+}
+
+function truthy(v: string | undefined): boolean {
+  if (!v) return false;
+  const s = v.trim().toLowerCase();
+  return s === "1" || s === "true" || s === "yes" || s === "on";
+}
+
+/**
+ * Read the Sign in with Google config from the environment. Default-OFF: the
+ * endpoint (and the login-page button) light up only when
+ * `LISA_CLOUD_GOOGLE_SIGNIN` is truthy AND `LISA_CLOUD_GOOGLE_CLIENT_ID` names
+ * the OAuth web client — same flag philosophy as the Apple channel.
+ */
+export function googleSignInConfig(env: NodeJS.ProcessEnv = process.env): GoogleSignInConfig {
+  const clientId = env.LISA_CLOUD_GOOGLE_CLIENT_ID?.trim() || null;
+  return {
+    enabled: truthy(env.LISA_CLOUD_GOOGLE_SIGNIN) && !!clientId,
+    clientId,
+  };
+}

--- a/src/web/html-syntax.test.ts
+++ b/src/web/html-syntax.test.ts
@@ -4,6 +4,7 @@ import vm from "node:vm";
 import { MAIN_HTML } from "./lisa-html.js";
 import { ISLAND_HTML } from "./island.js";
 import { ROOM_HTML } from "./room.js";
+import { LOGIN_HTML } from "./login.js";
 
 /**
  * Regression guard: the whole GUI/island is one big inline <script>. A single
@@ -29,6 +30,7 @@ describe("inline page <script> blocks are syntactically valid JS", () => {
     ["MAIN_HTML", MAIN_HTML],
     ["ISLAND_HTML", ISLAND_HTML],
     ["ROOM_HTML", ROOM_HTML],
+    ["LOGIN_HTML", LOGIN_HTML],
   ] as const) {
     test(`${name} parses`, () => {
       const blocks = inlineScripts(html);

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -60,6 +60,9 @@ export const LOGIN_HTML = `<!doctype html>
   <div id="apple-wrap">
     <button id="apple-btn" type="button"> Sign in with Apple</button>
   </div>
+  <div id="google-wrap" style="display:none; margin-bottom: 18px;">
+    <div id="google-btn"></div>
+  </div>
   <div class="divider" id="divider">or use email</div>
   <form id="f">
     <label for="email">Email</label>
@@ -115,10 +118,46 @@ export const LOGIN_HTML = `<!doctype html>
     return Array.from(new Uint8Array(d), (x) => x.toString(16).padStart(2, "0")).join("");
   }
 
+  // Sign in with Google on the web (S1): drawn only when the instance has an
+  // OAuth client id configured (GET /api/auth/config). GIS renders its own
+  // button; the callback hands back a Google-signed credential JWT which the
+  // server verifies against the client-id audience.
+  function initGoogle(cfg) {
+    if (!cfg || !cfg.googleWeb || !cfg.googleWeb.clientId) return;
+    const s = document.createElement("script");
+    s.src = "https://accounts.google.com/gsi/client";
+    s.onload = () => {
+      if (!window.google || !window.google.accounts || !window.google.accounts.id) return;
+      window.google.accounts.id.initialize({
+        client_id: cfg.googleWeb.clientId,
+        callback: async (resp) => {
+          err.textContent = "";
+          if (!resp || !resp.credential) { err.textContent = "Google didn't return a credential."; return; }
+          const res = await fetch("/api/auth/google", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({ credential: resp.credential }),
+          }).catch(() => null);
+          if (res && res.ok) { location.replace("/"); return; }
+          err.textContent = "Google sign-in was rejected" + (res ? " (" + res.status + ")." : ".");
+        },
+      });
+      window.google.accounts.id.renderButton(document.getElementById("google-btn"), {
+        theme: "filled_black", size: "large", width: 324, text: "signin_with",
+      });
+      document.getElementById("google-wrap").style.display = "block";
+      document.getElementById("divider").style.display = "flex";
+    };
+    // Unreachable networks (e.g. mainland China) just never show the button.
+    s.onerror = () => {};
+    document.head.appendChild(s);
+  }
+
   // Sign in with Apple on the web (B8b): drawn only when the instance has a
   // Services ID configured (GET /api/auth/config). Apple's JS runs a popup and
   // hands back an id_token; the server verifies it against the web audience.
   fetch("/api/auth/config").then((r) => r.json()).then((cfg) => {
+    initGoogle(cfg);
     if (!cfg || !cfg.appleWeb || !cfg.appleWeb.servicesId) return;
     const s = document.createElement("script");
     s.src = "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -88,6 +88,7 @@ import {
   createEmailAccount,
   verifyEmailLogin,
   upsertAppleAccount,
+  upsertGoogleAccount,
   deleteAccount,
   getAccount,
   sessionAccountValid,
@@ -123,6 +124,12 @@ import {
   audienceForClient,
   appleRequireNonce,
 } from "./cloudAuth.js";
+import {
+  verifyGoogleIdToken,
+  fetchGoogleKeys,
+  googleSignInConfig,
+  GoogleAuthError,
+} from "./googleAuth.js";
 import { detectLanHost, buildPairUrl } from "./pairing.js";
 import { TenantEventBus, sameTenant } from "./event-bus.js";
 import { qrSvg } from "./qr-svg.js";
@@ -1002,16 +1009,70 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // ── Sign in with Google (cloud edition; S1) ─────────────────────────────
+    // Same posture as /api/auth/apple: mints access, so it runs BEFORE the
+    // token gate, default-OFF, and shares the per-IP auth rate bucket. The
+    // login page's GIS callback POSTs the credential (a Google-signed JWT);
+    // we verify it against Google's JWKS and mint a per-uid session.
+    if (req.method === "POST" && url === "/api/auth/google") {
+      const gcfg = googleSignInConfig();
+      if (!cloud || !gcfg.enabled || !gcfg.clientId) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("google sign-in not available");
+        return;
+      }
+      if (!sessionSecret) {
+        res.writeHead(503, { "content-type": "text/plain" });
+        res.end("cloud sign-in misconfigured (no session secret)");
+        return;
+      }
+      if (!ipRateOk(`auth:${clientIp(req, remoteAddr)}`, AUTH_IP_LIMIT, AUTH_IP_WINDOW_MS)) {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "rate_limited", retryAfterSec: Math.ceil(AUTH_IP_WINDOW_MS / 1000) }));
+        return;
+      }
+      const payload = await readJsonBody(req, res);
+      if (!payload) return; // 413 already sent
+      const credential = typeof payload.credential === "string" ? payload.credential : "";
+      if (!credential) {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("credential required");
+        return;
+      }
+      try {
+        const id = await verifyGoogleIdToken(credential, {
+          audience: gcfg.clientId,
+          fetchKeys: fetchGoogleKeys,
+        });
+        const acct = await upsertGoogleAccount(id.sub, id.email, id.emailVerified);
+        const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "set-cookie": `lisa_token=${encodeURIComponent(session)}; HttpOnly; SameSite=Strict; Path=/${isCloud() ? "; Secure" : ""}`,
+        });
+        res.end(JSON.stringify({ ok: true, token: session, uid: acct.uid }));
+      } catch (e) {
+        const msg = e instanceof GoogleAuthError ? e.message : "verification failed";
+        res.writeHead(401, { "content-type": "text/plain" });
+        res.end(`google sign-in rejected: ${msg}`);
+      }
+      return;
+    }
+
     // Public sign-in surface config (pre-gate): the login page asks which
     // buttons to draw. Never exposes secrets — just feature flags + ids.
     if (req.method === "GET" && url === "/api/auth/config") {
       const cfg = appleSignInConfig();
+      const gcfg = googleSignInConfig();
       res.writeHead(200, { "content-type": "application/json" });
       res.end(
         JSON.stringify({
           accounts: cloud && !!sessionSecret,
           appleWeb: cloud && cfg.enabled && !!cfg.webServicesId
             ? { servicesId: cfg.webServicesId }
+            : null,
+          googleWeb: cloud && gcfg.enabled && gcfg.clientId
+            ? { clientId: gcfg.clientId }
             : null,
           stripe: cloud && !!stripeConfig().secretKey,
         }),


### PR DESCRIPTION
Part of [PLAN_WEB_SIGNUP_v1.0](https://github.com/oratis/LISA/pull/296) — milestone **S1**.

## What

Adds the third sign-in provider to LISA Cloud's login page, mirroring the Apple channel's zero-dependency posture:

- **`src/web/googleAuth.ts`** — pure RS256/JWKS verifier for Google ID tokens: dual issuer spellings, `aud` = OAuth web client id, clock tolerance, 1h-cached JWKS, typed `GoogleAuthError`. Default-OFF: lights up only when `LISA_CLOUD_GOOGLE_SIGNIN` **and** `LISA_CLOUD_GOOGLE_CLIENT_ID` are both set.
- **`POST /api/auth/google`** — pre-gate access-minting endpoint (same posture as `/api/auth/apple`), sharing the per-IP auth rate bucket; upserts the account, mints the per-uid HMAC session, pins the cookie.
- **Merge policy** (plan §3, D2 verdict): a Google sign-in whose email Google asserts verified links onto an existing **verified** same-email account — one uid, one Lisa across providers. Unverified squatter accounts never inherit a Google identity. Covered by tests.
- **Login page**: GIS button drawn only when `/api/auth/config` advertises `googleWeb`; script-load failure (e.g. mainland China) silently hides the button instead of erroring.
- `LOGIN_HTML` added to the inline-script syntax regression guard (it wasn't covered).
- `deploy/deploy.sh` plumbs the two new env vars.

## Replay posture

GIS button-flow tokens are minted per page-load by Google's script with no client-mintable raw nonce, so the ~1h token lifetime is the replay window — the same stance the Apple channel takes for pre-nonce clients. Documented in the module header.

## Tests

`npm test`: 1296 pass / 0 fail. New: `googleAuth.test.ts` (verifier + config, incl. alg-confusion and tampered-payload cases), 4 merge-policy cases in `accounts.test.ts`.

## Operator steps (not in this PR)

Create the OAuth web client in GCP console (authorized JS origin `https://cloud.meetlisa.ai`), then deploy with `LISA_CLOUD_GOOGLE_SIGNIN=1 LISA_CLOUD_GOOGLE_CLIENT_ID=…`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)