### PR TITLE
feat(mail): a real mail layer — HTML templates, one logged exit, address gate

### DIFF
--- a/docs/RUNBOOK_ACCOUNTS_LAUNCH.md
+++ b/docs/RUNBOOK_ACCOUNTS_LAUNCH.md
@@ -209,10 +209,24 @@ app now verifies the connection at sign-in time. Please review 1.1.
 > **没有可用的发信通道 = 没人收得到验证码 = 登录不了**（缺 key 时验证码只会
 > 打进服务端日志）。上线前务必确认这一条。
 
-1. **Resend**：确认 `RESEND_API_KEY` 已在 Cloud Run env 里，且 `meetlisa.ai`
-   在 Resend 后台是 **Verified**（SPF + DKIM 记录已加在 DNS）。
-   B8a 的验证邮件用的是同一条通道，所以之前若已验证过就无需重做。
-2. **自检**（部署后）：
+1. **Resend 域名**：发信域是 **`mail.meetlisa.ai`（子域，不是顶级域）**。
+   子域发信是刻意的：顶级域承载你自己的人类邮件和它的信誉，把批量事务邮件
+   隔到独立子域，这边退信炸了也不会连累那边。
+
+   Resend 后台 → **Domains → Add Domain** 填 `mail.meetlisa.ai`，它会列出
+   3–4 条记录（MX + SPF TXT + DKIM TXT，可选 DMARC）。**照抄它当场给的值**
+   到 DNS —— 具体主机名和值跟 Resend 分配的区域有关，别照别处的样例填。
+   加完点 Verify，状态变 **Verified** 才算数（通常几分钟，DNS 慢的话到几小时）。
+
+   代码里的默认 from 已经是 `LISA <no-reply@mail.meetlisa.ai>`，与之对齐；
+   想换显示名或地址就设 `LISA_MAIL_FROM`，但**必须仍在已验证的域内**，
+   否则 Resend 直接拒发。
+
+2. **API key**：Resend → API Keys 建一个（权限选 **Sending access** 即可，
+   不需要 Full access），部署时作为 `RESEND_API_KEY` 传入。
+   key 只在 Cloud Run env 里，别提交进仓库。轮换就是建新 key + 重部署。
+
+3. **自检**（部署后）：
 
 ```bash
 BASE=https://cloud.meetlisa.ai
@@ -224,9 +238,10 @@ curl -s $BASE/api/auth/otp/verify -H 'content-type: application/json' \
   -d '{"email":"你的邮箱@example.com","code":"123456"}'
 ```
 
-3. 免费额度：验证码登录建号即 `verified=true`，直接拿满额 $5 窗口（旧的
+4. 免费额度：验证码登录建号即 `verified=true`，直接拿满额 $5 窗口（旧的
    "未验证邮箱 $1" 只剩历史密码账号会遇到）。
-4. 审核账号不受影响：`reviewer@meetlisa.ai` 仍是密码登录，ASC 表单不用改。
+5. 审核账号不受影响：`reviewer@meetlisa.ai` 仍是密码登录，ASC 表单不用改。
+   （注意这是**收件**地址、与发信子域无关，不需要跟着改成 mail. 子域。）
 
 ## Phase 9 — Google 登录（GCP OAuth）
 

--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -139,6 +139,12 @@ struct CloudSignInForm: View {
         !email.isEmpty && AppState.parseCloudBase(cloudURL) != nil
     }
 
+    /// The domain half of the typed address, for rewriting it to a suggestion.
+    private var emailDomain: String {
+        guard let at = email.lastIndex(of: "@") else { return "" }
+        return String(email[email.index(after: at)...])
+    }
+
     private var passwordFormReady: Bool {
         !busy && addressReady && password.count >= 8
     }
@@ -190,6 +196,11 @@ struct CloudSignInForm: View {
         case "no_pending": return "No code outstanding — send one first."
         case "too_many_attempts": return "Too many wrong codes. Send a fresh one."
         case "invalid_email": return "That doesn't look like an email address."
+        case "email_typo":
+            // A named typo is one tap from fixed — offer the fix, don't scold.
+            return err.suggestion.map { "Did you mean \(email.replacingOccurrences(of: emailDomain, with: $0))?" }
+                ?? "That address looks misspelled."
+        case "undeliverable_email": return "That domain doesn't seem to accept mail — check the spelling."
         case "rate_limited": return "Too many attempts from this network — try again later."
         default:
             return err.status == 404

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -153,9 +153,11 @@ final class LisaClient {
     struct SignInCodeError: Error {
         let status: Int
         /// Server code — otp_cooldown, otp_daily_cap, bad_code, expired,
-        /// no_pending, too_many_attempts, invalid_email, rate_limited. Empty if
-        /// the body carried none.
+        /// no_pending, too_many_attempts, invalid_email, email_typo,
+        /// undeliverable_email, rate_limited. Empty if the body carried none.
         let reason: String
+        /// The corrected domain, when the server recognised a typo.
+        let suggestion: String?
     }
 
     private static func postAuth(
@@ -175,9 +177,9 @@ final class LisaClient {
         let (data, resp) = try await session.data(for: req)
         let status = (resp as? HTTPURLResponse)?.statusCode ?? -1
         guard (200..<300).contains(status) else {
-            struct E: Decodable { let error: String? }
-            let reason = (try? JSONDecoder().decode(E.self, from: data))?.error ?? ""
-            throw SignInCodeError(status: status, reason: reason)
+            struct E: Decodable { let error: String?; let suggestion: String? }
+            let body = try? JSONDecoder().decode(E.self, from: data)
+            throw SignInCodeError(status: status, reason: body?.error ?? "", suggestion: body?.suggestion)
         }
         return data
     }

--- a/packaging/mac-client/Sources/Lisa/AccountWindow.swift
+++ b/packaging/mac-client/Sources/Lisa/AccountWindow.swift
@@ -128,7 +128,10 @@ final class AccountWindowController: NSWindowController {
                 if status == 200 {
                     completion(obj, "")
                 } else {
-                    completion(nil, Self.hint(status: status, error: obj?["error"] as? String ?? ""))
+                    var reason = Self.hint(status: status, error: obj?["error"] as? String ?? "")
+                    // A named typo is one edit from fixed — say what to fix.
+                    if let fix = obj?["suggestion"] as? String { reason += " — did you mean @\(fix)?" }
+                    completion(nil, reason)
                 }
             }
         }.resume()
@@ -144,6 +147,8 @@ final class AccountWindowController: NSWindowController {
         case "too_many_attempts": return "too many wrong codes — send a fresh one"
         case "bad_credentials": return "wrong email or password"
         case "invalid_email": return "that doesn't look like an email address"
+        case "email_typo": return "that address looks misspelled"
+        case "undeliverable_email": return "that domain doesn't seem to accept mail"
         case "rate_limited", "throttled": return "too many attempts — wait a while"
         default:
             return status == 404 ? "this instance doesn't offer accounts"

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -92,6 +92,8 @@ const HINTS: Record<string, string> = {
   throttled: "too many attempts — wait 15 minutes",
   rate_limited: "too many attempts from this network — try again later",
   invalid_email: "that doesn't look like an email address",
+  email_typo: "that address looks misspelled",
+  undeliverable_email: "that domain doesn't seem to accept mail",
   otp_cooldown: "a code was just sent — check your inbox",
   otp_daily_cap: "too many codes for this address today",
   bad_code: "that code isn't right",
@@ -123,7 +125,11 @@ function sessionFrom(body: Record<string, unknown>): Session | null {
 async function loginWithCode(base: string, email: string): Promise<Session | null> {
   const asked = await post(`${base}/api/auth/otp/request`, { email });
   if (!asked.ok) {
-    console.error(`✗ couldn't send a code (${hintFor(asked.code, asked.status)}).`);
+    const suggestion = typeof asked.body.suggestion === "string" ? asked.body.suggestion : "";
+    console.error(
+      `✗ couldn't send a code (${hintFor(asked.code, asked.status)})` +
+        (suggestion ? ` — did you mean ${email.replace(/@.*$/, `@${suggestion}`)}?` : "."),
+    );
     return null;
   }
   if (asked.body.sent === false) {

--- a/src/web/email-deliverability.test.ts
+++ b/src/web/email-deliverability.test.ts
@@ -1,0 +1,121 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { checkDeliverable, findTypo } from "./email-deliverability.js";
+
+/** DNS stubs — no test in this file touches a resolver. */
+const found = async () => [{ exchange: "mx.example.com", priority: 10 }];
+const empty = async () => [];
+const notFound = async () => {
+  throw Object.assign(new Error("queryMx ENOTFOUND"), { code: "ENOTFOUND" });
+};
+const noData = async () => {
+  throw Object.assign(new Error("queryMx ENODATA"), { code: "ENODATA" });
+};
+const servfail = async () => {
+  throw Object.assign(new Error("queryMx SERVFAIL"), { code: "SERVFAIL" });
+};
+
+const dead = { resolveMx: notFound, resolve4: notFound };
+
+describe("typo detection (pure, no I/O)", () => {
+  test("names a misspelled popular domain and what was meant", () => {
+    assert.deepEqual(findTypo("someone@gmial.com"), { suggestion: "gmail.com" });
+    assert.deepEqual(findTypo("someone@hotmial.com"), { suggestion: "hotmail.com" });
+    assert.deepEqual(findTypo("someone@YAHOOO.COM"), { suggestion: "yahoo.com" });
+  });
+
+  test("names a misspelled TLD", () => {
+    assert.deepEqual(findTypo("someone@example.con"), { suggestion: "example.com" });
+    assert.deepEqual(findTypo("someone@my-company.cmo"), { suggestion: "my-company.com" });
+  });
+
+  test("real domains pass, including ccTLDs that look like typos", () => {
+    // .co is Colombia, .ne is Niger, .or.jp is real — none of these are mistakes.
+    for (const addr of [
+      "someone@gmail.com",
+      "someone@example.co",
+      "someone@example.ne",
+      "someone@example.or.jp",
+      "someone@qq.com",
+      "someone@163.com",
+      "someone@sub.domain.example.com",
+    ]) {
+      assert.equal(findTypo(addr), null, addr);
+    }
+  });
+});
+
+describe("deliverability — rejections", () => {
+  test("a typo is refused before any DNS work happens", async () => {
+    let calls = 0;
+    const counting = async () => { calls++; return []; };
+    const v = await checkDeliverable("someone@gmial.com", {
+      resolveMx: counting,
+      resolve4: counting,
+    });
+    assert.deepEqual(v, { ok: false, reason: "typo", suggestion: "gmail.com" });
+    assert.equal(calls, 0, "the cheap check must short-circuit the expensive one");
+  });
+
+  test("a domain that definitively does not exist is refused", async () => {
+    const v = await checkDeliverable("someone@no-such-domain-xyz.example", dead);
+    assert.deepEqual(v, { ok: false, reason: "no_such_domain" });
+  });
+
+  test("ENODATA on both lookups is also definitive", async () => {
+    const v = await checkDeliverable("someone@example.com", { resolveMx: noData, resolve4: noData });
+    assert.deepEqual(v, { ok: false, reason: "no_such_domain" });
+  });
+});
+
+describe("deliverability — admissions", () => {
+  test("an MX record admits the address", async () => {
+    assert.deepEqual(await checkDeliverable("someone@example.com", { resolveMx: found }), { ok: true });
+  });
+
+  test("no MX but an A record still admits it (RFC 5321 fallback)", async () => {
+    const v = await checkDeliverable("someone@example.com", {
+      resolveMx: noData,
+      resolve4: async () => ["93.184.216.34"],
+    });
+    assert.deepEqual(v, { ok: true });
+  });
+
+  test("an empty MX list falls through to the A record rather than rejecting", async () => {
+    const v = await checkDeliverable("someone@example.com", {
+      resolveMx: empty,
+      resolve4: async () => ["93.184.216.34"],
+    });
+    assert.deepEqual(v, { ok: true });
+  });
+});
+
+describe("deliverability — fails open (the property that matters)", () => {
+  // Getting this backwards locks people out of their own accounts because a
+  // resolver blinked, which is far worse than sending one mail into the void.
+  test("a resolver error admits the address", async () => {
+    assert.deepEqual(await checkDeliverable("someone@example.com", { resolveMx: servfail }), { ok: true });
+  });
+
+  test("an A-record error after a dead MX admits the address", async () => {
+    const v = await checkDeliverable("someone@example.com", { resolveMx: noData, resolve4: servfail });
+    assert.deepEqual(v, { ok: true });
+  });
+
+  test("a slow resolver admits the address rather than holding up sign-in", async () => {
+    const never = () => new Promise<unknown[]>(() => {}); // never settles
+    const started = Date.now();
+    const v = await checkDeliverable("someone@example.com", {
+      resolveMx: never,
+      resolve4: never,
+      timeoutMs: 50,
+    });
+    assert.deepEqual(v, { ok: true });
+    assert.ok(Date.now() - started < 1000, "must not wait for the hung lookup");
+  });
+
+  test("a resolver that throws synchronously still admits", async () => {
+    const boom = (() => { throw new Error("resolver exploded"); }) as unknown as () => Promise<unknown[]>;
+    assert.deepEqual(await checkDeliverable("someone@example.com", { resolveMx: boom }), { ok: true });
+  });
+});

--- a/src/web/email-deliverability.ts
+++ b/src/web/email-deliverability.ts
@@ -1,0 +1,158 @@
+/**
+ * Pre-send address check (docs/PLAN_AUTH_OTP_GOOGLE_v1.0.md A6).
+ *
+ * Sign-in by code has a failure mode that regular sign-in doesn't: a typo'd
+ * address doesn't bounce back to the person who typed it. They wait for a code
+ * that went somewhere else, burn a slot of their daily send budget, and have no
+ * way to tell a bad address from a slow one. So we look *before* we send.
+ *
+ * Two stages, cheapest first:
+ *
+ *  1. **Deterministic typo lists** — no I/O, catches the overwhelming majority
+ *     (`gmial.com`, `.con`). These can suggest a correction, which is the whole
+ *     point: "did you mean gmail.com?" fixes the problem in one tap.
+ *  2. **MX lookup**, raced against a short timeout, with an A-record fallback
+ *     (a domain with no MX but an A record still accepts mail, per RFC 5321).
+ *
+ * **It fails OPEN on every uncertainty.** A DNS hiccup, a timeout, a resolver
+ * that doesn't like us — all of those admit the address. The only rejection is
+ * a definitive "this domain does not exist" (ENOTFOUND/ENODATA on *both*
+ * lookups) or a typo we can name. Getting this backwards would lock people out
+ * of their own accounts because a resolver blinked, which is far worse than
+ * sending one mail into the void.
+ *
+ * Deliberately NOT an account-existence oracle: everything here is about the
+ * domain, never about whether we know the address.
+ */
+import dns from "node:dns/promises";
+
+export type DeliverabilityVerdict =
+  | { ok: true }
+  | { ok: false; reason: "typo" | "no_such_domain"; suggestion?: string };
+
+/** Mistyped TLDs. Each maps to what was almost certainly meant. */
+const TLD_TYPOS: Record<string, string> = {
+  con: "com",
+  comm: "com",
+  cmo: "com",
+  ocm: "com",
+  vom: "com",
+  xom: "com",
+  cim: "com",
+  "co,": "com",
+  nte: "net",
+  ner: "net",
+  orgg: "org",
+};
+
+/**
+ * Mistyped popular domains. Only entries that cannot be a real domain someone
+ * actually uses — when in doubt, leave it out and let DNS decide.
+ */
+const DOMAIN_TYPOS: Record<string, string> = {
+  "gmial.com": "gmail.com",
+  "gmai.com": "gmail.com",
+  "gmali.com": "gmail.com",
+  "gamil.com": "gmail.com",
+  "gnail.com": "gmail.com",
+  "gmail.co": "gmail.com",
+  "gmaill.com": "gmail.com",
+  "hotmial.com": "hotmail.com",
+  "hotmai.com": "hotmail.com",
+  "hotmal.com": "hotmail.com",
+  "outlok.com": "outlook.com",
+  "outloo.com": "outlook.com",
+  "yahooo.com": "yahoo.com",
+  "yaho.com": "yahoo.com",
+  "iclod.com": "icloud.com",
+  "icloud.co": "icloud.com",
+  "qq.co": "qq.com",
+  "163.co": "163.com",
+  "126.co": "126.com",
+};
+
+function domainOf(email: string): string {
+  return email.slice(email.lastIndexOf("@") + 1).toLowerCase();
+}
+
+/**
+ * Typo check only — pure, no I/O. Exported because it's the half worth running
+ * anywhere (including a client) and the half that can suggest a fix.
+ */
+export function findTypo(email: string): { suggestion: string } | null {
+  const domain = domainOf(email);
+  if (!domain) return null;
+
+  const fixed = DOMAIN_TYPOS[domain];
+  if (fixed) return { suggestion: fixed };
+
+  const dot = domain.lastIndexOf(".");
+  if (dot > 0) {
+    const tld = domain.slice(dot + 1);
+    const fixedTld = TLD_TYPOS[tld];
+    // Guard: ".co" is a real ccTLD (and ".ne"/".or" exist too), so only the
+    // entries above are treated as mistakes — never a bare prefix match.
+    if (fixedTld) return { suggestion: `${domain.slice(0, dot)}.${fixedTld}` };
+  }
+  return null;
+}
+
+export interface DeliverabilityOpts {
+  /** Milliseconds to wait for DNS before admitting the address. */
+  timeoutMs?: number;
+  /** Injected for tests. */
+  resolveMx?: (host: string) => Promise<unknown[]>;
+  resolve4?: (host: string) => Promise<unknown[]>;
+}
+
+/** Definitive "no such name" — anything else is a reason to fail open. */
+function isNoSuchDomain(e: unknown): boolean {
+  const code = (e as { code?: string })?.code;
+  return code === "ENOTFOUND" || code === "ENODATA";
+}
+
+/**
+ * Can mail plausibly reach this address? See the module header for why this
+ * fails open on everything except a named typo and a definitively dead domain.
+ */
+export async function checkDeliverable(
+  email: string,
+  opts: DeliverabilityOpts = {},
+): Promise<DeliverabilityVerdict> {
+  const typo = findTypo(email);
+  if (typo) return { ok: false, reason: "typo", suggestion: typo.suggestion };
+
+  const domain = domainOf(email);
+  if (!domain) return { ok: true }; // shape is validated elsewhere
+
+  const timeoutMs = opts.timeoutMs ?? 3000;
+  const resolveMx = opts.resolveMx ?? ((h: string) => dns.resolveMx(h));
+  const resolve4 = opts.resolve4 ?? ((h: string) => dns.resolve4(h));
+
+  // A slow resolver must not hold up a sign-in: whoever wins, we move on.
+  const admit = Symbol("timeout");
+  const timer = new Promise<typeof admit>((r) => setTimeout(() => r(admit), timeoutMs).unref?.());
+
+  try {
+    const lookup = (async (): Promise<DeliverabilityVerdict> => {
+      try {
+        const mx = await resolveMx(domain);
+        if (mx.length > 0) return { ok: true };
+      } catch (e) {
+        if (!isNoSuchDomain(e)) return { ok: true }; // resolver trouble ⇒ admit
+      }
+      // No MX: RFC 5321 says fall back to the A record before giving up.
+      try {
+        const a = await resolve4(domain);
+        return a.length > 0 ? { ok: true } : { ok: false, reason: "no_such_domain" };
+      } catch (e) {
+        return isNoSuchDomain(e) ? { ok: false, reason: "no_such_domain" } : { ok: true };
+      }
+    })();
+
+    const winner = await Promise.race([lookup, timer]);
+    return winner === admit ? { ok: true } : (winner as DeliverabilityVerdict);
+  } catch {
+    return { ok: true }; // never let this path be the reason a sign-in fails
+  }
+}

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -112,6 +112,7 @@ export const LOGIN_HTML = `<!doctype html>
     invalid_email: "That doesn't look like an email address.",
     throttled: "Too many attempts — wait 15 minutes.",
     rate_limited: "Too many attempts from this network — try again later.",
+    undeliverable_email: "That domain doesn't seem to accept mail — check the spelling.",
     otp_cooldown: "A code just went out — check your inbox.",
     otp_daily_cap: "Too many codes for this address today. Try again tomorrow or use a password.",
     bad_code: "That code isn't right.",
@@ -153,13 +154,25 @@ export const LOGIN_HTML = `<!doctype html>
       try { data = await res.json(); } catch {}
       return { ok: true, data: data };
     }
-    let code = "";
-    try { code = (await res.json()).error || ""; } catch {}
-    return { ok: false, code: code, status: res.status };
+    let code = "", suggestion = "";
+    try {
+      const body = await res.json();
+      code = body.error || "";
+      suggestion = body.suggestion || "";
+    } catch {}
+    return { ok: false, code: code, status: res.status, suggestion: suggestion };
   }
 
   function fail(r) {
     if (r.netFail) { say("Network error — try again.", true); return; }
+    // A named typo can be fixed in one tap, so offer the fix instead of a scolding.
+    if (r.code === "email_typo" && r.suggestion) {
+      const fixed = email.value.trim().replace(/@.*$/, "@" + r.suggestion);
+      say("Did you mean " + fixed + "? Fix the address and try again.", true);
+      email.value = fixed;
+      email.focus();
+      return;
+    }
     say(MSG[r.code] || ("Sign-in failed (" + r.status + ")."), true);
   }
 

--- a/src/web/mailer.test.ts
+++ b/src/web/mailer.test.ts
@@ -1,0 +1,205 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mailerConfig,
+  redactEmail,
+  escapeHtml,
+  signInCodeEmail,
+  verificationEmail,
+  sendSignInCodeEmail,
+  sendVerificationEmail,
+  type Mail,
+} from "./mailer.js";
+
+const CFG = { apiKey: "re_key", from: "LISA <no-reply@mail.meetlisa.ai>" };
+
+/** Capture what would go over the wire. */
+function recordingFetch(response = { id: "email_123" }, status = 200) {
+  const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+  const fn = (async (url: string | URL | Request, init?: RequestInit) => {
+    calls.push({ url: String(url), body: JSON.parse(String(init?.body ?? "{}")) });
+    return new Response(JSON.stringify(response), { status });
+  }) as typeof fetch;
+  return { calls, fn };
+}
+
+/** Strip tags/entities so the HTML can be compared as prose. */
+function htmlToText(html: string): string {
+  return html
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+const ALL_MAILS: Array<[string, Mail]> = [
+  ["signInCode", signInCodeEmail("123456", 10)],
+  ["verification", verificationEmail("https://cloud.meetlisa.ai/verify?token=abc123")],
+];
+
+describe("mailer — sending identity", () => {
+  test("defaults to the mail. subdomain Resend verifies, not the apex", () => {
+    const cfg = mailerConfig({});
+    assert.equal(cfg.apiKey, null);
+    assert.match(cfg.from, /@mail\.meetlisa\.ai>$/);
+  });
+
+  test("LISA_MAIL_FROM overrides; blank falls back to the default", () => {
+    assert.equal(mailerConfig({ LISA_MAIL_FROM: "L <hi@mail.meetlisa.ai>" }).from, "L <hi@mail.meetlisa.ai>");
+    assert.match(mailerConfig({ LISA_MAIL_FROM: "   " }).from, /no-reply@mail\.meetlisa\.ai/);
+  });
+});
+
+describe("mailer — log hygiene", () => {
+  test("redaction drops the local part and keeps the whole domain", () => {
+    // The domain stays because delivery problems cluster by provider.
+    assert.equal(redactEmail("alice.smith@example.com"), "al***@example.com");
+    assert.equal(redactEmail("a@b.co"), "a***@b.co");
+  });
+
+  test("malformed addresses redact to nothing rather than leaking", () => {
+    assert.equal(redactEmail("no-at-sign"), "***");
+    assert.equal(redactEmail("@example.com"), "***");
+    assert.equal(redactEmail("trailing@"), "***");
+  });
+
+  test("a recipient never reaches the log intact", async () => {
+    const logged: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => void logged.push(args.join(" "));
+    try {
+      await sendSignInCodeEmail("alice.smith@example.com", "123456", 10, CFG, recordingFetch().fn);
+    } finally {
+      console.error = original;
+    }
+    assert.equal(logged.length, 1, "exactly one line per send");
+    assert.match(logged[0]!, /outcome=success/);
+    assert.ok(!logged[0]!.includes("alice.smith"), "the local part must not be logged");
+    assert.ok(logged[0]!.includes("example.com"), "the domain must be logged");
+  });
+});
+
+describe("mailer — templates", () => {
+  test("the code appears in the subject, the text and the HTML", () => {
+    const mail = signInCodeEmail("123456", 10);
+    assert.match(mail.subject, /123456/); // visible in the notification preview
+    assert.match(mail.text, /123456/);
+    assert.match(mail.html, /123456/);
+    assert.match(mail.text, /10 minutes/);
+  });
+
+  test("every mail ships both parts, and they say the same thing", () => {
+    // multipart/alternative is a deliverability signal — but a text part that
+    // diverges from the HTML is itself a spam signal, so they must agree.
+    for (const [name, mail] of ALL_MAILS) {
+      assert.ok(mail.text.length > 0, `${name}: text part`);
+      assert.ok(mail.html.length > 0, `${name}: html part`);
+      assert.ok(!/<[a-z]/i.test(mail.text), `${name}: the text part must carry no markup`);
+
+      // Every link in the HTML must also be reachable from the text part.
+      const hrefs = [...mail.html.matchAll(/href="([^"]+)"/g)].map((m) => m[1]!);
+      const appLinks = hrefs.filter((h) => h.includes("verify") || h.includes("token"));
+      for (const link of appLinks) {
+        assert.ok(mail.text.includes(link), `${name}: ${link} missing from the text part`);
+      }
+    }
+  });
+
+  test("the HTML is email-client-safe: tables and inline styles, no <style>/flex", () => {
+    for (const [name, mail] of ALL_MAILS) {
+      assert.match(mail.html, /<!DOCTYPE html>/, `${name}: doctype`);
+      assert.match(mail.html, /<table/, `${name}: table layout`);
+      assert.ok(!/<style[\s>]/.test(mail.html), `${name}: no <style> block (Gmail strips it)`);
+      assert.ok(!/display:\s*flex/.test(mail.html), `${name}: no flexbox`);
+    }
+  });
+
+  test("a preheader is present but hidden", () => {
+    for (const [name, mail] of ALL_MAILS) {
+      assert.match(mail.html, /display:none;max-height:0/, `${name}: hidden preheader`);
+    }
+  });
+});
+
+describe("mailer — escaping", () => {
+  test("escapeHtml covers the five dangerous characters", () => {
+    assert.equal(escapeHtml("<script>"), "&lt;script&gt;");
+    assert.equal(escapeHtml('a"b'), "a&quot;b");
+    assert.equal(escapeHtml("a'b"), "a&#39;b");
+    assert.equal(escapeHtml("a&b"), "a&amp;b");
+    assert.equal(escapeHtml("plain"), "plain");
+    // & first, or the other escapes get double-escaped.
+    assert.equal(escapeHtml("&lt;"), "&amp;lt;");
+  });
+
+  test("a hostile verification link can't break out of the attribute", () => {
+    const mail = verificationEmail('https://x/verify?token="><script>alert(1)</script>');
+    assert.ok(!mail.html.includes("<script>alert"), "the payload must not survive as markup");
+    assert.match(mail.html, /&lt;script&gt;/);
+  });
+});
+
+describe("mailer — transport", () => {
+  test("sends both parts to Resend with the configured sender", async () => {
+    const { calls, fn } = recordingFetch();
+    const r = await sendSignInCodeEmail("a@b.co", "654321", 10, CFG, fn);
+    assert.deepEqual(r, { sent: true, detail: "email_123" });
+    assert.equal(calls.length, 1);
+    assert.match(calls[0]!.url, /api\.resend\.com/);
+    const body = calls[0]!.body;
+    assert.equal(body.from, CFG.from);
+    assert.deepEqual(body.to, ["a@b.co"]);
+    assert.match(String(body.text), /654321/);
+    assert.match(String(body.html), /654321/);
+  });
+
+  test("no api key → logged no-op, and the credential reaches the log", async () => {
+    const logged: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => void logged.push(args.join(" "));
+    try {
+      const r = await sendSignInCodeEmail("a@b.co", "123456", 10, mailerConfig({}));
+      assert.deepEqual(r, { sent: false, detail: "no_api_key" });
+    } finally {
+      console.error = original;
+    }
+    // Offline/dev: the operator is the transport, so the code has to be there.
+    assert.match(logged[0]!, /outcome=skipped_no_key/);
+    assert.match(logged[0]!, /123456/);
+  });
+
+  test("a 4xx is a failure even though the response is well-formed", async () => {
+    // Resend answers rate limits and unverified senders with a normal HTTP
+    // response — if that isn't treated as a failure it vanishes silently.
+    const logged: string[] = [];
+    const original = console.error;
+    console.error = (...args: unknown[]) => void logged.push(args.join(" "));
+    let r;
+    try {
+      r = await sendVerificationEmail("a@b.co", "https://x/verify?token=t", CFG,
+        recordingFetch({ id: "" }, 422).fn);
+    } finally {
+      console.error = original;
+    }
+    assert.deepEqual(r, { sent: false, detail: "http_422" });
+    assert.match(logged[0]!, /outcome=send_failed/);
+    assert.match(logged[0]!, /status=422/);
+  });
+
+  test("a network error is reported, not thrown", async () => {
+    const original = console.error;
+    console.error = () => {};
+    let r;
+    try {
+      const boom = (async () => { throw new Error("ECONNRESET"); }) as unknown as typeof fetch;
+      r = await sendVerificationEmail("a@b.co", "https://x/verify?token=t", CFG, boom);
+    } finally {
+      console.error = original;
+    }
+    assert.deepEqual(r, { sent: false, detail: "network_error" });
+  });
+});

--- a/src/web/mailer.ts
+++ b/src/web/mailer.ts
@@ -1,22 +1,47 @@
 /**
  * Outbound mail — account verification and sign-in codes
- * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md B8a; docs/PLAN_AUTH_OTP_GOOGLE_v1.0.md A1).
+ * (docs/PLAN_ACCOUNTS_BILLING_v1.0.md B8a; docs/PLAN_AUTH_OTP_GOOGLE_v1.0.md A1/A6).
  *
- * One provider, two messages, both over Resend's REST API (zero deps): the
- * verification link that levels an email account's free window from $1 to $5,
- * and the one-time code that signs a person in without a password.
+ * One provider (Resend's REST API, zero deps), one choke point, two messages:
+ * the verification link that levels an email account's free window from $1 to
+ * $5, and the one-time code that signs a person in without a password.
+ *
+ * ## Sending identity
+ *
+ * The domain is the **`mail.` subdomain, not the apex**, and that is deliberate:
+ * the apex carries the domain's human mail and its reputation, so signing bulk
+ * transactional mail from a dedicated subdomain keeps a bounce storm here from
+ * poisoning delivery there. Resend must show `mail.meetlisa.ai` as Verified (its
+ * SPF/DKIM records in DNS) before real sends succeed — a `from` outside a
+ * verified domain is refused by the provider, not by us.
+ *
+ * Everything we send today is security mail (a code, a confirmation link), so it
+ * all comes from one no-reply sender with **no `replyTo`** — there is no useful
+ * human on the other end of a sign-in code. When a mail arrives that a person
+ * might sensibly answer, give it its own sender constant and a `replyTo`, rather
+ * than overloading this one; and keep the code default and the deployed env
+ * pointing at the *same* domain, or you get a split-brain where the docs
+ * describe one sending identity and production uses another.
+ *
+ * ## Observability
+ *
+ * Every send goes through `deliver()`, which emits exactly one structured line
+ * with a fixed `outcome` vocabulary — `success` / `skipped_no_key` /
+ * `send_failed`. Recipients are redacted to `ab***@domain.tld`: logs are not a
+ * PII-safe store, but the **domain is kept in full on purpose**, because
+ * delivery problems cluster by provider and that's the first thing you need.
+ *
  * Without RESEND_API_KEY the mailer degrades loudly-but-safely: the link or code
- * is printed to the server log so an operator can forward it by hand (and dev
- * setups keep working offline). **Sign-in by code therefore needs a real key in
+ * is printed to the server log so an operator can forward it by hand, and dev
+ * setups keep working offline. **Sign-in by code therefore needs a real key in
  * production** — a code nobody receives is a sign-in nobody completes.
  *
- * Env: RESEND_API_KEY, LISA_MAIL_FROM (default "LISA <no-reply@meetlisa.ai>";
- * the domain must be verified in Resend before real sends succeed).
+ * Env: RESEND_API_KEY, LISA_MAIL_FROM (default "LISA <no-reply@mail.meetlisa.ai>").
  */
 
 export interface MailResult {
   sent: boolean;
-  /** Provider id or the reason it wasn't sent. */
+  /** Provider id on success, or the reason it wasn't sent. */
   detail: string;
 }
 
@@ -25,27 +50,130 @@ export interface MailerConfig {
   from: string;
 }
 
+/** A composed message. `text` mirrors `html` — see `deliver()`. */
+export interface Mail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
 export function mailerConfig(env: Record<string, string | undefined> = process.env): MailerConfig {
   return {
     apiKey: env.RESEND_API_KEY?.trim() || null,
-    from: env.LISA_MAIL_FROM?.trim() || "LISA <no-reply@meetlisa.ai>",
+    from: env.LISA_MAIL_FROM?.trim() || "LISA <no-reply@mail.meetlisa.ai>",
   };
 }
 
-/** Compose the verification mail (pure — unit-testable). */
-export function verificationEmail(link: string): { subject: string; text: string } {
-  return {
-    subject: "Verify your LISA account email",
-    text:
-      `Confirm this email address for your LISA account by opening the link below:\n\n` +
-      `${link}\n\n` +
-      `Verifying raises your free session allowance to the full amount. The link ` +
-      `expires in 24 hours. If you didn't create a LISA account, ignore this mail.`,
-  };
+// ── log hygiene ─────────────────────────────────────────────────────────────
+
+/**
+ * `alice.smith@example.com` → `al***@example.com`. The local part is the
+ * identifying half, so it goes; the domain stays whole because that's what you
+ * group by when delivery breaks.
+ */
+export function redactEmail(addr: string): string {
+  const at = addr.lastIndexOf("@");
+  if (at <= 0 || at === addr.length - 1) return "***";
+  return `${addr.slice(0, Math.min(2, at))}***@${addr.slice(at + 1)}`;
 }
 
-/** Compose the sign-in code mail (pure — unit-testable). */
-export function signInCodeEmail(code: string, ttlMinutes: number): { subject: string; text: string } {
+// ── HTML templating (hand-rolled: no MJML, no react-email, no deps) ─────────
+// Email HTML is 1998 HTML — tables, inline styles, no flexbox, no <style> that
+// survives Gmail. Everything below emits that shape on purpose.
+
+const BG = "#0b0e13";
+const CARD = "#12161e";
+const BORDER = "#232a36";
+const TEXT = "#e6e9ef";
+const MUTED = "#8a93a5";
+const ACCENT = "#5b8cff";
+
+/** Escape before inlining ANY value that didn't come from this file. */
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+export interface TemplateOpts {
+  /** The grey line clients show after the subject in the inbox list. */
+  preheader?: string;
+}
+
+/**
+ * The shell every mail shares: dark card, wordmark, footer. `content` is
+ * trusted HTML built from the partials below — callers escape their own values.
+ */
+function baseTemplate(content: string, opts: TemplateOpts = {}): string {
+  const preheader = opts.preheader
+    ? `<div style="display:none;max-height:0;overflow:hidden;opacity:0">${escapeHtml(opts.preheader)}</div>`
+    : "";
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="color-scheme" content="dark light">
+</head>
+<body style="margin:0;padding:0;background:${BG};">
+${preheader}
+<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="background:${BG};padding:32px 12px;">
+  <tr><td align="center">
+    <table role="presentation" width="600" cellpadding="0" cellspacing="0" border="0" style="width:100%;max-width:600px;">
+      <tr><td style="padding-bottom:20px;font:600 20px -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:${TEXT};">
+        LISA
+      </td></tr>
+      <tr><td style="background:${CARD};border:1px solid ${BORDER};border-radius:16px;padding:32px 28px;font:16px/1.6 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:${TEXT};">
+${content}
+      </td></tr>
+      <tr><td style="padding-top:18px;font:12px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:${MUTED};">
+        You received this because someone entered this address at
+        <a href="https://meetlisa.ai" style="color:${MUTED};">meetlisa.ai</a>.
+        If that wasn't you, no action is needed.
+      </td></tr>
+    </table>
+  </td></tr>
+</table>
+</body>
+</html>`;
+}
+
+function heading(text: string): string {
+  return `<h1 style="margin:0 0 12px;font-size:20px;font-weight:600;color:${TEXT};">${escapeHtml(text)}</h1>`;
+}
+
+function para(text: string): string {
+  return `<p style="margin:0 0 14px;color:${TEXT};">${escapeHtml(text)}</p>`;
+}
+
+function muted(text: string): string {
+  return `<p style="margin:0;font-size:13px;color:${MUTED};">${escapeHtml(text)}</p>`;
+}
+
+/** The six digits, big enough to read once and type. */
+function codeBlock(code: string): string {
+  return `<p style="margin:20px 0;padding:16px;background:${BG};border:1px solid ${BORDER};border-radius:12px;
+    font:600 30px/1.2 ui-monospace,SFMono-Regular,Menlo,monospace;letter-spacing:.28em;
+    text-align:center;color:${TEXT};">${escapeHtml(code)}</p>`;
+}
+
+function cta(text: string, href: string): string {
+  const safe = escapeHtml(href);
+  return `<p style="margin:22px 0;"><a href="${safe}"
+    style="display:inline-block;padding:12px 22px;background:${ACCENT};color:#fff;
+    text-decoration:none;border-radius:10px;font-weight:600;">${escapeHtml(text)}</a></p>
+<p style="margin:0 0 14px;font-size:13px;color:${MUTED};word-break:break-all;">${safe}</p>`;
+}
+
+// ── the messages (pure — unit-testable, no I/O) ─────────────────────────────
+// Each returns BOTH parts. multipart/alternative is a deliverability signal, and
+// a text part that says something different from the HTML is itself a spam
+// signal — so the two must carry the same words and the same links.
+
+export function signInCodeEmail(code: string, ttlMinutes: number): Mail {
   return {
     subject: `${code} is your LISA sign-in code`,
     text:
@@ -55,14 +183,40 @@ export function signInCodeEmail(code: string, ttlMinutes: number): { subject: st
       `and can be used once.\n\n` +
       `If you didn't try to sign in, ignore this mail — nobody can use the code ` +
       `without reading this inbox.`,
+    html: baseTemplate(
+      heading("Your sign-in code") +
+        para("Enter this code in the app or on the sign-in page:") +
+        codeBlock(code) +
+        para(`It expires in ${ttlMinutes} minutes and can be used once.`) +
+        muted(
+          "If you didn't try to sign in, ignore this mail — nobody can use the code without reading this inbox.",
+        ),
+      { preheader: `${code} — expires in ${ttlMinutes} minutes` },
+    ),
   };
 }
 
-/**
- * Mail the one-time sign-in code. Same degradation as the verification link:
- * with no API key the code goes to the server log (dev/offline), which is why
- * a production deployment must have RESEND_API_KEY set.
- */
+export function verificationEmail(link: string): Mail {
+  return {
+    subject: "Verify your LISA account email",
+    text:
+      `Confirm this email address for your LISA account by opening the link below:\n\n` +
+      `${link}\n\n` +
+      `Verifying raises your free session allowance to the full amount. The link ` +
+      `expires in 24 hours. If you didn't create a LISA account, ignore this mail.`,
+    html: baseTemplate(
+      heading("Confirm your email") +
+        para("Confirm this address for your LISA account:") +
+        cta("Verify this address", link) +
+        para("Verifying raises your free session allowance to the full amount. The link expires in 24 hours.") +
+        muted("If you didn't create a LISA account, ignore this mail."),
+      { preheader: "Confirm your address to unlock the full free allowance" },
+    ),
+  };
+}
+
+// ── transport ───────────────────────────────────────────────────────────────
+
 export async function sendSignInCodeEmail(
   to: string,
   code: string,
@@ -70,7 +224,7 @@ export async function sendSignInCodeEmail(
   cfg: MailerConfig = mailerConfig(),
   fetchFn: typeof fetch = fetch,
 ): Promise<MailResult> {
-  return deliver(to, signInCodeEmail(code, ttlMinutes), `sign-in code for ${to}: ${code}`, cfg, fetchFn);
+  return deliver("signin_code", to, signInCodeEmail(code, ttlMinutes), `code ${code}`, cfg, fetchFn);
 }
 
 export async function sendVerificationEmail(
@@ -79,18 +233,29 @@ export async function sendVerificationEmail(
   cfg: MailerConfig = mailerConfig(),
   fetchFn: typeof fetch = fetch,
 ): Promise<MailResult> {
-  return deliver(to, verificationEmail(link), `verification link for ${to}: ${link}`, cfg, fetchFn);
+  return deliver("verify_link", to, verificationEmail(link), link, cfg, fetchFn);
 }
 
+/**
+ * The single exit. Every send logs exactly one line, tagged `[mail]` with a
+ * fixed `outcome`, so "did it go out?" is one grep and never a guess.
+ *
+ * `fallback` is the credential (code or link) printed ONLY when there's no API
+ * key — that's the offline/dev path, where the operator is the transport.
+ */
 async function deliver(
+  kind: string,
   to: string,
-  mail: { subject: string; text: string },
-  fallbackLog: string,
+  mail: Mail,
+  fallback: string,
   cfg: MailerConfig,
   fetchFn: typeof fetch,
 ): Promise<MailResult> {
+  const who = redactEmail(to);
   if (!cfg.apiKey) {
-    console.error(`[mail] RESEND_API_KEY unset — ${fallbackLog}`);
+    // The one place a live credential is logged: no key means no delivery, so
+    // the alternative is a sign-in nobody can complete.
+    console.error(`[mail] outcome=skipped_no_key kind=${kind} to=${who} — ${fallback}`);
     return { sent: false, detail: "no_api_key" };
   }
   try {
@@ -100,17 +265,30 @@ async function deliver(
         authorization: `Bearer ${cfg.apiKey}`,
         "content-type": "application/json",
       },
-      body: JSON.stringify({ from: cfg.from, to: [to], subject: mail.subject, text: mail.text }),
+      body: JSON.stringify({
+        from: cfg.from,
+        to: [to],
+        subject: mail.subject,
+        text: mail.text,
+        html: mail.html,
+      }),
     });
     if (!res.ok) {
+      // A 4xx here is a *logical* failure (bad domain, unverified sender, rate
+      // limit) that returns a perfectly well-formed response — it must be
+      // logged as loudly as a thrown network error, or it vanishes.
       const body = await res.text().catch(() => "");
-      console.error(`[mail] resend rejected (${res.status}): ${body.slice(0, 200)}`);
+      console.error(
+        `[mail] outcome=send_failed kind=${kind} to=${who} status=${res.status} — ${body.slice(0, 200)}`,
+      );
       return { sent: false, detail: `http_${res.status}` };
     }
     const parsed = (await res.json().catch(() => ({}))) as { id?: string };
-    return { sent: true, detail: parsed.id ?? "sent" };
+    const id = parsed.id ?? "sent";
+    console.error(`[mail] outcome=success kind=${kind} to=${who} id=${id}`);
+    return { sent: true, detail: id };
   } catch (e) {
-    console.error(`[mail] send failed: ${(e as Error).message}`);
+    console.error(`[mail] outcome=send_failed kind=${kind} to=${who} — ${(e as Error).message}`);
     return { sent: false, detail: "network_error" };
   }
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -107,6 +107,7 @@ import {
   GoogleAuthError,
 } from "./googleAuth.js";
 import { requestEmailOtp, verifyEmailOtp, OTP_TTL_MS } from "./otp.js";
+import { checkDeliverable } from "./email-deliverability.js";
 import { sendVerificationEmail, sendSignInCodeEmail } from "./mailer.js";
 import { readBalance, creditPurchase } from "../billing/quota.js";
 import { PushBridge, listPush, registerPush, unregisterPush, setPushPrefs, registerLiveActivity, unregisterLiveActivity, type PushPrefs } from "./push.js";
@@ -1212,6 +1213,20 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       }
 
       if (url === "/api/auth/otp/request") {
+        // Before the send budget is touched: a typo'd address doesn't bounce
+        // back to whoever typed it, so catching it here is the only feedback
+        // they'll get — and it saves a slot of their daily allowance.
+        const reachable = await checkDeliverable(normalizeEmail(email));
+        if (!reachable.ok) {
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(
+            JSON.stringify({
+              error: reachable.reason === "typo" ? "email_typo" : "undeliverable_email",
+              ...(reachable.suggestion ? { suggestion: reachable.suggestion } : {}),
+            }),
+          );
+          return;
+        }
         const minted = await requestEmailOtp(email);
         if (!minted.ok) {
           res.writeHead(429, { "content-type": "application/json" });

--- a/src/web/verification.test.ts
+++ b/src/web/verification.test.ts
@@ -10,8 +10,6 @@ const FILE = path.join(TMP, "accounts.json");
 
 const { createEmailAccount, beginEmailVerification, confirmEmailVerification, upsertAppleAccount, getAccount } =
   await import("./accounts.js");
-const { verificationEmail, mailerConfig, sendVerificationEmail, signInCodeEmail, sendSignInCodeEmail } =
-  await import("./mailer.js");
 
 beforeEach(() => {
   fs.rmSync(FILE, { force: true });
@@ -53,67 +51,5 @@ describe("email verification", () => {
     const raw = (await beginEmailVerification(rec.uid))!;
     await confirmEmailVerification(raw);
     assert.equal(await beginEmailVerification(rec.uid), null);
-  });
-});
-
-describe("mailer", () => {
-  test("compose includes the link; config defaults are sane", () => {
-    const mail = verificationEmail("https://x/verify?token=t");
-    assert.match(mail.text, /https:\/\/x\/verify\?token=t/);
-    const cfg = mailerConfig({});
-    assert.equal(cfg.apiKey, null);
-    assert.match(cfg.from, /meetlisa\.ai/);
-  });
-
-  test("no api key → degrades to logged link, sent:false", async () => {
-    const r = await sendVerificationEmail("a@b.co", "https://x/verify?token=t", mailerConfig({}));
-    assert.deepEqual(r, { sent: false, detail: "no_api_key" });
-  });
-
-  test("sends through the injected fetch and reports the provider id", async () => {
-    const calls: Array<{ url: string; init: RequestInit }> = [];
-    const fakeFetch = (async (url: string | URL | Request, init?: RequestInit) => {
-      calls.push({ url: String(url), init: init! });
-      return new Response(JSON.stringify({ id: "email_123" }), { status: 200 });
-    }) as typeof fetch;
-    const r = await sendVerificationEmail(
-      "a@b.co",
-      "https://x/verify?token=t",
-      { apiKey: "re_key", from: "LISA <no-reply@meetlisa.ai>" },
-      fakeFetch,
-    );
-    assert.deepEqual(r, { sent: true, detail: "email_123" });
-    assert.equal(calls.length, 1);
-    assert.match(calls[0]!.url, /api\.resend\.com/);
-    assert.match(String(calls[0]!.init.body), /a@b\.co/);
-  });
-
-  test("the sign-in code mail carries the code in subject and body", () => {
-    const mail = signInCodeEmail("123456", 10);
-    assert.match(mail.subject, /123456/); // visible in the notification preview
-    assert.match(mail.text, /123456/);
-    assert.match(mail.text, /10 minutes/);
-  });
-
-  test("no api key → the code degrades to a server log, sent:false", async () => {
-    const r = await sendSignInCodeEmail("a@b.co", "123456", 10, mailerConfig({}));
-    assert.deepEqual(r, { sent: false, detail: "no_api_key" });
-  });
-
-  test("the code mail goes out through the same transport", async () => {
-    const bodies: string[] = [];
-    const fakeFetch = (async (_url: string | URL | Request, init?: RequestInit) => {
-      bodies.push(String(init?.body));
-      return new Response(JSON.stringify({ id: "email_456" }), { status: 200 });
-    }) as typeof fetch;
-    const r = await sendSignInCodeEmail(
-      "a@b.co",
-      "654321",
-      10,
-      { apiKey: "re_key", from: "LISA <no-reply@meetlisa.ai>" },
-      fakeFetch,
-    );
-    assert.deepEqual(r, { sent: true, detail: "email_456" });
-    assert.match(bodies[0]!, /654321/);
   });
 });


### PR DESCRIPTION
Stacked on #293. Builds out the mail capability, modelled on the mechanism in the Luddi codebase — taking the parts that earned their keep there and fixing the ones its own docs flag as problems.

## Sending identity: `mail.meetlisa.ai`

The sending domain moves to the **`mail.` subdomain, not the apex**. The apex carries the domain's human mail and its reputation; a bounce storm from transactional mail must not poison it.

The code default and the deployed env now name the **same** domain. Worth calling out, because the reference implementation drifted into a split-brain — its runbook documents one sending domain while production sends auth mail from a different subdomain, and a cold-reputation subdomain was later identified there as the root cause of a spam-folder incident.

## `src/web/mailer.ts` — templates + one logged exit

- **HTML + plain text** for both mails, hand-rolled with no template dependency: tables, inline styles, no `<style>` block (Gmail strips it), no flexbox. A layout with `heading`/`para`/`codeBlock`/`cta` partials and a hidden preheader.
- `escapeHtml` on everything that didn't come from the file. Covered by a test that a hostile verification link can't break out of its attribute.
- **The two parts must say the same thing.** multipart/alternative helps deliverability, but a text part that diverges from the HTML is itself a spam signal — so a test asserts every link in the HTML also appears in the text, and that the text carries no markup.
- **One exit** (`deliver()`), one structured line per send, fixed outcome vocabulary: `success` / `skipped_no_key` / `send_failed`. A non-2xx from Resend is a *well-formed response*, not a thrown error; logging it as loudly as a network failure is the point, or rate limits and unverified senders vanish silently.
- **Redaction**: recipients log as `ab***@domain.tld`. Logs aren't a PII-safe store — but the **domain stays whole on purpose**, because delivery problems cluster by provider and that's the first thing you need. A test asserts the local part never reaches the log.

## `src/web/email-deliverability.ts` — check before you send

Sign-in by code has a failure mode ordinary sign-in doesn't: **a typo'd address doesn't bounce back to whoever typed it**. They wait for a code that went somewhere else, burn a slot of their daily send budget, and can't tell a bad address from a slow one. So the address is checked *before* the budget is touched.

- Deterministic typo lists first (no I/O), which can **suggest the fix** — `gmial.com` → `gmail.com`. Careful that `.co`/`.ne` are real ccTLDs and never rejected by prefix match.
- Then MX, with an A-record fallback (RFC 5321), raced against a 3s timeout.
- **It fails OPEN on every uncertainty.** Only a named typo or a definitive ENOTFOUND/ENODATA on *both* lookups rejects. Locking someone out of their own account because a resolver blinked is far worse than sending one mail into the void — there's a whole test block on this property.

All four clients surface the suggestion, so a typo is one tap from fixed.

## Verification

- `npm test` → **1195 green** (+22: 15 mailer, 13 deliverability, minus 6 superseded). Typecheck clean; Mac `swift build` and iOS `swiftc -typecheck` clean.
- Both mails **rendered in a browser** at desktop and phone width — screenshots in the thread. The long verification token wraps instead of overflowing.

## Operator note

`mail.meetlisa.ai` must show **Verified** in Resend (its SPF/DKIM records in DNS) before real sends succeed — a `from` outside a verified domain is refused by the provider, not by us. Steps in the runbook, Phase 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)