### PR TITLE
feat(auth): email one-time codes — verification, passwordless login, password reset (S2)

### DIFF
--- a/src/web/accounts.ts
+++ b/src/web/accounts.ts
@@ -56,7 +56,23 @@ export interface AccountRecord {
    * the user keeps one uid (one Lisa) across providers.
    */
   googleSub?: string;
+  /** SHA-256 hex of the outstanding one-time code (S2). One OTP at a time. */
+  otpHash?: string;
+  /** What the outstanding code is FOR — a login code never resets a password. */
+  otpPurpose?: OtpPurpose;
+  /** Code expiry, ms epoch (10 minutes from mint). */
+  otpExpiresAt?: number;
+  /** Wrong guesses so far; the code burns itself after OTP_MAX_ATTEMPTS. */
+  otpAttempts?: number;
 }
+
+/**
+ * One-time-code purposes (S2). One infra, three uses:
+ *  - "verify": prove email ownership after signup (levels the free window)
+ *  - "login":  passwordless sign-in for email accounts
+ *  - "reset":  forgot-password — proves ownership, then sets a new password
+ */
+export type OtpPurpose = "verify" | "login" | "reset";
 
 export class AccountError extends Error {
   constructor(public code: "invalid_email" | "weak_password" | "email_taken" | "throttled") {
@@ -426,6 +442,147 @@ export async function ensureSeededAccount(email: string, password: string, now: 
     if (live && !live.verified) live.verified = true;
     return live ?? existing;
   });
+}
+
+// ── one-time codes (S2): verify / passwordless login / password reset ───────
+const OTP_TTL_MS = 10 * 60 * 1000;
+const OTP_MAX_ATTEMPTS = 5;
+const OTP_RESEND_COOLDOWN_MS = 60 * 1000;
+
+// Send-cooldown is keyed by (purpose, email) and applied BEFORE the account
+// lookup, uniformly for unknown emails too — so the 200-vs-429 pattern never
+// leaks whether an address has an account. In-memory is correct for the
+// single-instance cloud (same stance as the login throttle above).
+const otpCooldowns = new Map<string, number>();
+
+/** Test seam. */
+export function resetOtpCooldowns(): void {
+  otpCooldowns.clear();
+}
+
+function clearOtp(acct: AccountRecord): void {
+  delete acct.otpHash;
+  delete acct.otpPurpose;
+  delete acct.otpExpiresAt;
+  delete acct.otpAttempts;
+}
+
+/**
+ * Try to consume the record's outstanding code (mutates in place; call inside
+ * mutateAccounts). Every try counts an attempt; the code burns itself past
+ * OTP_MAX_ATTEMPTS — a 6-digit space is only safe because guessing is capped.
+ */
+function takeOtp(acct: AccountRecord, code: string, purpose: OtpPurpose, now: number): boolean {
+  if (!acct.otpHash || acct.otpPurpose !== purpose) return false;
+  if (!acct.otpExpiresAt || acct.otpExpiresAt < now) return false;
+  const attempts = (acct.otpAttempts ?? 0) + 1;
+  acct.otpAttempts = attempts;
+  if (attempts > OTP_MAX_ATTEMPTS) {
+    clearOtp(acct);
+    return false;
+  }
+  const presented = crypto.createHash("sha256").update(code).digest();
+  let stored: Buffer;
+  try {
+    stored = Buffer.from(acct.otpHash, "hex");
+  } catch {
+    return false;
+  }
+  if (stored.length !== presented.length || !crypto.timingSafeEqual(stored, presented)) return false;
+  clearOtp(acct);
+  return true;
+}
+
+export type OtpBegin =
+  | { status: "ok"; code: string; uid: string }
+  | { status: "cooldown"; retryAfterSec: number }
+  | { status: "none" };
+
+/**
+ * Mint a 6-digit code for (email, purpose). Returns the RAW code once — it
+ * goes into the mail — with only its hash persisted. "none" means no eligible
+ * account; callers still answer 200 so the endpoint can't be used to probe
+ * which emails exist.
+ */
+export async function beginAccountOtp(
+  emailRaw: string,
+  purpose: OtpPurpose,
+  now: number = Date.now(),
+): Promise<OtpBegin> {
+  const email = normalizeEmail(emailRaw);
+  const key = `${purpose}:${email}`;
+  const until = otpCooldowns.get(key) ?? 0;
+  if (until > now) return { status: "cooldown", retryAfterSec: Math.ceil((until - now) / 1000) };
+  otpCooldowns.set(key, now + OTP_RESEND_COOLDOWN_MS);
+  const code = String(crypto.randomInt(0, 1_000_000)).padStart(6, "0");
+  const hash = crypto.createHash("sha256").update(code).digest("hex");
+  return mutateAccounts((list) => {
+    const acct = list.find((a) => a.kind === "email" && a.email === email);
+    if (!acct) return { status: "none" } as const;
+    if (purpose === "verify" && acct.verified) return { status: "none" } as const;
+    acct.otpHash = hash;
+    acct.otpPurpose = purpose;
+    acct.otpExpiresAt = now + OTP_TTL_MS;
+    acct.otpAttempts = 0;
+    return { status: "ok", code, uid: acct.uid } as const;
+  });
+}
+
+/**
+ * Consume a code. Returns the account on success, null on any failure (wrong/
+ * expired/burned code, unknown email). "verify" marks the account verified;
+ * "login" stamps lastLoginAt — the caller mints the session.
+ */
+export async function consumeAccountOtp(
+  emailRaw: string,
+  code: string,
+  purpose: OtpPurpose,
+  now: number = Date.now(),
+): Promise<AccountRecord | null> {
+  const email = normalizeEmail(emailRaw);
+  if (!code || !/^\d{6}$/.test(code)) return null;
+  return mutateAccounts((list) => {
+    const acct = list.find((a) => a.kind === "email" && a.email === email);
+    if (!acct || !takeOtp(acct, code, purpose, now)) return null;
+    if (purpose === "verify") {
+      acct.verified = true;
+      delete acct.verifyTokenHash;
+      delete acct.verifyExpiresAt;
+    }
+    if (purpose === "login") acct.lastLoginAt = now;
+    return acct;
+  });
+}
+
+/**
+ * Forgot-password (S2): consume a "reset" code and install the new password in
+ * one atomic mutation. Bumps sessionVersion (every outstanding session dies),
+ * marks the account verified (the code just proved email ownership), and
+ * clears the login throttle so a locked-out owner can get back in.
+ */
+export async function resetPasswordWithOtp(
+  emailRaw: string,
+  code: string,
+  newPassword: string,
+  now: number = Date.now(),
+): Promise<AccountRecord | null> {
+  if (!validPassword(newPassword)) throw new AccountError("weak_password");
+  const email = normalizeEmail(emailRaw);
+  if (!code || !/^\d{6}$/.test(code)) return null;
+  const scrypt = await hashPassword(newPassword); // CPU work outside the CAS loop
+  const acct = await mutateAccounts((list) => {
+    const live = list.find((a) => a.kind === "email" && a.email === email);
+    if (!live || !takeOtp(live, code, "reset", now)) return null;
+    live.scrypt = scrypt;
+    live.sessionVersion += 1;
+    live.verified = true;
+    delete live.verifyTokenHash;
+    delete live.verifyExpiresAt;
+    live.lastLoginAt = now;
+    return live;
+  });
+  if (acct) clearThrottle(email);
+  return acct;
 }
 
 // ── email-ownership verification (B8a) ──────────────────────────────────────

--- a/src/web/login.ts
+++ b/src/web/login.ts
@@ -50,7 +50,10 @@ export const LOGIN_HTML = `<!doctype html>
   .divider { display: none; align-items: center; gap: 10px; color: #5d6575; font-size: 12px; margin-bottom: 4px; }
   .divider::before, .divider::after { content: ""; flex: 1; height: 1px; background: #232a36; }
   .err { color: #ff7a7a; font-size: 13px; margin-top: 12px; min-height: 1.2em; }
+  .ok { color: #7ad48a; font-size: 13px; min-height: 1.2em; }
   .hint { color: #5d6575; font-size: 12px; margin-top: 18px; }
+  .hint a { color: #8a93a5; text-decoration: none; }
+  .hint a:hover { color: #e6e9ef; }
 </style>
 </head>
 <body>
@@ -67,19 +70,33 @@ export const LOGIN_HTML = `<!doctype html>
   <form id="f">
     <label for="email">Email</label>
     <input id="email" type="email" autocomplete="username" required>
-    <label for="pw">Password</label>
+    <label for="pw" id="pw-label">Password</label>
     <input id="pw" type="password" autocomplete="current-password" minlength="8" required>
+    <label for="code" id="code-label" style="display:none">6-digit code</label>
+    <input id="code" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" style="display:none">
+    <label for="newpw" id="newpw-label" style="display:none">New password</label>
+    <input id="newpw" type="password" autocomplete="new-password" minlength="8" style="display:none">
+    <button id="sendcode" type="button" class="secondary" style="display:none">Email me a code</button>
     <button id="login" type="submit">Sign in</button>
     <button id="register" type="button" class="secondary">Create an account</button>
     <div class="err" id="err"></div>
+    <div class="ok" id="ok"></div>
   </form>
+  <div class="hint">
+    <a href="#" id="mode-code">Sign in with a code instead</a> &nbsp;·&nbsp;
+    <a href="#" id="mode-reset">Forgot password?</a>
+    <a href="#" id="mode-pw" style="display:none">Back to password sign-in</a>
+  </div>
   <div class="hint">Self-hosted with a shared token? Open this page as /?token=&lt;your token&gt;.</div>
 </div>
 <script>
   const f = document.getElementById("f");
   const err = document.getElementById("err");
+  const okMsg = document.getElementById("ok");
   const email = document.getElementById("email");
   const pw = document.getElementById("pw");
+  const codeIn = document.getElementById("code");
+  const newpw = document.getElementById("newpw");
   const MSG = {
     bad_credentials: "Wrong email or password.",
     email_taken: "That email already has an account — use Sign in.",
@@ -87,23 +104,79 @@ export const LOGIN_HTML = `<!doctype html>
     invalid_email: "That doesn't look like an email address.",
     throttled: "Too many attempts — wait 15 minutes.",
     rate_limited: "Too many attempts from this network — try again later.",
+    bad_code: "Wrong or expired code — request a fresh one if needed.",
+    otp_cooldown: "Code already sent — wait a minute before asking again.",
   };
-  async function auth(path) {
-    err.textContent = "";
+  async function post(path, body) {
+    err.textContent = ""; okMsg.textContent = "";
     const res = await fetch(path, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ email: email.value.trim(), password: pw.value }),
+      body: JSON.stringify(body),
     }).catch(() => null);
-    if (!res) { err.textContent = "Network error — try again."; return; }
-    if (res.ok) { location.replace("/"); return; }
+    if (!res) { err.textContent = "Network error — try again."; return null; }
+    return res;
+  }
+  async function showError(res, fallback) {
     let code = "";
     try { code = (await res.json()).error || ""; } catch {}
-    err.textContent = MSG[code] || ("Sign-in failed (" + res.status + ").");
+    err.textContent = MSG[code] || (fallback + " (" + res.status + ").");
   }
-  f.addEventListener("submit", (e) => { e.preventDefault(); auth("/api/auth/login"); });
+  async function auth(path, body) {
+    const res = await post(path, body);
+    if (!res) return;
+    if (res.ok) { location.replace("/"); return; }
+    await showError(res, "Sign-in failed");
+  }
+
+  // Three form modes (S2): password (default) / code (passwordless) / reset.
+  let mode = "pw";
+  function show(el, on) { el.style.display = on ? "" : "none"; }
+  function setMode(m) {
+    mode = m;
+    err.textContent = ""; okMsg.textContent = "";
+    const isPw = m === "pw", isCode = m === "code", isReset = m === "reset";
+    show(document.getElementById("pw-label"), isPw); show(pw, isPw);
+    pw.required = isPw;
+    show(document.getElementById("code-label"), !isPw); show(codeIn, !isPw);
+    codeIn.required = !isPw;
+    show(document.getElementById("newpw-label"), isReset); show(newpw, isReset);
+    newpw.required = isReset;
+    show(document.getElementById("sendcode"), !isPw);
+    show(document.getElementById("register"), isPw);
+    show(document.getElementById("mode-code"), isPw);
+    show(document.getElementById("mode-reset"), isPw);
+    show(document.getElementById("mode-pw"), !isPw);
+    document.getElementById("login").textContent =
+      isReset ? "Reset password" : isCode ? "Sign in with code" : "Sign in";
+  }
+  document.getElementById("mode-code").addEventListener("click", (e) => { e.preventDefault(); setMode("code"); });
+  document.getElementById("mode-reset").addEventListener("click", (e) => { e.preventDefault(); setMode("reset"); });
+  document.getElementById("mode-pw").addEventListener("click", (e) => { e.preventDefault(); setMode("pw"); });
+
+  document.getElementById("sendcode").addEventListener("click", async () => {
+    if (!email.reportValidity()) return;
+    const res = await post("/api/auth/email/code", {
+      email: email.value.trim(),
+      purpose: mode === "reset" ? "reset" : "login",
+    });
+    if (!res) return;
+    if (res.ok) { okMsg.textContent = "Code sent — check your email."; return; }
+    await showError(res, "Couldn't send the code");
+  });
+
+  f.addEventListener("submit", (e) => {
+    e.preventDefault();
+    const addr = email.value.trim();
+    if (mode === "code") { auth("/api/auth/email/login", { email: addr, code: codeIn.value.trim() }); return; }
+    if (mode === "reset") {
+      auth("/api/auth/password/reset", { email: addr, code: codeIn.value.trim(), newPassword: newpw.value });
+      return;
+    }
+    auth("/api/auth/login", { email: addr, password: pw.value });
+  });
   document.getElementById("register").addEventListener("click", () => {
-    if (f.reportValidity()) auth("/api/auth/register");
+    if (f.reportValidity()) auth("/api/auth/register", { email: email.value.trim(), password: pw.value });
   });
 
   // Fresh random nonce, or null when this context can't hash one (#261).

--- a/src/web/mailer.ts
+++ b/src/web/mailer.ts
@@ -30,27 +30,54 @@ export function mailerConfig(env: Record<string, string | undefined> = process.e
   };
 }
 
-/** Compose the verification mail (pure — unit-testable). */
-export function verificationEmail(link: string): { subject: string; text: string } {
+export interface ComposedMail {
+  subject: string;
+  text: string;
+}
+
+/**
+ * Compose the verification mail (pure — unit-testable). With a `code` (S2) the
+ * 6-digit code leads and the link stays as the fallback for mail clients where
+ * typing a code beats tapping a link that an in-app browser may hijack.
+ */
+export function verificationEmail(link: string, code?: string): ComposedMail {
+  const codePart = code
+    ? `Your verification code is: ${code}\n\n` +
+      `Enter it in LISA, or open the link below instead:\n\n`
+    : `Confirm this email address for your LISA account by opening the link below:\n\n`;
   return {
-    subject: "Verify your LISA account email",
+    subject: code ? `${code} is your LISA verification code` : "Verify your LISA account email",
     text:
-      `Confirm this email address for your LISA account by opening the link below:\n\n` +
+      codePart +
       `${link}\n\n` +
-      `Verifying raises your free session allowance to the full amount. The link ` +
+      `Verifying raises your free session allowance to the full amount. ` +
+      `${code ? "The code expires in 10 minutes; the link" : "The link"} ` +
       `expires in 24 hours. If you didn't create a LISA account, ignore this mail.`,
   };
 }
 
-export async function sendVerificationEmail(
+/** Compose a sign-in / password-reset code mail (S2; pure). */
+export function otpEmail(code: string, purpose: "login" | "reset"): ComposedMail {
+  const what = purpose === "login" ? "sign-in" : "password reset";
+  return {
+    subject: `${code} is your LISA ${what} code`,
+    text:
+      `Your LISA ${what} code is: ${code}\n\n` +
+      `It expires in 10 minutes. If you didn't request it, ignore this mail — ` +
+      `nothing happens without the code.`,
+  };
+}
+
+/** Send any composed mail through Resend; degrades to a loud server log without a key. */
+export async function sendMail(
   to: string,
-  link: string,
+  mail: ComposedMail,
   cfg: MailerConfig = mailerConfig(),
   fetchFn: typeof fetch = fetch,
 ): Promise<MailResult> {
-  const mail = verificationEmail(link);
   if (!cfg.apiKey) {
-    console.error(`[mail] RESEND_API_KEY unset — verification link for ${to}: ${link}`);
+    // The operator can hand-forward the secret; flatten so one log line has it.
+    console.error(`[mail] RESEND_API_KEY unset — for ${to}: ${mail.text.replace(/\n+/g, " | ").slice(0, 300)}`);
     return { sent: false, detail: "no_api_key" };
   }
   try {
@@ -73,4 +100,14 @@ export async function sendVerificationEmail(
     console.error(`[mail] send failed: ${(e as Error).message}`);
     return { sent: false, detail: "network_error" };
   }
+}
+
+/** Back-compat wrapper: verification mail without a code. */
+export async function sendVerificationEmail(
+  to: string,
+  link: string,
+  cfg: MailerConfig = mailerConfig(),
+  fetchFn: typeof fetch = fetch,
+): Promise<MailResult> {
+  return sendMail(to, verificationEmail(link), cfg, fetchFn);
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -95,8 +95,11 @@ import {
   ensureSeededAccount,
   beginEmailVerification,
   confirmEmailVerification,
+  beginAccountOtp,
+  consumeAccountOtp,
+  resetPasswordWithOtp,
 } from "./accounts.js";
-import { sendVerificationEmail } from "./mailer.js";
+import { sendMail, verificationEmail, otpEmail } from "./mailer.js";
 import { readBalance, creditPurchase } from "../billing/quota.js";
 import { PushBridge, listPush, registerPush, unregisterPush, setPushPrefs, registerLiveActivity, unregisterLiveActivity, type PushPrefs } from "./push.js";
 import { SenseService } from "../sense/service.js";
@@ -1178,10 +1181,17 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           return;
         }
         // First registration: kick off email verification (B8a) — verifying
-        // levels the free window from $1 to the full $5. Fire-and-forget.
+        // levels the free window from $1 to the full $5. One mail carries both
+        // the 6-digit code (S2, primary) and the link (fallback). Fire-and-forget.
         if (url === "/api/auth/register") {
           const raw = await beginEmailVerification(acct.uid);
-          if (raw) void sendVerificationEmail(acct.email!, verifyLinkFor(req, raw));
+          const otp = await beginAccountOtp(acct.email!, "verify");
+          if (raw) {
+            void sendMail(
+              acct.email!,
+              verificationEmail(verifyLinkFor(req, raw), otp.status === "ok" ? otp.code : undefined),
+            );
+          }
         }
         const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
         res.writeHead(200, {
@@ -1199,6 +1209,116 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         }
         res.writeHead(500, { "content-type": "text/plain" });
         res.end("account operation failed");
+      }
+      return;
+    }
+
+    // ── One-time codes (S2; pre-gate, same posture as register/login) ────────
+    // Request a code for passwordless login / password reset / verification.
+    // ALWAYS answers ok for ok/none so the endpoint can't probe which emails
+    // exist; the send-cooldown 429 is uniform for unknown emails too.
+    if (req.method === "POST" && url === "/api/auth/email/code") {
+      if (!cloud || !sessionSecret) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("accounts not available on this edition");
+        return;
+      }
+      if (!ipRateOk(`auth:${clientIp(req, remoteAddr)}`, AUTH_IP_LIMIT, AUTH_IP_WINDOW_MS)) {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "rate_limited", retryAfterSec: Math.ceil(AUTH_IP_WINDOW_MS / 1000) }));
+        return;
+      }
+      const body = await readJsonBody(req, res);
+      if (!body) return; // 413 already sent
+      const email = typeof body.email === "string" ? body.email : "";
+      const purpose = body.purpose === "reset" ? "reset" as const
+        : body.purpose === "verify" ? "verify" as const
+        : "login" as const;
+      const begin = await beginAccountOtp(email, purpose);
+      if (begin.status === "cooldown") {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "otp_cooldown", retryAfterSec: begin.retryAfterSec }));
+        return;
+      }
+      if (begin.status === "ok") {
+        void sendMail(email.trim().toLowerCase(), otpEmail(begin.code, purpose === "reset" ? "reset" : "login"));
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
+    // Passwordless sign-in: 6-digit code → per-uid session (S2).
+    if (req.method === "POST" && url === "/api/auth/email/login") {
+      if (!cloud || !sessionSecret) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("accounts not available on this edition");
+        return;
+      }
+      if (!ipRateOk(`auth:${clientIp(req, remoteAddr)}`, AUTH_IP_LIMIT, AUTH_IP_WINDOW_MS)) {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "rate_limited", retryAfterSec: Math.ceil(AUTH_IP_WINDOW_MS / 1000) }));
+        return;
+      }
+      const body = await readJsonBody(req, res);
+      if (!body) return;
+      const email = typeof body.email === "string" ? body.email : "";
+      const code = typeof body.code === "string" ? body.code.trim() : "";
+      const acct = await consumeAccountOtp(email, code, "login");
+      if (!acct) {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "bad_code" }));
+        return;
+      }
+      const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
+      res.writeHead(200, {
+        "content-type": "application/json",
+        "set-cookie": `lisa_token=${encodeURIComponent(session)}; HttpOnly; SameSite=Strict; Path=/${isCloud() ? "; Secure" : ""}`,
+      });
+      res.end(JSON.stringify({ ok: true, token: session, uid: acct.uid, verified: acct.verified }));
+      return;
+    }
+
+    // Forgot password: reset code + new password → fresh session (S2). The
+    // sessionVersion bump inside resetPasswordWithOtp kills every old session;
+    // the session minted here carries the NEW sv.
+    if (req.method === "POST" && url === "/api/auth/password/reset") {
+      if (!cloud || !sessionSecret) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("accounts not available on this edition");
+        return;
+      }
+      if (!ipRateOk(`auth:${clientIp(req, remoteAddr)}`, AUTH_IP_LIMIT, AUTH_IP_WINDOW_MS)) {
+        res.writeHead(429, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "rate_limited", retryAfterSec: Math.ceil(AUTH_IP_WINDOW_MS / 1000) }));
+        return;
+      }
+      const body = await readJsonBody(req, res);
+      if (!body) return;
+      const email = typeof body.email === "string" ? body.email : "";
+      const code = typeof body.code === "string" ? body.code.trim() : "";
+      const newPassword = typeof body.newPassword === "string" ? body.newPassword : "";
+      try {
+        const acct = await resetPasswordWithOtp(email, code, newPassword);
+        if (!acct) {
+          res.writeHead(401, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "bad_code" }));
+          return;
+        }
+        const session = mintSession(acct.uid, sessionSecret, { sv: acct.sessionVersion });
+        res.writeHead(200, {
+          "content-type": "application/json",
+          "set-cookie": `lisa_token=${encodeURIComponent(session)}; HttpOnly; SameSite=Strict; Path=/${isCloud() ? "; Secure" : ""}`,
+        });
+        res.end(JSON.stringify({ ok: true, token: session, uid: acct.uid, verified: acct.verified }));
+      } catch (e) {
+        if (e instanceof AccountError) {
+          res.writeHead(400, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: e.code }));
+          return;
+        }
+        res.writeHead(500, { "content-type": "text/plain" });
+        res.end("password reset failed");
       }
       return;
     }
@@ -1529,9 +1649,43 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         return;
       }
       const raw = await beginEmailVerification(acct.uid);
-      const mail = raw ? await sendVerificationEmail(acct.email, verifyLinkFor(req, raw)) : null;
+      const otp = await beginAccountOtp(acct.email, "verify");
+      const mail = raw
+        ? await sendMail(
+            acct.email,
+            verificationEmail(verifyLinkFor(req, raw), otp.status === "ok" ? otp.code : undefined),
+          )
+        : null;
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: true, sent: mail?.sent ?? false }));
+      return;
+    }
+
+    // Confirm the signed-in account's email with the mailed 6-digit code (S2)
+    // — the in-app alternative to tapping the /verify link.
+    if (req.method === "POST" && url === "/api/auth/verify/confirm") {
+      const acct = accountUid ? await getAccount(accountUid) : null;
+      if (!acct || acct.kind !== "email" || !acct.email) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "email_account_required" }));
+        return;
+      }
+      if (acct.verified) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, verified: true }));
+        return;
+      }
+      const body = await readJsonBody(req, res);
+      if (!body) return;
+      const code = typeof body.code === "string" ? body.code.trim() : "";
+      const confirmed = await consumeAccountOtp(acct.email, code, "verify");
+      if (!confirmed) {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "bad_code" }));
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true, verified: true }));
       return;
     }
 

--- a/src/web/verification.test.ts
+++ b/src/web/verification.test.ts
@@ -8,12 +8,26 @@ const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-verify-"));
 process.env.LISA_HOME = TMP;
 const FILE = path.join(TMP, "accounts.json");
 
-const { createEmailAccount, beginEmailVerification, confirmEmailVerification, upsertAppleAccount, getAccount } =
-  await import("./accounts.js");
-const { verificationEmail, mailerConfig, sendVerificationEmail } = await import("./mailer.js");
+const {
+  createEmailAccount,
+  beginEmailVerification,
+  confirmEmailVerification,
+  upsertAppleAccount,
+  getAccount,
+  beginAccountOtp,
+  consumeAccountOtp,
+  resetPasswordWithOtp,
+  resetOtpCooldowns,
+  resetLoginThrottles,
+  verifyEmailLogin,
+  AccountError,
+} = await import("./accounts.js");
+const { verificationEmail, otpEmail, mailerConfig, sendVerificationEmail } = await import("./mailer.js");
 
 beforeEach(() => {
   fs.rmSync(FILE, { force: true });
+  resetOtpCooldowns();
+  resetLoginThrottles();
 });
 
 describe("email verification", () => {
@@ -55,6 +69,94 @@ describe("email verification", () => {
   });
 });
 
+describe("one-time codes (S2)", () => {
+  test("begin → consume round-trip for login; purpose is enforced", async () => {
+    const rec = await createEmailAccount("otp@a.co", "password-123", 1000);
+    const begin = await beginAccountOtp("OTP@A.co", "login", 1000);
+    assert.equal(begin.status, "ok");
+    if (begin.status !== "ok") return;
+    assert.match(begin.code, /^\d{6}$/);
+    // raw code never persisted, only its hash
+    assert.equal(fs.readFileSync(FILE, "utf8").includes(begin.code), false);
+    // a login code must not reset a password or verify the email
+    assert.equal(await consumeAccountOtp("otp@a.co", begin.code, "reset", 2000), null);
+    // ...and the wrong-purpose try didn't burn the code for its real purpose:
+    const ok = await consumeAccountOtp("otp@a.co", begin.code, "login", 3000);
+    assert.equal(ok?.uid, rec.uid);
+    assert.equal(ok?.lastLoginAt, 3000);
+    // consumed — replay fails
+    assert.equal(await consumeAccountOtp("otp@a.co", begin.code, "login", 4000), null);
+  });
+
+  test("verify purpose levels the account", async () => {
+    const rec = await createEmailAccount("v@a.co", "password-123");
+    const begin = await beginAccountOtp("v@a.co", "verify", 1000);
+    assert.equal(begin.status, "ok");
+    if (begin.status !== "ok") return;
+    const ok = await consumeAccountOtp("v@a.co", begin.code, "verify", 2000);
+    assert.equal(ok?.verified, true);
+    assert.equal((await getAccount(rec.uid))?.verified, true);
+    // an already-verified account can't begin another verify code
+    resetOtpCooldowns();
+    assert.equal((await beginAccountOtp("v@a.co", "verify", 3000)).status, "none");
+  });
+
+  test("send-cooldown is uniform — known and unknown emails throttle alike", async () => {
+    await createEmailAccount("cool@a.co", "password-123");
+    assert.equal((await beginAccountOtp("cool@a.co", "login", 1000)).status, "ok");
+    assert.equal((await beginAccountOtp("cool@a.co", "login", 2000)).status, "cooldown");
+    // unknown email: first call answers "none" but STILL arms the cooldown
+    assert.equal((await beginAccountOtp("ghost@a.co", "login", 1000)).status, "none");
+    assert.equal((await beginAccountOtp("ghost@a.co", "login", 2000)).status, "cooldown");
+    // cooldown expires
+    assert.equal((await beginAccountOtp("cool@a.co", "login", 1000 + 61_000)).status, "ok");
+  });
+
+  test("five wrong guesses burn the code", async () => {
+    await createEmailAccount("burn@a.co", "password-123");
+    const begin = await beginAccountOtp("burn@a.co", "login", 1000);
+    if (begin.status !== "ok") { assert.fail("expected ok"); }
+    const wrong = begin.code === "000000" ? "000001" : "000000";
+    for (let i = 0; i < 5; i++) {
+      assert.equal(await consumeAccountOtp("burn@a.co", wrong, "login", 2000), null);
+    }
+    // even the CORRECT code now fails — burned
+    assert.equal(await consumeAccountOtp("burn@a.co", begin.code, "login", 3000), null);
+  });
+
+  test("codes expire after 10 minutes", async () => {
+    await createEmailAccount("exp@a.co", "password-123");
+    const begin = await beginAccountOtp("exp@a.co", "login", 1000);
+    if (begin.status !== "ok") { assert.fail("expected ok"); }
+    assert.equal(await consumeAccountOtp("exp@a.co", begin.code, "login", 1000 + 11 * 60_000), null);
+  });
+
+  test("password reset: new password lands, sessions die, account verifies", async () => {
+    const rec = await createEmailAccount("r@a.co", "old-password-1", 1000);
+    const begin = await beginAccountOtp("r@a.co", "reset", 2000);
+    if (begin.status !== "ok") { assert.fail("expected ok"); }
+    await assert.rejects(
+      resetPasswordWithOtp("r@a.co", begin.code, "short", 3000),
+      (e: InstanceType<typeof AccountError>) => e.code === "weak_password",
+    );
+    const after = await resetPasswordWithOtp("r@a.co", begin.code, "new-password-1", 3000);
+    assert.equal(after?.uid, rec.uid);
+    assert.equal(after?.sessionVersion, rec.sessionVersion + 1); // old sessions dead
+    assert.equal(after?.verified, true); // code proved ownership
+    assert.equal(await verifyEmailLogin("r@a.co", "old-password-1"), null);
+    assert.equal((await verifyEmailLogin("r@a.co", "new-password-1"))?.uid, rec.uid);
+  });
+
+  test("consume for an unknown email or malformed code is a clean null", async () => {
+    assert.equal(await consumeAccountOtp("nobody@a.co", "123456", "login"), null);
+    await createEmailAccount("m@a.co", "password-123");
+    const begin = await beginAccountOtp("m@a.co", "login", 1000);
+    if (begin.status !== "ok") { assert.fail("expected ok"); }
+    assert.equal(await consumeAccountOtp("m@a.co", "12345", "login", 2000), null); // 5 digits
+    assert.equal(await consumeAccountOtp("m@a.co", "", "login", 2000), null);
+  });
+});
+
 describe("mailer", () => {
   test("compose includes the link; config defaults are sane", () => {
     const mail = verificationEmail("https://x/verify?token=t");
@@ -62,6 +164,18 @@ describe("mailer", () => {
     const cfg = mailerConfig({});
     assert.equal(cfg.apiKey, null);
     assert.match(cfg.from, /meetlisa\.ai/);
+  });
+
+  test("verification mail with a code leads with it and keeps the link fallback (S2)", () => {
+    const mail = verificationEmail("https://x/verify?token=t", "123456");
+    assert.match(mail.subject, /123456/);
+    assert.match(mail.text, /123456/);
+    assert.match(mail.text, /https:\/\/x\/verify\?token=t/);
+  });
+
+  test("otp mails name their purpose (S2)", () => {
+    assert.match(otpEmail("654321", "login").subject, /654321.*sign-in/);
+    assert.match(otpEmail("654321", "reset").text, /password reset code is: 654321/);
   });
 
   test("no api key → degrades to logged link, sent:false", async () => {


### PR DESCRIPTION
Part of [PLAN_WEB_SIGNUP_v1.0](https://github.com/oratis/LISA/pull/296) — milestone **S2**. **Stacked on #297** (S1); merge that first — GitHub will retarget this to `main`.

## What

One OTP infrastructure, three uses:

1. **Signup email verification by code** — the verification mail now leads with a 6-digit code (mobile-friendly; in-app browsers hijack links) and keeps the 24h link as fallback. New session-authed `POST /api/auth/verify/confirm`.
2. **Passwordless sign-in** — `POST /api/auth/email/code` + `POST /api/auth/email/login`. Same trust root as an emailed reset link, so no new assumptions (plan §7 D4 verdict).
3. **Password reset** — fills a real hole: there was **no forgot-password flow at all**. `POST /api/auth/password/reset` consumes a reset code and installs the new scrypt hash atomically, bumps `sessionVersion` (kills every outstanding session), and marks the account verified (the code just proved ownership).

## Hardening

- Codes hashed at rest (raw never persisted), 10 min TTL, **5-attempt burn** (a 1M code space is only safe because guessing is capped), constant-time compare, purpose-scoped so a login code can never reset a password.
- Send-cooldown (60s) keyed by (purpose, email) and armed **uniformly for unknown emails** — the 200-vs-429 pattern can't probe which addresses have accounts.
- All three endpoints share the per-IP auth rate bucket; code-request always answers `{ok:true}` for existing and unknown emails alike.

## Login page

Three-mode form (password / code / reset) with a send-code flow; new modes toggle `required` flags so hidden inputs never block validity. Covered by the LOGIN_HTML syntax guard from S1.

## Tests

`npm test`: 1305 pass / 0 fail. New: 7 OTP cases (round-trip, purpose enforcement, uniform cooldown, attempt burn, expiry, reset semantics, malformed input) + 2 mail-compose cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)