### PR TITLE
fix(mail): detect real imapflow auth rejections; stop blaming the password for host errors

### DIFF
--- a/src/mail/connect-error.test.ts
+++ b/src/mail/connect-error.test.ts
@@ -1,0 +1,67 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { friendlyMailError } from "./connect-error.js";
+
+/**
+ * The exact error imapflow throws when Gmail rejects an app-password, captured
+ * from a live imap.gmail.com:993 probe. Note `message` is a useless "Command
+ * failed" — an earlier version keyed only on that and so fell through to the
+ * generic branch, which defeated the whole point of the guided connect UI.
+ */
+function gmailAuthRejection(): Error {
+  return Object.assign(new Error("Command failed"), {
+    response: "3 NO [AUTHENTICATIONFAILED] Invalid credentials (Failure)",
+    responseStatus: "NO",
+    executedCommand: "3 AUTHENTICATE PLAIN",
+    responseText: "Invalid credentials (Failure)",
+    serverResponseCode: "AUTHENTICATIONFAILED",
+    authenticationFailed: true,
+  });
+}
+
+test("real imapflow Gmail auth rejection → the app-password hint, not the generic branch", () => {
+  const msg = friendlyMailError(gmailAuthRejection(), "me@gmail.com", "imap.gmail.com");
+  assert.match(msg, /16-character app password/);
+  assert.match(msg, /2-Step Verification/);
+  assert.doesNotMatch(msg, /Command failed/);
+});
+
+test("auth rejection is detected from authenticationFailed alone", () => {
+  // Same failure with every text clue stripped — the boolean must carry it.
+  const bare = Object.assign(new Error("Command failed"), { authenticationFailed: true });
+  const msg = friendlyMailError(bare, "me@qq.com", "imap.qq.com");
+  assert.match(msg, /app-password \/ authorization code/);
+});
+
+test("non-Gmail auth failure gets the generic app-password wording", () => {
+  const msg = friendlyMailError(gmailAuthRejection(), "me@qq.com", "imap.qq.com");
+  assert.match(msg, /app-password \/ authorization code/);
+  assert.doesNotMatch(msg, /Gmail/);
+});
+
+test("gmail is recognized by host even when the address is a custom domain", () => {
+  const msg = friendlyMailError(gmailAuthRejection(), "me@mydomain.com", "imap.gmail.com");
+  assert.match(msg, /Gmail rejected the sign-in/);
+});
+
+test("DNS failure → check-the-host hint", () => {
+  const dns = Object.assign(new Error("getaddrinfo ENOTFOUND imap.nope.invalid"), { code: "ENOTFOUND" });
+  assert.match(friendlyMailError(dns, "me@nope.invalid", "imap.nope.invalid"), /Could not find the mail server/);
+});
+
+test("timeout → network hint", () => {
+  const to = new Error("timed out reaching the mail server");
+  assert.match(friendlyMailError(to, "me@x.com", "imap.x.com"), /network or timeout/);
+});
+
+test("unknown failure surfaces the server's own text, not \"Command failed\"", () => {
+  const odd = Object.assign(new Error("Command failed"), { responseText: "Server busy, try later" });
+  const msg = friendlyMailError(odd, "me@x.com", "imap.x.com");
+  assert.match(msg, /Server busy, try later/);
+  assert.doesNotMatch(msg, /Command failed/);
+});
+
+test("a non-Error value does not throw", () => {
+  assert.ok(friendlyMailError("boom", "me@x.com", "imap.x.com").length > 0);
+  assert.ok(friendlyMailError(undefined, "me@x.com", "imap.x.com").length > 0);
+});

--- a/src/mail/connect-error.ts
+++ b/src/mail/connect-error.ts
@@ -1,0 +1,68 @@
+/**
+ * Map a raw IMAP connect/probe failure to a plain-language hint for the
+ * connect-mailbox UI.
+ *
+ * Kept as its own pure module so it is unit-testable without importing the web
+ * server: the shape of an imapflow auth rejection is subtle enough that it
+ * needs a pinned regression test (see connect-error.test.ts).
+ */
+
+/** The parts of an imapflow error we key on. All optional — errors vary. */
+interface ImapErrorish {
+  message?: unknown;
+  /** Server text, e.g. "Invalid credentials (Failure)". */
+  responseText?: unknown;
+  /** e.g. "AUTHENTICATIONFAILED". */
+  serverResponseCode?: unknown;
+  /** imapflow sets this outright on an auth rejection. */
+  authenticationFailed?: unknown;
+  /** Node syscall errors, e.g. "ENOTFOUND". */
+  code?: unknown;
+}
+
+/**
+ * The single biggest cause of a failed connect is pasting a login password
+ * where an app-password / authorization code is required, so lead with that.
+ */
+export function friendlyMailError(err: unknown, email: string, host: string): string {
+  // imapflow reports an auth rejection as a bare `message: "Command failed"` —
+  // the actual signal lives on the error object (authenticationFailed +
+  // serverResponseCode "AUTHENTICATIONFAILED" + responseText "Invalid
+  // credentials (Failure)"). Match on all of it, not just `message`, or the
+  // most common failure of all falls through to the useless generic branch.
+  const e = (err ?? {}) as ImapErrorish;
+  const raw = err instanceof Error ? err.message : String(err);
+  const serverText = typeof e.responseText === "string" && e.responseText ? e.responseText : "";
+  const m = [raw, serverText, e.serverResponseCode, e.code]
+    .filter((t): t is string => typeof t === "string")
+    .join(" ")
+    .toLowerCase();
+  const isGmail = /(^|@)(gmail\.com|googlemail\.com)$/.test(email.toLowerCase()) || host === "imap.gmail.com";
+  const authHint = isGmail
+    ? "Gmail rejected the sign-in. Use a 16-character app password (not your Google login password), and make sure 2-Step Verification is on."
+    : "Authentication failed. Use an app-password / authorization code from your mail provider — not your login password.";
+
+  // 1. Signals the server states outright. Definitive — check these first.
+  if (e.authenticationFailed === true) return authHint;
+  if (String(e.serverResponseCode ?? "").toUpperCase() === "AUTHENTICATIONFAILED") return authHint;
+
+  // 2. Transport failures. These carry precise syscall codes, and must be
+  //    checked BEFORE the loose auth text heuristic below: a DNS error embeds
+  //    the hostname ("getaddrinfo ENOTFOUND imap.nope.invalid"), so a host
+  //    containing a word like "invalid" would otherwise be misread as a
+  //    credentials problem and send the user chasing the wrong fix.
+  if (/enotfound|eai_again|getaddrinfo|no such host|dns/.test(m)) {
+    return "Could not find the mail server. Check the IMAP host.";
+  }
+  if (/timed out|timeout|etimedout|econn|network|socket|refused/.test(m)) {
+    return "Could not reach the mail server (network or timeout). Check your connection and the IMAP host.";
+  }
+
+  // 3. Text heuristic, for servers that set no structured auth flag. Note
+  //    "credential" already covers "Invalid credentials", so no bare "invalid".
+  if (/auth|credential|denied|not accepted|username|password|login/.test(m)) {
+    return authHint;
+  }
+  // Prefer the server's own words over imapflow's opaque "Command failed".
+  return "Could not connect: " + (serverText || raw).slice(0, 160);
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -65,6 +65,7 @@ import { managedRegistry } from "../agents/managed.js";
 import { ptyRegistry, ptyEnabled, normalizeAgentKind } from "../agents/pty.js";
 import { liveClaudeSessionIds } from "../integrations/claude-code/liveness.js";
 import { sweepAll, pollNewMail, probeAccount } from "../mail/service.js";
+import { friendlyMailError } from "../mail/connect-error.js";
 import { pickImportant, formatAlert, alertLevel, pollMinutes } from "../mail/alerts.js";
 import { latestDigest } from "../mail/store.js";
 import { formatDigestText } from "../mail/digest.js";
@@ -132,28 +133,6 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ASSETS_DIR = path.join(__dirname, "assets");
 const MUSIC_DIR = path.join(ASSETS_DIR, "room", "music");
 
-/**
- * Turn a raw IMAP probe failure into a plain-language hint for the connect
- * modal. The single biggest cause is pasting a login password where an
- * app-password / authorization code is required, so lead with that.
- */
-function friendlyMailError(err: unknown, email: string, host: string): string {
-  const raw = err instanceof Error ? err.message : String(err);
-  const m = raw.toLowerCase();
-  const isGmail = /(^|@)(gmail\.com|googlemail\.com)$/.test(email.toLowerCase()) || host === "imap.gmail.com";
-  if (/auth|credential|login|invalid|denied|not accepted|username|password/.test(m)) {
-    return isGmail
-      ? "Gmail rejected the sign-in. Use a 16-character app password (not your Google login password), and make sure 2-Step Verification is on."
-      : "Authentication failed. Use an app-password / authorization code from your mail provider — not your login password.";
-  }
-  if (/enotfound|eai_again|getaddrinfo|dns|no such host/.test(m)) {
-    return "Could not find the mail server. Check the IMAP host.";
-  }
-  if (/timed out|timeout|etimedout|econn|network|socket|refused/.test(m)) {
-    return "Could not reach the mail server (network or timeout). Check your connection and the IMAP host.";
-  }
-  return "Could not connect: " + raw.slice(0, 160);
-}
 
 
 export interface WebServerOptions {


### PR DESCRIPTION
Found by running the connect flow end-to-end against the real
`imap.gmail.com:993` after #234 shipped.

## Bug 1 — the app-password hint never fired (the common case)

imapflow reports an auth rejection as a bare **`message: "Command failed"`**;
the real signal is on the error *object*:

```
message             : "Command failed"
authenticationFailed: true
serverResponseCode  : "AUTHENTICATIONFAILED"
responseText        : "Invalid credentials (Failure)"
```

`friendlyMailError()` matched only on `message`, so a wrong Gmail password —
the single most common failure, and the exact thing the guided modal exists to
prevent — fell through to the generic branch and showed:

> Could not connect: Command failed

Now it keys on `authenticationFailed` / `serverResponseCode` / `responseText`
too, and the generic fallback prefers the server's own words over imapflow's
opaque `"Command failed"`.

## Bug 2 — a bad hostname was reported as a credentials problem

Caught by the new tests. The loose auth regex contained a bare `invalid`, and a
DNS error embeds the hostname:

```
getaddrinfo ENOTFOUND imap.nope.invalid
                                ^^^^^^^ matched the auth branch
```

So a typo'd IMAP host told the user their password was wrong, sending them off
to regenerate an app-password that was never the problem. Transport failures
(DNS / timeout / refused) are now checked **before** the text heuristic, and
`invalid` is dropped (`credential` already covers "Invalid credentials").

Resulting precedence: structured auth flags → transport → text heuristic → generic.

## Testability

Extracted the mapper from `server.ts` into `src/mail/connect-error.ts` so it is
unit-testable without importing the whole web server, and added
`connect-error.test.ts` with the **real** imapflow error shape captured from a
live probe pinned as a fixture — that shape is subtle enough that it needs a
regression test.

## Verification

Live, against the deployed backend:

```
# wrong Gmail password → real imap.gmail.com rejection
Gmail rejected the sign-in. Use a 16-character app password (not your Google
login password), and make sure 2-Step Verification is on.   [HTTP 401]

# bad IMAP host → transport hint, not a password hint
Could not reach the mail server (network or timeout). …      [HTTP 401]
```

Neither failed attempt was persisted (verify-before-store still holds).
`tsc --noEmit` clean · full suite **1288 pass / 0 fail**.
