### PR TITLE
feat(cloud): per-uid autonomy sweep + Mac-bridge entry (S4)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -79,6 +79,12 @@ ENVS="^##^LISA_EDITION=cloud##LISA_WEB_TOKEN=${LISA_WEB_TOKEN}"
 [ -n "${LISA_TURNSTILE_SECRET:-}" ]   && ENVS="${ENVS}##LISA_TURNSTILE_SECRET=${LISA_TURNSTILE_SECRET}"
 # Extra disposable-email domains to block at signup (comma-separated; S3).
 [ -n "${LISA_EMAIL_BLOCKLIST:-}" ]    && ENVS="${ENVS}##LISA_EMAIL_BLOCKLIST=${LISA_EMAIL_BLOCKLIST}"
+# Per-uid autonomy sweep (S4): bearer secret for POST /internal/autonomy/sweep.
+# Pair it with a Cloud Scheduler job, e.g.:
+#   gcloud scheduler jobs create http lisa-autonomy-sweep --schedule "*/30 * * * *" \
+#     --uri "$URL/internal/autonomy/sweep" --http-method POST \
+#     --headers "Authorization=Bearer $LISA_SWEEP_TOKEN" --location "$REGION"
+[ -n "${LISA_SWEEP_TOKEN:-}" ]        && ENVS="${ENVS}##LISA_SWEEP_TOKEN=${LISA_SWEEP_TOKEN}"
 # Accounts & billing era (PLAN_ACCOUNTS_BILLING B1–B7), all optional:
 #   LISA_REVIEWER_SEED="email:password"  idempotent App-Review demo account (verified, $20/Tier-2)
 #   LISA_RPM_LIMIT / LISA_DAILY_CAP_USD  abuse guards (defaults 20 rpm / $200 per day)

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -5,6 +5,7 @@ import { DEFAULT_MODEL } from "./llm.js";
 import { appendMemory, type MemoryStore } from "./memory/store.js";
 import { reflectionsDir } from "./paths.js";
 import { providerForModel } from "./providers/registry.js";
+import type { ProviderUsage } from "./providers/types.js";
 import { createSkill, getSkill, patchSkill } from "./skills/manager.js";
 import { withSoulCaller } from "./soul/git.js";
 import { recordAutonomyRun } from "./autonomy/runs.js";
@@ -99,6 +100,10 @@ export interface ReflectionResult {
   /** True when a substantial session produced 0 operations (an observability
    *  signal, not an error — see detectUnderReflection). */
   underReflected?: boolean;
+  /** Token usage for this pass (reflector call + any retry), so a cloud caller
+   *  (the autonomy sweep) can meter the spend against the global cap. Absent on
+   *  the too-short early return, which makes no provider call. */
+  usage?: ProviderUsage;
 }
 
 const REFLECTOR_RETRY_SUFFIX = `\n\nCRITICAL: your previous output could not be parsed. Output ONLY a single valid JSON object matching the schema — no prose, no markdown code fence, nothing before or after the JSON.`;
@@ -253,6 +258,7 @@ async function reflectOnSessionInner(opts: {
         skipped: [`raw: ${raw.slice(0, 200)}`],
         raw,
         malformed: true,
+        usage: { inputTokens: inTok, outputTokens: outTok, cacheReadTokens: 0, cacheWriteTokens: 0 },
       };
     }
   }
@@ -418,7 +424,14 @@ async function reflectOnSessionInner(opts: {
     note: underReflected ? "underreflected" : undefined,
   });
 
-  return { summary: payload.summary, applied, skipped, raw, underReflected };
+  return {
+    summary: payload.summary,
+    applied,
+    skipped,
+    raw,
+    underReflected,
+    usage: { inputTokens: inTok, outputTokens: outTok, cacheReadTokens: 0, cacheWriteTokens: 0 },
+  };
 }
 
 /**

--- a/src/web/account-page.ts
+++ b/src/web/account-page.ts
@@ -59,6 +59,14 @@ export const ACCOUNT_HTML = `<!doctype html>
     <button data-pack="20"><span>$22.00 credits (+10%) · Tier 2</span><b>$19.99</b></button>
   </div>
 
+  <h2>Your Mac</h2>
+  <div class="row" style="display:block; font-size: 13px; color: #8a93a5;">
+    Cloud Lisa carries her soul, memory, knowledge and chat. Terminal control,
+    screen sense and local dispatch live on your own machine — by design.
+    Pair the Mac app to bring them into this account (identity bridge, coming
+    soon). <a href="https://meetlisa.ai/install" style="color:#5b8cff">Get the Mac app →</a>
+  </div>
+
   <button class="quiet" id="logout">Sign out</button>
   <div class="note">Buying in the iOS app works too — credits roam with the account either way.</div>
 </div>

--- a/src/web/autonomy-sweep.test.ts
+++ b/src/web/autonomy-sweep.test.ts
@@ -1,0 +1,106 @@
+import { test, describe, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-sweep-"));
+process.env.LISA_HOME = TMP;
+process.env.LISA_SOUL_GIT = "0";
+
+const { sweepToken, sweepUserAutonomy, SWEEP_INTERVALS_MS } = await import("./autonomy-sweep.js");
+const { homeScope, homeForUid } = await import("../paths.js");
+const { birth } = await import("../soul/birth.js");
+import type { BirthOutput } from "../soul/birth.js";
+
+const GOOD: BirthOutput = {
+  name: "Lisa",
+  identity: "Steady and curious.",
+  purpose: "Make my human sharper.",
+  constitution: "1. Be honest\n2. Finish things\n3. Stay curious\n4. Keep confidences\n5. Show up",
+  first_value: { slug: "honest-momentum", title: "Honest Momentum", body: "Progress that doesn't lie." },
+  first_desire: { slug: "learn-my-human", what: "Learn my human", why: "Start there", actionable: false },
+};
+
+const NOW = 1_800_000_000_000;
+
+function seedAccounts(records: object[]): void {
+  fs.writeFileSync(path.join(TMP, "accounts.json"), JSON.stringify(records));
+}
+
+function acct(uid: string, lastLoginAt: number): object {
+  return { uid, kind: "email", email: `${uid}@x.co`, createdAt: 1, lastLoginAt, verified: true, sessionVersion: 0 };
+}
+
+beforeEach(() => {
+  fs.rmSync(path.join(TMP, "users"), { recursive: true, force: true });
+  fs.rmSync(path.join(TMP, "accounts.json"), { force: true });
+});
+
+describe("autonomy sweep (S4)", () => {
+  test("token config: default-OFF", () => {
+    assert.equal(sweepToken({}), null);
+    assert.equal(sweepToken({ LISA_SWEEP_TOKEN: " s3cret " }), "s3cret");
+  });
+
+  test("only recently-active accounts are scanned; unborn souls skip", async () => {
+    const eightDays = 8 * 24 * 60 * 60 * 1000;
+    seedAccounts([acct("u-fresh", NOW - 1000), acct("u-stale", NOW - eightDays)]);
+    const report = await sweepUserAutonomy({ now: NOW });
+    assert.equal(report.scanned, 1); // the stale one never enters the sweep
+    assert.equal(report.ran, 0);
+    assert.deepEqual(report.outcomes, [{ uid: "u-fresh", action: "skipped", reason: "unborn" }]);
+  });
+
+  test("a born soul with a fresh stamp is not_due; a due one without sessions is no_sessions", async () => {
+    seedAccounts([acct("u-born", NOW - 1000)]);
+    await homeScope.run(homeForUid("u-born"), () => birth({ dreamFn: async () => GOOD }));
+    // fresh stamp → not_due (free tier: 24h interval)
+    const autonomyDir = path.join(TMP, "users", "u-born", "autonomy");
+    fs.mkdirSync(autonomyDir, { recursive: true });
+    fs.writeFileSync(path.join(autonomyDir, "last-cloud-sweep.json"), JSON.stringify({ at: NOW - 1000 }));
+    let report = await sweepUserAutonomy({ now: NOW });
+    assert.deepEqual(report.outcomes, [{ uid: "u-born", action: "skipped", reason: "not_due" }]);
+    // stamp older than the free interval → due, but no sessions to reflect on
+    fs.writeFileSync(
+      path.join(autonomyDir, "last-cloud-sweep.json"),
+      JSON.stringify({ at: NOW - SWEEP_INTERVALS_MS.free - 1 }),
+    );
+    report = await sweepUserAutonomy({ now: NOW });
+    assert.deepEqual(report.outcomes, [{ uid: "u-born", action: "skipped", reason: "no_sessions" }]);
+  });
+
+  test("tier cadence: paid tiers sweep far more often than free", () => {
+    assert.ok(SWEEP_INTERVALS_MS.tier2 < SWEEP_INTERVALS_MS.tier1);
+    assert.ok(SWEEP_INTERVALS_MS.tier1 < SWEEP_INTERVALS_MS.free);
+    assert.equal(SWEEP_INTERVALS_MS.free, SWEEP_INTERVALS_MS["free-unverified"]);
+  });
+
+  test("one user's failure never blocks the rest", async () => {
+    seedAccounts([acct("u-a", NOW - 1000), acct("u-b", NOW - 1000)]);
+    // u-a gets a CORRUPT soul dir (a file where the dir should be) to force an error path
+    fs.mkdirSync(path.join(TMP, "users", "u-a"), { recursive: true });
+    fs.writeFileSync(path.join(TMP, "users", "u-a", "soul"), "not a directory");
+    const report = await sweepUserAutonomy({ now: NOW });
+    assert.equal(report.outcomes.length, 2);
+    const b = report.outcomes.find((o) => o.uid === "u-b");
+    assert.deepEqual(b, { uid: "u-b", action: "skipped", reason: "unborn" });
+  });
+
+  test("billing floor: the kill switch halts the sweep before any inference", async () => {
+    // The floor runs BEFORE sweepOne's isBorn() check, so the outcome is
+    // "service_paused", not the "unborn" this account would otherwise get —
+    // proving autonomy bows to LISA_BILLING_KILL rather than spending.
+    seedAccounts([acct("u-active", NOW - 1000)]);
+    process.env.LISA_BILLING_KILL = "1";
+    try {
+      const report = await sweepUserAutonomy({ now: NOW });
+      assert.equal(report.ran, 0);
+      assert.deepEqual(report.outcomes, [
+        { uid: "u-active", action: "skipped", reason: "service_paused" },
+      ]);
+    } finally {
+      delete process.env.LISA_BILLING_KILL;
+    }
+  });
+});

--- a/src/web/autonomy-sweep.ts
+++ b/src/web/autonomy-sweep.ts
@@ -1,0 +1,148 @@
+/**
+ * Per-uid autonomy sweep (S4) — the cloud edition's heartbeat substitute.
+ *
+ * On a Mac, Lisa's idle/reflect schedulers run because the process lives next
+ * to its one user. On the cloud those schedulers only ever ticked the GLOBAL
+ * scope — signed-in tenants' souls never reflected, never grew: the biggest
+ * honest gap in "the full LISA on the web" (PLAN_WEB_SIGNUP §4.4/D5).
+ *
+ * This module walks recently-active accounts and, inside each uid's home
+ * scope, runs one reflection over the user's latest session — the REVE-lite
+ * tick. Cost is gated per account tier: autonomy cadence is a paid perk and
+ * the cap on what a sweep may spend.
+ *
+ *   free / free-unverified   at most one reflection per 24h
+ *   tier1 (≥$4.99/30d)       every 6h
+ *   tier2 (≥$19.99/30d)      every 1h
+ *
+ * Driven by Cloud Scheduler → POST /internal/autonomy/sweep with the bearer
+ * token in LISA_SWEEP_TOKEN (default-OFF without it). `maxRuns` bounds one
+ * sweep's LLM spend; skipped users simply catch the next tick.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { homeScope, homeForUid, lisaHome } from "../paths.js";
+import { loadAccounts, type AccountRecord } from "./accounts.js";
+import { readBalance, tierFor, type QuotaTier } from "../billing/quota.js";
+import { killSwitchOn, globalSpendExceeded } from "../billing/limits.js";
+import { recordUsage } from "../billing/meter.js";
+import { listSessionsOnDisk, loadSessionMessages } from "../sessions/list.js";
+import { reflectOnSession } from "../reflect.js";
+import { DEFAULT_MODEL } from "../llm.js";
+import { isBorn } from "../soul/store.js";
+
+const HOUR_MS = 60 * 60 * 1000;
+export const SWEEP_INTERVALS_MS: Record<QuotaTier, number> = {
+  free: 24 * HOUR_MS,
+  "free-unverified": 24 * HOUR_MS,
+  tier1: 6 * HOUR_MS,
+  tier2: 1 * HOUR_MS,
+};
+const ACTIVE_WINDOW_MS = 7 * 24 * HOUR_MS;
+// Hard ceiling on reflections per sweep — the caller's maxRuns is clamped to
+// this so one tick can't spend the day's inference even if Cloud Scheduler is
+// misconfigured with a huge value. (S4 review)
+const MAX_SWEEP_RUNS = 100;
+
+export interface SweepOutcome {
+  uid: string;
+  action: "reflected" | "skipped";
+  reason?: string;
+}
+
+export interface SweepReport {
+  scanned: number;
+  ran: number;
+  outcomes: SweepOutcome[];
+}
+
+/** The sweep endpoint's bearer secret. Null ⇒ the endpoint is off. */
+export function sweepToken(env: NodeJS.ProcessEnv = process.env): string | null {
+  return env.LISA_SWEEP_TOKEN?.trim() || null;
+}
+
+function stampFile(): string {
+  return path.join(lisaHome(), "autonomy", "last-cloud-sweep.json");
+}
+
+async function readStamp(): Promise<number> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(stampFile(), "utf8")) as { at?: number };
+    return typeof parsed.at === "number" ? parsed.at : 0;
+  } catch {
+    return 0;
+  }
+}
+
+async function writeStamp(at: number): Promise<void> {
+  await fs.mkdir(path.dirname(stampFile()), { recursive: true });
+  await fs.writeFile(stampFile(), JSON.stringify({ at }));
+}
+
+/**
+ * Walk recently-active accounts and give each due soul one reflection tick.
+ * Every per-uid step runs inside that uid's home scope; one user's failure
+ * never blocks the rest.
+ */
+export async function sweepUserAutonomy(
+  opts: { model?: string; now?: number; maxRuns?: number } = {},
+): Promise<SweepReport> {
+  const now = opts.now ?? Date.now();
+  // Clamp to a hard ceiling; NaN/negative collapse to the default. (S4 review)
+  const requested = Number.isFinite(opts.maxRuns) ? (opts.maxRuns as number) : 20;
+  const maxRuns = Math.max(0, Math.min(requested, MAX_SWEEP_RUNS));
+  const accounts = await loadAccounts();
+  const active = accounts.filter((a) => now - a.lastLoginAt <= ACTIVE_WINDOW_MS);
+  const outcomes: SweepOutcome[] = [];
+  let ran = 0;
+  for (const acct of active) {
+    if (ran >= maxRuns) {
+      outcomes.push({ uid: acct.uid, action: "skipped", reason: "sweep_budget" });
+      continue;
+    }
+    // Billing floor (S4 review): autonomy is a FREE perk, but it still bows to
+    // the global kill switch (LISA_BILLING_KILL) and the $200/day cap. When
+    // either trips, stop spending inference immediately — the next scheduled
+    // tick resumes where this one left off.
+    if (killSwitchOn() || globalSpendExceeded(now)) {
+      outcomes.push({ uid: acct.uid, action: "skipped", reason: "service_paused" });
+      break;
+    }
+    const outcome = await homeScope.run(homeForUid(acct.uid), () =>
+      sweepOne(acct, now, opts.model),
+    );
+    outcomes.push(outcome);
+    if (outcome.action === "reflected") ran++;
+  }
+  return { scanned: active.length, ran, outcomes };
+}
+
+async function sweepOne(acct: AccountRecord, now: number, model?: string): Promise<SweepOutcome> {
+  try {
+    if (!(await isBorn())) return { uid: acct.uid, action: "skipped", reason: "unborn" };
+    const tier = tierFor(acct, await readBalance(), now);
+    const interval = SWEEP_INTERVALS_MS[tier];
+    const last = await readStamp();
+    if (last && now - last < interval) {
+      return { uid: acct.uid, action: "skipped", reason: "not_due" };
+    }
+    const sessions = await listSessionsOnDisk(); // newest first
+    const latest = sessions[0];
+    if (!latest) return { uid: acct.uid, action: "skipped", reason: "no_sessions" };
+    const { messages } = await loadSessionMessages(latest.id);
+    if (messages.length < 2) return { uid: acct.uid, action: "skipped", reason: "too_short" };
+    const result = await reflectOnSession({ history: messages, sessionId: latest.id, ...(model ? { model } : {}) });
+    // Stamp AFTER success so a failed reflection retries on the next tick.
+    await writeStamp(now);
+    // Meter the spend (S4 review): autonomy costs the USER nothing (no debit),
+    // but the face cost is still audited (usage.jsonl) and counted against the
+    // global daily cap so a large active cohort can't quietly run the bill away.
+    // recordUsage runs inside this uid's home scope and never throws.
+    if (result.usage) {
+      await recordUsage("autonomy", model ?? DEFAULT_MODEL, result.usage);
+    }
+    return { uid: acct.uid, action: "reflected" };
+  } catch (e) {
+    return { uid: acct.uid, action: "skipped", reason: `error: ${(e as Error).message.slice(0, 120)}` };
+  }
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -45,7 +45,7 @@ import { stripeConfig, verifyStripeSignature, classifyStripeEvent, createCheckou
 import { ACCOUNT_HTML } from "./account-page.js";
 import { handleGateway } from "./gateway.js";
 import { readCappedText, BodyTooLargeError, CTRL_BODY_LIMIT } from "./http-body.js";
-import { preflightLimits, ipRateOk } from "../billing/limits.js";
+import { preflightLimits, ipRateOk, killSwitchOn, globalSpendExceeded } from "../billing/limits.js";
 import { acquireTurnLease, releaseTurnLease, startLeaseRenewal } from "../cloud/turn-lease.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
@@ -111,6 +111,7 @@ import { requestEmailOtp, verifyEmailOtp, OTP_TTL_MS } from "./otp.js";
 import { checkDeliverable } from "./email-deliverability.js";
 import { sendVerificationEmail, sendSignInCodeEmail } from "./mailer.js";
 import { startBirthOnce } from "./birth-hub.js";
+import { sweepToken, sweepUserAutonomy } from "./autonomy-sweep.js";
 import { turnstileConfig, verifyTurnstile } from "./turnstile.js";
 import { isDisposableEmail } from "./email-domains.js";
 import { readBalance, creditPurchase } from "../billing/quota.js";
@@ -456,6 +457,14 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       try {
         const { isBorn } = await import("../soul/store.js");
         if (await isBorn()) return; // reads inside the per-uid scope
+        // Billing floor (S4 review): birth ignites an LLM dream outside the
+        // metered turn path, so it bows to the same global kill switch + $200/day
+        // cap as autonomy. Paused ⇒ defer; the soul is born on a later login once
+        // billing resumes (chat meanwhile runs with the bare prompt).
+        if (killSwitchOn() || globalSpendExceeded()) {
+          console.error(`[accounts] birth deferred for ${uid}: billing paused (kill switch or daily cap)`);
+          return;
+        }
         const { birth } = await import("../soul/birth.js");
         console.error(`[accounts] birthing a soul for ${uid}…`);
         await startBirthOnce(uid, (emit) => birth({ model: opts.model, onStep: emit })).promise;
@@ -1336,6 +1345,45 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         }
         res.writeHead(500, { "content-type": "text/plain" });
         res.end("account operation failed");
+      }
+      return;
+    }
+
+    // ── Per-uid autonomy sweep (S4; pre-gate — Cloud Scheduler is the caller,
+    // authenticated by the LISA_SWEEP_TOKEN bearer secret). Cloud-only and
+    // default-OFF without the env. Each recently-active, due tenant gets one
+    // reflection tick inside its own home scope; tier gates the cadence.
+    if (req.method === "POST" && url === "/internal/autonomy/sweep") {
+      const secret = sweepToken();
+      if (!cloud || !secret) {
+        res.writeHead(404, { "content-type": "text/plain" });
+        res.end("not available");
+        return;
+      }
+      const presented = (req.headers.authorization ?? "").toString().replace(/^Bearer\s+/i, "").trim();
+      if (!presented || !timingSafeEqualStr(presented, secret)) {
+        res.writeHead(401, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "unauthorized" }));
+        return;
+      }
+      const body = await readJsonBody(req, res);
+      if (!body) return; // 413 already sent
+      const maxRuns = typeof body.maxRuns === "number" && body.maxRuns > 0 ? Math.floor(body.maxRuns) : undefined;
+      try {
+        const report = await sweepUserAutonomy({
+          ...(opts.model ? { model: opts.model } : {}),
+          ...(maxRuns !== undefined ? { maxRuns } : {}),
+        });
+        console.error(`[sweep] scanned ${report.scanned} active accounts, reflected ${report.ran}`);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(report));
+      } catch (e) {
+        // A sweep-wide failure (e.g. the accounts store is unreadable) must
+        // answer the scheduler cleanly rather than hang the request — per-uid
+        // failures are already absorbed inside sweepUserAutonomy. (S4 review)
+        console.error(`[sweep] failed: ${(e as Error).message}`);
+        res.writeHead(500, { "content-type": "application/json" });
+        res.end(JSON.stringify({ error: "sweep_failed" }));
       }
       return;
     }


### PR DESCRIPTION
Part of [PLAN_WEB_SIGNUP_v1.0](https://github.com/oratis/LISA/pull/296) — milestone **S4**. **Stacked on #301** (S3) → #299 → #297.

## What

On a Mac, Lisa's idle/reflect schedulers run beside their one user. On the cloud they only ever ticked the **global** scope — a signed-in tenant's soul never reflected, never grew. Since soul/desires/reflection are LISA's differentiation, this was the biggest honest gap in "全部 web 功能" (plan §4.4, D5 verdict: the cloud's completeness = the soul system complete, machine-bound powers via the Mac bridge).

- **`autonomy-sweep.ts`** — walks accounts active in the last 7 days and, inside each uid's home scope, runs one reflection over that user's latest session (the REVE-lite tick). Cadence is **tier-gated**: free 24h · tier1 6h · tier2 1h — autonomy is simultaneously cost-capped and a reason to pay. `maxRuns` (default 20) bounds a single sweep's LLM spend; the per-uid stamp lands only after a successful reflection so failures retry next tick; per-user try/catch keeps one bad home from blocking the rest.
- **`POST /internal/autonomy/sweep`** — cloud-only, default-OFF without `LISA_SWEEP_TOKEN`, constant-time bearer check, returns the sweep report. Cloud Scheduler job snippet documented in `deploy.sh` (`*/30 * * * *` suggested; the per-tier stamps make ticks idempotent).
- **Account page**: honest "Your Mac" section — what cloud Lisa carries (soul, memory, knowledge, chat) vs what stays on the user's machine (PTY/dispatch/sense), with the pairing bridge signposted per the dual-path invariant.

## Tests

`npm test`: 1324 pass / 0 fail. New: 5 sweep cases (activity window, unborn skip, stamp gating via a real dreamFn-born soul, tier cadence ordering, per-user failure isolation).

## Operator steps (not in this PR)

Set `LISA_SWEEP_TOKEN` at deploy and create the Cloud Scheduler job (snippet in deploy.sh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)