### PR TITLE
feat(deploy): production hardening — Secret Manager mode, B9 import script, prod runbook (S6)

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -52,57 +52,78 @@ if [ -z "${LISA_MODEL:-}" ]; then
   fi   # else: leave unset → Anthropic default (claude-sonnet-4-6)
 fi
 
-# Build the env list with a custom '##' delimiter (gcloud's ^d^ syntax) so secret
-# values may safely contain commas.
-ENVS="^##^LISA_EDITION=cloud##LISA_WEB_TOKEN=${LISA_WEB_TOKEN}"
-[ -n "${LISA_MODEL:-}" ]        && ENVS="${ENVS}##LISA_MODEL=${LISA_MODEL}"
-[ -n "${ANTHROPIC_API_KEY:-}" ] && ENVS="${ENVS}##ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}"
-[ -n "${ZHIPU_API_KEY:-}" ]     && ENVS="${ENVS}##ZHIPU_API_KEY=${ZHIPU_API_KEY}"
-[ -n "${OPENAI_API_KEY:-}" ]    && ENVS="${ENVS}##OPENAI_API_KEY=${OPENAI_API_KEY}"
+# ── Secret routing (S6) ─────────────────────────────────────────────────────
+# SECRETS_MODE=env (default): everything ships as plain env vars — unchanged
+#   demo behavior, values visible in the Cloud Run console.
+# SECRETS_MODE=sm: sensitive values go to Secret Manager (a version is pushed
+#   on every deploy) and reach the container via --set-secrets; only
+#   non-sensitive config stays in env vars. The PRODUCTION setting.
+SECRETS_MODE="${SECRETS_MODE:-env}"
+SECRET_VARS=" LISA_WEB_TOKEN ANTHROPIC_API_KEY ZHIPU_API_KEY OPENAI_API_KEY RESEND_API_KEY STRIPE_SECRET_KEY STRIPE_WEBHOOK_SECRET LISA_TURNSTILE_SECRET LISA_SWEEP_TOKEN LISA_REVIEWER_SEED "
+PENDING_SECRETS=()
+SET_SECRETS=""
+# Build the env list with a custom '##' delimiter (gcloud's ^d^ syntax) so
+# values may safely contain commas. addenv routes each var to env or secret.
+ENVS="^##^LISA_EDITION=cloud"
+addenv() { # addenv NAME VALUE
+  local name="$1" val="$2"
+  [ -z "$val" ] && return 0
+  if [ "$SECRETS_MODE" = "sm" ] && [[ "$SECRET_VARS" == *" $name "* ]]; then
+    PENDING_SECRETS+=("${name}=${val}")
+    SET_SECRETS="${SET_SECRETS:+$SET_SECRETS,}${name}=${name}:latest"
+  else
+    ENVS="${ENVS}##${name}=${val}"
+  fi
+}
+addenv LISA_WEB_TOKEN        "${LISA_WEB_TOKEN}"
+addenv LISA_MODEL            "${LISA_MODEL:-}"
+addenv ANTHROPIC_API_KEY     "${ANTHROPIC_API_KEY:-}"
+addenv ZHIPU_API_KEY         "${ZHIPU_API_KEY:-}"
+addenv OPENAI_API_KEY        "${OPENAI_API_KEY:-}"
 # Optional: Sign in with Apple for the iOS app (src/web/cloudAuth.ts). Off unless
 # LISA_CLOUD_APPLE_SIGNIN is set; LISA_CLOUD_APPLE_SUBS is an optional allowlist of
 # Apple `sub`s, LISA_CLOUD_APPLE_AUD overrides the expected bundle id.
-[ -n "${LISA_CLOUD_APPLE_SIGNIN:-}" ] && ENVS="${ENVS}##LISA_CLOUD_APPLE_SIGNIN=${LISA_CLOUD_APPLE_SIGNIN}"
-[ -n "${LISA_CLOUD_APPLE_SUBS:-}" ]   && ENVS="${ENVS}##LISA_CLOUD_APPLE_SUBS=${LISA_CLOUD_APPLE_SUBS}"
-[ -n "${LISA_CLOUD_APPLE_AUD:-}" ]    && ENVS="${ENVS}##LISA_CLOUD_APPLE_AUD=${LISA_CLOUD_APPLE_AUD}"
+addenv LISA_CLOUD_APPLE_SIGNIN  "${LISA_CLOUD_APPLE_SIGNIN:-}"
+addenv LISA_CLOUD_APPLE_SUBS    "${LISA_CLOUD_APPLE_SUBS:-}"
+addenv LISA_CLOUD_APPLE_AUD     "${LISA_CLOUD_APPLE_AUD:-}"
 # Sign in with Apple on the WEB login page (B8b): the Services ID registered in
 # the Apple portal for cloud.meetlisa.ai (needs domain verification there).
-[ -n "${LISA_CLOUD_APPLE_WEB_SID:-}" ] && ENVS="${ENVS}##LISA_CLOUD_APPLE_WEB_SID=${LISA_CLOUD_APPLE_WEB_SID}"
+addenv LISA_CLOUD_APPLE_WEB_SID "${LISA_CLOUD_APPLE_WEB_SID:-}"
 # Sign in with Google (PLAN_AUTH_OTP_GOOGLE A3/A4): the OAuth client ids from the
 # GCP console — Web application (the GIS button) and iOS (the app's PKCE flow).
 # Each surface draws its button only when its own id is here. Both unset ⇒ Google
 # sign-in is off everywhere and /api/auth/google 404s.
-[ -n "${LISA_GOOGLE_WEB_CLIENT_ID:-}" ] && ENVS="${ENVS}##LISA_GOOGLE_WEB_CLIENT_ID=${LISA_GOOGLE_WEB_CLIENT_ID}"
-[ -n "${LISA_GOOGLE_IOS_CLIENT_ID:-}" ] && ENVS="${ENVS}##LISA_GOOGLE_IOS_CLIENT_ID=${LISA_GOOGLE_IOS_CLIENT_ID}"
+addenv LISA_GOOGLE_WEB_CLIENT_ID "${LISA_GOOGLE_WEB_CLIENT_ID:-}"
+addenv LISA_GOOGLE_IOS_CLIENT_ID "${LISA_GOOGLE_IOS_CLIENT_ID:-}"
 # Turnstile bot gate on signup (S3): widget site key + siteverify secret.
-[ -n "${LISA_TURNSTILE_SITE_KEY:-}" ] && ENVS="${ENVS}##LISA_TURNSTILE_SITE_KEY=${LISA_TURNSTILE_SITE_KEY}"
-[ -n "${LISA_TURNSTILE_SECRET:-}" ]   && ENVS="${ENVS}##LISA_TURNSTILE_SECRET=${LISA_TURNSTILE_SECRET}"
+addenv LISA_TURNSTILE_SITE_KEY "${LISA_TURNSTILE_SITE_KEY:-}"
+addenv LISA_TURNSTILE_SECRET   "${LISA_TURNSTILE_SECRET:-}"
 # Extra disposable-email domains to block at signup (comma-separated; S3).
-[ -n "${LISA_EMAIL_BLOCKLIST:-}" ]    && ENVS="${ENVS}##LISA_EMAIL_BLOCKLIST=${LISA_EMAIL_BLOCKLIST}"
+addenv LISA_EMAIL_BLOCKLIST    "${LISA_EMAIL_BLOCKLIST:-}"
 # Per-uid autonomy sweep (S4): bearer secret for POST /internal/autonomy/sweep.
 # Pair it with a Cloud Scheduler job, e.g.:
 #   gcloud scheduler jobs create http lisa-autonomy-sweep --schedule "*/30 * * * *" \
 #     --uri "$URL/internal/autonomy/sweep" --http-method POST \
 #     --headers "Authorization=Bearer $LISA_SWEEP_TOKEN" --location "$REGION"
-[ -n "${LISA_SWEEP_TOKEN:-}" ]        && ENVS="${ENVS}##LISA_SWEEP_TOKEN=${LISA_SWEEP_TOKEN}"
+addenv LISA_SWEEP_TOKEN        "${LISA_SWEEP_TOKEN:-}"
 # Accounts & billing era (PLAN_ACCOUNTS_BILLING B1–B7), all optional:
 #   LISA_REVIEWER_SEED="email:password"  idempotent App-Review demo account (verified, $20/Tier-2)
 #   LISA_RPM_LIMIT / LISA_DAILY_CAP_USD  abuse guards (defaults 20 rpm / $200 per day)
 #   LISA_BILLING_KILL=1                  pause ALL metered inference immediately
-[ -n "${LISA_REVIEWER_SEED:-}" ]  && ENVS="${ENVS}##LISA_REVIEWER_SEED=${LISA_REVIEWER_SEED}"
+addenv LISA_REVIEWER_SEED  "${LISA_REVIEWER_SEED:-}"
 #   RESEND_API_KEY / LISA_MAIL_FROM  email verification (B8a; domain verified in Resend)
 #   STRIPE_SECRET_KEY / STRIPE_WEBHOOK_SECRET  desktop/web top-up (B8c)
-[ -n "${RESEND_API_KEY:-}" ]        && ENVS="${ENVS}##RESEND_API_KEY=${RESEND_API_KEY}"
-[ -n "${LISA_MAIL_FROM:-}" ]        && ENVS="${ENVS}##LISA_MAIL_FROM=${LISA_MAIL_FROM}"
-[ -n "${STRIPE_SECRET_KEY:-}" ]     && ENVS="${ENVS}##STRIPE_SECRET_KEY=${STRIPE_SECRET_KEY}"
-[ -n "${STRIPE_WEBHOOK_SECRET:-}" ] && ENVS="${ENVS}##STRIPE_WEBHOOK_SECRET=${STRIPE_WEBHOOK_SECRET}"
+addenv RESEND_API_KEY        "${RESEND_API_KEY:-}"
+addenv LISA_MAIL_FROM        "${LISA_MAIL_FROM:-}"
+addenv STRIPE_SECRET_KEY     "${STRIPE_SECRET_KEY:-}"
+addenv STRIPE_WEBHOOK_SECRET "${STRIPE_WEBHOOK_SECRET:-}"
 #   LISA_FIRESTORE=1  move accounts/balances/tx-index/day-cap/turn-lease to Firestore
 #   (enable the API + Native-mode DB in the project first; unlocks MAX_INSTANCES>1)
-[ -n "${LISA_FIRESTORE:-}" ]         && ENVS="${ENVS}##LISA_FIRESTORE=${LISA_FIRESTORE}"
-[ -n "${LISA_FIRESTORE_PROJECT:-}" ] && ENVS="${ENVS}##LISA_FIRESTORE_PROJECT=${LISA_FIRESTORE_PROJECT}"
-[ -n "${LISA_RPM_LIMIT:-}" ]      && ENVS="${ENVS}##LISA_RPM_LIMIT=${LISA_RPM_LIMIT}"
-[ -n "${LISA_DAILY_CAP_USD:-}" ]  && ENVS="${ENVS}##LISA_DAILY_CAP_USD=${LISA_DAILY_CAP_USD}"
-[ -n "${LISA_BILLING_KILL:-}" ]   && ENVS="${ENVS}##LISA_BILLING_KILL=${LISA_BILLING_KILL}"
+addenv LISA_FIRESTORE         "${LISA_FIRESTORE:-}"
+addenv LISA_FIRESTORE_PROJECT "${LISA_FIRESTORE_PROJECT:-}"
+addenv LISA_RPM_LIMIT         "${LISA_RPM_LIMIT:-}"
+addenv LISA_DAILY_CAP_USD     "${LISA_DAILY_CAP_USD:-}"
+addenv LISA_BILLING_KILL      "${LISA_BILLING_KILL:-}"
 
 # ── durable home (C2): a GCS bucket mounted at /data keeps the soul across restarts ──
 BUCKET="${LISA_BUCKET:-${PROJECT}-lisa-cloud-data}"
@@ -113,6 +134,22 @@ gcloud storage buckets describe "gs://$BUCKET" --project "$PROJECT" >/dev/null 2
 SA="$(gcloud projects describe "$PROJECT" --format='value(projectNumber)')-compute@developer.gserviceaccount.com"
 gcloud storage buckets add-iam-policy-binding "gs://$BUCKET" --project "$PROJECT" \
   --member "serviceAccount:$SA" --role roles/storage.objectAdmin >/dev/null
+
+# ── Secret Manager push (S6; SECRETS_MODE=sm only) ──────────────────────────
+# Idempotent: ensure each secret exists, push the value as a new version, and
+# grant the runtime SA accessor. Values never appear in the service's env.
+if [ "$SECRETS_MODE" = "sm" ] && [ "${#PENDING_SECRETS[@]}" -gt 0 ]; then
+  echo "→ pushing ${#PENDING_SECRETS[@]} secrets to Secret Manager"
+  gcloud services enable secretmanager.googleapis.com --project "$PROJECT" >/dev/null
+  for pair in "${PENDING_SECRETS[@]}"; do
+    name="${pair%%=*}"; val="${pair#*=}"
+    gcloud secrets describe "$name" --project "$PROJECT" >/dev/null 2>&1 \
+      || gcloud secrets create "$name" --project "$PROJECT" --replication-policy automatic >/dev/null
+    printf '%s' "$val" | gcloud secrets versions add "$name" --project "$PROJECT" --data-file=- >/dev/null
+    gcloud secrets add-iam-policy-binding "$name" --project "$PROJECT" \
+      --member "serviceAccount:$SA" --role roles/secretmanager.secretAccessor >/dev/null
+  done
+fi
 
 cd "$ROOT"
 cp deploy/Dockerfile ./Dockerfile
@@ -149,8 +186,17 @@ gcloud run deploy "$SERVICE" \
   --add-volume "name=soul,type=cloud-storage,bucket=$BUCKET" \
   --add-volume-mount "volume=soul,mount-path=/data" \
   --memory 4Gi --cpu 2 --timeout 3600 \
-  --set-env-vars "$ENVS"
+  --set-env-vars "$ENVS" \
+  ${SET_SECRETS:+--set-secrets "$SET_SECRETS"}
 
 URL="$(gcloud run services describe "$SERVICE" --project "$PROJECT" --region "$REGION" --format='value(status.url)' 2>/dev/null || true)"
 echo "✓ deployed${URL:+: $URL}"
-[ -n "$URL" ] && echo "  Reviewer demo URL (opens authed, pins the cookie):  $URL/?token=$LISA_WEB_TOKEN"
+if [ -n "$URL" ]; then
+  if [ "$SECRETS_MODE" = "sm" ]; then
+    # Production (S6): never print the master token into the deploy log — real
+    # users sign in with accounts, and the token-in-URL is a demo-only shortcut.
+    echo "  Console: $URL"
+  else
+    echo "  Reviewer demo URL (opens authed, pins the cookie):  $URL/?token=$LISA_WEB_TOKEN"
+  fi
+fi

--- a/docs/RUNBOOK_CLOUD_PROD.md
+++ b/docs/RUNBOOK_CLOUD_PROD.md
@@ -1,0 +1,129 @@
+# RUNBOOK — LISA Cloud 公开注册上线（S6）
+
+**这是把 cloud.meetlisa.ai 从"审核 demo"推到"公开注册"的操作手册。**
+承接 [RUNBOOK_ACCOUNTS_LAUNCH.md](RUNBOOK_ACCOUNTS_LAUNCH.md)（Apple/ASC 侧手续）与
+[PLAN_WEB_SIGNUP_v1.0.md](PLAN_WEB_SIGNUP_v1.0.md)（S 系列设计）。**除注明外全部
+需要 owner 凭据，由人工执行**；每一步幂等，可安全重跑。
+
+先决条件：S1–S5 的 PR 已合并（Google 登录、OTP、birth 硬化、per-uid sweep、官网入口）。
+
+---
+
+## 0. 独立生产项目（一次性）
+
+Demo 与个人项目混居 `oratis-491316`；公开注册前迁到专属项目，隔离账单与 IAM 爆炸半径。
+
+```bash
+gcloud projects create lisa-cloud-prod --name "LISA Cloud"
+gcloud billing projects link lisa-cloud-prod --billing-account <BILLING_ACCOUNT_ID>
+gcloud services enable run.googleapis.com cloudbuild.googleapis.com \
+  firestore.googleapis.com secretmanager.googleapis.com \
+  cloudscheduler.googleapis.com --project lisa-cloud-prod
+```
+
+之后所有命令带 `PROJECT=lisa-cloud-prod`。（继续用旧项目也行——跳过本节，其余照旧。）
+
+## 1. Firestore（多实例前置，B9）
+
+```bash
+gcloud firestore databases create --project $PROJECT --location us-central1 --type firestore-native
+```
+
+**导入现有账号**（服务仍在 `MAX_INSTANCES=1` 时执行；脚本幂等，tx 索引 create-only）：
+
+```bash
+# 先把 GCS 家目录同步到本地（或直接挂载）：
+gcloud storage rsync -r gs://<project>-lisa-cloud-data /tmp/lisa-home
+LISA_FIRESTORE=1 LISA_FIRESTORE_PROJECT=$PROJECT \
+  LISA_FIRESTORE_TOKEN="$(gcloud auth print-access-token)" \
+  npx tsx scripts/import-accounts-firestore.ts /tmp/lisa-home --dry-run   # 先看
+# 去掉 --dry-run 正式导入；重复导入安全（已存在则跳过）
+```
+
+## 2. 部署（Secret Manager 模式 + Firestore 开启）
+
+```bash
+# 先生成并 export sweep bearer：内联在部署命令里的变量不会留在当前 shell，
+# §5 的 Cloud Scheduler 会取到空值。export 让两处用同一个 token。
+export LISA_SWEEP_TOKEN="$(openssl rand -hex 24)"
+
+PROJECT=$PROJECT SECRETS_MODE=sm LISA_FIRESTORE=1 MAX_INSTANCES=3 \
+  LISA_WEB_TOKEN=… ZHIPU_API_KEY=… ANTHROPIC_API_KEY=… \
+  RESEND_API_KEY=… LISA_MAIL_FROM='LISA <no-reply@meetlisa.ai>' \
+  STRIPE_SECRET_KEY=… STRIPE_WEBHOOK_SECRET=… \
+  LISA_CLOUD_APPLE_SIGNIN=1 LISA_CLOUD_APPLE_WEB_SID=… \
+  LISA_GOOGLE_WEB_CLIENT_ID=… LISA_GOOGLE_IOS_CLIENT_ID=… \
+  LISA_TURNSTILE_SITE_KEY=… LISA_TURNSTILE_SECRET=… \
+  deploy/deploy.sh
+```
+
+- `SECRETS_MODE=sm`：敏感值进 Secret Manager（每次部署推新版本），容器经
+  `--set-secrets` 引用，控制台 env 页不再可见明文。
+- 部署脚本自带护栏：`MAX_INSTANCES>1` 必须配 `LISA_FIRESTORE=1`。
+
+## 3. 第三方控制台开关（各一次性，人工）
+
+| 事项 | 在哪配 | 备注 |
+|---|---|---|
+| Google OAuth Client | GCP Console → Credentials → OAuth client (Web) | Authorized JS origin = `https://cloud.meetlisa.ai`；产出的 client id 即 `LISA_GOOGLE_WEB_CLIENT_ID`；同意屏(Branding)配 logo/域名 |
+| Apple web Services ID | Apple Developer portal | 见 RUNBOOK_ACCOUNTS_LAUNCH §B8b；域名验证 cloud.meetlisa.ai |
+| Turnstile widget | Cloudflare dash → Turnstile | hostname = cloud.meetlisa.ai；site key/secret 即两个 `LISA_TURNSTILE_*` |
+| Resend 域名 | Resend dash | `meetlisa.ai` 已验证（B8a）；确认 SPF/DKIM 仍绿 |
+| Stripe webhook | Stripe dash | endpoint `https://cloud.meetlisa.ai/api/billing/stripe/webhook`，事件 checkout.session.completed + charge.refunded |
+
+## 4. 域名 `cloud.meetlisa.ai`
+
+```bash
+gcloud beta run domain-mappings create --service lisa-cloud \
+  --domain cloud.meetlisa.ai --project $PROJECT --region us-central1
+```
+
+Cloudflare DNS：`cloud` CNAME → `ghs.googlehosted.com`，**DNS-only（灰云）**——TLS 由
+Google 管，代理会破坏证书签发。等 mapping 状态 ready（约 15 分钟）。
+
+## 5. Cloud Scheduler：per-uid 自主性 sweep（S4）
+
+```bash
+URL="$(gcloud run services describe lisa-cloud --project $PROJECT --region us-central1 --format='value(status.url)')"
+gcloud scheduler jobs create http lisa-autonomy-sweep --project $PROJECT \
+  --schedule "*/30 * * * *" --location us-central1 \
+  --uri "$URL/internal/autonomy/sweep" --http-method POST \
+  --headers "Authorization=Bearer $LISA_SWEEP_TOKEN,Content-Type=application/json" \
+  --message-body '{}'
+```
+
+半小时一跳是安全的：档位节奏（free 24h / t1 6h / t2 1h）由每用户 stamp 幂等控制，
+空跳几乎零成本。验证：`curl -X POST -H "Authorization: Bearer $LISA_SWEEP_TOKEN" $URL/internal/autonomy/sweep` 应返回 `{"scanned":…}`。
+
+## 6. 监控与告警
+
+```bash
+# Uptime check 打公开的 auth 配置端点（无需凭据、恒 200）
+gcloud monitoring uptime create lisa-cloud-auth \
+  --resource-type uptime-url --resource-labels host=cloud.meetlisa.ai \
+  --path /api/auth/config --project $PROJECT
+# 预算告警（月 $200 起步，超 50/90/100% 邮件）
+gcloud billing budgets create --billing-account <BILLING_ACCOUNT_ID> \
+  --display-name lisa-cloud --budget-amount 200USD \
+  --threshold-rule=percent=0.5 --threshold-rule=percent=0.9 --threshold-rule=percent=1.0
+```
+
+日志侧已内建：异常消费告警（meter.ts，>$10/天/用户打 `[billing] ANOMALY`）、
+sweep 报告行（`[sweep] scanned…`）。建一条 log-based alert 盯 `ANOMALY` 即可。
+
+## 7. 急停开关（记住这三个）
+
+| 开关 | 效果 |
+|---|---|
+| `LISA_BILLING_KILL=1` 重部署 | 立停一切计量推理（登录/账号页仍可用） |
+| Cloudflare Turnstile 调成 Managed-challenge 全量 | 注册口收紧到人类 |
+| `gcloud run services update lisa-cloud --max-instances 0` | 整站下线（保数据） |
+
+## 8. 上线冒烟清单
+
+- [ ] 无痕窗口 → cloud.meetlisa.ai → 登录页三种方式齐全（Google/Apple/邮箱+验证码）
+- [ ] 新邮箱注册 → 收到验证码邮件 → birth 仪式打字机完整跑完 → 落进 island
+- [ ] `DELETE /api/account`（账号页删除）→ 再登录 404/需重注册，家目录已消失
+- [ ] 免费窗口计量在账号页可见；Stripe 测试卡充值到账
+- [ ] 官网 meetlisa.ai 导航「登录」与 /cloud 页链接可达
+- [ ] sweep 手动 curl 返回报告；Scheduler 首跳成功

--- a/scripts/import-accounts-firestore.ts
+++ b/scripts/import-accounts-firestore.ts
@@ -1,0 +1,135 @@
+/**
+ * B9 cutover: import file-backed account state into Firestore (S6).
+ *
+ * The Firestore layer (src/cloud/firestore.ts) starts EMPTY — flipping
+ * LISA_FIRESTORE=1 without this import would orphan every existing account.
+ * This script reads a LISA home directory (the GCS-mounted /data, or a local
+ * copy of it) and writes the three stores the runtime reads:
+ *
+ *   accounts.json                          → lisa-global/accounts   {list}
+ *   users/<uid>/billing/balance.json       → lisa-balances/<uid>
+ *   iap-transactions.json                  → lisa-txindex/<txId>    (create-only)
+ *
+ * Idempotent: tx docs are create-only (409s are counted as already-present),
+ * accounts/balances refuse to overwrite an existing doc unless --force.
+ *
+ * Usage (run while the service still has MAX_INSTANCES=1, then flip the env):
+ *   LISA_FIRESTORE=1 \
+ *   LISA_FIRESTORE_PROJECT=<project> \
+ *   LISA_FIRESTORE_TOKEN="$(gcloud auth print-access-token)" \
+ *   npx tsx scripts/import-accounts-firestore.ts /path/to/lisa-home [--dry-run] [--force]
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { getDoc, setDoc } from "../src/cloud/firestore.js";
+import { FirestoreError } from "../src/cloud/firestore.js";
+
+const args = process.argv.slice(2);
+const home = args.find((a) => !a.startsWith("--"));
+const dryRun = args.includes("--dry-run");
+const force = args.includes("--force");
+
+if (!home || !fs.existsSync(home)) {
+  console.error("usage: import-accounts-firestore.ts <lisa-home-dir> [--dry-run] [--force]");
+  process.exit(1);
+}
+if (!process.env.LISA_FIRESTORE) {
+  console.error("✗ set LISA_FIRESTORE=1 (plus LISA_FIRESTORE_PROJECT and LISA_FIRESTORE_TOKEN)");
+  process.exit(1);
+}
+
+function readJson<T>(file: string): T | null {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8")) as T;
+  } catch {
+    return null;
+  }
+}
+
+interface TxEntry {
+  transactionId: string;
+  uid: string;
+  productId: string;
+  microUSD: number;
+  at: number;
+}
+
+async function main(): Promise<void> {
+  let wrote = 0;
+  let skipped = 0;
+
+  // 1. accounts.json → lisa-global/accounts
+  const accounts = readJson<unknown[]>(path.join(home!, "accounts.json")) ?? [];
+  console.log(`accounts.json: ${accounts.length} records`);
+  const existing = await getDoc("lisa-global/accounts");
+  const existingCount = Array.isArray(existing?.data.list) ? (existing!.data.list as unknown[]).length : 0;
+  if (accounts.length === 0) {
+    // Guard: never write an empty list. A missing/wrong home dir (or an unmounted
+    // GCS bucket) reads as [], and with --force that would WIPE a populated
+    // Firestore. An empty source is a misinvocation, not an import.
+    console.log(`  ↷ accounts.json is empty or absent — skipping (refusing to overwrite Firestore with an empty list)`);
+    skipped++;
+  } else if (existing && existingCount > 0 && !force) {
+    console.log(`  ↷ lisa-global/accounts already holds ${existingCount} records — skipping (use --force to overwrite)`);
+    skipped++;
+  } else if (dryRun) {
+    console.log(`  (dry-run) would write lisa-global/accounts with ${accounts.length} records`);
+  } else {
+    await setDoc("lisa-global/accounts", { list: accounts as Record<string, unknown>[] });
+    console.log(`  ✓ wrote lisa-global/accounts`);
+    wrote++;
+  }
+
+  // 2. users/<uid>/billing/balance.json → lisa-balances/<uid>
+  const usersDir = path.join(home!, "users");
+  const uids = fs.existsSync(usersDir)
+    ? fs.readdirSync(usersDir).filter((d) => fs.statSync(path.join(usersDir, d)).isDirectory())
+    : [];
+  console.log(`users/: ${uids.length} homes`);
+  for (const uid of uids) {
+    const balance = readJson<Record<string, unknown>>(path.join(usersDir, uid, "billing", "balance.json"));
+    if (!balance) continue;
+    const doc = `lisa-balances/${uid}`;
+    if (!force && (await getDoc(doc))) {
+      console.log(`  ↷ ${doc} exists — skipping`);
+      skipped++;
+      continue;
+    }
+    if (dryRun) {
+      console.log(`  (dry-run) would write ${doc} (paid=${balance.paidMicroUSD})`);
+      continue;
+    }
+    await setDoc(doc, balance);
+    console.log(`  ✓ ${doc}`);
+    wrote++;
+  }
+
+  // 3. iap-transactions.json → lisa-txindex/<txId> (create-only, replay-safe)
+  const txs = readJson<TxEntry[]>(path.join(home!, "iap-transactions.json")) ?? [];
+  console.log(`iap-transactions.json: ${txs.length} entries`);
+  for (const tx of txs) {
+    if (!tx?.transactionId) continue;
+    const doc = `lisa-txindex/${encodeURIComponent(tx.transactionId)}`;
+    if (dryRun) {
+      console.log(`  (dry-run) would create ${doc}`);
+      continue;
+    }
+    try {
+      await setDoc(doc, { ...tx } as unknown as Record<string, unknown>, { exists: false });
+      wrote++;
+    } catch (e) {
+      if (e instanceof FirestoreError && (e.status === 409 || e.status === 412)) {
+        skipped++; // already imported — the create-only precondition held
+        continue;
+      }
+      throw e;
+    }
+  }
+
+  console.log(`\ndone: ${wrote} written, ${skipped} skipped${dryRun ? " (dry-run — nothing written)" : ""}`);
+}
+
+main().catch((e) => {
+  console.error(`✗ import failed: ${(e as Error).message}`);
+  process.exit(1);
+});

--- a/src/cloud/firestore.ts
+++ b/src/cloud/firestore.ts
@@ -34,6 +34,11 @@ let tokenCache: { token: string; expiresAt: number } | null = null;
 let projectCache: string | null = null;
 
 async function adcToken(fetchFn: typeof fetch): Promise<string> {
+  // Operator/admin override (S6): lets the B9 import script (and any local
+  // tooling) run OUTSIDE Cloud Run, where there is no metadata server —
+  //   LISA_FIRESTORE_TOKEN="$(gcloud auth print-access-token)"
+  const envToken = process.env.LISA_FIRESTORE_TOKEN?.trim();
+  if (envToken) return envToken;
   if (tokenCache && Date.now() < tokenCache.expiresAt - 60_000) return tokenCache.token;
   const res = await fetchFn(`${METADATA_BASE}/instance/service-accounts/default/token`, {
     headers: { "Metadata-Flavor": "Google" },


### PR DESCRIPTION
Part of [PLAN_WEB_SIGNUP_v1.0](https://github.com/oratis/LISA/pull/296) — milestone **S6**, the hard gate before public signups. **Stacked on #302** (S4) → #301 → #299 → #297.

## What

### `SECRETS_MODE=sm` for deploy.sh
The deploy script passed every secret (LLM keys, Stripe keys, the web token…) as **plain `--set-env-vars`**, visible to anyone with console read access. In `sm` mode those values are now pushed to **Secret Manager** (secret created if absent, new version per deploy, runtime SA granted accessor) and reach the container via `--set-secrets`. Default `env` mode keeps today's demo behavior byte-identical. All plumbing routes through one `addenv` helper — verified with a bash unit test of the routing and `bash -n`.

### The missing B9 import script
RUNBOOK_ACCOUNTS_LAUNCH's Firestore section literally said "问我要导入脚本" — flipping `LISA_FIRESTORE=1` on an empty database would orphan every existing account. `scripts/import-accounts-firestore.ts` imports the three file-backed stores into the **exact** docs the runtime seam reads:
- `accounts.json` → `lisa-global/accounts {list}`
- `users/<uid>/billing/balance.json` → `lisa-balances/<uid>`
- `iap-transactions.json` → `lisa-txindex/<txId>` (create-only, so replays are naturally deduped)

Idempotent; `--dry-run` / `--force`. `firestore.ts` gains a `LISA_FIRESTORE_TOKEN` override so admin tooling can authenticate with `gcloud auth print-access-token` outside Cloud Run (no metadata server there).

### `docs/RUNBOOK_CLOUD_PROD.md`
The operator checklist from reviewer-demo to public signup: dedicated prod project → Firestore create + import → `SECRETS_MODE=sm LISA_FIRESTORE=1 MAX_INSTANCES=3` deploy → third-party console table (Google OAuth client, Apple Services ID, Turnstile widget, Resend domain, Stripe webhook) → `cloud.meetlisa.ai` domain mapping (DNS-only/grey-cloud, TLS by Google) → Cloud Scheduler sweep job → uptime check + budget alerts + the built-in anomaly log alert → **three kill switches** → a launch smoke checklist. Every credential-gated step is flagged for the owner.

## Tests

`npm test`: 1324 pass / 0 fail; `bash -n` + an addenv routing check on deploy.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)