### PR TITLE
fix(security): CSRF-guard auth POSTs + close the birth crash-window

### DIFF
--- a/src/soul/birth.ts
+++ b/src/soul/birth.ts
@@ -79,11 +79,11 @@ async function birthInner(opts: BirthOptions): Promise<void> {
   // 1. Seed
   await onStep({ step: "seed", detail: "rolling the dice…" });
   const seed = generateSeed();
-  await writeSeed(seed);
-  // Initialize the soul git repo now that the seed + dirs exist. This makes
-  // the initial commit capture "she has been seeded but not yet shaped",
-  // and every subsequent write gets its own commit attributed to "birth".
-  await initSoulRepo();
+  // seed.json + the git repo are written LAST (step 5). seed.json is the
+  // isBorn() flip, so writing it before the soul is complete meant a crash
+  // mid-birth (Cloud Run eviction / OOM / the LLM call below) left isBorn()=true
+  // with no identity — refusing re-birth forever, unrecoverable without an
+  // operator hand-deleting the file.
   await onStep({
     step: "seed",
     detail: `born ${seed.bornAt} on host:${seed.bornOn.slice(0, 8)} · big5(O${(seed.bigFive.openness * 100) | 0} C${(seed.bigFive.conscientiousness * 100) | 0} E${(seed.bigFive.extraversion * 100) | 0} A${(seed.bigFive.agreeableness * 100) | 0} N${(seed.bigFive.neuroticism * 100) | 0})`,
@@ -157,6 +157,15 @@ async function birthInner(opts: BirthOptions): Promise<void> {
   // 4. Initial emotions + lock
   await writeEmotions({ ...DEFAULT_EMOTIONS, updatedAt: new Date().toISOString() });
   await saveLock(await recomputeLock());
+
+  // 5. Flip isBorn() LAST. seed.json is the born marker and atomicWrite is
+  // tmp+rename, so the transition is atomic — a crash any time before here
+  // leaves isBorn()=false and the birth simply re-runs (the writes above are
+  // overwritten). Then init the git repo, whose `add .` + initial commit
+  // snapshots the now-complete soul in one go (the per-write commitSoulChange
+  // calls above no-op while there is no .git).
+  await writeSeed(seed);
+  await initSoulRepo();
 
   await onStep({ step: "done", detail: `${parsed.name} is alive.` });
 }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -277,6 +277,20 @@ async function readJsonBody(
   res: http.ServerResponse,
   limitBytes: number = CTRL_BODY_LIMIT,
 ): Promise<Record<string, unknown> | null> {
+  // CSRF guard. A cross-site request can only reach a state-changing endpoint
+  // via a "simple" form POST (Content-Type text/plain / urlencoded / multipart);
+  // setting application/json cross-origin triggers a CORS preflight this server
+  // has no headers to satisfy, so it never arrives. Requiring application/json
+  // therefore blocks the enctype=text/plain login-CSRF (session fixation on the
+  // auth routes) while every real client is unaffected — web, iOS and the CLI
+  // all send application/json. (The Stripe webhook reads the raw body directly,
+  // not through here, so its signature path is untouched.)
+  const ctype = String(req.headers["content-type"] ?? "").toLowerCase();
+  if (!ctype.includes("application/json")) {
+    res.writeHead(415, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "unsupported_media_type" }));
+    return null;
+  }
   let body: string;
   try {
     body = await readCappedText(req, limitBytes);


### PR DESCRIPTION
Two **LIVE** issues on `main` surfaced by the adversarial review of the S-series auth PRs (#297/#299/#301) — these apply to the **A-series auth already merged** (#305), independent of the S-series' fate.

## 1. login-CSRF (Medium) — `readJsonBody` had no Content-Type check
Every auth POST (`/api/auth/google`, `/otp/verify`, `/login`, `/register`, `/apple`) was reachable by a cross-site `enctype=text/plain` form POST (a CORS "simple request" → no preflight). The server would verify the **attacker's own** valid credential and `Set-Cookie` their session into the victim's jar → **session fixation**: the victim, on their next same-site visit, silently operates inside the attacker's account (their chats/uploads/spend land there). `SameSite=Strict` doesn't help (governs sending, not storing).

**Fix:** require `application/json` in `readJsonBody`. Cross-site JS can't set that content-type without a CORS preflight this server has no headers to satisfy, so the attack never arrives — while **every real client already sends it** (verified: web `lisa-client.ts`, iOS `LisaClient.swift`, CLI `account.ts`). Stripe's webhook reads the raw body directly (signature over raw), so it's untouched.

## 2. birth crash-window (Med-High) — `seed.json` written first
`birth()` wrote `seed.json` (the `isBorn()` flip) **before** the LLM call + identity writes. A crash in that window (Cloud Run eviction / OOM / hung LLM) left `seed.json` with no `identity.md` → `isBorn()=true` forever, re-birth refused, unrecoverable without hand-deleting the file.

**Fix:** write `seed.json` **last** (after the whole soul is on disk). `atomicWrite` is tmp+rename so the flip is atomic — a crash before it leaves `isBorn()=false` and birth simply re-runs. A final `initSoulRepo` (`add .` + initial commit) snapshots the complete soul in one go; the per-write `commitSoulChange` calls no-op while there's no `.git`.

Full suite green (**1355 pass, 0 fail**) — no client or test relied on a non-json POST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)