### PR TITLE
Enforce Cloud capability boundaries

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -20,6 +20,7 @@ import { parseArgs, type ParsedArgs } from "./cli-args.js";
 import { connectMcpServers } from "./mcp/client.js";
 import { loadMcpConfig } from "./mcp/config.js";
 import { lisaHome } from "./paths.js";
+import { isCloud } from "./edition.js";
 import { loadAllPlugins, PLUGINS_ROOT } from "./plugins/loader.js";
 import type { HookSpec } from "./plugins/types.js";
 import { buildSystemPromptSnapshot, getPromptFingerprint } from "./prompt.js";
@@ -31,7 +32,7 @@ import { SessionStore } from "./sessions/store.js";
 import { birth } from "./soul/birth.js";
 import { isBorn, readSoulSummary } from "./soul/store.js";
 import { createTaskTool } from "./tools/task.js";
-import { buildToolRegistry, readOnlySubset } from "./tools/registry.js";
+import { buildToolRegistry, cloudSafeSubset, readOnlySubset } from "./tools/registry.js";
 import type { AgentEvent, StoredMessage, ToolDefinition } from "./types.js";
 
 const HELP = `Lisa — your self-evolving local AI assistant.
@@ -194,6 +195,7 @@ async function main(): Promise<void> {
 
   await ensureDir(lisaHome());
   loadConfigEnv();
+  const cloudEdition = isCloud();
   // If the user didn't pass --model, resolve the default now that config.env is
   // loaded: an explicit LISA_MODEL (e.g. `lisa model use`) wins, else auto-detect
   // from the single configured cloud key. An explicit --model always overrides.
@@ -431,28 +433,34 @@ async function main(): Promise<void> {
   // that have been explicitly approved by SHA. Sandbox is the user's review,
   // not the runtime — these run in-process. Unapproved or stale ones are
   // surfaced as a startup notice; the user runs `lisa skills approve <slug>`.
-  const { discoverExecutableSkills, loadApprovedExecutableTools, summarizeCandidate } =
-    await import("./skills/executable.js");
-  const skillCandidates = await discoverExecutableSkills();
-  const executableTools = await loadApprovedExecutableTools((m) => console.error(m));
-  if (skillCandidates.length > 0) {
-    const pending = skillCandidates.filter((c) => c.status !== "approved-current");
-    if (pending.length > 0) {
-      console.error(`\n[skills] ${executableTools.length} executable tool(s) loaded; ${pending.length} pending:`);
-      for (const c of pending) console.error(summarizeCandidate(c));
-      console.error(`Run \`lisa skills approve <slug>\` to review and approve.\n`);
+  let executableTools: ToolDefinition[] = [];
+  if (!cloudEdition) {
+    const { discoverExecutableSkills, loadApprovedExecutableTools, summarizeCandidate } =
+      await import("./skills/executable.js");
+    const skillCandidates = await discoverExecutableSkills();
+    executableTools = await loadApprovedExecutableTools((m) => console.error(m));
+    if (skillCandidates.length > 0) {
+      const pending = skillCandidates.filter((c) => c.status !== "approved-current");
+      if (pending.length > 0) {
+        console.error(`\n[skills] ${executableTools.length} executable tool(s) loaded; ${pending.length} pending:`);
+        for (const c of pending) console.error(summarizeCandidate(c));
+        console.error(`Run \`lisa skills approve <slug>\` to review and approve.\n`);
+      }
     }
   }
-  const baseTools = buildToolRegistry({ includeVoice: args.voice, extra: executableTools });
+  const baseTools = buildToolRegistry({
+    includeVoice: !cloudEdition && args.voice,
+    extra: executableTools,
+  });
 
   // Load plugins (skills/commands/agents/hooks/mcp).
-  const plugins = args.loadPlugins ? await loadAllPlugins() : [];
+  const plugins = args.loadPlugins && !cloudEdition ? await loadAllPlugins() : [];
   const allHooks: HookSpec[] = plugins.flatMap((p) => p.hooks);
   const pluginMcp = plugins.flatMap((p) => p.mcpServers);
 
   // Load MCP servers (config + plugins).
   let mcpConnections: Awaited<ReturnType<typeof connectMcpServers>> = [];
-  if (args.loadMcp) {
+  if (args.loadMcp && !cloudEdition) {
     const configMcp = await loadMcpConfig();
     const allSpecs = [...configMcp, ...pluginMcp];
     if (allSpecs.length > 0) {
@@ -468,15 +476,23 @@ async function main(): Promise<void> {
   process.on("SIGINT", () => abortController.abort());
   const cwd = process.cwd();
 
-  const composedTools: ToolDefinition[] = [...baseTools, ...mcpTools];
-  const taskTool = createTaskTool({
-    fullToolset: () => composedTools,
-    readOnlyToolset: () => readOnlySubset(composedTools),
-    cwd,
-    signal: abortController.signal,
-    defaultModel: args.model,
-  });
-  composedTools.push(taskTool as ToolDefinition);
+  const composedTools: ToolDefinition[] = [
+    ...(cloudEdition ? cloudSafeSubset(baseTools) : baseTools),
+    ...mcpTools,
+  ];
+  // task captures the complete toolset in a closure. Never construct it in the
+  // hosted edition: filtering the visible list later would not be a sufficient
+  // capability boundary if the closure were accidentally reintroduced.
+  if (!cloudEdition) {
+    const taskTool = createTaskTool({
+      fullToolset: () => composedTools,
+      readOnlyToolset: () => readOnlySubset(composedTools),
+      cwd,
+      signal: abortController.signal,
+      defaultModel: args.model,
+    });
+    composedTools.push(taskTool as ToolDefinition);
+  }
   composedTools.sort((a, b) => a.name.localeCompare(b.name));
 
   // Heartbeat sub-command — uses the assembled toolset.

--- a/src/tools/registry.ts
+++ b/src/tools/registry.ts
@@ -219,3 +219,38 @@ export const REMOTE_BLOCKED_TOOL_NAMES = new Set([
 export function remoteSafeSubset(tools: ToolDefinition[]): ToolDefinition[] {
   return tools.filter((t) => !REMOTE_BLOCKED_TOOL_NAMES.has(t.name));
 }
+
+/**
+ * Tools exposed by the hosted multi-tenant edition.
+ *
+ * This is deliberately an allow-list rather than another block-list:
+ * executable skills, plugin tools, MCP tools, and future builtins must never
+ * become cloud capabilities merely because somebody forgot to add their name
+ * to a deny-list. Every tool here resolves storage through the active
+ * per-account Lisa home and does not execute a host process or fetch an
+ * arbitrary URL.
+ */
+export const CLOUD_ALLOWED_TOOL_NAMES = new Set([
+  "memory",
+  "memory_search",
+  "set_mood",
+  "soul_patch",
+  "soul_journal",
+  "soul_read",
+  "soul_feel",
+  "soul_history",
+  "soul_diff",
+  "soul_object",
+  "desire_progress_log",
+  "desire_close",
+  "kb_search",
+  "kb_read",
+  "kb_links",
+  "kb_list",
+  "kb_add",
+  "kb_write",
+]);
+
+export function cloudSafeSubset(tools: ToolDefinition[]): ToolDefinition[] {
+  return tools.filter((t) => CLOUD_ALLOWED_TOOL_NAMES.has(t.name));
+}

--- a/src/tools/subsets.test.ts
+++ b/src/tools/subsets.test.ts
@@ -3,8 +3,10 @@ import assert from "node:assert/strict";
 import type { ToolDefinition } from "../types.js";
 import {
   AUTONOMOUS_BLOCKED_TOOL_NAMES,
+  CLOUD_ALLOWED_TOOL_NAMES,
   REMOTE_BLOCKED_TOOL_NAMES,
   autonomousSubset,
+  cloudSafeSubset,
   remoteSafeSubset,
 } from "./registry.js";
 
@@ -98,6 +100,40 @@ describe("remoteSafeSubset — IM-channel toolset", () => {
     const names = new Set(remoteSafeSubset(SAMPLE).map((t) => t.name));
     for (const kept of ["memory", "memory_search", "soul_journal", "soul_read", "web_fetch", "set_mood"]) {
       assert.equal(names.has(kept), true, `${kept} must stay available`);
+    }
+  });
+});
+
+describe("cloudSafeSubset — hosted multi-tenant toolset", () => {
+  test("uses an allow-list and rejects host, process, network-fetch, and unknown plugin tools", () => {
+    const unknown = fake("operator_plugin_secret");
+    const names = new Set(cloudSafeSubset([...SAMPLE, unknown]).map((t) => t.name));
+    for (const blocked of [
+      "bash",
+      "read",
+      "write",
+      "grep",
+      "ls",
+      "task",
+      "web_fetch",
+      "dispatch_agent",
+      "mcp",
+      "skill_manage",
+      "operator_plugin_secret",
+    ]) {
+      assert.equal(names.has(blocked), false, `${blocked} must be blocked`);
+    }
+  });
+
+  test("keeps only explicitly approved tenant-scoped tools", () => {
+    const candidates = [...SAMPLE, fake("kb_search"), fake("kb_write"), fake("soul_object")];
+    const names = new Set(cloudSafeSubset(candidates).map((t) => t.name));
+    for (const kept of ["memory", "memory_search", "soul_read", "soul_object", "kb_search", "kb_write", "set_mood"]) {
+      assert.equal(CLOUD_ALLOWED_TOOL_NAMES.has(kept), true);
+      assert.equal(names.has(kept), true, `${kept} must stay available`);
+    }
+    for (const name of names) {
+      assert.equal(CLOUD_ALLOWED_TOOL_NAMES.has(name), true, `${name} must be allow-listed`);
     }
   });
 });

--- a/src/web/capabilities.test.ts
+++ b/src/web/capabilities.test.ts
@@ -1,0 +1,68 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import type { ToolDefinition } from "../types.js";
+import {
+  capabilityProfileForEdition,
+  isCloudDeniedRoute,
+  toolsForCapabilityProfile,
+} from "./capabilities.js";
+
+const fake = (name: string): ToolDefinition =>
+  ({ name, description: name, inputSchema: { type: "object" }, execute: async () => "" }) as ToolDefinition;
+
+describe("capability profiles", () => {
+  test("maps editions to explicit profiles", () => {
+    assert.equal(capabilityProfileForEdition("mac"), "local-owner");
+    assert.equal(capabilityProfileForEdition("cloud"), "cloud-chat");
+  });
+
+  test("local owner retains the original toolset while cloud is allow-listed", () => {
+    const tools = [fake("bash"), fake("soul_read"), fake("operator_mcp")];
+    assert.equal(toolsForCapabilityProfile(tools, "local-owner"), tools);
+    assert.deepEqual(
+      toolsForCapabilityProfile(tools, "cloud-chat").map((tool) => tool.name),
+      ["soul_read"],
+    );
+  });
+});
+
+describe("cloud route capability boundary", () => {
+  test("denies machine-control and arbitrary outbound routes, including query forms", () => {
+    for (const route of [
+      "/api/agents/managed/start",
+      "/api/agents/pty/a/output",
+      "/api/dispatch/status?id=secret",
+      "/api/control/policy",
+      "/api/config/save",
+      "/api/devices",
+      "/api/pair/start",
+      "/api/plans",
+      "/api/mail/connect",
+      "/api/vision/capture",
+      "/api/sense/recent",
+      "/api/kb/ingest?force=1",
+    ]) {
+      assert.equal(isCloudDeniedRoute(route), true, `${route} must be denied`);
+    }
+  });
+
+  test("keeps tenant data, auth, billing, chat, and bounded KB routes available", () => {
+    for (const route of [
+      "/api/auth/me",
+      "/api/billing/quota",
+      "/api/autonomy/state",
+      "/api/kb/search?q=lisa",
+      "/api/kb/add",
+      "/api/soul",
+      "/chat",
+      "/reflect",
+      "/api/plans-public",
+    ]) {
+      assert.equal(isCloudDeniedRoute(route), false, `${route} must stay available`);
+    }
+  });
+
+  test("fails closed for malformed URLs", () => {
+    assert.equal(isCloudDeniedRoute("http://["), true);
+  });
+});

--- a/src/web/capabilities.test.ts
+++ b/src/web/capabilities.test.ts
@@ -37,6 +37,7 @@ describe("cloud route capability boundary", () => {
       "/api/devices",
       "/api/pair/start",
       "/api/plans",
+      "/api/plans/select",
       "/api/mail/connect",
       "/api/vision/capture",
       "/api/sense/recent",

--- a/src/web/capabilities.ts
+++ b/src/web/capabilities.ts
@@ -30,6 +30,7 @@ const CLOUD_DENIED_ROUTE_PREFIXES = [
   "/api/dispatch/",
   "/api/mail/",
   "/api/pair/",
+  "/api/plans/",
   "/api/screen-advisor/",
   "/api/sense/",
   "/api/vision/",

--- a/src/web/capabilities.ts
+++ b/src/web/capabilities.ts
@@ -1,0 +1,55 @@
+import type { Edition } from "../edition.js";
+import type { ToolDefinition } from "../types.js";
+import { cloudSafeSubset } from "../tools/registry.js";
+
+export type CapabilityProfile = "local-owner" | "cloud-chat";
+
+export function capabilityProfileForEdition(edition: Edition): CapabilityProfile {
+  return edition === "cloud" ? "cloud-chat" : "local-owner";
+}
+
+export function toolsForCapabilityProfile(
+  tools: ToolDefinition[],
+  profile: CapabilityProfile,
+): ToolDefinition[] {
+  return profile === "cloud-chat" ? cloudSafeSubset(tools) : tools;
+}
+
+/**
+ * Host-control routes that have meaning only when the caller owns the machine
+ * running LISA. These are denied at the HTTP boundary in the hosted edition,
+ * independently from client-side edition flags and tool filtering.
+ */
+const CLOUD_DENIED_ROUTE_PREFIXES = [
+  "/api/agent/",
+  "/api/agents/",
+  "/api/claude/",
+  "/api/config/",
+  "/api/control/",
+  "/api/devices/",
+  "/api/dispatch/",
+  "/api/mail/",
+  "/api/pair/",
+  "/api/screen-advisor/",
+  "/api/sense/",
+  "/api/vision/",
+] as const;
+
+const CLOUD_DENIED_EXACT_ROUTES = new Set([
+  "/api/kb/ingest",
+  "/api/plans",
+]);
+
+export function isCloudDeniedRoute(rawUrl: string): boolean {
+  let pathname: string;
+  try {
+    pathname = new URL(rawUrl, "http://localhost").pathname;
+  } catch {
+    return true;
+  }
+  if (CLOUD_DENIED_EXACT_ROUTES.has(pathname)) return true;
+  return CLOUD_DENIED_ROUTE_PREFIXES.some((prefix) => {
+    const root = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+    return pathname === root || pathname.startsWith(`${root}/`);
+  });
+}

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -144,6 +144,11 @@ import {
 import { detectLanHost, buildPairUrl } from "./pairing.js";
 import { TenantEventBus, sameTenant } from "./event-bus.js";
 import { qrSvg } from "./qr-svg.js";
+import {
+  capabilityProfileForEdition,
+  isCloudDeniedRoute,
+  toolsForCapabilityProfile,
+} from "./capabilities.js";
 import type { ToolDefinition, StoredMessage } from "../types.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -337,6 +342,9 @@ async function resumeOrCreateWebSession(model: string): Promise<SessionStore> {
 export async function startWebServer(opts: WebServerOptions): Promise<http.Server> {
   const host = opts.host ?? "127.0.0.1";
   const webToken = process.env.LISA_WEB_TOKEN?.trim() || null;
+  const cloudEdition = isCloud();
+  const capabilityProfile = capabilityProfileForEdition(cloudEdition ? "cloud" : "mac");
+  const runtimeTools = toolsForCapabilityProfile(opts.tools, capabilityProfile);
   // Account sessions (PLAN_ACCOUNTS_BILLING B1): the signing secret lives in
   // $lisaHome() (auto-created 0600; durable on the cloud's /data mount). Only the
   // cloud edition mints/verifies account sessions today — the Mac edition gains
@@ -826,7 +834,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           }
         }
         const result = await runIdleOnce({
-          tools: opts.tools,
+          tools: runtimeTools,
           cwd: process.cwd(),
           signal: abort.signal,
           model: opts.model,
@@ -1752,6 +1760,18 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // Hosted users never own the machine running this process. Deny local
+    // control-plane and arbitrary-outbound routes server-side before their
+    // handlers run; the client edition descriptor is presentation only.
+    if (cloud && isCloudDeniedRoute(url)) {
+      res.writeHead(403, { "content-type": "application/json" });
+      res.end(JSON.stringify({
+        error: "capability_denied",
+        profile: capabilityProfile,
+      }));
+      return;
+    }
+
     // Per-request gate for high-risk control actions from REMOTE callers. The Mac
     // owner (loopback) is never gated; a remote (token) device may take only what
     // the Mac-side policy permits. denyRemote() writes the 403 and returns true
@@ -2409,7 +2429,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       }
       const cwd = typeof payload.cwd === "string" && payload.cwd.startsWith("/") ? payload.cwd : process.cwd();
       // A managed agent doesn't control other agents — drop dispatch/signal.
-      const tools = opts.tools.filter((t) => t.name !== "dispatch_agent" && t.name !== "signal_agent");
+      const tools = runtimeTools.filter((t) => t.name !== "dispatch_agent" && t.name !== "signal_agent");
       const systemPrompt =
         `You are a delegated agent working in ${cwd}, launched by the user through Lisa. ` +
         `Complete the user's task using the available tools, then report what you did concisely. ` +
@@ -2988,7 +3008,7 @@ self.addEventListener('fetch', (event) => {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(
         JSON.stringify({
-          tools: opts.tools.map((t) => ({
+          tools: runtimeTools.map((t) => ({
             name: t.name,
             description: t.description,
           })),
@@ -3381,7 +3401,7 @@ self.addEventListener('fetch', (event) => {
           const result = await runAgent({
             provider: getProvider(),
             systemPrompt: fresh.text,
-            tools: opts.tools,
+            tools: runtimeTools,
             toolCtx: {
               cwd: process.cwd(),
               // Abort on server shutdown OR this client disconnecting (Stop).


### PR DESCRIPTION
## What changed

- introduce explicit `local-owner` and `cloud-chat` capability profiles
- use a strict allow-list for hosted tools; unknown plugin, MCP, and future tools are denied by default
- skip executable skills, plugins, hooks, MCP connections, voice tools, and the full-tool `task` closure when booting the Cloud edition
- apply the filtered toolset to chat, idle runs, managed agents, and `/api/tools`
- deny host-control and arbitrary-outbound routes at the Cloud HTTP boundary, including agent/PTY control, dispatch, config, coding plans, device pairing, IMAP, screen/sense capture, and URL ingestion
- add denial-path tests for tools and routes

## Why

The Web server previously received the same assembled toolset as the local CLI. In a multi-tenant Cloud deployment that made local-owner capabilities such as shell, arbitrary file access, process control, operator plugins, and MCP tools reachable from a tenant-facing runtime. Client-side edition hiding and approval prompts are not authorization boundaries.

## Impact

Local and remote-device behavior in the Mac edition is unchanged. Hosted chat retains tenant-scoped Soul, memory, mood, and bounded KB tools. Cloud-only endpoints that control the host or initiate arbitrary network connections now return a structured 403 `capability_denied` response.

## Validation

- `npm run typecheck`
- `npm test`: 1,390 passed, 1 PTY-only skip, 0 failed
- `npm run build`
- focused capability tests: 13 passed
- `git diff --check`