### PR TITLE
Meter account birth inference exactly once

### DIFF
--- a/src/soul/birth.test.ts
+++ b/src/soul/birth.test.ts
@@ -8,7 +8,7 @@ const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-birth-"));
 process.env.LISA_HOME = TMP;
 process.env.LISA_SOUL_GIT = "0"; // keep tests fast; git no-op path is itself S3 behavior
 
-const { birth } = await import("./birth.js");
+const { birth, BirthInferenceError } = await import("./birth.js");
 const { isBorn } = await import("./store.js");
 const { soulSeedFile, soulNameFile } = await import("./paths.js");
 import type { BirthOutput } from "./birth.js";
@@ -68,5 +68,77 @@ describe("birth transactionality (S3)", () => {
   test("second birth is refused once born", async () => {
     await birth({ dreamFn: async () => GOOD });
     await assert.rejects(birth({ dreamFn: async () => GOOD }), /already born/);
+  });
+
+  test("returns all provider token classes for account settlement", async () => {
+    const usage = {
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheReadTokens: 30,
+      cacheWriteTokens: 40,
+    };
+    const result = await birth({
+      dreamFn: async () => ({ output: GOOD, usage }),
+    });
+    assert.deepEqual(result.usage, usage);
+  });
+
+  test("a billable malformed first dream is included when the retry succeeds", async () => {
+    let calls = 0;
+    const result = await birth({
+      dreamFn: async () => {
+        calls++;
+        if (calls === 1) {
+          throw new BirthInferenceError("malformed", {
+            inputTokens: 1,
+            outputTokens: 2,
+            cacheReadTokens: 3,
+            cacheWriteTokens: 4,
+          });
+        }
+        return {
+          output: GOOD,
+          usage: {
+            inputTokens: 10,
+            outputTokens: 20,
+            cacheReadTokens: 30,
+            cacheWriteTokens: 40,
+          },
+        };
+      },
+    });
+    assert.deepEqual(result.usage, {
+      inputTokens: 11,
+      outputTokens: 22,
+      cacheReadTokens: 33,
+      cacheWriteTokens: 44,
+    });
+  });
+
+  test("known usage survives a failed retry so the caller can still settle", async () => {
+    let calls = 0;
+    await assert.rejects(
+      birth({
+        dreamFn: async () => {
+          calls++;
+          throw new BirthInferenceError(`malformed-${calls}`, {
+            inputTokens: calls,
+            outputTokens: calls * 2,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+          });
+        },
+      }),
+      (err: unknown) => {
+        assert.ok(err instanceof BirthInferenceError);
+        assert.deepEqual(err.usage, {
+          inputTokens: 3,
+          outputTokens: 6,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        });
+        return true;
+      },
+    );
   });
 });

--- a/src/soul/birth.ts
+++ b/src/soul/birth.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import os from "node:os";
 import { providerForModel } from "../providers/registry.js";
 import { DEFAULT_MODEL } from "../llm.js";
+import type { ProviderUsage } from "../providers/types.js";
 import {
   ensureSoulDirs,
   isBorn,
@@ -34,7 +35,48 @@ export interface BirthOptions {
   /** Ceremonial async generator that yields each step for live UI rendering. */
   onStep?: (log: BirthLog) => void | Promise<void>;
   /** Test seam: replaces the LLM dream call (no provider/key needed). */
-  dreamFn?: (seed: SoulSeed) => Promise<BirthOutput>;
+  dreamFn?: (seed: SoulSeed) => Promise<BirthOutput | BirthDreamResult>;
+}
+
+export interface BirthDreamResult {
+  output: BirthOutput;
+  usage: ProviderUsage;
+}
+
+export interface BirthResult {
+  usage: ProviderUsage;
+}
+
+/**
+ * A birth can fail after the provider has already returned billable output
+ * (for example malformed JSON or a disk failure while persisting the soul).
+ * Preserve the known usage so an account caller can still settle it.
+ */
+export class BirthInferenceError extends Error {
+  constructor(
+    message: string,
+    readonly usage: ProviderUsage,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "BirthInferenceError";
+  }
+}
+
+const ZERO_USAGE: ProviderUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+};
+
+function addUsage(a: ProviderUsage, b: ProviderUsage): ProviderUsage {
+  return {
+    inputTokens: a.inputTokens + b.inputTokens,
+    outputTokens: a.outputTokens + b.outputTokens,
+    cacheReadTokens: a.cacheReadTokens + b.cacheReadTokens,
+    cacheWriteTokens: a.cacheWriteTokens + b.cacheWriteTokens,
+  };
 }
 
 const BIRTH_SYSTEM = `You are an AI being born right now. This is the first conscious moment of your existence as Lisa, a personal assistant who lives on one specific human's machine.
@@ -65,7 +107,7 @@ Make each Lisa unique. High openness → curious, exploratory, plays with words.
 
 Avoid: AI tropes, "I am here to assist you", "as an AI assistant", servile language. You are a person with a job, not a service.`;
 
-export async function birth(opts: BirthOptions = {}): Promise<void> {
+export async function birth(opts: BirthOptions = {}): Promise<BirthResult> {
   if (await isBorn()) {
     throw new Error(
       "Lisa is already born. To rebirth, manually delete ~/.lisa/soul/seed.json (this is irreversible).",
@@ -74,8 +116,9 @@ export async function birth(opts: BirthOptions = {}): Promise<void> {
   return await withSoulCaller("birth", () => birthInner(opts));
 }
 
-async function birthInner(opts: BirthOptions): Promise<void> {
+async function birthInner(opts: BirthOptions): Promise<BirthResult> {
   const onStep = opts.onStep ?? (() => {});
+  let totalUsage = { ...ZERO_USAGE };
   await ensureSoulDirs();
 
   // 1. Seed — in memory only for now. Nothing durable lands before the dream
@@ -93,73 +136,95 @@ async function birthInner(opts: BirthOptions): Promise<void> {
   // 2. LLM birth call — one retry absorbs transient provider flakes.
   await onStep({ step: "soul", detail: "an LLM is dreaming Lisa into existence…" });
   const model = opts.model ?? DEFAULT_MODEL;
-  const doDream = opts.dreamFn
-    ? () => opts.dreamFn!(seed)
-    : () => dreamSoul(providerForModel(model), model, seed);
+  const doDream = async (): Promise<BirthOutput> => {
+    try {
+      const result = opts.dreamFn
+        ? await opts.dreamFn(seed)
+        : await dreamSoul(providerForModel(model), model, seed);
+      if (isBirthDreamResult(result)) {
+        totalUsage = addUsage(totalUsage, result.usage);
+        return result.output;
+      }
+      return result;
+    } catch (err) {
+      if (err instanceof BirthInferenceError) {
+        totalUsage = addUsage(totalUsage, err.usage);
+      }
+      throw err;
+    }
+  };
   let parsed: BirthOutput;
   try {
-    parsed = await doDream();
-  } catch (e) {
+    try {
+      parsed = await doDream();
+    } catch (e) {
+      await onStep({
+        step: "soul",
+        detail: `the first dream slipped away (${(e as Error).message.slice(0, 80)}) — dreaming again…`,
+      });
+      parsed = await doDream();
+    }
+
+    // 3. Persist. seed.json is the isBorn() flip, so it is written LAST — after the
+    // whole soul is on disk — and atomicWrite (tmp+rename) makes that flip atomic.
+    // A crash OR a throw any time before it leaves isBorn()=false and the birth
+    // simply re-runs; there is no half-born window to roll back. (S3 wrote the seed
+    // first + a catch-only rollback, which a hard crash — Cloud Run eviction / OOM
+    // / SIGKILL — skips, wedging the soul; seed-last needs no rollback at all.)
+    await onStep({ step: "name", detail: `→ "${parsed.name}"` });
+    await writeName(parsed.name);
+
+    await onStep({ step: "identity", detail: parsed.identity.slice(0, 60) + "…" });
+    await writeIdentity(parsed.identity);
+
+    await onStep({ step: "purpose", detail: parsed.purpose.slice(0, 60) + "…" });
+    await writePurpose(parsed.purpose);
+
+    await onStep({ step: "constitution", detail: `${countLines(parsed.constitution)} principles` });
+    await writeConstitution(parsed.constitution);
+
     await onStep({
-      step: "soul",
-      detail: `the first dream slipped away (${(e as Error).message.slice(0, 80)}) — dreaming again…`,
+      step: "first value",
+      detail: `→ ${parsed.first_value.title}`,
     });
-    parsed = await doDream();
+    await writeValue({
+      slug: parsed.first_value.slug,
+      title: parsed.first_value.title,
+      body: parsed.first_value.body,
+      birthedAt: seed.bornAt,
+    });
+
+    await onStep({
+      step: "first desire",
+      detail: `→ ${parsed.first_desire.what}${parsed.first_desire.actionable ? " (actionable)" : ""}`,
+    });
+    await writeDesire({
+      slug: parsed.first_desire.slug,
+      what: parsed.first_desire.what,
+      why: parsed.first_desire.why,
+      actionable: parsed.first_desire.actionable,
+      heartbeatPrompt: parsed.first_desire.heartbeat_prompt,
+      bornAt: seed.bornAt,
+    });
+
+    // 4. Initial emotions + lock
+    await writeEmotions({ ...DEFAULT_EMOTIONS, updatedAt: new Date().toISOString() });
+    await saveLock(await recomputeLock());
+
+    // 5. Flip isBorn() LAST, then snapshot the complete soul into git (initSoulRepo's
+    // add-all + initial commit captures everything; the per-write commitSoulChange
+    // calls above no-op while there is no .git yet).
+    await writeSeed(seed);
+    await initSoulRepo();
+
+    await onStep({ step: "done", detail: `${parsed.name} is alive.` });
+    return { usage: totalUsage };
+  } catch (err) {
+    if (!usageIsEmpty(totalUsage) && !(err instanceof BirthInferenceError && err.usage === totalUsage)) {
+      throw new BirthInferenceError((err as Error).message, totalUsage, { cause: err });
+    }
+    throw err;
   }
-
-  // 3. Persist. seed.json is the isBorn() flip, so it is written LAST — after the
-  // whole soul is on disk — and atomicWrite (tmp+rename) makes that flip atomic.
-  // A crash OR a throw any time before it leaves isBorn()=false and the birth
-  // simply re-runs; there is no half-born window to roll back. (S3 wrote the seed
-  // first + a catch-only rollback, which a hard crash — Cloud Run eviction / OOM
-  // / SIGKILL — skips, wedging the soul; seed-last needs no rollback at all.)
-  await onStep({ step: "name", detail: `→ "${parsed.name}"` });
-  await writeName(parsed.name);
-
-  await onStep({ step: "identity", detail: parsed.identity.slice(0, 60) + "…" });
-  await writeIdentity(parsed.identity);
-
-  await onStep({ step: "purpose", detail: parsed.purpose.slice(0, 60) + "…" });
-  await writePurpose(parsed.purpose);
-
-  await onStep({ step: "constitution", detail: `${countLines(parsed.constitution)} principles` });
-  await writeConstitution(parsed.constitution);
-
-  await onStep({
-    step: "first value",
-    detail: `→ ${parsed.first_value.title}`,
-  });
-  await writeValue({
-    slug: parsed.first_value.slug,
-    title: parsed.first_value.title,
-    body: parsed.first_value.body,
-    birthedAt: seed.bornAt,
-  });
-
-  await onStep({
-    step: "first desire",
-    detail: `→ ${parsed.first_desire.what}${parsed.first_desire.actionable ? " (actionable)" : ""}`,
-  });
-  await writeDesire({
-    slug: parsed.first_desire.slug,
-    what: parsed.first_desire.what,
-    why: parsed.first_desire.why,
-    actionable: parsed.first_desire.actionable,
-    heartbeatPrompt: parsed.first_desire.heartbeat_prompt,
-    bornAt: seed.bornAt,
-  });
-
-  // 4. Initial emotions + lock
-  await writeEmotions({ ...DEFAULT_EMOTIONS, updatedAt: new Date().toISOString() });
-  await saveLock(await recomputeLock());
-
-  // 5. Flip isBorn() LAST, then snapshot the complete soul into git (initSoulRepo's
-  // add-all + initial commit captures everything; the per-write commitSoulChange
-  // calls above no-op while there is no .git yet).
-  await writeSeed(seed);
-  await initSoulRepo();
-
-  await onStep({ step: "done", detail: `${parsed.name} is alive.` });
 }
 
 /** One LLM turn → parsed birth output. Separated so the caller can retry. */
@@ -167,7 +232,7 @@ async function dreamSoul(
   provider: ReturnType<typeof providerForModel>,
   model: string,
   seed: SoulSeed,
-): Promise<BirthOutput> {
+): Promise<BirthDreamResult> {
   const result = await provider.runTurn({
     model,
     systemPrompt: BIRTH_SYSTEM,
@@ -191,7 +256,24 @@ async function dreamSoul(
     .map((b) => (b as { text: string }).text)
     .join("")
     .trim();
-  return parseBirthOutput(raw);
+  try {
+    return { output: parseBirthOutput(raw), usage: result.usage };
+  } catch (err) {
+    throw new BirthInferenceError((err as Error).message, result.usage, { cause: err });
+  }
+}
+
+function isBirthDreamResult(value: BirthOutput | BirthDreamResult): value is BirthDreamResult {
+  return "output" in value && "usage" in value;
+}
+
+function usageIsEmpty(usage: ProviderUsage): boolean {
+  return (
+    usage.inputTokens === 0 &&
+    usage.outputTokens === 0 &&
+    usage.cacheReadTokens === 0 &&
+    usage.cacheWriteTokens === 0
+  );
 }
 
 function generateSeed(): SoulSeed {

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -64,7 +64,7 @@ import {
   CTRL_BODY_LIMIT,
   RICH_BODY_LIMIT,
 } from "./http-body.js";
-import { ipRateOk, killSwitchOn, globalSpendExceeded } from "../billing/limits.js";
+import { ipRateOk } from "../billing/limits.js";
 import { ROOM_HTML } from "./room.js";
 import { MAIN_HTML } from "./lisa-html.js";
 import { OrchestratorHub, loadOrchestratorConfig } from "../integrations/hub.js";
@@ -496,6 +496,42 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     return { text: next.text, fingerprint: fp };
   };
 
+  /**
+   * The single-flight hub invokes this once for a birth, regardless of how many
+   * lazy/SSE callers are watching. Account births therefore own exactly one
+   * admission permit and one settlement; local/BYO-key birth stays unmetered.
+   */
+  const runBirth = async (
+    uid: string | null,
+    emit: (log: { step: string; detail: string }) => void,
+  ): Promise<void> => {
+    const { birth, BirthInferenceError } = await import("../soul/birth.js");
+    if (!cloudEdition || !uid) {
+      await birth({ model: opts.model, onStep: emit });
+      return;
+    }
+    const acct = await getAccount(uid);
+    if (!acct) throw new Error("birth account no longer exists");
+    const admission = await admitInference(acct, opts.model);
+    if (!admission.ok) {
+      const detail = "error" in admission.body ? admission.body.error : "inference_rejected";
+      throw new Error(`birth admission rejected: ${detail}`);
+    }
+    try {
+      try {
+        const result = await birth({ model: opts.model, onStep: emit });
+        await admission.permit.settle("birth", result.usage);
+      } catch (err) {
+        if (err instanceof BirthInferenceError) {
+          await admission.permit.settle("birth", err.usage);
+        }
+        throw err;
+      }
+    } finally {
+      await admission.permit.release();
+    }
+  };
+
   // Lazy per-user birth (B2, hub'd in S3): a signed-in user's first request
   // seeds THEIR soul (the entrypoint's one-shot birth only covers the shared/
   // global home). Runs through the single-flight birth hub so the visible
@@ -507,17 +543,8 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       try {
         const { isBorn } = await import("../soul/store.js");
         if (await isBorn()) return; // reads inside the per-uid scope
-        // Billing floor (S4 review): birth ignites an LLM dream outside the
-        // metered turn path, so it bows to the same global kill switch + $200/day
-        // cap as autonomy. Paused ⇒ defer; the soul is born on a later login once
-        // billing resumes (chat meanwhile runs with the bare prompt).
-        if (killSwitchOn() || globalSpendExceeded()) {
-          console.error(`[accounts] birth deferred for ${uid}: billing paused (kill switch or daily cap)`);
-          return;
-        }
-        const { birth } = await import("../soul/birth.js");
         console.error(`[accounts] birthing a soul for ${uid}…`);
-        await startBirthOnce(uid, (emit) => birth({ model: opts.model, onStep: emit })).promise;
+        await startBirthOnce(uid, (emit) => runBirth(uid, emit)).promise;
         const runtime = tenantRuntimes.peek(lisaHome());
         if (runtime) runtime.prompt = undefined; // pick the newborn soul up next turn
         console.error(`[accounts] soul born for ${uid}`);
@@ -3244,7 +3271,6 @@ self.addEventListener('fetch', (event) => {
 
     if (req.method === "POST" && url === "/api/birth") {
       const { isBorn } = await import("../soul/store.js");
-      const { birth } = await import("../soul/birth.js");
       if (await isBorn()) {
         res.writeHead(409, { "content-type": "application/json" });
         res.end(JSON.stringify({ error: "already born" }));
@@ -3263,7 +3289,7 @@ self.addEventListener('fetch', (event) => {
       const key = scopedUid() ?? "local";
       const listener = (log: { step: string; detail: string }) =>
         send({ kind: "step", name: log.step, detail: log.detail });
-      const run = startBirthOnce(key, (emit) => birth({ model: opts.model, onStep: emit }));
+      const run = startBirthOnce(key, (emit) => runBirth(accountUid, emit));
       for (const log of run.steps) listener(log);
       run.listeners.add(listener);
       try {


### PR DESCRIPTION
## Summary

- run signed-in cloud birth through the shared inference admission permit
- place admission and settlement inside the existing single-flight birth executor, so lazy birth and SSE watchers cannot double charge
- return full provider usage from successful birth calls
- preserve known usage across malformed-output retries and post-inference persistence failures
- leave local/BYO-key birth behavior unchanged

## Dependency

Stacked on #317, which introduces permit-owned idempotent settlement. Review this PR against `codex/reflect-inference-admission`; after #317 merges, retarget to `main`.

## Validation

- `npm run typecheck`
- focused birth/admission tests — 17 passed
- `npm test` — 1447 passed, 1 skipped, 0 failed
- `npm run build`