### PR TITLE
Add duration-priced voice cost governance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@google/genai": "^2.0.1",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "imapflow": "^1.4.2",
+        "music-metadata": "^11.14.0",
         "openai": "^6.35.0",
         "qrcode-terminal": "^0.12.0",
         "undici": "^8.2.0"
@@ -61,6 +62,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -1183,6 +1194,29 @@
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.17.tgz",
@@ -1775,6 +1809,24 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
@@ -2036,6 +2088,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/imapflow": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/imapflow/-/imapflow-1.4.2.tgz",
@@ -2243,6 +2315,63 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/music-metadata": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-11.14.0.tgz",
+      "integrity": "sha512-RyOSq98kuVfXB1emJ+NjBF0av8Ph3oBuqNy+Z5sFFfLhjYrkBQEB53V8u+U0RNTVwNo20WoPUwNkfKwZfrOqmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/Borewit"
+        },
+        {
+          "type": "buymeacoffee",
+          "url": "https://buymeacoffee.com/borewit"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.2",
+        "@tokenizer/token": "^0.3.0",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "file-type": "^21.3.4",
+        "media-typer": "^2.0.0",
+        "strtok3": "^10.3.5",
+        "token-types": "^6.1.2",
+        "uint8array-extras": "^1.5.0",
+        "win-guid": "^0.2.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/music-metadata/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/music-metadata/node_modules/media-typer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-2.0.0.tgz",
+      "integrity": "sha512-kOy3OxT2HH39N70UnKgu4NWDZjLOz8W/mfyvniHjRH/DrL3f2pOfvWQ4p60offbbtDAnXWp0v9LfMIqMec269Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/negotiator": {
       "version": "1.0.0",
@@ -2919,6 +3048,22 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/thread-stream": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.2.0.tgz",
@@ -2944,6 +3089,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/ts-algebra": {
@@ -3024,6 +3187,18 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/undici": {
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
@@ -3080,6 +3255,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/win-guid": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/win-guid/-/win-guid-0.2.1.tgz",
+      "integrity": "sha512-gEIQU4mkgl2OPeoNrWflcJFJ3Ae2BPd4eCsHHA/XikslkIVms/nHhvnvzIZV7VLmBvtFlDOzLt9rrZT+n6D67A==",
+      "license": "MIT"
     },
     "node_modules/wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@google/genai": "^2.0.1",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "imapflow": "^1.4.2",
+    "music-metadata": "^11.14.0",
     "openai": "^6.35.0",
     "qrcode-terminal": "^0.12.0",
     "undici": "^8.2.0"

--- a/src/billing/media-admission.test.ts
+++ b/src/billing/media-admission.test.ts
@@ -1,0 +1,104 @@
+import { describe, test } from "node:test";
+import assert from "node:assert/strict";
+import type { AccountRecord } from "../web/accounts.js";
+import type { TurnLease } from "../cloud/turn-lease.js";
+import type { MediaUsageRecord } from "./media-meter.js";
+import {
+  admitMedia,
+  type MediaAdmissionDependencies,
+} from "./media-admission.js";
+
+const ACCT: AccountRecord = {
+  uid: "u-media",
+  kind: "apple",
+  createdAt: "2026-07-26T00:00:00.000Z",
+  verified: true,
+  sessionVersion: 0,
+};
+const LEASE: TurnLease = "off";
+const RECORD: MediaUsageRecord = {
+  at: "2026-07-26T00:00:00.000Z",
+  source: "voice_transcription",
+  provider: "elevenlabs",
+  model: "scribe_v2",
+  durationMs: 1000,
+  microUSD: 86,
+  pricesVersion: 1,
+};
+
+function dependencies(
+  overrides: Partial<MediaAdmissionDependencies> = {},
+): { value: MediaAdmissionDependencies; calls: string[] } {
+  const calls: string[] = [];
+  return {
+    calls,
+    value: {
+      limits: () => {
+        calls.push("limits");
+        return { ok: true };
+      },
+      precheck: async () => {
+        calls.push("precheck");
+        return { ok: true, budgetMicroUSD: 1000 };
+      },
+      acquire: async () => {
+        calls.push("acquire");
+        return LEASE;
+      },
+      startRenewal: () => {
+        calls.push("renew");
+        return () => calls.push("stop");
+      },
+      releaseLease: async () => {
+        calls.push("release");
+      },
+      settle: async () => {
+        calls.push("settle");
+        return RECORD;
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe("admitMedia", () => {
+  test("a limit rejection performs no quota or lease work", async () => {
+    const deps = dependencies({
+      limits: () => ({ ok: false, status: 402, body: { error: "service_paused" } }),
+    });
+    const result = await admitMedia(ACCT, deps.value);
+    assert.equal(result.ok, false);
+    assert.deepEqual(deps.calls, []);
+  });
+
+  test("settlement and release are both idempotent", async () => {
+    const deps = dependencies();
+    const result = await admitMedia(ACCT, deps.value);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    const usage = {
+      provider: "elevenlabs" as const,
+      model: "scribe_v2",
+      durationMs: 1000,
+    };
+    assert.equal(await result.permit.settle("voice_transcription", usage), RECORD);
+    assert.equal(await result.permit.settle("ignored", { ...usage, durationMs: 9999 }), RECORD);
+    await result.permit.release();
+    await result.permit.release();
+    assert.equal(deps.calls.filter((call) => call === "settle").length, 1);
+    assert.equal(deps.calls.filter((call) => call === "release").length, 1);
+  });
+
+  test("quota rejection releases the acquired lease", async () => {
+    const deps = dependencies({
+      precheck: async () => ({
+        ok: false,
+        error: "premium_requires_balance",
+        tier: "free",
+      }),
+    });
+    const result = await admitMedia(ACCT, deps.value);
+    assert.equal(result.ok, false);
+    assert.deepEqual(deps.calls, ["limits", "acquire", "release"]);
+  });
+});

--- a/src/billing/media-admission.ts
+++ b/src/billing/media-admission.ts
@@ -1,0 +1,106 @@
+/**
+ * Account admission for duration-priced media provider calls.
+ */
+import type { AccountRecord } from "../web/accounts.js";
+import type { MediaUsage } from "./media-prices.js";
+import { recordMediaUsage, type MediaUsageRecord } from "./media-meter.js";
+import { preflightLimits, type LimitVerdict } from "./limits.js";
+import { debitTurn, precheckTurn, type PrecheckResult } from "./quota.js";
+import {
+  acquireTurnLease,
+  releaseTurnLease,
+  startLeaseRenewal,
+  type TurnLease,
+} from "../cloud/turn-lease.js";
+
+/** Unknown models are premium in quota.ts: media never consumes free LLM credit. */
+export const MEDIA_BILLING_MODEL = "media/voice-transcription";
+
+export interface MediaPermit {
+  settle(source: string, usage: MediaUsage): Promise<MediaUsageRecord>;
+  release(): Promise<void>;
+}
+
+export type MediaAdmission =
+  | { ok: true; permit: MediaPermit }
+  | { ok: false; status: number; body: Record<string, unknown> };
+
+export interface MediaAdmissionDependencies {
+  limits(uid: string): LimitVerdict;
+  precheck(acct: AccountRecord): Promise<PrecheckResult>;
+  acquire(uid: string): Promise<TurnLease | null>;
+  startRenewal(lease: TurnLease): () => void;
+  releaseLease(lease: TurnLease): Promise<void>;
+  settle(acct: AccountRecord, source: string, usage: MediaUsage): Promise<MediaUsageRecord>;
+}
+
+const DEFAULT_DEPS: MediaAdmissionDependencies = {
+  limits: preflightLimits,
+  precheck: (acct) => precheckTurn(acct, MEDIA_BILLING_MODEL),
+  acquire: acquireTurnLease,
+  startRenewal: startLeaseRenewal,
+  releaseLease: releaseTurnLease,
+  settle: async (acct, source, usage) => {
+    const record = await recordMediaUsage(source, usage);
+    await debitTurn(acct, MEDIA_BILLING_MODEL, record.microUSD);
+    return record;
+  },
+};
+
+function quotaRejection(
+  pre: Exclude<PrecheckResult, { ok: true }>,
+): MediaAdmission {
+  if (pre.error === "premium_requires_balance") {
+    return { ok: false, status: 402, body: { error: pre.error, tier: pre.tier } };
+  }
+  return {
+    ok: false,
+    status: 402,
+    body: { error: pre.error, resetAt: pre.resetAt, tier: pre.tier },
+  };
+}
+
+export async function admitMedia(
+  acct: AccountRecord,
+  deps: MediaAdmissionDependencies = DEFAULT_DEPS,
+): Promise<MediaAdmission> {
+  const limits = deps.limits(acct.uid);
+  if (!limits.ok) return limits;
+
+  const lease = await deps.acquire(acct.uid);
+  if (!lease) {
+    return { ok: false, status: 429, body: { error: "turn_in_progress" } };
+  }
+
+  let released = false;
+  let settlement: Promise<MediaUsageRecord> | null = null;
+  let stopRenewal: () => void = () => {};
+  const release = async (): Promise<void> => {
+    if (released) return;
+    released = true;
+    stopRenewal();
+    await deps.releaseLease(lease);
+  };
+
+  try {
+    const precheck = await deps.precheck(acct);
+    if (!precheck.ok) {
+      await release();
+      return quotaRejection(precheck);
+    }
+    stopRenewal = deps.startRenewal(lease);
+    return {
+      ok: true,
+      permit: {
+        settle: (source, usage) => {
+          settlement ??= deps.settle(acct, source, usage);
+          return settlement;
+        },
+        release,
+      },
+    };
+  } catch (err) {
+    await release();
+    throw err;
+  }
+}

--- a/src/billing/media-meter.test.ts
+++ b/src/billing/media-meter.test.ts
@@ -1,0 +1,31 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-media-meter-"));
+process.env.LISA_HOME = TMP;
+
+const { readMediaUsage, recordMediaUsage, summarizeMediaUsage } =
+  await import("./media-meter.js");
+
+test("media ledger records and summarizes duration-priced usage", async () => {
+  const now = new Date("2026-07-26T12:00:00.000Z");
+  const record = await recordMediaUsage(
+    "voice_transcription",
+    {
+      provider: "elevenlabs",
+      model: "scribe_v2",
+      durationMs: 1000,
+    },
+    now,
+  );
+  assert.equal(record.microUSD, 86);
+  assert.deepEqual(await readMediaUsage(), [record]);
+  assert.deepEqual(await summarizeMediaUsage(now.getTime() - 1), {
+    microUSD: 86,
+    durationMs: 1000,
+    operations: 1,
+  });
+});

--- a/src/billing/media-meter.ts
+++ b/src/billing/media-meter.ts
@@ -1,0 +1,112 @@
+/**
+ * Append-only audit ledger for duration-priced media operations.
+ */
+import path from "node:path";
+import { appendLine, atomicWrite, readTextOrEmpty } from "../fs-utils.js";
+import { withFileLock } from "../soul/lock.js";
+import { billingDir } from "./meter.js";
+import { globalSpendAdd } from "./limits.js";
+import {
+  MEDIA_PRICES_VERSION,
+  mediaCostMicroUSD,
+  type MediaUsage,
+} from "./media-prices.js";
+
+export interface MediaUsageRecord extends MediaUsage {
+  at: string;
+  source: string;
+  microUSD: number;
+  pricesVersion: number;
+}
+
+function mediaUsageFile(): string {
+  return path.join(billingDir(), "media-usage.jsonl");
+}
+
+function mediaUsageLock(): string {
+  return path.join(billingDir(), "media-usage.lock");
+}
+
+const MAX_LINES = 5000;
+
+/**
+ * Pricing and debit remain independent of the best-effort audit append, matching
+ * the token meter's fail-closed economics.
+ */
+export async function recordMediaUsage(
+  source: string,
+  usage: MediaUsage,
+  now: Date = new Date(),
+): Promise<MediaUsageRecord> {
+  const record: MediaUsageRecord = {
+    at: now.toISOString(),
+    source,
+    ...usage,
+    microUSD: mediaCostMicroUSD(usage),
+    pricesVersion: MEDIA_PRICES_VERSION,
+  };
+  try {
+    await appendLine(mediaUsageFile(), JSON.stringify(record));
+    void trimIfNeeded();
+  } catch (err) {
+    console.error(
+      `[billing] media usage audit append failed (operation still priced + debited): ${(err as Error).message}`,
+    );
+  }
+  globalSpendAdd(record.microUSD, now.getTime());
+  return record;
+}
+
+async function trimIfNeeded(): Promise<void> {
+  try {
+    const lines = (await readTextOrEmpty(mediaUsageFile())).split("\n").filter(Boolean);
+    if (lines.length <= MAX_LINES) return;
+    await withFileLock(mediaUsageLock(), async () => {
+      const current = (await readTextOrEmpty(mediaUsageFile())).split("\n").filter(Boolean);
+      if (current.length <= MAX_LINES) return;
+      await atomicWrite(mediaUsageFile(), current.slice(-MAX_LINES).join("\n") + "\n");
+    });
+  } catch {
+    // Audit compaction is best-effort.
+  }
+}
+
+export async function readMediaUsage(): Promise<MediaUsageRecord[]> {
+  const text = await readTextOrEmpty(mediaUsageFile());
+  const records: MediaUsageRecord[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const value = JSON.parse(line) as MediaUsageRecord;
+      if (
+        typeof value.at === "string" &&
+        typeof value.durationMs === "number" &&
+        typeof value.microUSD === "number"
+      ) {
+        records.push(value);
+      }
+    } catch {
+      // A corrupt audit line does not hide the rest of the ledger.
+    }
+  }
+  return records;
+}
+
+export interface MediaUsageSummary {
+  microUSD: number;
+  durationMs: number;
+  operations: number;
+}
+
+export async function summarizeMediaUsage(sinceMs: number): Promise<MediaUsageSummary> {
+  const records = await readMediaUsage();
+  const summary: MediaUsageSummary = { microUSD: 0, durationMs: 0, operations: 0 };
+  for (const record of records) {
+    const timestamp = Date.parse(record.at);
+    if (!Number.isFinite(timestamp) || timestamp < sinceMs) continue;
+    summary.microUSD += record.microUSD;
+    summary.durationMs += record.durationMs;
+    summary.operations += 1;
+  }
+  return summary;
+}

--- a/src/billing/media-prices.test.ts
+++ b/src/billing/media-prices.test.ts
@@ -1,0 +1,45 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mediaCostMicroUSD, mediaHourlyUSD } from "./media-prices.js";
+
+test("duration prices use provider-native units plus the shared margin", () => {
+  assert.equal(
+    mediaCostMicroUSD({
+      provider: "elevenlabs",
+      model: "scribe_v2",
+      durationMs: 3_600_000,
+    }),
+    308_000,
+  );
+  assert.equal(
+    mediaCostMicroUSD({
+      provider: "openai",
+      model: "whisper-1",
+      durationMs: 60_000,
+    }),
+    8_400,
+  );
+});
+
+test("an unknown media model gets the conservative supported fallback", () => {
+  assert.equal(mediaHourlyUSD("elevenlabs", "future-model"), 0.36);
+  assert.equal(
+    mediaCostMicroUSD({
+      provider: "elevenlabs",
+      model: "future-model",
+      durationMs: 3_600_000,
+    }),
+    504_000,
+  );
+});
+
+test("invalid durations can never poison the ledger", () => {
+  assert.equal(
+    mediaCostMicroUSD({
+      provider: "openai",
+      model: "whisper-1",
+      durationMs: Number.NaN,
+    }),
+    0,
+  );
+});

--- a/src/billing/media-prices.ts
+++ b/src/billing/media-prices.ts
@@ -1,0 +1,43 @@
+/**
+ * Duration-priced provider media usage. Kept separate from token prices so an
+ * audit never has to reinterpret seconds as synthetic tokens.
+ */
+import { MARGIN } from "./prices.js";
+
+export const MEDIA_PRICES_VERSION = 1;
+
+export type MediaProvider = "openai" | "elevenlabs";
+
+export interface MediaUsage {
+  provider: MediaProvider;
+  model: string;
+  durationMs: number;
+}
+
+/** Provider list USD/hour, verified against official pricing in 2026-07. */
+const HOURLY_USD: Array<{ provider: MediaProvider; prefix: string; usd: number }> = [
+  { provider: "elevenlabs", prefix: "scribe_v2", usd: 0.22 },
+  { provider: "openai", prefix: "whisper-1", usd: 0.36 },
+];
+
+// Conservative fallback: the more expensive supported batch transcriber.
+const FALLBACK_USD_PER_HOUR = 0.36;
+
+export function mediaHourlyUSD(provider: MediaProvider, model: string): number {
+  const normalized = model.trim().toLowerCase();
+  return (
+    HOURLY_USD.find(
+      (entry) => entry.provider === provider && normalized.startsWith(entry.prefix),
+    )?.usd ?? FALLBACK_USD_PER_HOUR
+  );
+}
+
+/** Face cost for a duration-priced operation, integer micro-USD. */
+export function mediaCostMicroUSD(usage: MediaUsage): number {
+  if (!Number.isFinite(usage.durationMs) || usage.durationMs <= 0) return 0;
+  const listMicroUSDPerHour = mediaHourlyUSD(usage.provider, usage.model) * 1_000_000;
+  return Math.max(
+    0,
+    Math.ceil((usage.durationMs / 3_600_000) * listMicroUSDPerHour * MARGIN),
+  );
+}

--- a/src/voice/dictation.test.ts
+++ b/src/voice/dictation.test.ts
@@ -1,6 +1,11 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { cleanDictationOutput, polishDictation, type DictationProvider } from "./dictation.js";
+import {
+  cleanDictationOutput,
+  polishDictation,
+  polishDictationMetered,
+  type DictationProvider,
+} from "./dictation.js";
 
 describe("cleanDictationOutput", () => {
   test("passes clean text through", () => {
@@ -71,5 +76,31 @@ describe("polishDictation", () => {
       transcript: "ship the release",
     });
     assert.equal(out, "Ship the release.");
+  });
+
+  test("returns provider usage and estimates conservatively when it is absent", async () => {
+    const estimated = await polishDictationMetered({
+      provider: fakeProvider("Ship it."),
+      model: "m",
+      transcript: "ship it",
+    });
+    assert.ok(estimated.usage.inputTokens > 0);
+    assert.ok(estimated.usage.outputTokens > 0);
+
+    const exact = {
+      inputTokens: 1,
+      outputTokens: 2,
+      cacheReadTokens: 3,
+      cacheWriteTokens: 4,
+    };
+    const provider: DictationProvider = {
+      async runTurn() {
+        return { content: [{ type: "text", text: "Ship it." }], usage: exact };
+      },
+    };
+    assert.deepEqual(
+      (await polishDictationMetered({ provider, model: "m", transcript: "ship it" })).usage,
+      exact,
+    );
   });
 });

--- a/src/voice/dictation.ts
+++ b/src/voice/dictation.ts
@@ -17,6 +17,7 @@
  * Provider-agnostic + side-effect-light so the prompt + output-cleanup logic
  * are unit-testable without a real LLM.
  */
+import type { ProviderUsage } from "../providers/types.js";
 
 export const DICTATION_SYSTEM = `You are a dictation cleanup engine. You are given a raw speech-to-text transcript of someone talking, and you return the polished WRITTEN text they intended — as if they had carefully typed it themselves.
 
@@ -38,7 +39,31 @@ export interface DictationProvider {
     tools: unknown[];
     model: string;
     maxTokens?: number;
-  }): Promise<{ content: Array<{ type: string; text?: string }> }>;
+  }): Promise<{
+    content: Array<{ type: string; text?: string }>;
+    usage?: ProviderUsage;
+  }>;
+}
+
+export interface DictationResult {
+  text: string;
+  usage: ProviderUsage;
+}
+
+const ZERO_USAGE: ProviderUsage = {
+  inputTokens: 0,
+  outputTokens: 0,
+  cacheReadTokens: 0,
+  cacheWriteTokens: 0,
+};
+
+export function estimateDictationUsage(input: string, output: string): ProviderUsage {
+  return {
+    inputTokens: Math.max(1, Math.ceil(Buffer.byteLength(DICTATION_SYSTEM + input, "utf8") / 4)),
+    outputTokens: Math.max(1, Math.ceil(Buffer.byteLength(output, "utf8") / 4)),
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+  };
 }
 
 /**
@@ -72,8 +97,16 @@ export async function polishDictation(opts: {
   model: string;
   transcript: string;
 }): Promise<string> {
+  return (await polishDictationMetered(opts)).text;
+}
+
+export async function polishDictationMetered(opts: {
+  provider: DictationProvider;
+  model: string;
+  transcript: string;
+}): Promise<DictationResult> {
   const raw = (opts.transcript ?? "").trim();
-  if (!raw) return "";
+  if (!raw) return { text: "", usage: ZERO_USAGE };
   const result = await opts.provider.runTurn({
     systemPrompt: DICTATION_SYSTEM,
     messages: [{ role: "user", content: raw }],
@@ -82,5 +115,9 @@ export async function polishDictation(opts: {
     maxTokens: 1500,
   });
   const text = result.content.find((b) => b.type === "text")?.text ?? "";
-  return cleanDictationOutput(text, raw);
+  const cleaned = cleanDictationOutput(text, raw);
+  return {
+    text: cleaned,
+    usage: result.usage ?? estimateDictationUsage(raw, cleaned),
+  };
 }

--- a/src/voice/transcribe.test.ts
+++ b/src/voice/transcribe.test.ts
@@ -3,7 +3,30 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import { transcribeAudio } from "./transcribe.js";
+import {
+  AudioValidationError,
+  prepareTranscription,
+  transcribeAudio,
+} from "./transcribe.js";
+
+function oneSecondWav(): Buffer {
+  const sampleRate = 8_000;
+  const dataSize = sampleRate * 2;
+  const out = Buffer.alloc(44 + dataSize);
+  out.write("RIFF", 0);
+  out.writeUInt32LE(36 + dataSize, 4);
+  out.write("WAVEfmt ", 8);
+  out.writeUInt32LE(16, 16);
+  out.writeUInt16LE(1, 20);
+  out.writeUInt16LE(1, 22);
+  out.writeUInt32LE(sampleRate, 24);
+  out.writeUInt32LE(sampleRate * 2, 28);
+  out.writeUInt16LE(2, 32);
+  out.writeUInt16LE(16, 34);
+  out.write("data", 36);
+  out.writeUInt32LE(dataSize, 40);
+  return out;
+}
 
 async function withEnv(
   key: string,
@@ -39,11 +62,15 @@ test("ElevenLabs is preferred and POSTs the file with xi-api-key", async () => {
   let calledUrl = "";
   let sentKey: unknown;
   let sentFile = false;
+  let sentModel: unknown;
 
   globalThis.fetch = (async (url: unknown, init: { headers?: Record<string, string>; body?: unknown }) => {
     calledUrl = String(url);
     sentKey = init?.headers?.["xi-api-key"];
     sentFile = init?.body instanceof FormData && (init.body as FormData).has("file");
+    sentModel = init?.body instanceof FormData
+      ? (init.body as FormData).get("model_id")
+      : undefined;
     return new Response(JSON.stringify({ text: "hello world" }), { status: 200 });
   }) as typeof fetch;
 
@@ -54,9 +81,32 @@ test("ElevenLabs is preferred and POSTs the file with xi-api-key", async () => {
       assert.match(calledUrl, /api\.elevenlabs\.io\/v1\/speech-to-text$/);
       assert.equal(sentKey, "sk_test_key");
       assert.ok(sentFile, "posts a `file` field in multipart FormData");
+      assert.equal(sentModel, "scribe_v2");
     });
   } finally {
     globalThis.fetch = realFetch;
+    fs.rmSync(tmp, { force: true });
+  }
+});
+
+test("server-side metadata determines duration and enforces the clip limit", async () => {
+  const tmp = path.join(os.tmpdir(), `lisa-asr-duration-${process.pid}.wav`);
+  fs.writeFileSync(tmp, oneSecondWav());
+  try {
+    await withEnv("ELEVENLABS_API_KEY", "sk_test_key", async () => {
+      const prepared = await prepareTranscription({ audioPath: tmp }, 2);
+      assert.equal(prepared.provider, "elevenlabs");
+      assert.equal(prepared.model, "scribe_v2");
+      assert.ok(prepared.durationMs >= 999 && prepared.durationMs <= 1001);
+      await assert.rejects(
+        () => prepareTranscription({ audioPath: tmp }, 0.5),
+        (err: unknown) =>
+          err instanceof AudioValidationError &&
+          err.status === 413 &&
+          /0.5-second/.test(err.message),
+      );
+    });
+  } finally {
     fs.rmSync(tmp, { force: true });
   }
 });

--- a/src/voice/transcribe.test.ts
+++ b/src/voice/transcribe.test.ts
@@ -7,6 +7,7 @@ import {
   AudioValidationError,
   prepareTranscription,
   transcribeAudio,
+  transcribePrepared,
 } from "./transcribe.js";
 
 function oneSecondWav(): Buffer {
@@ -107,6 +108,40 @@ test("server-side metadata determines duration and enforces the clip limit", asy
       );
     });
   } finally {
+    fs.rmSync(tmp, { force: true });
+  }
+});
+
+test("prepared OpenAI transcription preserves an explicitly supplied API key", async () => {
+  const tmp = path.join(os.tmpdir(), `lisa-asr-openai-${process.pid}.wav`);
+  fs.writeFileSync(tmp, oneSecondWav());
+  const realFetch = globalThis.fetch;
+  let authorization = "";
+  globalThis.fetch = (async (_url: unknown, init?: RequestInit) => {
+    const headers = new Headers(init?.headers);
+    authorization = headers.get("authorization") ?? "";
+    return new Response(JSON.stringify({ text: "hello from openai" }), {
+      status: 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as typeof fetch;
+  try {
+    await withEnv("ELEVENLABS_API_KEY", undefined, () =>
+      withEnv("OPENAI_API_KEY", undefined, async () => {
+        const prepared = await prepareTranscription({
+          audioPath: tmp,
+          apiKey: "sk_explicit",
+        });
+        assert.equal(prepared.provider, "openai");
+        assert.equal(
+          await transcribePrepared(prepared, "sk_explicit"),
+          "hello from openai",
+        );
+        assert.equal(authorization, "Bearer sk_explicit");
+      }),
+    );
+  } finally {
+    globalThis.fetch = realFetch;
     fs.rmSync(tmp, { force: true });
   }
 });

--- a/src/voice/transcribe.ts
+++ b/src/voice/transcribe.ts
@@ -105,10 +105,14 @@ export async function prepareTranscription(
   };
 }
 
-export async function transcribePrepared(prepared: PreparedTranscription): Promise<string> {
+export async function transcribePrepared(
+  prepared: PreparedTranscription,
+  apiKey?: string,
+): Promise<string> {
   const plan = configuredPlan({
     audioPath: prepared.audioPath,
     model: prepared.provider === "openai" ? prepared.model : undefined,
+    apiKey,
   });
   if (plan.provider !== prepared.provider || plan.model !== prepared.model) {
     throw new Error("transcription provider configuration changed during the request");
@@ -123,7 +127,7 @@ export async function transcribeAudioMetered(
   maxSeconds: number = maxTranscriptionSeconds(),
 ): Promise<MeteredTranscription> {
   const prepared = await prepareTranscription(opts, maxSeconds);
-  const text = await transcribePrepared(prepared);
+  const text = await transcribePrepared(prepared, opts.apiKey);
   return {
     text,
     usage: {

--- a/src/voice/transcribe.ts
+++ b/src/voice/transcribe.ts
@@ -1,6 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import OpenAI from "openai";
+import { parseFile } from "music-metadata";
+import type { MediaProvider, MediaUsage } from "../billing/media-prices.js";
 
 export interface TranscribeOptions {
   audioPath: string;
@@ -8,6 +10,128 @@ export interface TranscribeOptions {
   model?: string;
   /** OpenAI key override (back-compat); ElevenLabs uses ELEVENLABS_API_KEY. */
   apiKey?: string;
+}
+
+export interface PreparedTranscription {
+  audioPath: string;
+  provider: MediaProvider;
+  model: string;
+  durationMs: number;
+}
+
+export interface MeteredTranscription {
+  text: string;
+  usage: MediaUsage;
+}
+
+export const DEFAULT_MAX_TRANSCRIPTION_SECONDS = 10 * 60;
+
+export class AudioValidationError extends Error {
+  constructor(
+    message: string,
+    readonly status: 400 | 413,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = "AudioValidationError";
+  }
+}
+
+function configuredPlan(opts: TranscribeOptions): {
+  provider: MediaProvider;
+  model: string;
+  apiKey: string;
+} {
+  const elevenKey = process.env.ELEVENLABS_API_KEY;
+  if (elevenKey) {
+    return {
+      provider: "elevenlabs",
+      model: process.env.ELEVENLABS_STT_MODEL || "scribe_v2",
+      apiKey: elevenKey,
+    };
+  }
+  const openaiKey = opts.apiKey ?? process.env.OPENAI_API_KEY;
+  if (openaiKey) {
+    return { provider: "openai", model: opts.model ?? "whisper-1", apiKey: openaiKey };
+  }
+  throw new Error(
+    "Voice transcription needs ELEVENLABS_API_KEY (ElevenLabs Scribe) or OPENAI_API_KEY (OpenAI Whisper).",
+  );
+}
+
+export function maxTranscriptionSeconds(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const value = Number(env.LISA_VOICE_MAX_SECONDS);
+  return Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_MAX_TRANSCRIPTION_SECONDS;
+}
+
+/**
+ * Parse duration on the server before any provider call. This is the billing
+ * source of truth; client-supplied duration is intentionally ignored.
+ */
+export async function prepareTranscription(
+  opts: TranscribeOptions,
+  maxSeconds: number = maxTranscriptionSeconds(),
+): Promise<PreparedTranscription> {
+  const plan = configuredPlan(opts);
+  let durationSeconds: number | undefined;
+  try {
+    const metadata = await parseFile(opts.audioPath, { duration: true });
+    durationSeconds = metadata.format.duration;
+  } catch (err) {
+    throw new AudioValidationError(
+      `cannot read audio duration: ${(err as Error).message}`,
+      400,
+      { cause: err },
+    );
+  }
+  if (!Number.isFinite(durationSeconds) || (durationSeconds ?? 0) <= 0) {
+    throw new AudioValidationError("audio has no measurable duration", 400);
+  }
+  if (durationSeconds! > maxSeconds) {
+    throw new AudioValidationError(
+      `audio exceeds the ${maxSeconds}-second transcription limit`,
+      413,
+    );
+  }
+  return {
+    audioPath: opts.audioPath,
+    provider: plan.provider,
+    model: plan.model,
+    durationMs: Math.ceil(durationSeconds! * 1000),
+  };
+}
+
+export async function transcribePrepared(prepared: PreparedTranscription): Promise<string> {
+  const plan = configuredPlan({
+    audioPath: prepared.audioPath,
+    model: prepared.provider === "openai" ? prepared.model : undefined,
+  });
+  if (plan.provider !== prepared.provider || plan.model !== prepared.model) {
+    throw new Error("transcription provider configuration changed during the request");
+  }
+  return plan.provider === "elevenlabs"
+    ? transcribeWithElevenLabs(prepared.audioPath, plan.apiKey, plan.model)
+    : transcribeWithOpenAI(prepared.audioPath, plan.apiKey, plan.model);
+}
+
+export async function transcribeAudioMetered(
+  opts: TranscribeOptions,
+  maxSeconds: number = maxTranscriptionSeconds(),
+): Promise<MeteredTranscription> {
+  const prepared = await prepareTranscription(opts, maxSeconds);
+  const text = await transcribePrepared(prepared);
+  return {
+    text,
+    usage: {
+      provider: prepared.provider,
+      model: prepared.model,
+      durationMs: prepared.durationMs,
+    },
+  };
 }
 
 /**
@@ -18,17 +142,10 @@ export interface TranscribeOptions {
  * care which provider runs.
  */
 export async function transcribeAudio(opts: TranscribeOptions): Promise<string> {
-  const elevenKey = process.env.ELEVENLABS_API_KEY;
-  if (elevenKey) {
-    return transcribeWithElevenLabs(opts.audioPath, elevenKey);
-  }
-  const openaiKey = opts.apiKey ?? process.env.OPENAI_API_KEY;
-  if (openaiKey) {
-    return transcribeWithOpenAI(opts.audioPath, openaiKey, opts.model);
-  }
-  throw new Error(
-    "Voice transcription needs ELEVENLABS_API_KEY (ElevenLabs Scribe) or OPENAI_API_KEY (OpenAI Whisper).",
-  );
+  const plan = configuredPlan(opts);
+  return plan.provider === "elevenlabs"
+    ? transcribeWithElevenLabs(opts.audioPath, plan.apiKey, plan.model)
+    : transcribeWithOpenAI(opts.audioPath, plan.apiKey, plan.model);
 }
 
 async function transcribeWithOpenAI(
@@ -48,11 +165,15 @@ async function transcribeWithOpenAI(
  * ElevenLabs Scribe speech-to-text — POST /v1/speech-to-text, multipart `file` +
  * `model_id`, authed with the `xi-api-key` header. Returns `{ text }`.
  */
-async function transcribeWithElevenLabs(audioPath: string, apiKey: string): Promise<string> {
+async function transcribeWithElevenLabs(
+  audioPath: string,
+  apiKey: string,
+  model: string,
+): Promise<string> {
   const buf = await fs.promises.readFile(audioPath);
   const form = new FormData();
   form.append("file", new Blob([buf]), path.basename(audioPath) || "audio.webm");
-  form.append("model_id", process.env.ELEVENLABS_STT_MODEL || "scribe_v1");
+  form.append("model_id", model);
 
   const res = await fetch("https://api.elevenlabs.io/v1/speech-to-text", {
     method: "POST",

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -75,8 +75,15 @@ import { recordEvent } from "../orchestrator/journal.js";
 import { buildRecap, formatRecap } from "../orchestrator/recap.js";
 import type { AgentSession } from "../integrations/types.js";
 import { captureScreenshot, captureSupported, type CaptureMode } from "../vision/capture.js";
-import { transcribeAudio } from "../voice/transcribe.js";
-import { polishDictation, type DictationProvider } from "../voice/dictation.js";
+import {
+  AudioValidationError,
+  prepareTranscription,
+  transcribePrepared,
+} from "../voice/transcribe.js";
+import { polishDictationMetered, type DictationProvider } from "../voice/dictation.js";
+import { admitMedia, type MediaPermit } from "../billing/media-admission.js";
+import { recordMediaUsage, summarizeMediaUsage } from "../billing/media-meter.js";
+import { MEDIA_PRICES_VERSION } from "../billing/media-prices.js";
 import { listGrants, grant, revoke, revokeAll, isGranted, SENSE_SIGNALS, SIGNAL_DESCRIPTIONS } from "../consent/store.js";
 import { signalAgentTool } from "../tools/signal_agent.js";
 import { managedRegistry } from "../agents/managed.js";
@@ -1789,12 +1796,34 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         return;
       }
       const now = Date.now();
-      const [window12h, today] = await Promise.all([
+      const todayStart = new Date(new Date(now).setHours(0, 0, 0, 0)).getTime();
+      const [windowTokens, todayTokens, windowMedia, todayMedia] = await Promise.all([
         summarizeUsage(now - 12 * 60 * 60 * 1000),
-        summarizeUsage(new Date(new Date(now).setHours(0, 0, 0, 0)).getTime()),
+        summarizeUsage(todayStart),
+        summarizeMediaUsage(now - 12 * 60 * 60 * 1000),
+        summarizeMediaUsage(todayStart),
       ]);
+      const window12h = {
+        ...windowTokens,
+        microUSD: windowTokens.microUSD + windowMedia.microUSD,
+        mediaDurationMs: windowMedia.durationMs,
+        mediaOperations: windowMedia.operations,
+      };
+      const today = {
+        ...todayTokens,
+        microUSD: todayTokens.microUSD + todayMedia.microUSD,
+        mediaDurationMs: todayMedia.durationMs,
+        mediaOperations: todayMedia.operations,
+      };
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ window12h, today, pricesVersion: PRICES_VERSION }));
+      res.end(
+        JSON.stringify({
+          window12h,
+          today,
+          pricesVersion: PRICES_VERSION,
+          mediaPricesVersion: MEDIA_PRICES_VERSION,
+        }),
+      );
       return;
     }
 
@@ -2072,10 +2101,35 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
             : "webm";
       const stamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
       const tmp = path.join(os.tmpdir(), `lisa-rec-${stamp}-${process.pid}.${ext}`);
+      let mediaPermit: MediaPermit | null = null;
       try {
-        await fs.writeFile(tmp, Buffer.from(payload.data, "base64"));
-        console.error(`[voice] transcribing ${Buffer.from(payload.data, "base64").length} bytes (${ext})`);
-        const transcript = await transcribeAudio({ audioPath: tmp });
+        const audio = Buffer.from(payload.data, "base64");
+        await fs.writeFile(tmp, audio);
+        const prepared = await prepareTranscription({ audioPath: tmp });
+        console.error(
+          `[voice] transcribing ${audio.length} bytes / ${(prepared.durationMs / 1000).toFixed(1)}s ` +
+            `(${ext}, ${prepared.provider}/${prepared.model})`,
+        );
+        const acct = cloud && accountUid ? await getAccount(accountUid) : null;
+        if (acct) {
+          const admission = await admitMedia(acct);
+          if (!admission.ok) {
+            res.writeHead(admission.status, { "content-type": "application/json" });
+            res.end(JSON.stringify(admission.body));
+            return;
+          }
+          mediaPermit = admission.permit;
+        }
+        const transcript = await transcribePrepared(prepared);
+        const mediaUsage = {
+          provider: prepared.provider,
+          model: prepared.model,
+          durationMs: prepared.durationMs,
+        };
+        if (mediaPermit) await mediaPermit.settle("voice_transcription", mediaUsage);
+        else if (cloud) await recordMediaUsage("voice_transcription", mediaUsage);
+        await mediaPermit?.release();
+        mediaPermit = null;
         // S2-voice: when `voice` is granted, distill this push-to-talk transcript
         // into the ambient sense log (PII-redacted, no audio). No-op otherwise,
         // so dictation works unchanged when voice consent is off.
@@ -2086,23 +2140,53 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         // composer. Falls back to the raw transcript if the polish call fails.
         let text: string | undefined;
         if (payload.mode === "dictation") {
+          let polishPermit: InferencePermit | null = null;
           try {
-            text = await polishDictation({
-              provider: getProvider() as unknown as DictationProvider,
-              model: opts.model,
-              transcript,
-            });
+            if (acct) {
+              const admission = await admitInference(acct, opts.model);
+              if (admission.ok) polishPermit = admission.permit;
+              else {
+                console.error(
+                  `[voice] dictation polish skipped: ${JSON.stringify(admission.body)}`,
+                );
+                text = transcript;
+              }
+            }
+            if (text === undefined) {
+              const polished = await polishDictationMetered({
+                provider: getProvider() as unknown as DictationProvider,
+                model: opts.model,
+                transcript,
+              });
+              text = polished.text;
+              if (cloud && polished.usage) {
+                if (polishPermit) await polishPermit.settle("voice_dictation", polished.usage);
+                else await recordUsage("voice_dictation", opts.model, polished.usage);
+              }
+            }
           } catch (err) {
             console.error(`[voice] dictation polish failed: ${(err as Error).message}`);
             text = transcript;
+          } finally {
+            await polishPermit?.release();
           }
         }
         res.writeHead(200, { "content-type": "application/json" });
         res.end(JSON.stringify(text !== undefined ? { transcript, text } : { transcript }));
       } catch (err) {
-        res.writeHead(500, { "content-type": "application/json" });
-        res.end(JSON.stringify({ error: (err as Error).message }));
+        if (err instanceof AudioValidationError) {
+          res.writeHead(err.status, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: err.message }));
+        } else if (err instanceof BillingStateError || err instanceof AccountStoreError) {
+          console.error(`[billing] voice admission/settlement unavailable: ${err.message}`);
+          res.writeHead(503, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: "billing_state_unavailable" }));
+        } else {
+          res.writeHead(500, { "content-type": "application/json" });
+          res.end(JSON.stringify({ error: (err as Error).message }));
+        }
       } finally {
+        await mediaPermit?.release();
         await fs.rm(tmp, { force: true }).catch(() => {});
       }
       return;

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -2165,6 +2165,9 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
               }
             }
           } catch (err) {
+            if (err instanceof BillingStateError || err instanceof AccountStoreError) {
+              throw err;
+            }
             console.error(`[voice] dictation polish failed: ${(err as Error).message}`);
             text = transcript;
           } finally {


### PR DESCRIPTION
## Summary

- introduce a separate duration-priced media ledger instead of encoding audio as fake tokens
- parse audio duration server-side for WebM/MP4/WAV/OGG and reject invalid or overlong clips (10-minute default, `LISA_VOICE_MAX_SECONDS` override)
- gate signed-in cloud transcription through paid-only account admission, a renewable turn lease, global spend guards, and idempotent settlement
- price ElevenLabs Scribe v2 at $0.22/hour and OpenAI Whisper at $0.006/minute, then apply the existing 1.4x face-price margin
- move the ElevenLabs default from `scribe_v1` to current `scribe_v2`
- route dictation polish through normal LLM admission/settlement; estimate conservatively if a provider omits token usage
- include media spend/duration/operation counts in the billing usage response
- preserve local/BYO-key behavior and audit operator-funded shared-token cloud usage

## Dependencies

Stacked on #318, which is stacked on #317. Merge order: #317 → #318 → this PR, retargeting each successor to `main` as its parent merges.

## Pricing sources

- OpenAI Whisper: https://developers.openai.com/api/docs/models/whisper-1
- ElevenLabs Scribe: https://elevenlabs.io/pricing/api?price.section=speech_to_text

## Validation

- `npm run typecheck`
- focused media/voice/admission tests — 27 passed
- `npm test` — 1456 passed, 1 skipped, 0 failed
- `npm run build`
- `npm audit --omit=dev` — 3 pre-existing moderate findings in the Google GenAI/MCP/Hono chain; no finding in `music-metadata`