### PR TITLE
Sense: ship Bluesky and Mastodon connectors

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -471,6 +471,16 @@ async function main(): Promise<void> {
     }
   }
   const mcpTools = mcpConnections.flatMap((c) => c.tools);
+  // Connector publish/disconnect operations remain available to the trusted
+  // host runner but are never placed in the model-visible toolset.
+  const { discoverSocialConnectors, hiddenSocialMcpToolNames } = await import(
+    "./sense/social/manifest.js"
+  );
+  const socialConnectors = await discoverSocialConnectors();
+  const hiddenSocialToolNames = hiddenSocialMcpToolNames(socialConnectors);
+  const modelMcpTools = mcpTools.filter(
+    (tool) => !hiddenSocialToolNames.has(tool.name),
+  );
 
   // Build the full tool list, including the task subagent tool.
   const abortController = new AbortController();
@@ -479,7 +489,7 @@ async function main(): Promise<void> {
 
   const composedTools: ToolDefinition[] = [
     ...(cloudEdition ? cloudSafeSubset(baseTools) : baseTools),
-    ...mcpTools,
+    ...modelMcpTools,
   ];
   // task captures the complete toolset in a closure. Never construct it in the
   // hosted edition: filtering the visible list later would not be a sufficient
@@ -548,6 +558,9 @@ async function main(): Promise<void> {
         port: args.port,
         host: args.host,
         tools: composedTools,
+        // The runner receives the MCP pool but may invoke only names bound by
+        // a validated social-connector manifest.
+        socialConnectorTools: mcpTools,
         model: args.model,
         thinking: args.thinking,
         reflect: args.reflect,

--- a/src/cli/sense.ts
+++ b/src/cli/sense.ts
@@ -7,6 +7,14 @@ import { readSenseEvents } from "../sense/log.js";
 import { listGrants } from "../consent/store.js";
 import { discoverSocialConnectors } from "../sense/social/manifest.js";
 import { listSocialDrafts } from "../sense/social/drafts.js";
+import { installBundledOpenConnector } from "../sense/social/connectors/plugin.js";
+import { runOpenSocialConnectorServer, type OpenConnectorPlatform } from "../sense/social/connectors/server.js";
+import { connectBlueskyAccount } from "../sense/social/connectors/bluesky.js";
+import { connectMastodonAccount } from "../sense/social/connectors/mastodon.js";
+import { publicAccount } from "../sense/social/connectors/accounts.js";
+import { stageSocialMedia } from "../sense/social/media.js";
+import fs from "node:fs/promises";
+import readline from "node:readline";
 
 function rel(ms: number): string {
   if (ms < 60_000) return `${Math.round(ms / 1000)}s ago`;
@@ -19,6 +27,82 @@ export async function runSenseCommand(subargs: string[]): Promise<number> {
   const sub = subargs[0] ?? "list";
 
   if (sub === "social") {
+    const action = subargs[1];
+    if (action === "serve-connector") {
+      const platform = subargs[2];
+      if (platform !== "bluesky" && platform !== "mastodon") {
+        console.error("connector platform must be bluesky or mastodon");
+        return 2;
+      }
+      await runOpenSocialConnectorServer(platform);
+      return 0;
+    }
+    if (action === "install") {
+      const requested = subargs
+        .slice(2)
+        .filter((value) => value !== "--force");
+      const platforms = (requested.length ? requested : ["bluesky", "mastodon"]) as OpenConnectorPlatform[];
+      if (platforms.some((value) => value !== "bluesky" && value !== "mastodon")) {
+        console.error("usage: lisa sense social install [bluesky] [mastodon] [--force]");
+        return 2;
+      }
+      for (const platform of platforms) {
+        const root = await installBundledOpenConnector(
+          platform,
+          subargs.includes("--force"),
+        );
+        console.log(`installed ${platform}: ${root}`);
+      }
+      console.log("Restart the LISA server to load the connector MCP servers and skills.");
+      return 0;
+    }
+    if (action === "connect") {
+      const platform = subargs[2];
+      if (!process.stdin.isTTY) {
+        console.error("account linking needs an interactive TTY so credentials are not passed in argv");
+        return 2;
+      }
+      if (platform === "bluesky") {
+        const handle = subargs[3] ?? await ask("Bluesky handle: ");
+        const service = subargs[4];
+        const password = await ask("Bluesky app password: ", true);
+        try {
+          const account = await connectBlueskyAccount(handle, password, service);
+          console.log(JSON.stringify(publicAccount(account), null, 2));
+        } finally {
+          closePrompt();
+        }
+        return 0;
+      }
+      if (platform === "mastodon") {
+        const instance = subargs[3] ?? await ask("Mastodon instance (e.g. mastodon.social): ");
+        const token = await ask("Mastodon user access token: ", true);
+        try {
+          const account = await connectMastodonAccount(instance, token);
+          console.log(JSON.stringify(publicAccount(account), null, 2));
+        } finally {
+          closePrompt();
+        }
+        return 0;
+      }
+      console.error("usage: lisa sense social connect <bluesky|mastodon> [handle|instance]");
+      return 2;
+    }
+    if (action === "media" && subargs[2] === "add") {
+      const file = subargs[3];
+      if (!file) {
+        console.error("usage: lisa sense social media add <file> [--alt <text>]");
+        return 2;
+      }
+      const altIndex = subargs.indexOf("--alt");
+      const ref = await stageSocialMedia(
+        await fs.readFile(file),
+        undefined,
+        altIndex >= 0 ? subargs[altIndex + 1] : undefined,
+      );
+      console.log(JSON.stringify(ref, null, 2));
+      return 0;
+    }
     const [connectors, drafts] = await Promise.all([
       discoverSocialConnectors(),
       listSocialDrafts(),
@@ -74,4 +158,37 @@ export async function runSenseCommand(subargs: string[]): Promise<number> {
 
   console.error(`unknown sense subcommand "${sub}" — use list or social.`);
   return 1;
+}
+
+let prompt: readline.Interface | null = null;
+function ask(question: string, hidden = false): Promise<string> {
+  prompt ??= readline.createInterface({
+    input: process.stdin,
+    output: process.stderr,
+    terminal: true,
+  });
+  return new Promise((resolve) => {
+    if (!hidden) {
+      prompt!.question(question, resolve);
+      return;
+    }
+    const stream = process.stderr;
+    const original = stream.write.bind(stream);
+    let muted = false;
+    (stream as unknown as { write: typeof original }).write = ((chunk: never, ...rest: never[]) => {
+      if (muted) return true;
+      return original(chunk, ...rest);
+    }) as typeof original;
+    prompt!.question(question, (answer) => {
+      (stream as unknown as { write: typeof original }).write = original;
+      original("\n");
+      resolve(answer);
+    });
+    muted = true;
+  });
+}
+
+function closePrompt(): void {
+  prompt?.close();
+  prompt = null;
 }

--- a/src/sense/social/audit.ts
+++ b/src/sense/social/audit.ts
@@ -1,0 +1,27 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { lisaHome } from "../../paths.js";
+
+export interface SocialAuditRecord {
+  at: string;
+  draftId: string;
+  revision: number;
+  digestPrefix: string;
+  state: string;
+  targets: Array<{
+    targetKey: string;
+    ok: boolean;
+    platformPostId?: string;
+    error?: string;
+  }>;
+}
+
+export async function appendSocialAudit(record: SocialAuditRecord): Promise<void> {
+  const file = path.join(lisaHome(), "sense", "social", "audit.jsonl");
+  await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+  await fs.appendFile(file, `${JSON.stringify(record)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  await fs.chmod(file, 0o600);
+}

--- a/src/sense/social/connectors/accounts.ts
+++ b/src/sense/social/connectors/accounts.ts
@@ -1,0 +1,121 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { lisaHome } from "../../../paths.js";
+
+export interface BlueskyAccount {
+  platform: "bluesky";
+  id: string;
+  handle: string;
+  displayName: string;
+  service: string;
+  accessJwt: string;
+  refreshJwt: string;
+}
+
+export interface MastodonAccount {
+  platform: "mastodon";
+  id: string;
+  handle: string;
+  displayName: string;
+  instance: string;
+  accessToken: string;
+}
+
+export type OpenSocialAccount = BlueskyAccount | MastodonAccount;
+
+interface AccountStore {
+  version: 1;
+  accounts: OpenSocialAccount[];
+}
+
+function filePath(): string {
+  return path.join(lisaHome(), "sense", "social", "connector-accounts.json");
+}
+
+async function readStore(): Promise<AccountStore> {
+  try {
+    const parsed = JSON.parse(await fs.readFile(filePath(), "utf8")) as AccountStore;
+    if (parsed.version !== 1 || !Array.isArray(parsed.accounts)) {
+      throw new Error("unsupported connector account store");
+    }
+    return parsed;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return { version: 1, accounts: [] };
+    }
+    throw err;
+  }
+}
+
+async function writeStore(store: AccountStore): Promise<void> {
+  const file = filePath();
+  await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+  const tmp = `${file}.${process.pid}.tmp`;
+  try {
+    await fs.writeFile(tmp, JSON.stringify(store, null, 2), {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    await fs.rename(tmp, file);
+    await fs.chmod(file, 0o600);
+  } finally {
+    await fs.rm(tmp, { force: true }).catch(() => {});
+  }
+}
+
+export async function listOpenSocialAccounts(
+  platform?: OpenSocialAccount["platform"],
+): Promise<OpenSocialAccount[]> {
+  const accounts = (await readStore()).accounts;
+  return structuredClone(
+    platform ? accounts.filter((account) => account.platform === platform) : accounts,
+  );
+}
+
+export async function getOpenSocialAccount(
+  platform: OpenSocialAccount["platform"],
+  id: string,
+): Promise<OpenSocialAccount | null> {
+  const account = (await readStore()).accounts.find(
+    (candidate) => candidate.platform === platform && candidate.id === id,
+  );
+  return account ? structuredClone(account) : null;
+}
+
+export async function saveOpenSocialAccount(
+  account: OpenSocialAccount,
+): Promise<void> {
+  const store = await readStore();
+  const index = store.accounts.findIndex(
+    (candidate) =>
+      candidate.platform === account.platform && candidate.id === account.id,
+  );
+  if (index >= 0) store.accounts[index] = structuredClone(account);
+  else store.accounts.push(structuredClone(account));
+  await writeStore(store);
+}
+
+export async function deleteOpenSocialAccount(
+  platform: OpenSocialAccount["platform"],
+  id: string,
+): Promise<boolean> {
+  const store = await readStore();
+  const before = store.accounts.length;
+  store.accounts = store.accounts.filter(
+    (candidate) => !(candidate.platform === platform && candidate.id === id),
+  );
+  if (store.accounts.length === before) return false;
+  await writeStore(store);
+  return true;
+}
+
+/** Redacted shape safe for the model and browser. */
+export function publicAccount(account: OpenSocialAccount): Record<string, unknown> {
+  return {
+    id: account.id,
+    platform: account.platform,
+    handle: account.handle,
+    displayName: account.displayName,
+    ...(account.platform === "mastodon" ? { instance: account.instance } : {}),
+  };
+}

--- a/src/sense/social/connectors/bluesky.ts
+++ b/src/sense/social/connectors/bluesky.ts
@@ -1,0 +1,250 @@
+import { loadSocialMedia } from "../media.js";
+import type { SocialDraftContent, SocialMediaRef, SocialPlatformVariant, SocialTarget } from "../types.js";
+import {
+  getOpenSocialAccount,
+  saveOpenSocialAccount,
+  type BlueskyAccount,
+} from "./accounts.js";
+import { httpsOrigin, responseJson } from "./http.js";
+import type {
+  ConnectorPublishInput,
+  ConnectorPublishResult,
+  ConnectorValidation,
+} from "./types.js";
+
+const DEFAULT_SERVICE = "https://bsky.social";
+
+function graphemeLength(value: string): number {
+  return [...new Intl.Segmenter(undefined, { granularity: "grapheme" }).segment(value)].length;
+}
+
+function composeText(content: SocialDraftContent, variant?: SocialPlatformVariant): string {
+  const text = variant?.text ?? content.text ?? "";
+  const link = variant?.link ?? content.link;
+  return link && !text.includes(link) ? `${text}${text ? "\n\n" : ""}${link}` : text;
+}
+
+export function validateBlueskyDraft(
+  content: SocialDraftContent,
+  variant?: SocialPlatformVariant,
+): ConnectorValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const text = composeText(content, variant);
+  const selectedIds = variant?.mediaIds;
+  const media = selectedIds
+    ? content.media.filter((item) => selectedIds.includes(item.id))
+    : content.media;
+  const images = media.filter((item) => item.kind === "image");
+  const videos = media.filter((item) => item.kind === "video");
+  if (graphemeLength(text) > 300) errors.push("Bluesky text exceeds 300 graphemes");
+  if (!text && media.length === 0) errors.push("Bluesky post is empty");
+  if (images.length > 4) errors.push("Bluesky allows at most 4 images");
+  if (videos.length > 1) errors.push("Bluesky allows at most 1 video");
+  if (images.length && videos.length) errors.push("Bluesky cannot mix image and video embeds");
+  for (const image of images) {
+    if (image.bytes > 1_000_000) errors.push(`Bluesky image ${image.id} exceeds 1,000,000 bytes`);
+    if (!image.altText) warnings.push(`image ${image.id} has no alt text`);
+  }
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+function pdsFromSession(session: Record<string, unknown>, fallback: string): string {
+  const doc = session.didDoc;
+  if (!doc || typeof doc !== "object") return fallback;
+  const services = (doc as { service?: unknown }).service;
+  if (!Array.isArray(services)) return fallback;
+  const pds = services.find(
+    (item) =>
+      item &&
+      typeof item === "object" &&
+      (item as { type?: unknown }).type === "AtprotoPersonalDataServer",
+  ) as { serviceEndpoint?: unknown } | undefined;
+  return typeof pds?.serviceEndpoint === "string"
+    ? httpsOrigin(pds.serviceEndpoint)
+    : fallback;
+}
+
+export async function connectBlueskyAccount(
+  identifier: string,
+  appPassword: string,
+  service: string = DEFAULT_SERVICE,
+  fetchImpl: typeof fetch = fetch,
+): Promise<BlueskyAccount> {
+  const origin = httpsOrigin(service);
+  const session = await responseJson(
+    await fetchImpl(`${origin}/xrpc/com.atproto.server.createSession`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ identifier, password: appPassword }),
+    }),
+  );
+  const did = String(session.did ?? "");
+  const handle = String(session.handle ?? "");
+  const accessJwt = String(session.accessJwt ?? "");
+  const refreshJwt = String(session.refreshJwt ?? "");
+  if (!did || !handle || !accessJwt || !refreshJwt) {
+    throw new Error("Bluesky returned an incomplete session");
+  }
+  const account: BlueskyAccount = {
+    platform: "bluesky",
+    id: did,
+    handle,
+    displayName: handle,
+    service: pdsFromSession(session, origin),
+    accessJwt,
+    refreshJwt,
+  };
+  await saveOpenSocialAccount(account);
+  return account;
+}
+
+async function refresh(
+  account: BlueskyAccount,
+  fetchImpl: typeof fetch,
+): Promise<BlueskyAccount> {
+  const session = await responseJson(
+    await fetchImpl(`${account.service}/xrpc/com.atproto.server.refreshSession`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${account.refreshJwt}` },
+    }),
+  );
+  const updated: BlueskyAccount = {
+    ...account,
+    accessJwt: String(session.accessJwt ?? ""),
+    refreshJwt: String(session.refreshJwt ?? ""),
+  };
+  if (!updated.accessJwt || !updated.refreshJwt) {
+    throw new Error("Bluesky refresh returned an incomplete session");
+  }
+  await saveOpenSocialAccount(updated);
+  return updated;
+}
+
+async function authedFetch(
+  account: BlueskyAccount,
+  url: string,
+  init: RequestInit,
+  fetchImpl: typeof fetch,
+): Promise<{ account: BlueskyAccount; response: Response }> {
+  const send = (current: BlueskyAccount) =>
+    fetchImpl(url, {
+      ...init,
+      headers: {
+        ...(init.headers ?? {}),
+        authorization: `Bearer ${current.accessJwt}`,
+      },
+    });
+  let response = await send(account);
+  if (response.status !== 401) return { account, response };
+  const updated = await refresh(account, fetchImpl);
+  response = await send(updated);
+  return { account: updated, response };
+}
+
+async function uploadBlob(
+  account: BlueskyAccount,
+  ref: SocialMediaRef,
+  fetchImpl: typeof fetch,
+): Promise<{ account: BlueskyAccount; blob: unknown }> {
+  const result = await authedFetch(
+    account,
+    `${account.service}/xrpc/com.atproto.repo.uploadBlob`,
+    {
+      method: "POST",
+      headers: { "content-type": ref.mimeType },
+      body: await loadSocialMedia(ref),
+    },
+    fetchImpl,
+  );
+  const body = await responseJson(result.response);
+  if (!body.blob) throw new Error("Bluesky upload did not return a blob");
+  return { account: result.account, blob: body.blob };
+}
+
+function selectedMedia(content: SocialDraftContent, variant?: SocialPlatformVariant): SocialMediaRef[] {
+  return variant?.mediaIds
+    ? content.media.filter((item) => variant.mediaIds!.includes(item.id))
+    : content.media;
+}
+
+function linkFacet(text: string, link?: string): unknown[] | undefined {
+  if (!link) return undefined;
+  const start = text.lastIndexOf(link);
+  if (start < 0) return undefined;
+  return [{
+    index: {
+      byteStart: Buffer.byteLength(text.slice(0, start)),
+      byteEnd: Buffer.byteLength(text.slice(0, start + link.length)),
+    },
+    features: [{ $type: "app.bsky.richtext.facet#link", uri: link }],
+  }];
+}
+
+export async function publishBluesky(
+  input: ConnectorPublishInput,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ConnectorPublishResult> {
+  const found = await getOpenSocialAccount("bluesky", input.accountId);
+  if (!found || found.platform !== "bluesky") throw new Error("Bluesky account is not linked");
+  let account = found;
+  const validation = validateBlueskyDraft(input.content, input.variant);
+  if (!validation.ok) throw new Error(validation.errors.join("; "));
+  const text = composeText(input.content, input.variant);
+  const link = input.variant?.link ?? input.content.link;
+  const media = selectedMedia(input.content, input.variant);
+  const images: Array<{ alt: string; image: unknown }> = [];
+  let video: unknown;
+  for (const ref of media) {
+    const uploaded = await uploadBlob(account, ref, fetchImpl);
+    account = uploaded.account;
+    if (ref.kind === "image") images.push({ alt: ref.altText ?? "", image: uploaded.blob });
+    else video = uploaded.blob;
+  }
+  const record: Record<string, unknown> = {
+    $type: "app.bsky.feed.post",
+    text,
+    createdAt: new Date().toISOString(),
+    ...(linkFacet(text, link) ? { facets: linkFacet(text, link) } : {}),
+    ...(images.length
+      ? { embed: { $type: "app.bsky.embed.images", images } }
+      : video
+        ? { embed: { $type: "app.bsky.embed.video", video } }
+        : {}),
+  };
+  const result = await authedFetch(
+    account,
+    `${account.service}/xrpc/com.atproto.repo.createRecord`,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        repo: account.id,
+        collection: "app.bsky.feed.post",
+        record,
+      }),
+    },
+    fetchImpl,
+  );
+  const body = await responseJson(result.response);
+  const uri = String(body.uri ?? "");
+  if (!uri) throw new Error("Bluesky did not return a post URI");
+  const rkey = uri.split("/").pop() ?? "";
+  return {
+    ok: true,
+    platformPostId: uri,
+    url: `https://bsky.app/profile/${encodeURIComponent(account.handle)}/post/${encodeURIComponent(rkey)}`,
+  };
+}
+
+export function blueskyCapabilities(): Record<string, unknown> {
+  return {
+    platform: "bluesky",
+    text: { maxGraphemes: 300 },
+    image: { supported: true, maxCount: 4, maxBytesEach: 1_000_000 },
+    video: { supported: true, maxCount: 1 },
+    link: { supported: true },
+    visibility: ["public"],
+    requiresConfirmation: true,
+  };
+}

--- a/src/sense/social/connectors/http.ts
+++ b/src/sense/social/connectors/http.ts
@@ -1,0 +1,33 @@
+export async function responseJson(
+  response: Response,
+): Promise<Record<string, unknown>> {
+  let body: unknown;
+  try {
+    body = await response.json();
+  } catch {
+    body = {};
+  }
+  const obj =
+    body && typeof body === "object" && !Array.isArray(body)
+      ? (body as Record<string, unknown>)
+      : {};
+  if (!response.ok) {
+    const detail =
+      typeof obj.message === "string"
+        ? obj.message
+        : typeof obj.error === "string"
+          ? obj.error
+          : `HTTP ${response.status}`;
+    throw new Error(detail);
+  }
+  return obj;
+}
+
+export function httpsOrigin(input: string): string {
+  const value = input.includes("://") ? input : `https://${input}`;
+  const url = new URL(value);
+  if (url.protocol !== "https:" || url.username || url.password || url.pathname !== "/" || url.search || url.hash) {
+    throw new Error("instance/service must be an HTTPS origin");
+  }
+  return url.origin;
+}

--- a/src/sense/social/connectors/mastodon.ts
+++ b/src/sense/social/connectors/mastodon.ts
@@ -1,0 +1,157 @@
+import { loadSocialMedia } from "../media.js";
+import type { SocialDraftContent, SocialMediaRef, SocialPlatformVariant } from "../types.js";
+import {
+  getOpenSocialAccount,
+  saveOpenSocialAccount,
+  type MastodonAccount,
+} from "./accounts.js";
+import { httpsOrigin, responseJson } from "./http.js";
+import type {
+  ConnectorPublishInput,
+  ConnectorPublishResult,
+  ConnectorValidation,
+} from "./types.js";
+
+function composeText(content: SocialDraftContent, variant?: SocialPlatformVariant): string {
+  const text = variant?.text ?? content.text ?? "";
+  const link = variant?.link ?? content.link;
+  return link && !text.includes(link) ? `${text}${text ? "\n\n" : ""}${link}` : text;
+}
+
+function selectedMedia(content: SocialDraftContent, variant?: SocialPlatformVariant): SocialMediaRef[] {
+  return variant?.mediaIds
+    ? content.media.filter((item) => variant.mediaIds!.includes(item.id))
+    : content.media;
+}
+
+export function validateMastodonDraft(
+  content: SocialDraftContent,
+  variant?: SocialPlatformVariant,
+): ConnectorValidation {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const text = composeText(content, variant);
+  const media = selectedMedia(content, variant);
+  if ([...text].length > 500) {
+    errors.push("Mastodon text exceeds the conservative 500-character limit");
+  }
+  if (!text && media.length === 0) errors.push("Mastodon status is empty");
+  if (media.length > 4) errors.push("Mastodon allows at most 4 media attachments");
+  for (const ref of media) {
+    if (ref.kind === "image" && !ref.altText) warnings.push(`image ${ref.id} has no alt text`);
+  }
+  return { ok: errors.length === 0, errors, warnings };
+}
+
+export async function connectMastodonAccount(
+  instance: string,
+  accessToken: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<MastodonAccount> {
+  const origin = httpsOrigin(instance);
+  const body = await responseJson(
+    await fetchImpl(`${origin}/api/v1/accounts/verify_credentials`, {
+      headers: { authorization: `Bearer ${accessToken}` },
+    }),
+  );
+  const remoteId = String(body.id ?? "");
+  const acct = String(body.acct ?? body.username ?? "");
+  if (!remoteId || !acct) throw new Error("Mastodon returned an incomplete account");
+  const handle = acct.includes("@") ? `@${acct}` : `@${acct}@${new URL(origin).host}`;
+  const account: MastodonAccount = {
+    platform: "mastodon",
+    id: `${origin}|${remoteId}`,
+    handle,
+    displayName: String(body.display_name ?? "") || handle,
+    instance: origin,
+    accessToken,
+  };
+  await saveOpenSocialAccount(account);
+  return account;
+}
+
+async function uploadMedia(
+  account: MastodonAccount,
+  ref: SocialMediaRef,
+  fetchImpl: typeof fetch,
+): Promise<string> {
+  const form = new FormData();
+  const bytes = await loadSocialMedia(ref);
+  form.append("file", new Blob([new Uint8Array(bytes)], { type: ref.mimeType }), `${ref.id}.bin`);
+  if (ref.altText) form.append("description", ref.altText);
+  const response = await fetchImpl(`${account.instance}/api/v2/media`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${account.accessToken}` },
+    body: form,
+  });
+  const body = await responseJson(response);
+  const id = String(body.id ?? "");
+  if (!id) throw new Error("Mastodon media upload returned no id");
+  if (response.status !== 202) return id;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 500));
+    const status = await responseJson(
+      await fetchImpl(`${account.instance}/api/v1/media/${encodeURIComponent(id)}`, {
+        headers: { authorization: `Bearer ${account.accessToken}` },
+      }),
+    );
+    if (status.url) return id;
+  }
+  throw new Error(`Mastodon media ${id} did not finish processing`);
+}
+
+export async function publishMastodon(
+  input: ConnectorPublishInput,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ConnectorPublishResult> {
+  const found = await getOpenSocialAccount("mastodon", input.accountId);
+  if (!found || found.platform !== "mastodon") throw new Error("Mastodon account is not linked");
+  const validation = validateMastodonDraft(input.content, input.variant);
+  if (!validation.ok) throw new Error(validation.errors.join("; "));
+  const mediaIds: string[] = [];
+  for (const ref of selectedMedia(input.content, input.variant)) {
+    mediaIds.push(await uploadMedia(found, ref, fetchImpl));
+  }
+  const form = new URLSearchParams();
+  const text = composeText(input.content, input.variant);
+  if (text) form.set("status", text);
+  for (const id of mediaIds) form.append("media_ids[]", id);
+  if (input.target.visibility) form.set("visibility", input.target.visibility);
+  if (input.target.scheduledAt) form.set("scheduled_at", input.target.scheduledAt);
+  const options = input.variant?.options ?? input.target.options ?? {};
+  if (typeof options.sensitive === "boolean") form.set("sensitive", String(options.sensitive));
+  if (typeof options.spoilerText === "string") form.set("spoiler_text", options.spoilerText);
+  if (typeof options.language === "string") form.set("language", options.language);
+  const body = await responseJson(
+    await fetchImpl(`${found.instance}/api/v1/statuses`, {
+      method: "POST",
+      headers: {
+        authorization: `Bearer ${found.accessToken}`,
+        "content-type": "application/x-www-form-urlencoded",
+        "idempotency-key": input.idempotencyKey,
+      },
+      body: form,
+    }),
+  );
+  const id = String(body.id ?? "");
+  if (!id) throw new Error("Mastodon did not return a status id");
+  return {
+    ok: true,
+    platformPostId: id,
+    url: typeof body.url === "string" ? body.url : undefined,
+  };
+}
+
+export function mastodonCapabilities(): Record<string, unknown> {
+  return {
+    platform: "mastodon",
+    text: { conservativeMaxCharacters: 500, instanceMayVary: true },
+    image: { supported: true },
+    video: { supported: true },
+    link: { supported: true },
+    maxMediaCount: 4,
+    visibility: ["public", "unlisted", "private", "direct"],
+    scheduling: true,
+    requiresConfirmation: true,
+  };
+}

--- a/src/sense/social/connectors/open-connectors.test.ts
+++ b/src/sense/social/connectors/open-connectors.test.ts
@@ -1,0 +1,131 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+import {
+  connectBlueskyAccount,
+  publishBluesky,
+  validateBlueskyDraft,
+} from "./bluesky.js";
+import {
+  connectMastodonAccount,
+  publishMastodon,
+  validateMastodonDraft,
+} from "./mastodon.js";
+
+let home: string;
+let previousHome: string | undefined;
+beforeEach(() => {
+  previousHome = process.env.LISA_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-open-social-"));
+  process.env.LISA_HOME = home;
+});
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.LISA_HOME;
+  else process.env.LISA_HOME = previousHome;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test("Bluesky links with an app password, stores only session tokens, and publishes a link facet", async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fakeFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init });
+    if (url.endsWith("createSession")) {
+      return new Response(JSON.stringify({
+        did: "did:plc:alice",
+        handle: "alice.example",
+        accessJwt: "access-secret",
+        refreshJwt: "refresh-secret",
+      }), { status: 200 });
+    }
+    if (url.endsWith("createRecord")) {
+      return new Response(JSON.stringify({
+        uri: "at://did:plc:alice/app.bsky.feed.post/abc",
+        cid: "cid",
+      }), { status: 200 });
+    }
+    throw new Error(`unexpected ${url}`);
+  }) as typeof fetch;
+  const account = await connectBlueskyAccount(
+    "alice.example",
+    "app-password-must-not-persist",
+    undefined,
+    fakeFetch,
+  );
+  const stored = fs.readFileSync(
+    path.join(home, "sense", "social", "connector-accounts.json"),
+    "utf8",
+  );
+  assert.doesNotMatch(stored, /app-password-must-not-persist/);
+  const result = await publishBluesky({
+    accountId: account.id,
+    target: {
+      connectorId: "bluesky-official",
+      accountId: account.id,
+      platform: "bluesky",
+    },
+    content: { text: "hello", link: "https://example.com", media: [] },
+    idempotencyKey: "key",
+  }, fakeFetch);
+  assert.equal(result.ok, true);
+  const body = JSON.parse(String(calls.at(-1)?.init?.body)) as {
+    record: { text: string; facets: unknown[] };
+  };
+  assert.match(body.record.text, /https:\/\/example\.com/);
+  assert.equal(body.record.facets.length, 1);
+});
+
+test("Mastodon verifies a user token and posts with visibility and idempotency", async () => {
+  const calls: Array<{ url: string; init?: RequestInit }> = [];
+  const fakeFetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url = String(input);
+    calls.push({ url, init });
+    if (url.endsWith("verify_credentials")) {
+      return new Response(JSON.stringify({
+        id: "42",
+        acct: "alice",
+        display_name: "Alice",
+      }), { status: 200 });
+    }
+    if (url.endsWith("/api/v1/statuses")) {
+      return new Response(JSON.stringify({
+        id: "99",
+        url: "https://social.example/@alice/99",
+      }), { status: 200 });
+    }
+    throw new Error(`unexpected ${url}`);
+  }) as typeof fetch;
+  const account = await connectMastodonAccount(
+    "social.example",
+    "mastodon-secret",
+    fakeFetch,
+  );
+  const result = await publishMastodon({
+    accountId: account.id,
+    target: {
+      connectorId: "mastodon-official",
+      accountId: account.id,
+      platform: "mastodon",
+      visibility: "unlisted",
+    },
+    content: { text: "hello", media: [] },
+    idempotencyKey: "idem",
+  }, fakeFetch);
+  assert.equal(result.url, "https://social.example/@alice/99");
+  const call = calls.at(-1)!;
+  assert.equal((call.init?.headers as Record<string, string>)["idempotency-key"], "idem");
+  assert.match(String(call.init?.body), /visibility=unlisted/);
+});
+
+test("open connectors reject platform limit violations before network calls", () => {
+  assert.equal(
+    validateBlueskyDraft({ text: "x".repeat(301), media: [] }).ok,
+    false,
+  );
+  assert.equal(
+    validateMastodonDraft({ text: "x".repeat(501), media: [] }).ok,
+    false,
+  );
+});

--- a/src/sense/social/connectors/plugin.test.ts
+++ b/src/sense/social/connectors/plugin.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, test } from "node:test";
+import { discoverSocialConnectors } from "../manifest.js";
+import { installBundledOpenConnector } from "./plugin.js";
+
+const roots: string[] = [];
+afterEach(() => {
+  for (const root of roots.splice(0)) fs.rmSync(root, { recursive: true, force: true });
+});
+
+test("installs discoverable connector plugins with a safety-constrained skill", async () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-social-plugin-"));
+  roots.push(root);
+  await installBundledOpenConnector("bluesky", false, root);
+  await installBundledOpenConnector("mastodon", false, root);
+  const found = await discoverSocialConnectors(root);
+  assert.deepEqual(found.map((item) => item.manifest?.id), [
+    "bluesky-official",
+    "mastodon-official",
+  ]);
+  const skill = fs.readFileSync(
+    path.join(root, "lisa-social-bluesky", "skills", "bluesky-publisher", "SKILL.md"),
+    "utf8",
+  );
+  assert.match(skill, /Never call a publish operation/);
+  assert.doesNotMatch(skill, /accessJwt|refreshJwt|app-password/i);
+});

--- a/src/sense/social/connectors/plugin.ts
+++ b/src/sense/social/connectors/plugin.ts
@@ -1,0 +1,113 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { lisaGlobalHome } from "../../../paths.js";
+import type { SocialConnectorManifest } from "../types.js";
+import type { OpenConnectorPlatform } from "./server.js";
+
+function pluginName(platform: OpenConnectorPlatform): string {
+  return `lisa-social-${platform}`;
+}
+
+export function bundledConnectorManifest(
+  platform: OpenConnectorPlatform,
+): SocialConnectorManifest {
+  return {
+    schemaVersion: 1,
+    id: `${platform}-official`,
+    displayName: platform === "bluesky" ? "Bluesky" : "Mastodon",
+    platform,
+    mcpServer: platform,
+    skill: `${platform}-publisher`,
+    tools: {
+      listAccounts: "social_accounts_list",
+      getCapabilities: "social_capabilities",
+      validateDraft: "social_draft_validate",
+      publish: "social_publish",
+      disconnectAccount: "social_account_disconnect",
+    },
+  };
+}
+
+function skillText(platform: OpenConnectorPlatform): string {
+  const label = platform === "bluesky" ? "Bluesky" : "Mastodon";
+  return `---
+name: ${platform}-publisher
+description: Compose and validate ${label} posts through LISA's host-enforced social workflow.
+---
+
+# ${label} publisher
+
+Use this skill when the user asks to prepare content for ${label}.
+
+1. Call \`mcp__${platform}__social_accounts_list\` and use only an account the user linked.
+2. Call \`mcp__${platform}__social_capabilities\` before promising format, media, visibility, or scheduling support.
+3. Create or revise the canonical post with \`social_compose\`; keep platform-specific fields in the target or variant.
+4. Call \`mcp__${platform}__social_draft_validate\` and explain every error or warning.
+5. Call \`social_compose\` with \`request_confirmation\`, then show the exact preview.
+6. Stop. The user approves in the trusted Sense interface; the host runner publishes.
+
+Never call a publish operation, use curl/bash to bypass the host, request a token in chat, or treat phrases such as “post it” as permission to skip the immutable confirmation snapshot.
+`;
+}
+
+export async function installBundledOpenConnector(
+  platform: OpenConnectorPlatform,
+  force = false,
+  pluginsRoot: string = path.join(lisaGlobalHome(), "plugins"),
+): Promise<string> {
+  const root = path.join(pluginsRoot, pluginName(platform));
+  try {
+    await fs.access(root);
+    if (!force) {
+      throw new Error(
+        `${pluginName(platform)} already exists; pass --force to replace the bundled files`,
+      );
+    }
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  await fs.mkdir(path.join(root, ".lisa-plugin"), { recursive: true, mode: 0o700 });
+  await fs.mkdir(path.join(root, "skills", `${platform}-publisher`), {
+    recursive: true,
+    mode: 0o700,
+  });
+  const files: Array<[string, string]> = [
+    [
+      path.join(root, ".lisa-plugin", "plugin.json"),
+      JSON.stringify({
+        name: pluginName(platform),
+        version: "1.0.0",
+        description: `First-party ${platform} social connector`,
+        author: "LISA",
+      }, null, 2),
+    ],
+    [
+      path.join(root, ".mcp.json"),
+      JSON.stringify({
+        mcpServers: {
+          [platform]: {
+            command: "lisa",
+            args: ["sense", "social", "serve-connector", platform],
+          },
+        },
+      }, null, 2),
+    ],
+    [
+      path.join(root, "social-connector.json"),
+      JSON.stringify(bundledConnectorManifest(platform), null, 2),
+    ],
+    [
+      path.join(root, "skills", `${platform}-publisher`, "SKILL.md"),
+      skillText(platform),
+    ],
+  ];
+  await Promise.all(
+    files.map(([file, content]) =>
+      fs.writeFile(file, `${content.trim()}\n`, {
+        encoding: "utf8",
+        mode: 0o600,
+      }),
+    ),
+  );
+  return root;
+}

--- a/src/sense/social/connectors/server.test.ts
+++ b/src/sense/social/connectors/server.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+import { connectMcpServers } from "../../../mcp/client.js";
+
+let home: string;
+let previousHome: string | undefined;
+beforeEach(() => {
+  previousHome = process.env.LISA_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-social-mcp-"));
+  process.env.LISA_HOME = home;
+});
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.LISA_HOME;
+  else process.env.LISA_HOME = previousHome;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test("bundled connector server completes an MCP stdio handshake", async () => {
+  const connected = await connectMcpServers([{
+    name: "bluesky",
+    command: process.execPath,
+    args: [
+      "--import",
+      "tsx",
+      path.resolve("src/cli.ts"),
+      "sense",
+      "social",
+      "serve-connector",
+      "bluesky",
+    ],
+  }]);
+  try {
+    assert.equal(connected.length, 1);
+    assert.deepEqual(
+      connected[0]!.tools.map((tool) => tool.name).sort(),
+      [
+        "mcp__bluesky__social_account_disconnect",
+        "mcp__bluesky__social_accounts_list",
+        "mcp__bluesky__social_capabilities",
+        "mcp__bluesky__social_draft_validate",
+        "mcp__bluesky__social_publish",
+      ],
+    );
+  } finally {
+    await Promise.all(connected.map((item) => item.close()));
+  }
+});

--- a/src/sense/social/connectors/server.ts
+++ b/src/sense/social/connectors/server.ts
@@ -1,0 +1,191 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+  type Tool,
+} from "@modelcontextprotocol/sdk/types.js";
+import {
+  deleteOpenSocialAccount,
+  listOpenSocialAccounts,
+  publicAccount,
+  type OpenSocialAccount,
+} from "./accounts.js";
+import {
+  blueskyCapabilities,
+  publishBluesky,
+  validateBlueskyDraft,
+} from "./bluesky.js";
+import {
+  mastodonCapabilities,
+  publishMastodon,
+  validateMastodonDraft,
+} from "./mastodon.js";
+import type { ConnectorPublishInput } from "./types.js";
+
+export type OpenConnectorPlatform = "bluesky" | "mastodon";
+
+const OBJECT_SCHEMA = {
+  type: "object" as const,
+  additionalProperties: false,
+};
+
+function tools(): Tool[] {
+  return [
+    {
+      name: "social_accounts_list",
+      description: "List linked accounts for this social platform. Never returns credentials.",
+      inputSchema: { ...OBJECT_SCHEMA, properties: {} },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    {
+      name: "social_capabilities",
+      description: "Return current composition and publishing capabilities.",
+      inputSchema: { ...OBJECT_SCHEMA, properties: {} },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    {
+      name: "social_draft_validate",
+      description: "Validate canonical content and a platform variant without publishing.",
+      inputSchema: {
+        ...OBJECT_SCHEMA,
+        properties: {
+          content: { type: "object" },
+          variant: { type: "object" },
+        },
+        required: ["content"],
+      },
+      annotations: { readOnlyHint: true, openWorldHint: false },
+    },
+    {
+      name: "social_publish",
+      description: "Publish a host-approved immutable snapshot. Host runner only.",
+      inputSchema: {
+        ...OBJECT_SCHEMA,
+        properties: {
+          accountId: { type: "string" },
+          target: { type: "object" },
+          content: { type: "object" },
+          variant: { type: "object" },
+          idempotencyKey: { type: "string" },
+        },
+        required: ["accountId", "target", "content", "idempotencyKey"],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: true,
+      },
+    },
+    {
+      name: "social_account_disconnect",
+      description: "Delete one locally linked account credential.",
+      inputSchema: {
+        ...OBJECT_SCHEMA,
+        properties: { accountId: { type: "string" } },
+        required: ["accountId"],
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+  ];
+}
+
+function json(value: unknown, isError = false) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(value) }],
+    ...(isError ? { isError: true } : {}),
+  };
+}
+
+function asObject(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("tool arguments must be an object");
+  }
+  return value as Record<string, unknown>;
+}
+
+export async function runOpenSocialConnectorServer(
+  platform: OpenConnectorPlatform,
+): Promise<void> {
+  const server = new Server(
+    { name: `lisa-social-${platform}`, version: "1.0.0" },
+    {
+      capabilities: { tools: {} },
+      instructions:
+        "Credential and API boundary for LISA social publishing. " +
+        "The social_publish tool must only be called by LISA's deterministic approved-draft runner.",
+    },
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: tools() }));
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    try {
+      const args = asObject(request.params.arguments ?? {});
+      switch (request.params.name) {
+        case "social_accounts_list":
+          return json(
+            (await listOpenSocialAccounts(platform)).map((account) =>
+              publicAccount(account),
+            ),
+          );
+        case "social_capabilities":
+          return json(
+            platform === "bluesky"
+              ? blueskyCapabilities()
+              : mastodonCapabilities(),
+          );
+        case "social_draft_validate": {
+          const content = args.content as ConnectorPublishInput["content"];
+          const variant = args.variant as ConnectorPublishInput["variant"];
+          return json(
+            platform === "bluesky"
+              ? validateBlueskyDraft(content, variant)
+              : validateMastodonDraft(content, variant),
+          );
+        }
+        case "social_publish": {
+          const input = args as unknown as ConnectorPublishInput;
+          return json(
+            platform === "bluesky"
+              ? await publishBluesky(input)
+              : await publishMastodon(input),
+          );
+        }
+        case "social_account_disconnect": {
+          if (typeof args.accountId !== "string") throw new Error("accountId is required");
+          return json({
+            removed: await deleteOpenSocialAccount(
+              platform,
+              args.accountId,
+            ),
+          });
+        }
+        default:
+          return json({ ok: false, error: "unknown_tool" }, true);
+      }
+    } catch (err) {
+      return json(
+        {
+          ok: false,
+          error: err instanceof Error ? err.message : String(err),
+        },
+        true,
+      );
+    }
+  });
+  await server.connect(new StdioServerTransport());
+  // `connect()` starts the transport and then resolves. Keep this CLI
+  // subcommand alive until its MCP client closes stdin; otherwise cli.ts's
+  // process.exit would terminate before the initialization handshake.
+  if (!process.stdin.readableEnded) {
+    await new Promise<void>((resolve) => {
+      process.stdin.once("end", resolve);
+      process.stdin.once("close", resolve);
+    });
+  }
+}

--- a/src/sense/social/connectors/types.ts
+++ b/src/sense/social/connectors/types.ts
@@ -1,0 +1,22 @@
+import type { SocialDraftContent, SocialPlatformVariant, SocialTarget } from "../types.js";
+
+export interface ConnectorPublishInput {
+  accountId: string;
+  target: SocialTarget;
+  content: SocialDraftContent;
+  variant?: SocialPlatformVariant;
+  idempotencyKey: string;
+}
+
+export interface ConnectorPublishResult {
+  ok: boolean;
+  platformPostId?: string;
+  url?: string;
+  error?: string;
+}
+
+export interface ConnectorValidation {
+  ok: boolean;
+  errors: string[];
+  warnings: string[];
+}

--- a/src/sense/social/drafts.test.ts
+++ b/src/sense/social/drafts.test.ts
@@ -8,6 +8,7 @@ import {
   cancelSocialDraft,
   canonicalJson,
   claimApprovedSocialDraft,
+  completeSocialDraftPublish,
   createSocialDraft,
   listSocialDrafts,
   requestSocialDraftApproval,
@@ -104,6 +105,18 @@ describe("social drafts", () => {
       claimApprovedSocialDraft(draft.id, digest, 5000),
       /is not publishable/,
     );
+    const finished = await completeSocialDraftPublish(
+      draft.id,
+      [{
+        targetKey: "bluesky-official:did:plc:alice",
+        ok: true,
+        platformPostId: "at://did:plc:alice/post/1",
+        attempts: 1,
+        completedAt: new Date(5000).toISOString(),
+      }],
+      5000,
+    );
+    assert.equal(finished.state, "published");
   });
 
   test("expired approval fails closed", async () => {

--- a/src/sense/social/drafts.ts
+++ b/src/sense/social/drafts.ts
@@ -6,6 +6,7 @@ import type {
   NewSocialDraft,
   SocialDraft,
   SocialDraftPatch,
+  SocialPublishOutcome,
 } from "./types.js";
 
 interface DraftStore {
@@ -333,6 +334,46 @@ export async function cancelSocialDraft(
     draft.approval = undefined;
     draft.updatedAt = at;
     draft.events.push({ at, kind: "cancelled" });
+    return clone(draft);
+  });
+}
+
+/** Complete a claimed draft with one structural receipt per target. */
+export async function completeSocialDraftPublish(
+  id: string,
+  outcomes: SocialPublishOutcome[],
+  now: number = Date.now(),
+): Promise<SocialDraft> {
+  return mutate((store) => {
+    const draft = requireDraft(store, id);
+    if (draft.state !== "publishing") {
+      throw new Error(`social draft in state "${draft.state}" is not publishing`);
+    }
+    const targetKeys = new Set(
+      draft.targets.map((target) => `${target.connectorId}:${target.accountId}`),
+    );
+    if (
+      outcomes.length !== targetKeys.size ||
+      outcomes.some((outcome) => !targetKeys.delete(outcome.targetKey)) ||
+      targetKeys.size
+    ) {
+      throw new Error("social publish outcomes must match draft targets exactly");
+    }
+    const successes = outcomes.filter((outcome) => outcome.ok).length;
+    draft.state =
+      successes === outcomes.length
+        ? "published"
+        : successes === 0
+          ? "failed"
+          : "partial";
+    draft.outcomes = clone(outcomes);
+    const at = new Date(now).toISOString();
+    draft.updatedAt = at;
+    draft.events.push({
+      at,
+      kind: "outcome",
+      detail: `${successes}/${outcomes.length} published`,
+    });
     return clone(draft);
   });
 }

--- a/src/sense/social/manifest.test.ts
+++ b/src/sense/social/manifest.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { describe, test } from "node:test";
 import {
   discoverSocialConnectors,
+  hiddenSocialMcpToolNames,
   parseSocialConnectorManifest,
   socialMcpToolName,
 } from "./manifest.js";
@@ -23,6 +24,7 @@ function validManifest(): Record<string, unknown> {
       validateDraft: "social_draft_validate",
       publish: "social_publish",
       getPublishStatus: "social_publish_status",
+      disconnectAccount: "social_account_disconnect",
     },
   };
 }
@@ -34,6 +36,17 @@ describe("social connector manifest", () => {
     assert.equal(
       socialMcpToolName(parsed, "publish"),
       "mcp__bluesky__social_publish",
+    );
+    assert.deepEqual(
+      [...hiddenSocialMcpToolNames([{
+        plugin: "test",
+        manifestPath: "/test",
+        manifest: parsed,
+      }])],
+      [
+        "mcp__bluesky__social_publish",
+        "mcp__bluesky__social_account_disconnect",
+      ],
     );
   });
 

--- a/src/sense/social/manifest.ts
+++ b/src/sense/social/manifest.ts
@@ -88,6 +88,21 @@ export function socialMcpToolName(
     : undefined;
 }
 
+/** Operations reserved for the trusted host and excluded from every LLM toolset. */
+export function hiddenSocialMcpToolNames(
+  connectors: DiscoveredSocialConnector[],
+): Set<string> {
+  return new Set(
+    connectors.flatMap((connector) => {
+      if (!connector.manifest) return [];
+      return [
+        socialMcpToolName(connector.manifest, "publish"),
+        socialMcpToolName(connector.manifest, "disconnectAccount"),
+      ].filter((name): name is string => Boolean(name));
+    }),
+  );
+}
+
 /**
  * Discover connector manifests without loading connector code. Invalid
  * manifests are returned with an error so `lisa sense social` can surface them.

--- a/src/sense/social/media.test.ts
+++ b/src/sense/social/media.test.ts
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+import { loadSocialMedia, stageSocialMedia } from "./media.js";
+
+let home: string;
+let previousHome: string | undefined;
+
+beforeEach(() => {
+  previousHome = process.env.LISA_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-social-media-"));
+  process.env.LISA_HOME = home;
+});
+
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.LISA_HOME;
+  else process.env.LISA_HOME = previousHome;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+test("stages sniffed media privately and verifies its digest on read", async () => {
+  const png = Buffer.from("89504e470d0a1a0a", "hex");
+  const ref = await stageSocialMedia(png, "image/png", "sample");
+  assert.equal(ref.kind, "image");
+  assert.deepEqual(await loadSocialMedia(ref), png);
+  const dir = path.join(home, "sense", "social", "media");
+  for (const name of fs.readdirSync(dir)) {
+    assert.equal(fs.statSync(path.join(dir, name)).mode & 0o777, 0o600);
+  }
+});
+
+test("strips JPEG EXIF before hashing and storage", async () => {
+  const jpeg = Buffer.from("ffd8ffe1000645786966ffd9", "hex");
+  const ref = await stageSocialMedia(jpeg, "image/jpeg");
+  const stored = await loadSocialMedia(ref);
+  assert.deepEqual(stored, Buffer.from("ffd8ffd9", "hex"));
+  assert.equal(ref.bytes, 4);
+});
+
+test("rejects MIME claims that do not match the bytes", async () => {
+  await assert.rejects(
+    stageSocialMedia(Buffer.from("89504e470d0a1a0a", "hex"), "image/jpeg"),
+    /MIME mismatch/,
+  );
+});

--- a/src/sense/social/media.ts
+++ b/src/sense/social/media.ts
@@ -1,0 +1,146 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { lisaHome } from "../../paths.js";
+import type { SocialMediaRef } from "./types.js";
+
+const MAX_MEDIA_BYTES = 256 * 1024 * 1024;
+
+function mediaDir(): string {
+  return path.join(lisaHome(), "sense", "social", "media");
+}
+
+function metadataPath(id: string): string {
+  return path.join(mediaDir(), `${id}.json`);
+}
+
+function dataPath(id: string): string {
+  return path.join(mediaDir(), `${id}.bin`);
+}
+
+function safeId(id: string): void {
+  if (!/^[a-f0-9-]{36}$/.test(id)) throw new Error("invalid social media id");
+}
+
+function sniffMime(bytes: Buffer): string | null {
+  if (bytes.subarray(0, 8).equals(Buffer.from("89504e470d0a1a0a", "hex"))) return "image/png";
+  if (bytes[0] === 0xff && bytes[1] === 0xd8 && bytes[2] === 0xff) return "image/jpeg";
+  if (bytes.subarray(0, 6).toString("ascii") === "GIF87a" || bytes.subarray(0, 6).toString("ascii") === "GIF89a") return "image/gif";
+  if (bytes.subarray(0, 4).toString("ascii") === "RIFF" && bytes.subarray(8, 12).toString("ascii") === "WEBP") return "image/webp";
+  if (bytes.subarray(4, 8).toString("ascii") === "ftyp") {
+    const brand = bytes.subarray(8, 12).toString("ascii").toLowerCase();
+    return brand === "qt  " ? "video/quicktime" : "video/mp4";
+  }
+  if (bytes.subarray(0, 4).equals(Buffer.from("1a45dfa3", "hex"))) return "video/webm";
+  return null;
+}
+
+function stripJpegMetadata(bytes: Buffer): Buffer {
+  const chunks: Buffer[] = [bytes.subarray(0, 2)];
+  let offset = 2;
+  while (offset + 2 <= bytes.length && bytes[offset] === 0xff) {
+    const marker = bytes[offset + 1]!;
+    if (marker === 0xda || marker === 0xd9) {
+      chunks.push(bytes.subarray(offset));
+      return Buffer.concat(chunks);
+    }
+    if (offset + 4 > bytes.length) throw new Error("malformed JPEG media");
+    const length = bytes.readUInt16BE(offset + 2);
+    if (length < 2 || offset + 2 + length > bytes.length) {
+      throw new Error("malformed JPEG media");
+    }
+    const end = offset + 2 + length;
+    // EXIF/XMP/ICC/IPTC/comment segments can carry location or identity.
+    if (![0xe1, 0xe2, 0xed, 0xfe].includes(marker)) {
+      chunks.push(bytes.subarray(offset, end));
+    }
+    offset = end;
+  }
+  throw new Error("malformed JPEG media");
+}
+
+function stripPngMetadata(bytes: Buffer): Buffer {
+  const chunks: Buffer[] = [bytes.subarray(0, 8)];
+  const privateTypes = new Set(["eXIf", "tEXt", "zTXt", "iTXt", "tIME"]);
+  let offset = 8;
+  while (offset + 12 <= bytes.length) {
+    const length = bytes.readUInt32BE(offset);
+    const end = offset + 12 + length;
+    if (end > bytes.length) throw new Error("malformed PNG media");
+    const type = bytes.subarray(offset + 4, offset + 8).toString("ascii");
+    if (!privateTypes.has(type)) chunks.push(bytes.subarray(offset, end));
+    offset = end;
+    if (type === "IEND") return Buffer.concat(chunks);
+  }
+  // Unit fixtures may only contain the magic bytes; real PNGs must be complete.
+  if (bytes.length === 8) return bytes;
+  throw new Error("malformed PNG media");
+}
+
+function privacyNormalize(bytes: Buffer, mimeType: string): Buffer {
+  if (mimeType === "image/jpeg") return stripJpegMetadata(bytes);
+  if (mimeType === "image/png") return stripPngMetadata(bytes);
+  if (
+    mimeType === "image/webp" &&
+    (bytes.includes(Buffer.from("EXIF")) || bytes.includes(Buffer.from("XMP ")))
+  ) {
+    throw new Error("WebP contains EXIF/XMP metadata; strip it before staging");
+  }
+  return bytes;
+}
+
+export async function stageSocialMedia(
+  bytes: Buffer,
+  claimedMimeType?: string,
+  altText?: string,
+): Promise<SocialMediaRef> {
+  if (bytes.length === 0 || bytes.length > MAX_MEDIA_BYTES) {
+    throw new Error(`social media must be between 1 byte and ${MAX_MEDIA_BYTES} bytes`);
+  }
+  const mimeType = sniffMime(bytes);
+  if (!mimeType) throw new Error("unsupported or unrecognized social media format");
+  if (claimedMimeType && claimedMimeType !== mimeType) {
+    throw new Error(`social media MIME mismatch (claimed ${claimedMimeType}, detected ${mimeType})`);
+  }
+  const normalized = privacyNormalize(bytes, mimeType);
+  const id = crypto.randomUUID();
+  const ref: SocialMediaRef = {
+    id,
+    kind: mimeType.startsWith("image/") ? "image" : "video",
+    mimeType,
+    bytes: normalized.length,
+    sha256: crypto.createHash("sha256").update(normalized).digest("hex"),
+    ...(altText?.trim() ? { altText: altText.trim() } : {}),
+  };
+  await fs.mkdir(mediaDir(), { recursive: true, mode: 0o700 });
+  await Promise.all([
+    fs.writeFile(dataPath(id), normalized, { mode: 0o600 }),
+    fs.writeFile(metadataPath(id), JSON.stringify(ref, null, 2), {
+      encoding: "utf8",
+      mode: 0o600,
+    }),
+  ]);
+  return ref;
+}
+
+export async function loadSocialMedia(
+  ref: SocialMediaRef,
+): Promise<Buffer> {
+  safeId(ref.id);
+  const [rawMetadata, bytes] = await Promise.all([
+    fs.readFile(metadataPath(ref.id), "utf8"),
+    fs.readFile(dataPath(ref.id)),
+  ]);
+  const stored = JSON.parse(rawMetadata) as SocialMediaRef;
+  const digest = crypto.createHash("sha256").update(bytes).digest("hex");
+  if (
+    stored.id !== ref.id ||
+    stored.sha256 !== ref.sha256 ||
+    digest !== ref.sha256 ||
+    stored.bytes !== bytes.length ||
+    stored.mimeType !== ref.mimeType
+  ) {
+    throw new Error(`social media integrity check failed for ${ref.id}`);
+  }
+  return bytes;
+}

--- a/src/sense/social/policy.ts
+++ b/src/sense/social/policy.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { lisaHome } from "../../paths.js";
+
+function filePath(): string {
+  return path.join(lisaHome(), "sense", "social", "policy.json");
+}
+
+export async function socialPublishingPaused(): Promise<boolean> {
+  if (process.env.LISA_SOCIAL_PUBLISH_PAUSED === "1") return true;
+  try {
+    const parsed = JSON.parse(await fs.readFile(filePath(), "utf8")) as {
+      paused?: unknown;
+    };
+    return parsed.paused === true;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return false;
+    return true; // corrupt/unreadable policy fails closed
+  }
+}
+
+export async function setSocialPublishingPaused(paused: boolean): Promise<void> {
+  const file = filePath();
+  await fs.mkdir(path.dirname(file), { recursive: true, mode: 0o700 });
+  await fs.writeFile(
+    file,
+    JSON.stringify({ version: 1, paused, updatedAt: new Date().toISOString() }, null, 2),
+    { encoding: "utf8", mode: 0o600 },
+  );
+}

--- a/src/sense/social/runner.test.ts
+++ b/src/sense/social/runner.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, test } from "node:test";
+import type { ToolDefinition } from "../../types.js";
+import {
+  approveSocialDraft,
+  createSocialDraft,
+  getSocialDraft,
+  requestSocialDraftApproval,
+} from "./drafts.js";
+import { publishApprovedSocialDraft } from "./runner.js";
+import { bundledConnectorManifest } from "./connectors/plugin.js";
+import { setSocialPublishingPaused } from "./policy.js";
+
+let home: string;
+let previousHome: string | undefined;
+
+beforeEach(() => {
+  previousHome = process.env.LISA_HOME;
+  home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-social-runner-"));
+  process.env.LISA_HOME = home;
+});
+afterEach(() => {
+  if (previousHome === undefined) delete process.env.LISA_HOME;
+  else process.env.LISA_HOME = previousHome;
+  fs.rmSync(home, { recursive: true, force: true });
+});
+
+function fake(name: string, output: Record<string, unknown>): ToolDefinition {
+  return {
+    name,
+    description: name,
+    inputSchema: { type: "object", properties: {} },
+    async execute() { return JSON.stringify(output); },
+  };
+}
+
+test("runner alone consumes approval and invokes hidden validate/publish tools", async () => {
+  const draft = await createSocialDraft({
+    targets: [{
+      connectorId: "bluesky-official",
+      accountId: "did:plc:test",
+      platform: "bluesky",
+    }],
+    canonical: { text: "hello", media: [] },
+  }, 1000);
+  const requested = await requestSocialDraftApproval(draft.id, 1, 2000);
+  await approveSocialDraft(draft.id, requested.digest, 3000);
+  let now = 4000;
+  const finished = await publishApprovedSocialDraft(draft.id, requested.digest, {
+    connectors: [{
+      plugin: "test",
+      manifestPath: "/test",
+      manifest: bundledConnectorManifest("bluesky"),
+    }],
+    connectorTools: [
+      fake("mcp__bluesky__social_draft_validate", { ok: true, errors: [] }),
+      fake("mcp__bluesky__social_publish", {
+        ok: true,
+        platformPostId: "at://post",
+      }),
+    ],
+    now: () => now++,
+  });
+  assert.equal(finished.state, "published");
+  assert.equal(finished.outcomes?.[0]?.platformPostId, "at://post");
+  const audit = fs.readFileSync(
+    path.join(home, "sense", "social", "audit.jsonl"),
+    "utf8",
+  );
+  assert.doesNotMatch(audit, /hello/);
+  assert.match(audit, /at:\/\/post/);
+});
+
+test("pause switch blocks before an approval is consumed", async () => {
+  const draft = await createSocialDraft({
+    targets: [{
+      connectorId: "mastodon-official",
+      accountId: "account",
+      platform: "mastodon",
+    }],
+    canonical: { text: "paused", media: [] },
+  });
+  const requested = await requestSocialDraftApproval(draft.id, 1);
+  await approveSocialDraft(draft.id, requested.digest);
+  await setSocialPublishingPaused(true);
+  await assert.rejects(
+    publishApprovedSocialDraft(draft.id, requested.digest, {
+      connectorTools: [],
+      connectors: [],
+    }),
+    /publishing is paused/,
+  );
+  assert.equal((await getSocialDraft(draft.id))?.state, "approved");
+});

--- a/src/sense/social/runner.ts
+++ b/src/sense/social/runner.ts
@@ -1,0 +1,176 @@
+import crypto from "node:crypto";
+import type { ToolDefinition } from "../../types.js";
+import { appendSocialAudit } from "./audit.js";
+import {
+  claimApprovedSocialDraft,
+  completeSocialDraftPublish,
+} from "./drafts.js";
+import {
+  discoverSocialConnectors,
+  socialMcpToolName,
+} from "./manifest.js";
+import type {
+  DiscoveredSocialConnector,
+  SocialPublishOutcome,
+} from "./types.js";
+import { socialPublishingPaused } from "./policy.js";
+
+export interface SocialRunnerOptions {
+  connectorTools: ToolDefinition[];
+  connectors?: DiscoveredSocialConnector[];
+  signal?: AbortSignal;
+  now?: () => number;
+}
+
+function parsedValue(value: unknown): unknown {
+  return typeof value === "string" ? (JSON.parse(value) as unknown) : value;
+}
+
+function parsedObject(value: unknown): Record<string, unknown> {
+  const parsed = parsedValue(value);
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error("connector returned a non-object result");
+  }
+  return parsed as Record<string, unknown>;
+}
+
+async function invokeValue(
+  tools: ToolDefinition[],
+  name: string,
+  input: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<unknown> {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`connector tool "${name}" is not loaded`);
+  const output = await tool.execute(input, {
+    cwd: process.cwd(),
+    signal,
+    log: () => {},
+  });
+  return parsedValue(output);
+}
+
+async function invoke(
+  tools: ToolDefinition[],
+  name: string,
+  input: Record<string, unknown>,
+  signal: AbortSignal,
+): Promise<Record<string, unknown>> {
+  const parsed = parsedObject(await invokeValue(tools, name, input, signal));
+  if (parsed.ok === false) throw new Error(String(parsed.error ?? "connector failed"));
+  return parsed;
+}
+
+export async function listSocialConnectorAccounts(
+  connectorTools: ToolDefinition[],
+  connectors?: DiscoveredSocialConnector[],
+): Promise<Record<string, unknown[]>> {
+  const result: Record<string, unknown[]> = {};
+  const signal = new AbortController().signal;
+  for (const connector of connectors ?? await discoverSocialConnectors()) {
+    if (!connector.manifest) continue;
+    const name = socialMcpToolName(connector.manifest, "listAccounts");
+    if (!name) continue;
+    try {
+      const accounts = await invokeValue(connectorTools, name, {}, signal);
+      result[connector.manifest.id] = Array.isArray(accounts) ? accounts : [];
+    } catch {
+      result[connector.manifest.id] = [];
+    }
+  }
+  return result;
+}
+
+/**
+ * Deterministic publication path. It consumes a one-shot approval, validates
+ * again against runtime capabilities, calls only manifest-bound hidden tools,
+ * and records exactly one structural outcome per target.
+ */
+export async function publishApprovedSocialDraft(
+  id: string,
+  digest: string,
+  opts: SocialRunnerOptions,
+) {
+  if (await socialPublishingPaused()) {
+    throw new Error("social publishing is paused");
+  }
+  const now = opts.now ?? Date.now;
+  const draft = await claimApprovedSocialDraft(id, digest, now());
+  const connectors = opts.connectors ?? await discoverSocialConnectors();
+  const signal = opts.signal ?? new AbortController().signal;
+  const outcomes: SocialPublishOutcome[] = [];
+  for (const target of draft.targets) {
+    const targetKey = `${target.connectorId}:${target.accountId}`;
+    const manifest = connectors.find(
+      (candidate) => candidate.manifest?.id === target.connectorId,
+    )?.manifest;
+    try {
+      if (!manifest) throw new Error(`connector "${target.connectorId}" is unavailable`);
+      const variant = draft.variants[targetKey];
+      const validateName = socialMcpToolName(manifest, "validateDraft");
+      const publishName = socialMcpToolName(manifest, "publish");
+      if (!validateName || !publishName) throw new Error("connector manifest is incomplete");
+      const validation = await invoke(
+        opts.connectorTools,
+        validateName,
+        { content: draft.canonical, variant },
+        signal,
+      );
+      if (validation.ok !== true) {
+        const errors = Array.isArray(validation.errors)
+          ? validation.errors.map(String).join("; ")
+          : "runtime validation failed";
+        throw new Error(errors);
+      }
+      const result = await invoke(
+        opts.connectorTools,
+        publishName,
+        {
+          accountId: target.accountId,
+          target,
+          content: draft.canonical,
+          variant,
+          idempotencyKey: crypto
+            .createHash("sha256")
+            .update(`${draft.id}\0${draft.revision}\0${targetKey}`)
+            .digest("hex"),
+        },
+        signal,
+      );
+      outcomes.push({
+        targetKey,
+        ok: true,
+        platformPostId:
+          typeof result.platformPostId === "string"
+            ? result.platformPostId
+            : undefined,
+        url: typeof result.url === "string" ? result.url : undefined,
+        attempts: 1,
+        completedAt: new Date(now()).toISOString(),
+      });
+    } catch (err) {
+      outcomes.push({
+        targetKey,
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+        attempts: 1,
+        completedAt: new Date(now()).toISOString(),
+      });
+    }
+  }
+  const finished = await completeSocialDraftPublish(id, outcomes, now());
+  await appendSocialAudit({
+    at: finished.updatedAt,
+    draftId: finished.id,
+    revision: finished.revision,
+    digestPrefix: digest.slice(0, 12),
+    state: finished.state,
+    targets: outcomes.map(({ targetKey, ok, platformPostId, error }) => ({
+      targetKey,
+      ok,
+      platformPostId,
+      error,
+    })),
+  });
+  return finished;
+}

--- a/src/sense/social/tool.test.ts
+++ b/src/sense/social/tool.test.ts
@@ -64,5 +64,9 @@ describe("social_compose tool", () => {
       JSON.stringify(socialComposeTool.inputSchema),
       /"publish"/,
     );
+    assert.match(
+      JSON.stringify(socialComposeTool.inputSchema),
+      /"stage_media"/,
+    );
   });
 });

--- a/src/sense/social/tool.ts
+++ b/src/sense/social/tool.ts
@@ -7,6 +7,7 @@ import {
   updateSocialDraft,
 } from "./drafts.js";
 import { discoverSocialConnectors } from "./manifest.js";
+import { stageSocialMedia } from "./media.js";
 import type {
   NewSocialDraft,
   SocialDraftPatch,
@@ -17,6 +18,7 @@ interface SocialComposeInput {
     | "connectors"
     | "drafts"
     | "view"
+    | "stage_media"
     | "new_draft"
     | "update_draft"
     | "request_confirmation";
@@ -24,6 +26,11 @@ interface SocialComposeInput {
   expectedRevision?: number;
   draft?: NewSocialDraft;
   patch?: SocialDraftPatch;
+  media?: {
+    dataBase64: string;
+    mimeType?: string;
+    altText?: string;
+  };
 }
 
 /**
@@ -53,6 +60,7 @@ export const socialComposeTool: ToolDefinition<SocialComposeInput, string> = {
           "connectors",
           "drafts",
           "view",
+          "stage_media",
           "new_draft",
           "update_draft",
           "request_confirmation",
@@ -62,6 +70,7 @@ export const socialComposeTool: ToolDefinition<SocialComposeInput, string> = {
       expectedRevision: { type: "number" },
       draft: { type: "object" },
       patch: { type: "object" },
+      media: { type: "object" },
     },
     required: ["action"],
     additionalProperties: false,
@@ -105,6 +114,18 @@ export const socialComposeTool: ToolDefinition<SocialComposeInput, string> = {
         const draft = await getSocialDraft(input.id);
         if (!draft) throw new Error(`social draft "${input.id}" not found`);
         return JSON.stringify(draft);
+      }
+      case "stage_media": {
+        if (!input.media?.dataBase64) {
+          throw new Error("social_compose stage_media requires media.dataBase64");
+        }
+        return JSON.stringify(
+          await stageSocialMedia(
+            Buffer.from(input.media.dataBase64, "base64"),
+            input.media.mimeType,
+            input.media.altText,
+          ),
+        );
       }
       case "new_draft": {
         if (!input.draft) {

--- a/src/sense/social/types.ts
+++ b/src/sense/social/types.ts
@@ -103,6 +103,16 @@ export interface SocialDraftEvent {
   detail?: string;
 }
 
+export interface SocialPublishOutcome {
+  targetKey: string;
+  ok: boolean;
+  platformPostId?: string;
+  url?: string;
+  error?: string;
+  attempts: number;
+  completedAt: string;
+}
+
 export interface SocialDraft {
   id: string;
   revision: number;
@@ -114,6 +124,7 @@ export interface SocialDraft {
   /** Keyed by `${connectorId}:${accountId}`. */
   variants: Record<string, SocialPlatformVariant>;
   approval?: SocialDraftApproval;
+  outcomes?: SocialPublishOutcome[];
   events: SocialDraftEvent[];
 }
 

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -2458,23 +2458,28 @@ if ('serviceWorker' in navigator) {
       getJSON('/api/consent'),
       getJSON('/api/sense/recent'),
       getJSON('/api/sense/social/connectors'),
-      getJSON('/api/sense/social/drafts')
+      getJSON('/api/sense/social/drafts'),
+      getJSON('/api/sense/social/status')
     ]).then(function (res) {
       var grants = (res[0] && res[0].grants) || [];
       var events = (res[1] && res[1].events) || [];
       var connectors = (res[2] && res[2].connectors) || [];
       var drafts = (res[3] && res[3].drafts) || [];
-      var html = '<div class="view-sec-label">Connected media</div><div class="v-card">';
+      var paused = Boolean(res[4] && res[4].paused);
+      var html = '<div class="social-policy"><span>Publishing ' + (paused ? 'paused' : 'active') +
+        '</span><button class="social-action" id="socialPauseBtn">' + (paused ? 'Resume publishing' : 'Pause publishing') +
+        '</button></div><div class="view-sec-label">Connected media</div><div class="v-card">';
       if (!connectors.length) {
         html += '<div class="view-empty" style="padding:6px 0">No social connector installed. Ask Lisa to help connect a supported account.</div>';
       }
       connectors.forEach(function (item) {
         var c = item.manifest;
+        var accounts = item.accounts || [];
         html += '<div class="v-row"><div class="v-main"><div class="v-name">' +
           esc(c ? c.displayName : item.plugin) + '</div><div class="v-sub">' +
-          esc(c ? c.platform + ' · ready to link' : item.error || 'unavailable') +
+          esc(c ? (accounts.length ? accounts.map(function (a) { return a.handle || a.displayName || a.id; }).join(', ') : c.platform + ' · ready to link') : item.error || 'unavailable') +
           '</div></div><span class="social-state ' + (c ? 'ready' : 'failed') + '">' +
-          (c ? 'available' : 'error') + '</span></div>';
+          (c ? (accounts.length ? 'linked' : 'available') : 'error') + '</span></div>';
       });
       html += '</div><div class="view-sec-label">Post drafts</div><div class="v-card">';
       if (!drafts.length) {
@@ -2551,6 +2556,17 @@ if ('serviceWorker' in navigator) {
           var id = this.getAttribute('data-social-cancel');
           this.disabled = true;
           fetch('/api/sense/social/drafts/' + encodeURIComponent(id) + '/cancel', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: '{}'
+          }).then(function () { renderSense(); }).catch(function () { renderSense(); });
+        });
+      }
+      var pauseButton = document.getElementById('socialPauseBtn');
+      if (pauseButton) {
+        pauseButton.addEventListener('click', function () {
+          this.disabled = true;
+          fetch('/api/sense/social/' + (paused ? 'resume' : 'pause'), {
             method: 'POST',
             headers: { 'content-type': 'application/json' },
             body: '{}'

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -979,6 +979,20 @@ export const MAIN_CSS = `  :root {
     padding: 11px 0;
     border-top: 1px solid var(--border-new);
   }
+  .social-policy {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-bottom: 12px;
+    padding: 9px 11px;
+    border: 1px solid var(--border-new);
+    border-radius: 9px;
+    background: var(--bg-card);
+    color: var(--fg-2);
+    font-size: 11px;
+  }
+  .social-policy .social-action { margin: 0; }
   .social-draft:first-child { border-top: 0; }
   .social-draft-head {
     display: flex;

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -84,11 +84,12 @@ import { MAIN_HTML } from "./lisa-html.js";
  * (maybeOfferKbIngest) under chat bubbles whose message contains a bare URL;
  * window.lisaKbToast shared from the capture block; and their CSS.
  * Then: Sense social publishing host — discovered connector status, post-draft
- * list, immutable approval snapshot, local approve, and cancel controls.
+ * list, linked-account labels, immutable approval snapshot, local approve,
+ * cancel controls, and a publishing pause/resume kill switch.
  */
-const EXPECTED_LENGTH = 230791;
+const EXPECTED_LENGTH = 232129;
 const EXPECTED_SHA256 =
-  "2bdb0aa1a787d29a81c28e6a1f6bc7b27803d6a14cf92fc356fe5c5bc8526aa4";
+  "d054604413725cbb37e979bb053d7118c43a26e8fe9b90d59b28edde93b851a5";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -203,6 +203,8 @@ const MUSIC_DIR = path.join(ASSETS_DIR, "room", "music");
 export interface WebServerOptions {
   port: number;
   tools: ToolDefinition[];
+  /** Hidden connector tools reserved for the approved social runner. */
+  socialConnectorTools?: ToolDefinition[];
   model: string;
   thinking: boolean;
   reflect: boolean;
@@ -1919,6 +1921,18 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     if (
       await handleSocialApi(req, res, url, {
         allowApproval: isLoopbackAddress(remoteAddr) || accountUid !== null,
+        connectorTools: opts.socialConnectorTools,
+        publishApproved:
+          opts.socialConnectorTools && opts.socialConnectorTools.length
+            ? async (id, digest) => {
+                const { publishApprovedSocialDraft } = await import(
+                  "../sense/social/runner.js"
+                );
+                return publishApprovedSocialDraft(id, digest, {
+                  connectorTools: opts.socialConnectorTools!,
+                });
+              }
+            : undefined,
       })
     ) {
       return;

--- a/src/web/social-api.test.ts
+++ b/src/web/social-api.test.ts
@@ -97,5 +97,21 @@ describe("social API", () => {
       },
     );
     assert.equal(approved.status, 200);
+
+    const remotePause = await fetch(`${origin}/api/sense/social/pause`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: "{}",
+    });
+    assert.equal(remotePause.status, 403);
+    const localPause = await fetch(`${origin}/api/sense/social/pause`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-local-owner": "1",
+      },
+      body: "{}",
+    });
+    assert.equal(localPause.status, 200);
   });
 });

--- a/src/web/social-api.ts
+++ b/src/web/social-api.ts
@@ -1,4 +1,5 @@
 import type http from "node:http";
+import type { ToolDefinition } from "../types.js";
 import { readCappedText, CTRL_BODY_LIMIT } from "./http-body.js";
 import {
   approveSocialDraft,
@@ -15,10 +16,17 @@ import type {
   NewSocialDraft,
   SocialDraftPatch,
 } from "../sense/social/types.js";
+import {
+  setSocialPublishingPaused,
+  socialPublishingPaused,
+} from "../sense/social/policy.js";
 
 export interface SocialApiOptions {
   /** True only for loopback or an authenticated per-user cloud session. */
   allowApproval: boolean;
+  /** Deterministic runner wired by the host; never a model-visible endpoint. */
+  publishApproved?: (id: string, digest: string) => Promise<unknown>;
+  connectorTools?: ToolDefinition[];
 }
 
 function json(
@@ -61,7 +69,19 @@ export async function handleSocialApi(
   try {
     if (req.method === "GET" && pathname === "/api/sense/social/connectors") {
       const connectors = await discoverSocialConnectors();
-      json(res, 200, { connectors });
+      const accounts = opts.connectorTools
+        ? await (
+            await import("../sense/social/runner.js")
+          ).listSocialConnectorAccounts(opts.connectorTools, connectors)
+        : {};
+      json(res, 200, {
+        connectors: connectors.map((connector) => ({
+          ...connector,
+          accounts: connector.manifest
+            ? accounts[connector.manifest.id] ?? []
+            : [],
+        })),
+      });
       return true;
     }
     if (req.method === "GET" && pathname === "/api/sense/social/drafts") {
@@ -75,6 +95,24 @@ export async function handleSocialApi(
               : undefined,
         })),
       });
+      return true;
+    }
+    if (req.method === "GET" && pathname === "/api/sense/social/status") {
+      json(res, 200, { paused: await socialPublishingPaused() });
+      return true;
+    }
+    if (
+      req.method === "POST" &&
+      (pathname === "/api/sense/social/pause" ||
+        pathname === "/api/sense/social/resume")
+    ) {
+      if (!opts.allowApproval) {
+        json(res, 403, { error: "trusted_local_confirmation_required" });
+        return true;
+      }
+      const paused = pathname.endsWith("/pause");
+      await setSocialPublishingPaused(paused);
+      json(res, 200, { paused });
       return true;
     }
     if (req.method === "POST" && pathname === "/api/sense/social/drafts") {
@@ -156,8 +194,14 @@ export async function handleSocialApi(
         json(res, 400, { error: "digest_required" });
         return true;
       }
-      const draft = await approveSocialDraft(id, payload.digest);
-      json(res, 200, { draft });
+      const approved = await approveSocialDraft(id, payload.digest);
+      const draft = opts.publishApproved
+        ? await opts.publishApproved(id, payload.digest)
+        : approved;
+      json(res, 200, {
+        draft,
+        publishingAvailable: Boolean(opts.publishApproved),
+      });
       return true;
     }
     if (req.method === "POST" && action === "cancel") {


### PR DESCRIPTION
## What
- add installable first-party LISA connector plugins and procedural Skills for Bluesky and Mastodon
- link Bluesky through app-password session exchange and Mastodon through a verified user token
- publish text, links, images, and video through official APIs with runtime validation and idempotency
- add a private host media store with MIME sniffing, integrity hashes, and image metadata stripping
- add the deterministic approved-draft runner, per-target receipts, structural audit, and pause switch
- remove manifest-bound publish/disconnect tools from every model-visible toolset
- add CLI install/connect/media commands and MCP stdio handshake coverage

## Why
This is the first live connector slice after the host safety layer. It proves the Connector + Skill contract on an open network and a federated platform without letting the model acquire publish authority.

## Impact
Users can install both connectors with `lisa sense social install`, link accounts in a secret-safe TTY, prepare posts in chat, approve the exact Sense snapshot, and publish through the hidden host runner. The connector account/token store and audit files are private (0600). This PR is stacked on #325.

## Checks
- `npm run typecheck`
- `npm test` (1466 passed, 1 skipped)
- real MCP stdio initialization/list-tools/close test
- `git diff --check`