### PR TITLE
Preserve active social drafts during retention

### DIFF
--- a/src/sense/social/drafts.test.ts
+++ b/src/sense/social/drafts.test.ts
@@ -166,4 +166,23 @@ describe("social drafts", () => {
     ], 5000);
     assert.equal(finished.state, "partial");
   });
+
+  test("terminal-history compaction never evicts a publishing draft", async () => {
+    const active = await createSocialDraft(input(), 1000);
+    const { digest } = await requestSocialDraftApproval(active.id, 1, 2000);
+    await approveSocialDraft(active.id, digest, 3000);
+    await claimApprovedSocialDraft(active.id, digest, 4000);
+
+    for (let index = 0; index < 205; index++) {
+      const draft = await createSocialDraft(input(), 5000 + index * 2);
+      await cancelSocialDraft(draft.id, 5001 + index * 2);
+    }
+
+    const drafts = await listSocialDrafts();
+    assert.equal(drafts.length, 200);
+    assert.equal(
+      drafts.find((draft) => draft.id === active.id)?.state,
+      "publishing",
+    );
+  });
 });

--- a/src/sense/social/drafts.ts
+++ b/src/sense/social/drafts.ts
@@ -17,6 +17,12 @@ interface DraftStore {
 const STORE_VERSION = 1 as const;
 const MAX_DRAFTS = 200;
 const DEFAULT_APPROVAL_TTL_MS = 10 * 60_000;
+const TERMINAL_DRAFT_STATES = new Set<SocialDraft["state"]>([
+  "published",
+  "partial",
+  "cancelled",
+  "expired",
+]);
 let mutationTail: Promise<void> = Promise.resolve();
 
 function storePath(): string {
@@ -76,9 +82,20 @@ async function mutate<T>(fn: (store: DraftStore) => Promise<T> | T): Promise<T> 
   try {
     const store = await readStore();
     const result = await fn(store);
-    store.drafts = store.drafts
-      .sort((a, b) => a.updatedAt.localeCompare(b.updatedAt))
-      .slice(-MAX_DRAFTS);
+    const sorted = store.drafts.sort((a, b) =>
+      a.updatedAt.localeCompare(b.updatedAt),
+    );
+    const active = sorted.filter(
+      (draft) => !TERMINAL_DRAFT_STATES.has(draft.state),
+    );
+    const terminalBudget = Math.max(0, MAX_DRAFTS - active.length);
+    const terminal = sorted.filter((draft) =>
+      TERMINAL_DRAFT_STATES.has(draft.state),
+    );
+    store.drafts = [
+      ...active,
+      ...(terminalBudget > 0 ? terminal.slice(-terminalBudget) : []),
+    ].sort((a, b) => a.updatedAt.localeCompare(b.updatedAt));
     await writeStore(store);
     return result;
   } finally {
@@ -163,6 +180,14 @@ export async function createSocialDraft(
 ): Promise<SocialDraft> {
   assertDraftInput(input);
   return mutate((store) => {
+    const activeCount = store.drafts.filter(
+      (draft) => !TERMINAL_DRAFT_STATES.has(draft.state),
+    ).length;
+    if (activeCount >= MAX_DRAFTS) {
+      throw new Error(
+        `social draft store already has ${MAX_DRAFTS} active drafts; finish or cancel one first`,
+      );
+    }
     const at = new Date(now).toISOString();
     const draft: SocialDraft = {
       id: crypto.randomUUID(),


### PR DESCRIPTION
## What changed

- retain all non-terminal social drafts during store compaction
- prune only terminal history to the 200-record budget
- reject new drafts once 200 active drafts already exist
- add regression coverage for publishing-draft retention

## Why

The original #324 retention logic could evict an approved or publishing draft, losing durable publication outcomes after the external side effect.

## Validation

- `node --import tsx --test src/sense/social/drafts.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run check:api-contract`
- `git diff --check`