### PR TITLE
Redact social connector discovery paths

### DIFF
--- a/src/web/social-api.test.ts
+++ b/src/web/social-api.test.ts
@@ -34,6 +34,39 @@ afterEach(async () => {
 });
 
 describe("social API", () => {
+  test("connector discovery never exposes local manifest paths", async () => {
+    const pluginRoot = path.join(home, "plugins", "test-social");
+    fs.mkdirSync(pluginRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(pluginRoot, "social-connector.json"),
+      JSON.stringify({
+        schemaVersion: 1,
+        id: "test-social",
+        displayName: "Test Social",
+        platform: "test",
+        mcpServer: "test",
+        skill: "test-publisher",
+        tools: {
+          listAccounts: "accounts",
+          getCapabilities: "capabilities",
+          validateDraft: "validate",
+          publish: "publish",
+        },
+      }),
+    );
+
+    const response = await fetch(`${origin}/api/sense/social/connectors`);
+    assert.equal(response.status, 200);
+    const raw = await response.text();
+    assert.doesNotMatch(raw, /manifestPath/);
+    assert.doesNotMatch(raw, new RegExp(home.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+    const body = JSON.parse(raw) as {
+      connectors: Array<{ plugin: string; manifest?: { id: string } }>;
+    };
+    assert.equal(body.connectors[0]?.plugin, "test-social");
+    assert.equal(body.connectors[0]?.manifest?.id, "test-social");
+  });
+
   test("draft preview can be prepared remotely but approval needs a trusted caller", async () => {
     const createdResponse = await fetch(`${origin}/api/sense/social/drafts`, {
       method: "POST",

--- a/src/web/social-api.ts
+++ b/src/web/social-api.ts
@@ -75,12 +75,19 @@ export async function handleSocialApi(
           ).listSocialConnectorAccounts(opts.connectorTools, connectors)
         : {};
       json(res, 200, {
-        connectors: connectors.map((connector) => ({
-          ...connector,
-          accounts: connector.manifest
-            ? accounts[connector.manifest.id] ?? []
-            : [],
-        })),
+        connectors: connectors.map((connector) =>
+          connector.manifest
+            ? {
+                plugin: connector.plugin,
+                manifest: connector.manifest,
+                accounts: accounts[connector.manifest.id] ?? [],
+              }
+            : {
+                plugin: connector.plugin,
+                error: connector.error ?? "invalid manifest",
+                accounts: [],
+              },
+        ),
       });
       return true;
     }


### PR DESCRIPTION
## What changed

- project social connector discovery onto an explicit public API shape
- omit internal `manifestPath` values from Sense responses
- retain validated manifest metadata, redacted accounts, and safe errors
- add regression coverage against local path disclosure

## Why

The original #325 API returned connector discovery objects verbatim, exposing absolute local plugin paths that the client does not need.

## Validation

- `node --import tsx --test src/web/social-api.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run check:api-contract`
- `git diff --check`