### PR TITLE
Make Bluesky publishing idempotent

### DIFF
--- a/src/sense/social/connectors/bluesky.ts
+++ b/src/sense/social/connectors/bluesky.ts
@@ -1,3 +1,4 @@
+import crypto from "node:crypto";
 import { loadSocialMedia } from "../media.js";
 import type { SocialDraftContent, SocialMediaRef, SocialPlatformVariant, SocialTarget } from "../types.js";
 import {
@@ -181,6 +182,22 @@ function linkFacet(text: string, link?: string): unknown[] | undefined {
   }];
 }
 
+function deterministicRecordKey(idempotencyKey: string): string {
+  if (!idempotencyKey) throw new Error("Bluesky publish needs an idempotency key");
+  return `lisa-${crypto
+    .createHash("sha256")
+    .update(idempotencyKey)
+    .digest("hex")}`;
+}
+
+function stableCreatedAt(value: string): string {
+  const timestamp = Date.parse(value);
+  if (!Number.isFinite(timestamp)) {
+    throw new Error("Bluesky publish needs a valid approval timestamp");
+  }
+  return new Date(timestamp).toISOString();
+}
+
 export async function publishBluesky(
   input: ConnectorPublishInput,
   fetchImpl: typeof fetch = fetch,
@@ -204,7 +221,7 @@ export async function publishBluesky(
   const record: Record<string, unknown> = {
     $type: "app.bsky.feed.post",
     text,
-    createdAt: new Date().toISOString(),
+    createdAt: stableCreatedAt(input.createdAt),
     ...(linkFacet(text, link) ? { facets: linkFacet(text, link) } : {}),
     ...(images.length
       ? { embed: { $type: "app.bsky.embed.images", images } }
@@ -212,15 +229,17 @@ export async function publishBluesky(
         ? { embed: { $type: "app.bsky.embed.video", video } }
         : {}),
   };
+  const rkey = deterministicRecordKey(input.idempotencyKey);
   const result = await authedFetch(
     account,
-    `${account.service}/xrpc/com.atproto.repo.createRecord`,
+    `${account.service}/xrpc/com.atproto.repo.putRecord`,
     {
       method: "POST",
       headers: { "content-type": "application/json" },
       body: JSON.stringify({
         repo: account.id,
         collection: "app.bsky.feed.post",
+        rkey,
         record,
       }),
     },
@@ -229,7 +248,6 @@ export async function publishBluesky(
   const body = await responseJson(result.response);
   const uri = String(body.uri ?? "");
   if (!uri) throw new Error("Bluesky did not return a post URI");
-  const rkey = uri.split("/").pop() ?? "";
   return {
     ok: true,
     platformPostId: uri,

--- a/src/sense/social/connectors/open-connectors.test.ts
+++ b/src/sense/social/connectors/open-connectors.test.ts
@@ -40,9 +40,10 @@ test("Bluesky links with an app password, stores only session tokens, and publis
         refreshJwt: "refresh-secret",
       }), { status: 200 });
     }
-    if (url.endsWith("createRecord")) {
+    if (url.endsWith("putRecord")) {
+      const payload = JSON.parse(String(init?.body)) as { rkey: string };
       return new Response(JSON.stringify({
-        uri: "at://did:plc:alice/app.bsky.feed.post/abc",
+        uri: `at://did:plc:alice/app.bsky.feed.post/${payload.rkey}`,
         cid: "cid",
       }), { status: 200 });
     }
@@ -59,7 +60,7 @@ test("Bluesky links with an app password, stores only session tokens, and publis
     "utf8",
   );
   assert.doesNotMatch(stored, /app-password-must-not-persist/);
-  const result = await publishBluesky({
+  const input = {
     accountId: account.id,
     target: {
       connectorId: "bluesky-official",
@@ -68,13 +69,22 @@ test("Bluesky links with an app password, stores only session tokens, and publis
     },
     content: { text: "hello", link: "https://example.com", media: [] },
     idempotencyKey: "key",
-  }, fakeFetch);
-  assert.equal(result.ok, true);
-  const body = JSON.parse(String(calls.at(-1)?.init?.body)) as {
-    record: { text: string; facets: unknown[] };
+    createdAt: "2026-07-27T06:00:00.000Z",
   };
+  const first = await publishBluesky(input, fakeFetch);
+  const second = await publishBluesky(input, fakeFetch);
+  assert.deepEqual(second, first);
+  const publishCalls = calls.filter((call) => call.url.endsWith("putRecord"));
+  assert.equal(publishCalls.length, 2);
+  assert.equal(publishCalls[0]?.init?.body, publishCalls[1]?.init?.body);
+  const body = JSON.parse(String(publishCalls[0]?.init?.body)) as {
+    rkey: string;
+    record: { text: string; facets: unknown[]; createdAt: string };
+  };
+  assert.match(body.rkey, /^lisa-[a-f0-9]{64}$/);
   assert.match(body.record.text, /https:\/\/example\.com/);
   assert.equal(body.record.facets.length, 1);
+  assert.equal(body.record.createdAt, input.createdAt);
 });
 
 test("Mastodon verifies a user token and posts with visibility and idempotency", async () => {
@@ -112,6 +122,7 @@ test("Mastodon verifies a user token and posts with visibility and idempotency",
     },
     content: { text: "hello", media: [] },
     idempotencyKey: "idem",
+    createdAt: "2026-07-27T06:00:00.000Z",
   }, fakeFetch);
   assert.equal(result.url, "https://social.example/@alice/99");
   const call = calls.at(-1)!;

--- a/src/sense/social/connectors/server.ts
+++ b/src/sense/social/connectors/server.ts
@@ -68,8 +68,15 @@ function tools(): Tool[] {
           content: { type: "object" },
           variant: { type: "object" },
           idempotencyKey: { type: "string" },
+          createdAt: { type: "string" },
         },
-        required: ["accountId", "target", "content", "idempotencyKey"],
+        required: [
+          "accountId",
+          "target",
+          "content",
+          "idempotencyKey",
+          "createdAt",
+        ],
       },
       annotations: {
         readOnlyHint: false,

--- a/src/sense/social/connectors/types.ts
+++ b/src/sense/social/connectors/types.ts
@@ -6,6 +6,8 @@ export interface ConnectorPublishInput {
   content: SocialDraftContent;
   variant?: SocialPlatformVariant;
   idempotencyKey: string;
+  /** Stable host approval time used for deterministic platform records. */
+  createdAt: string;
 }
 
 export interface ConnectorPublishResult {

--- a/src/sense/social/runner.ts
+++ b/src/sense/social/runner.ts
@@ -130,6 +130,7 @@ export async function publishApprovedSocialDraft(
           target,
           content: draft.canonical,
           variant,
+          createdAt: draft.approval?.approvedAt ?? draft.updatedAt,
           idempotencyKey: crypto
             .createHash("sha256")
             .update(`${draft.id}\0${draft.revision}\0${targetKey}`)


### PR DESCRIPTION
## What changed

- carry the stable approval timestamp into connector publish calls
- derive a deterministic Bluesky record key from the host idempotency key
- use AT Protocol `putRecord` instead of duplicate-prone `createRecord`
- validate the approval timestamp before publishing
- prove repeated identical publish inputs target the same record and body

## Why

The original #326 Bluesky connector ignored the host idempotency key while advertising an idempotent publish tool. Retries after an unknown outcome could create duplicate public posts.

## Validation

- targeted open connector, runner, and MCP server tests
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run check:api-contract`
- `git diff --check`