### PR TITLE
Enforce commercial account readiness gates

### DIFF
--- a/src/sense/social/connectors/commercial.test.ts
+++ b/src/sense/social/connectors/commercial.test.ts
@@ -36,6 +36,43 @@ test("readiness never calls an unaudited or unconfigured platform ready", () => 
   assert.equal(youtube.state, "private-test-only");
 });
 
+test("account eligibility and role gates fail closed", () => {
+  const metaBase = {
+    oauthClientConfigured: true,
+    redirectOriginConfigured: true,
+    platformReviewApproved: true,
+    businessVerificationComplete: true,
+  };
+  const instagram = evaluateCommercialReadiness("instagram", {
+    ...metaBase,
+    publicMediaStagingConfigured: true,
+  });
+  assert.equal(instagram.state, "draft-only");
+  assert.match(instagram.blockers.join(" "), /Professional account eligibility/);
+
+  const linkedin = evaluateCommercialReadiness("linkedin", {
+    oauthClientConfigured: true,
+    redirectOriginConfigured: true,
+    platformReviewApproved: true,
+    linkedinAccountKind: "organization",
+  });
+  assert.equal(linkedin.state, "draft-only");
+  assert.match(linkedin.blockers.join(" "), /organization role/);
+  assert.equal(
+    evaluateCommercialReadiness("linkedin", {
+      oauthClientConfigured: true,
+      redirectOriginConfigured: true,
+      platformReviewApproved: true,
+      linkedinAccountKind: "member",
+    }).state,
+    "ready",
+  );
+
+  const facebook = evaluateCommercialReadiness("facebook", metaBase);
+  assert.equal(facebook.state, "draft-only");
+  assert.match(facebook.blockers.join(" "), /Page role/);
+});
+
 test("platform-specific required fields fail closed", () => {
   const youtube = validateCommercialDraft(
     "youtube",

--- a/src/sense/social/connectors/commercial.ts
+++ b/src/sense/social/connectors/commercial.ts
@@ -36,6 +36,10 @@ export interface CommercialReadinessInput {
   youtubeAuditApproved?: boolean;
   tiktokAuditApproved?: boolean;
   xPaidAccessConfirmed?: boolean;
+  instagramProfessionalAccountEligible?: boolean;
+  linkedinAccountKind?: "member" | "organization";
+  linkedinOrganizationRoleVerified?: boolean;
+  facebookPageRoleVerified?: boolean;
 }
 
 export interface CommercialReadiness {
@@ -188,6 +192,25 @@ export function evaluateCommercialReadiness(
   }
   if (platform === "x" && !input.xPaidAccessConfirmed) {
     blockers.push("X paid API access/quota is not confirmed");
+  }
+  if (
+    platform === "instagram" &&
+    !input.instagramProfessionalAccountEligible
+  ) {
+    blockers.push("Instagram Professional account eligibility is not verified");
+  }
+  if (platform === "linkedin") {
+    if (!input.linkedinAccountKind) {
+      blockers.push("LinkedIn target account kind is not verified");
+    } else if (
+      input.linkedinAccountKind === "organization" &&
+      !input.linkedinOrganizationRoleVerified
+    ) {
+      blockers.push("LinkedIn organization role is not verified");
+    }
+  }
+  if (platform === "facebook" && !input.facebookPageRoleVerified) {
+    blockers.push("Facebook Page role is not verified");
   }
   if (platform === "youtube" && !input.youtubeAuditApproved) {
     notices.push("unverified YouTube API projects can upload only private videos");


### PR DESCRIPTION
## What changed

- require verified Instagram Professional-account eligibility
- distinguish LinkedIn member and organization targets
- require an organization-role check for LinkedIn organization publishing
- require a verified Facebook Page role
- add fail-closed readiness tests for every new account-level gate

## Why

The original #327 profiles documented these external gates but readiness could still return `ready` without proving them, overstating production capability.

## Validation

- `node --import tsx --test src/sense/social/connectors/commercial.test.ts`
- `npm run typecheck`
- `npm test`
- `npm run build`
- `npm run check:api-contract`
- `git diff --check`