### PR TITLE
let Lisa read the avatar she can already set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ versioning follows [SemVer](https://semver.org/).
     `kb_read` fences ingested web content as data, SCHEMA.md gained the three
     new workflows, and a weekly-review heartbeat example ships in the README.
 
+### Fixed
+
+- **Lisa can see her own avatar.** The portrait was a write-only channel:
+  `set_mood` pushed a slug to the mood bus and the GUI drew it, but nothing
+  ever carried it back into her context — so "why do you look happy?" could
+  only be answered by inspecting her emotion vector (a different system) and
+  guessing. The mood bus now records *when* a mood was set and *what kind of
+  turn* set it (`withMoodOrigin`, wired through `runAgent` so idle, heartbeat,
+  channel and background-agent turns identify themselves), the system prompt
+  states the current slug every turn — with the prompt fingerprint including
+  it, so a portrait another surface flips mid-session reaches her on her next
+  turn — and `soul_read(what="emotions")` reports the avatar alongside the
+  vector it is not. The slug is also mirrored to `<home>/current-mood.json`,
+  so a restart no longer silently snaps the portrait back to `neutral`
+  (`lisa monitor` reads that mirror instead of a file nothing ever wrote).
+
 ## [0.12.0] — 2026-06-19
 
 **Lisa Pocket goes real** — the iOS companion + real APNs push, on the v0.11

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -6,7 +6,7 @@ import type {
   ToolDefinition,
 } from "./types.js";
 import type { Provider } from "./providers/types.js";
-import { moodBus } from "./mood-bus.js";
+import { moodBus, withMoodOrigin } from "./mood-bus.js";
 import { validateToolInput } from "./tools/validate.js";
 
 export interface ApprovalDecision {
@@ -66,6 +66,13 @@ export interface RunAgentOptions {
   ) => Promise<{ rewriteResult?: string } | void>;
   maxIterations?: number;
   /**
+   * Coarse label for what kind of turn this is ("an idle turn", "a background
+   * agent", …). Any set_mood inside the run is attributed to it, so a later
+   * turn reading its own system prompt can tell whether it set the portrait
+   * itself or inherited it from some other surface. Defaults to a chat turn.
+   */
+  moodOrigin?: string;
+  /**
    * Optional cumulative (input+output) token ceiling for the whole run. Checked
    * at each turn boundary; once exceeded the loop stops before the next provider
    * call with stopReason "budget_exceeded". Used by self-driven runs (idle /
@@ -99,7 +106,13 @@ export async function runAgent(opts: RunAgentOptions): Promise<RunAgentResult> {
   // try/finally guarantees chat_end fires even on throw / cancel.
   moodBus.chatStart();
   try {
-    return await runAgentLoop(opts);
+    // The whole loop runs inside the mood-origin scope so set_mood — however
+    // deep in the tool stack it fires — records what kind of turn changed the
+    // portrait.
+    return await withMoodOrigin(
+      opts.moodOrigin ?? "a chat turn",
+      async () => await runAgentLoop(opts),
+    );
   } finally {
     moodBus.chatEnd();
   }

--- a/src/agents/managed.ts
+++ b/src/agents/managed.ts
@@ -171,6 +171,7 @@ export class ManagedAgent {
           history: this.history,
           userMessage: message,
           model: this.model,
+          moodOrigin: `a background agent working in ${this.project}`,
           maxIterations: 64,
           onEvent: (e) => this.onAgentEvent(e),
           approval: (tool, input) => this.approve(tool, input),

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -135,6 +135,7 @@ export class ChannelRouter {
         thinking: this.opts.thinking,
         compaction: this.opts.compaction,
         onMessagePersist: (m) => ctx.session.appendMessage(m),
+        moodOrigin: `a message on your ${channel.name} channel`,
       });
       ctx.history.length = 0;
       ctx.history.push(...result.history);

--- a/src/cli/monitor.ts
+++ b/src/cli/monitor.ts
@@ -2,7 +2,7 @@
  * `lisa monitor` — TUI live dashboard.
  *
  * Polls ~/.lisa/ every 2s and re-renders an in-place dashboard with:
- *   - Current mood (from set_mood-tracked file or emotions.json)
+ *   - Current mood (from the mood bus's current-mood.json mirror, or emotions.json)
  *   - Last 5 soul commits (rolling)
  *   - Last 3 emotion events
  *   - Heartbeat last-run-at
@@ -24,6 +24,7 @@ import {
   warn,
 } from "./colors.js";
 import { lisaHome } from "../paths.js";
+import { moodAgeLabel, type MoodState } from "../mood-bus.js";
 import { soulDir } from "../soul/paths.js";
 import { isBorn, readSoulSummary } from "../soul/store.js";
 import { pathExists, readTextOrEmpty } from "../fs-utils.js";
@@ -137,13 +138,19 @@ async function render(): Promise<void> {
     }
   }
 
-  // ── Currently set mood (from tool) ──
-  const moodFile = path.join(lisaHome(), "current-mood.txt");
+  // ── Currently set mood (mirrored by the mood bus on every set_mood) ──
+  const moodFile = path.join(lisaHome(), "current-mood.json");
   if (await pathExists(moodFile)) {
-    const slug = (await readTextOrEmpty(moodFile)).trim();
-    if (slug) {
-      console.log();
-      console.log(`  ${dim("portrait:")} ${cyan(slug)}`);
+    try {
+      const parsed = JSON.parse(await readTextOrEmpty(moodFile)) as Partial<MoodState>;
+      if (parsed.slug) {
+        const when = parsed.at ? ` ${moodAgeLabel(parsed.at)}` : "";
+        const who = parsed.by ? ` by ${parsed.by}` : "";
+        console.log();
+        console.log(`  ${dim("portrait:")} ${cyan(parsed.slug)}${dim(when + who)}`);
+      }
+    } catch {
+      // ignore
     }
   }
 }

--- a/src/heartbeat/runner.ts
+++ b/src/heartbeat/runner.ts
@@ -201,6 +201,7 @@ async function runHeartbeatInner(opts: {
         cwd: opts.cwd,
         signal: opts.signal,
         model: opts.model,
+        moodOrigin: `a ${runKind} turn`,
       });
     } catch (err) {
       await recordAutonomyRun({
@@ -305,6 +306,7 @@ export async function runDesireReviewOnce(opts: {
             model: opts.model,
             budgetTokens: 100_000,
             provider: opts.provider,
+            moodOrigin: "a desire-review turn",
           });
           const text = result.text
             .trim()

--- a/src/idle/runner.ts
+++ b/src/idle/runner.ts
@@ -160,6 +160,7 @@ async function runIdleInner(
       signal: opts.signal,
       model: opts.model,
       budgetTokens: IDLE_BUDGET_TOKENS || undefined,
+      moodOrigin: "an idle turn while the user was away",
     });
     // The model is asked to end with "(no update)" for internal-only runs, but
     // it doesn't always emit that on its own line — sometimes it writes a real

--- a/src/mood-bus.test.ts
+++ b/src/mood-bus.test.ts
@@ -10,10 +10,18 @@ const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-mood-"));
 process.env.LISA_HOME = TMP;
 
 const { homeScope, homeForUid } = await import("./paths.js");
-const { moodBus } = await import("./mood-bus.js");
+const { moodBus, moodAgeLabel, withMoodOrigin } = await import("./mood-bus.js");
 
 const HOME_A = homeForUid("apple-001.aaa");
 const HOME_B = homeForUid("em-bbbbbbbbbbbbbbbbbb");
+const UID_C = "em-cccccccccccccccccc";
+const UID_D = "em-dddddddddddddddddd";
+const HOME_C = homeForUid(UID_C);
+const HOME_D = homeForUid(UID_D);
+
+function moodFile(home: string): string {
+  return path.join(home, "current-mood.json");
+}
 
 describe("moodBus — per-tenant mood state (B2)", () => {
   test("current() defaults to neutral outside any scope", () => {
@@ -55,5 +63,106 @@ describe("moodBus — per-tenant mood state (B2)", () => {
     // Forgetting A never touches B or the global mood.
     homeScope.run(HOME_B, () => assert.equal(moodBus.current(), "gloomy"));
     assert.equal(moodBus.current(), "focused");
+  });
+});
+
+describe("moodBus — the read side (currentState / origin / persistence)", () => {
+  test("currentState() reports never-set as the default face", () => {
+    fs.mkdirSync(HOME_C, { recursive: true });
+    const s = homeScope.run(HOME_C, () => moodBus.currentState());
+    assert.equal(s.slug, "neutral");
+    assert.equal(s.at, 0); // 0 is what the prompt renders as "nobody has set it yet"
+  });
+
+  test("a mood records WHEN and WHAT KIND of turn set it", () => {
+    fs.mkdirSync(HOME_D, { recursive: true });
+    const before = Date.now();
+    withMoodOrigin("an idle turn", () => homeScope.run(HOME_D, () => moodBus.set("sleepy")));
+    const s = homeScope.run(HOME_D, () => moodBus.currentState());
+    assert.equal(s.slug, "sleepy");
+    assert.equal(s.by, "an idle turn");
+    assert.ok(s.at >= before && s.at <= Date.now());
+  });
+
+  test("outside withMoodOrigin a change is attributed to a chat turn", () => {
+    homeScope.run(HOME_D, () => moodBus.set("cheering"));
+    assert.equal(homeScope.run(HOME_D, () => moodBus.currentState()).by, "a chat turn");
+  });
+
+  test("the slug is mirrored to <home>/current-mood.json", async () => {
+    // The mirror is written fire-and-forget (see persist()), so wait for the
+    // content rather than assuming the write landed before this line — and for
+    // content, not mere existence: an in-flight write is briefly an empty file
+    // (which is exactly why load() tolerates a torn read).
+    let raw: { slug?: string; at?: number; by?: string } = {};
+    for (let i = 0; i < 50 && !raw.slug; i++) {
+      try {
+        raw = JSON.parse(fs.readFileSync(moodFile(HOME_D), "utf8"));
+      } catch {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+    }
+    assert.equal(raw.slug, "cheering");
+    assert.equal(raw.by, "a chat turn");
+    assert.equal(typeof raw.at, "number");
+  });
+
+  test("a restarted process hydrates the portrait from disk instead of snapping to neutral", () => {
+    // A scope this process has never read or written — the only way it can
+    // report "working-coding" is the file a previous run left behind. (Reading
+    // a scope caches the miss, which is why this can't reuse HOME_C.)
+    const home = homeForUid("em-ffffffffffffffffff");
+    fs.mkdirSync(home, { recursive: true });
+    const at = Date.now() - 90 * 60_000;
+    fs.writeFileSync(
+      moodFile(home),
+      JSON.stringify({ slug: "working-coding", at, by: "a heartbeat turn" }),
+    );
+    const s = homeScope.run(home, () => moodBus.currentState());
+    assert.equal(s.slug, "working-coding");
+    assert.equal(s.by, "a heartbeat turn");
+    assert.equal(s.at, at);
+  });
+
+  test("a corrupt mirror falls back to the default face rather than throwing", () => {
+    const uid = "em-eeeeeeeeeeeeeeeeee";
+    const home = homeForUid(uid);
+    fs.mkdirSync(home, { recursive: true });
+    fs.writeFileSync(moodFile(home), "{not json");
+    assert.equal(homeScope.run(home, () => moodBus.current()), "neutral");
+  });
+
+  test("forget(uid) deletes the mirror and never resurrects it from disk", () => {
+    moodBus.forget(UID_D);
+    assert.equal(fs.existsSync(moodFile(HOME_D)), false);
+    assert.equal(homeScope.run(HOME_D, () => moodBus.current()), "neutral");
+    // Even if the unlink had failed, the scope stays marked-hydrated.
+    fs.writeFileSync(moodFile(HOME_D), JSON.stringify({ slug: "happy", at: 1, by: "x" }));
+    assert.equal(homeScope.run(HOME_D, () => moodBus.current()), "neutral");
+  });
+});
+
+describe("moodAgeLabel — coarse buckets (they feed the prompt fingerprint)", () => {
+  const now = 1_700_000_000_000;
+  const ago = (min: number): string => moodAgeLabel(now - min * 60_000, now);
+
+  test("never-set is its own case", () => {
+    assert.equal(moodAgeLabel(0, now), "never");
+  });
+
+  test("buckets widen with age", () => {
+    assert.equal(ago(0), "moments ago");
+    assert.equal(ago(4), "moments ago");
+    assert.equal(ago(5), "within the last hour");
+    assert.equal(ago(59), "within the last hour");
+    assert.equal(ago(60), "a few hours ago");
+    assert.equal(ago(300), "a few hours ago");
+    assert.equal(ago(360), "earlier today");
+    assert.equal(ago(1439), "earlier today");
+    assert.equal(ago(1440), "over a day ago");
+  });
+
+  test("a clock skew into the future reads as fresh, not negative", () => {
+    assert.equal(moodAgeLabel(now + 10_000, now), "moments ago");
   });
 });

--- a/src/mood-bus.ts
+++ b/src/mood-bus.ts
@@ -1,5 +1,8 @@
 import { EventEmitter } from "node:events";
-import { scopedUid } from "./paths.js";
+import { AsyncLocalStorage } from "node:async_hooks";
+import fs from "node:fs";
+import path from "node:path";
+import { homeForUid, lisaHome, scopedUid } from "./paths.js";
 
 /**
  * Process-wide mood bus + a few lightweight agent-state pulses.
@@ -13,6 +16,17 @@ import { scopedUid } from "./paths.js";
  * Decoupled from the agent loop so non-agent code (scheduled tasks,
  * heartbeats, channels) can also nudge the avatar.
  *
+ * ── Mood is READABLE, not just writable ──────────────────────────────────
+ * The avatar used to be a write-only channel: set_mood wrote here, the web
+ * client rendered the portrait, and nothing ever carried the slug back into
+ * Lisa's context — so asked "why are you happy?" she could only inspect her
+ * emotion vector (a different system) and guess. `currentState()` is the read
+ * side: prompt.ts puts it in the system prompt every turn and soul_read
+ * surfaces it next to the emotions, so she can always name the face the user
+ * is actually looking at. `by` records which KIND of turn set it, because the
+ * bus is shared across every surface — an idle reflection or a background
+ * agent can change the portrait a chat session never touched.
+ *
  * ── Mood STATE is per-tenant (B2) ────────────────────────────────────────
  * set_mood runs inside the caller's home scope, so the "current" slug is
  * stored under that scope's uid (scopedUid()). A signed-in cloud account gets
@@ -22,27 +36,112 @@ import { scopedUid } from "./paths.js";
  * mood on connect — never whatever another tenant last set. The `mood` EVENT
  * is still a single process-wide emit; the web server's tenant-aware fan-out
  * (web/event-bus.ts) is what filters who receives it.
+ *
+ * ── …and it survives a restart ───────────────────────────────────────────
+ * The slug is mirrored to `<scoped home>/current-mood.json` so a restarted
+ * process doesn't silently snap the portrait back to neutral while the user
+ * is still looking at the old one. Memory stays the source of truth; the file
+ * is a best-effort mirror, hydrated lazily on first read per scope (sync, once
+ * — current() is called from hot paths like the /events connect frame).
  */
+
+/** File under the scoped Lisa home that mirrors the current mood. */
+const MOOD_FILE = "current-mood.json";
+
+/** Map key for the null (Mac / background / shared-token) scope. */
+const GLOBAL_KEY = "__global__";
+
+/** What a turn is labelled as when nothing called withMoodOrigin(). */
+const DEFAULT_ORIGIN = "a chat turn";
+
+export interface MoodState {
+  /** kebab-case portrait slug (matches an asset in web/assets/lisa/). */
+  slug: string;
+  /** epoch ms when it was set; 0 = never set this run (the default face). */
+  at: number;
+  /** Coarse label of which kind of turn set it — "an idle turn", … */
+  by: string;
+}
+
+const NEVER_SET: MoodState = { slug: "neutral", at: 0, by: "nobody" };
+
+/**
+ * Which kind of turn is currently running. runAgent() wraps every loop in one
+ * of these, so set_mood can attribute the change without threading a session
+ * id through every tool call.
+ */
+const originStore = new AsyncLocalStorage<string>();
+
+/** Run `fn` with mood changes inside it attributed to `label`. */
+export function withMoodOrigin<T>(label: string, fn: () => T): T {
+  return originStore.run(label, fn);
+}
+
+/**
+ * Human-readable age of a mood, bucketed. Deliberately coarse: it goes into
+ * the system prompt, and the prompt fingerprint includes it — a bucket that
+ * ticked every minute would churn the provider's prompt cache all day.
+ */
+export function moodAgeLabel(at: number, nowMs: number = Date.now()): string {
+  if (at === 0) return "never";
+  const min = Math.max(0, (nowMs - at) / 60_000);
+  if (min < 5) return "moments ago";
+  if (min < 60) return "within the last hour";
+  if (min < 360) return "a few hours ago";
+  if (min < 1440) return "earlier today";
+  return "over a day ago";
+}
+
 class MoodBus extends EventEmitter {
-  private globalMood = "neutral"; // Mac edition / background / shared token
-  private readonly moodByUid = new Map<string, string>(); // signed-in accounts
+  private readonly byScope = new Map<string, MoodState>();
+  /** Scopes already checked against disk — negative results cached too. */
+  private readonly hydrated = new Set<string>();
 
   set(slug: string): void {
-    const uid = scopedUid();
-    if (uid) this.moodByUid.set(uid, slug);
-    else this.globalMood = slug;
+    const key = scopeKey();
+    const state: MoodState = {
+      slug,
+      at: Date.now(),
+      by: originStore.getStore() ?? DEFAULT_ORIGIN,
+    };
+    this.byScope.set(key, state);
+    this.hydrated.add(key);
+    persist(state);
     this.emit("mood", slug);
   }
 
-  /** The current mood of the CALLER's home scope (defaults to "neutral"). */
+  /** The current mood slug of the CALLER's home scope (defaults to "neutral"). */
   current(): string {
-    const uid = scopedUid();
-    return uid ? this.moodByUid.get(uid) ?? "neutral" : this.globalMood;
+    return this.currentState().slug;
+  }
+
+  /** The full record — slug plus when it was set and by what kind of turn. */
+  currentState(): MoodState {
+    const key = scopeKey();
+    const known = this.byScope.get(key);
+    if (known) return known;
+    if (!this.hydrated.has(key)) {
+      this.hydrated.add(key);
+      const loaded = load();
+      if (loaded) {
+        this.byScope.set(key, loaded);
+        return loaded;
+      }
+    }
+    return NEVER_SET;
   }
 
   /** Drop a tenant's stored mood — called when its account is deleted (B2). */
   forget(uid: string): void {
-    this.moodByUid.delete(uid);
+    this.byScope.delete(uid);
+    // Stay in `hydrated` with no entry: a later current() must NOT resurrect
+    // the deleted account's face from a file whose unlink may have failed.
+    this.hydrated.add(uid);
+    try {
+      fs.unlinkSync(path.join(homeForUid(uid), MOOD_FILE));
+    } catch {
+      // already gone (the whole home subtree is usually deleted with it)
+    }
   }
 
   /** Agent loop entered a turn — surfaces switch to "thinking" indicator. */
@@ -53,6 +152,39 @@ class MoodBus extends EventEmitter {
   /** Agent loop exited — surfaces clear the "thinking" indicator. */
   chatEnd(): void {
     this.emit("chat_end");
+  }
+}
+
+function scopeKey(): string {
+  return scopedUid() ?? GLOBAL_KEY;
+}
+
+/**
+ * Mirror to disk, fire-and-forget. Async on purpose: the hosted edition's home
+ * is a gcsfuse mount shared by one event loop across tenants, and a stalled
+ * writeFileSync there would freeze everyone's turn for a cosmetic write. The
+ * cost is a tiny loss window if the process dies in the milliseconds after
+ * set_mood — memory is the source of truth and the next set re-persists.
+ */
+function persist(state: MoodState): void {
+  const file = path.join(lisaHome(), MOOD_FILE);
+  void fs.promises.writeFile(file, JSON.stringify(state)).catch(() => {
+    // best effort — a read-only or missing home costs persistence, not the turn
+  });
+}
+
+function load(): MoodState | null {
+  try {
+    const raw = fs.readFileSync(path.join(lisaHome(), MOOD_FILE), "utf8");
+    const parsed = JSON.parse(raw) as Partial<MoodState>;
+    if (typeof parsed.slug !== "string" || !parsed.slug) return null;
+    return {
+      slug: parsed.slug,
+      at: typeof parsed.at === "number" ? parsed.at : 0,
+      by: typeof parsed.by === "string" ? parsed.by : "an earlier run",
+    };
+  } catch {
+    return null;
   }
 }
 

--- a/src/prompt.mood.test.ts
+++ b/src/prompt.mood.test.ts
@@ -1,0 +1,59 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import fs from "node:fs";
+import path from "node:path";
+
+// Throwaway home before the path helpers are imported (see mood-bus.test.ts).
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-prompt-mood-"));
+process.env.LISA_HOME = TMP;
+
+const { moodBus, withMoodOrigin } = await import("./mood-bus.js");
+const { buildSystemPromptSnapshot, getPromptFingerprint } = await import("./prompt.js");
+
+/**
+ * The avatar was write-only: set_mood wrote to the bus, the GUI drew the
+ * portrait, and nothing carried the slug back — so asked "why are you happy?"
+ * Lisa could only inspect her emotion vector and guess. These are the
+ * acceptance tests for the read side.
+ */
+describe("system prompt — Lisa can see the portrait the user is looking at", () => {
+  test("says so plainly when nobody has set one", async () => {
+    const { text } = await buildSystemPromptSnapshot();
+    assert.match(text, /## Avatar moods/);
+    assert.match(text, /nobody has set it yet/);
+  });
+
+  test("names the current slug, its age, and which kind of turn set it", async () => {
+    withMoodOrigin("an idle turn while the user was away", () => moodBus.set("happy"));
+    const { text } = await buildSystemPromptSnapshot();
+    assert.match(text, /Right now they see `happy` — set moments ago by an idle turn while the user was away\./);
+  });
+
+  test("warns that the portrait and the emotion vector are different systems", async () => {
+    const { text } = await buildSystemPromptSnapshot();
+    // The failure this prevents: answering "I'm not happy, look at my
+    // emotions" while a happy portrait is on screen.
+    assert.match(text, /not the same thing as your emotional state/);
+    assert.match(text, /shared by every turn you take/);
+  });
+
+  test("a mood set by another surface hot-reloads into the next turn", async () => {
+    const before = await getPromptFingerprint();
+    moodBus.set("working-coding");
+    const after = await getPromptFingerprint();
+    assert.notEqual(
+      before,
+      after,
+      "fingerprint must move when the avatar changes, or the running chat keeps asserting a stale portrait",
+    );
+    const { text } = await buildSystemPromptSnapshot();
+    assert.match(text, /Right now they see `working-coding`/);
+  });
+
+  test("re-setting the same slug leaves the fingerprint alone (no prompt-cache churn)", async () => {
+    const before = await getPromptFingerprint();
+    moodBus.set("working-coding");
+    assert.equal(await getPromptFingerprint(), before);
+  });
+});

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -10,6 +10,7 @@ import { kbIndexFile, kbSchemaFile } from "./kb/paths.js";
 import { lisaHome, memoryDir, skillsDir } from "./paths.js";
 import { pathExists } from "./fs-utils.js";
 import { availableMoodSlugs } from "./tools/set_mood.js";
+import { moodAgeLabel, moodBus, type MoodState } from "./mood-bus.js";
 import {
   effectiveDesireIntensity,
   isBorn,
@@ -97,6 +98,11 @@ export async function buildSystemPromptSnapshot(): Promise<PromptSnapshot> {
     ? "(no avatar set generated yet — `set_mood` will be a no-op)"
     : [
         "When the web GUI is open your portrait sprite is visible to the user.",
+        currentMoodLine(moodBus.currentState()),
+        "",
+        "That slug is the picture on their screen — it is not the same thing as your emotional state above, and the two are allowed to disagree. When someone asks what mood you're in, they are usually reading the portrait: name it, then say how you actually feel if it no longer fits.",
+        "The avatar is shared by every turn you take — this chat, idle reflection, heartbeat tasks, background agents — so a slug you don't remember choosing was most likely set by one of those, not by you in this conversation.",
+        "",
         "Use `set_mood` when your mood/state shifts — at most once per response, near the start.",
         "Available mood slugs:",
         "",
@@ -190,6 +196,21 @@ export async function buildSystemPromptSnapshot(): Promise<PromptSnapshot> {
   };
 }
 
+/**
+ * The one line that closes the write-only loop: the avatar used to be
+ * something Lisa could set but never read, so "what mood are you in?" could
+ * only be answered by guessing (or by reading the emotion vector, which is a
+ * different system). Rebuilt every turn — the hot-reload fingerprint below
+ * includes the slug, so another surface flipping the portrait mid-session
+ * reaches her on her next turn.
+ */
+function currentMoodLine(mood: MoodState): string {
+  if (mood.at === 0) {
+    return "Right now they see the default `neutral` portrait — nobody has set it yet.";
+  }
+  return `Right now they see \`${mood.slug}\` — set ${moodAgeLabel(mood.at)} by ${mood.by}.`;
+}
+
 function formatEmotionsForPrompt(values: Record<string, number>): string {
   const ranked = Object.entries(values)
     .filter(([, v]) => Math.abs(v) > 0.05)
@@ -219,6 +240,13 @@ export async function getPromptFingerprint(): Promise<string> {
   // A daily bucket makes a long-lived chat rebuild the prompt as wants cool,
   // without churning it every second.
   parts.push(`desire-clock-day:${Math.floor(Date.now() / 86_400_000)}`);
+  // The avatar is process state, not a file — and any surface can change it
+  // (an idle turn, a background agent, another tab on the same account). Without
+  // it here, Lisa's prompt would keep asserting the portrait she saw at session
+  // start. The age is bucketed (moodAgeLabel), so this shifts a handful of times
+  // a day at most rather than churning the provider's prompt cache every minute.
+  const mood = moodBus.currentState();
+  parts.push(`mood:${mood.slug}:${moodAgeLabel(mood.at)}`);
   // Single files
   for (const p of [
     soulNameFile(),

--- a/src/soul/tools.ts
+++ b/src/soul/tools.ts
@@ -27,6 +27,7 @@ import {
   writeValue,
 } from "./store.js";
 import { gitDiffPatch, gitLogOneline, withSoulCaller } from "./git.js";
+import { moodAgeLabel, moodBus } from "../mood-bus.js";
 import type { ToolDefinition } from "../types.js";
 import { EMOTION_EVENTS_MAX, type EmotionState } from "./types.js";
 
@@ -300,7 +301,16 @@ export const soulReadTool: ToolDefinition<SoulReadInput, string> = {
         // view (readSoulSummary also decays). Otherwise the two surfaces
         // would show different intensities for the same emotion.
         const e = decayEmotions(await readEmotions());
-        return formatEmotions(e);
+        // The avatar rides along because this is where she looks when asked
+        // "why do you seem happy?" — the portrait is a separate system from
+        // this vector, and answering from the vector alone reads as denying
+        // the face the user is looking at.
+        const mood = moodBus.currentState();
+        const avatar =
+          mood.at === 0
+            ? "avatar: neutral (default — nobody has set it yet)"
+            : `avatar: ${mood.slug} (what the user sees right now — set ${moodAgeLabel(mood.at)} by ${mood.by}; separate from the vector above)`;
+        return `${formatEmotions(e)}\n\n${avatar}`;
       }
       case "journal_today":
         return (await readJournal(today())) || "(no entries today yet)";

--- a/src/subagent.ts
+++ b/src/subagent.ts
@@ -19,6 +19,12 @@ export interface SubagentOptions {
   budgetTokens?: number;
   /** Injectable provider (tests); defaults to providerForModel(model). */
   provider?: Provider;
+  /**
+   * How a set_mood inside this run is attributed in Lisa's next system prompt.
+   * Every subagent is by definition off to the side of the conversation, so the
+   * default says so; idle / heartbeat pass something more specific.
+   */
+  moodOrigin?: string;
 }
 
 export interface SubagentResult {
@@ -53,6 +59,7 @@ export async function runSubagent(opts: SubagentOptions): Promise<SubagentResult
     },
     maxIterations: 32,
     budgetTokens: opts.budgetTokens,
+    moodOrigin: opts.moodOrigin ?? "a background agent",
   });
   return {
     text: result.finalText,

--- a/src/tools/set_mood.ts
+++ b/src/tools/set_mood.ts
@@ -45,8 +45,9 @@ export const setMoodTool: ToolDefinition<SetMoodInput, string> = {
     "shifts — e.g. about to run a destructive command (`scared`), focused " +
     "coding work (`working-coding`), thanking the user (`grateful`), " +
     "celebrating a win (`cheering`). Don't call it every turn — only when " +
-    "the avatar would actually change. The full catalog is in your system " +
-    "prompt; pick the closest match by slug.",
+    "the avatar would actually change. The full catalog — and the slug the " +
+    "user is looking at right now — is in the `## Avatar moods` section of " +
+    "your system prompt; pick the closest match by slug.",
   inputSchema: {
     type: "object",
     properties: {
@@ -69,7 +70,10 @@ export const setMoodTool: ToolDefinition<SetMoodInput, string> = {
         `unknown mood "${mood}". Closest: ${fuzzy.join(", ") || "(none)"}. Use one of the slugs from the catalog.`,
       );
     }
+    // Name what it was: the previous slug may have been set by an idle turn or
+    // a background agent, so the transition is news to this conversation.
+    const previous = moodBus.current();
     moodBus.set(mood);
-    return `mood→${mood}`;
+    return previous === mood ? `mood→${mood} (unchanged)` : `mood→${mood} (was ${previous})`;
   },
 };


### PR DESCRIPTION
## 问题

头像是个**只写通道**。`set_mood` 把 slug 推给 mood bus，GUI 画出来，但没有任何一条路把它带回 Lisa 的 context——没有 `get_mood` 工具，system prompt 只列可用 slug 目录、不含当前值。

所以侧边栏显示 `MOOD: HAPPY` 时问她"为什么这么高兴"，她只能去查 `soul_read {"what":"emotions"}` ——那是另一套系统（带衰减的情绪向量，和 avatar slug 之间没有任何映射）——然后回答"我没高兴，看我的情绪状态"，同时用户正看着一张笑脸。她还会顺口编一个"我上次手动设的 neutral"（`neutral` 恰好是 `#mascotTag` 的 HTML 默认值）。

而 mood bus 是**进程级、按租户隔离、但不按 session 隔离**的：任意一轮 turn——idle 反思、heartbeat、后台 agent、另一个标签页——都能翻这张脸，当前会话的上下文里却没有那条 tool result。

## 读侧

- `moodBus.currentState()` → `{slug, at, by}`。`by` 来自一个 `withMoodOrigin` AsyncLocalStorage，`runAgent` 把整个 loop 包在里面，所以 `set_mood` 无论在工具栈多深触发都能归因——不用往 `ToolContext` 里塞 session id。idle / heartbeat / desire-review / channel / background-agent 各自报出身份。
- **system prompt 每轮说出当前那张脸**，并挑明头像与情绪向量是两套系统、允许不一致：

  ```
  Right now they see `happy` — set moments ago by an idle turn while the user was away.

  That slug is the picture on their screen — it is not the same thing as your emotional
  state above, and the two are allowed to disagree. When someone asks what mood you're
  in, they are usually reading the portrait: name it, then say how you actually feel if
  it no longer fits.
  ```
- `getPromptFingerprint()` 纳入 `mood:<slug>:<age-bucket>`——否则长会话里别的 surface 翻了头像，她的 prompt 会一直断言 session 启动时那张。年龄**分桶**正是为此：一天最多跳几次，不 churn provider 的 prompt cache（有测试守着"同 slug 重设不改 fingerprint"）。
- `soul_read(what="emotions")` 在向量下方报出 avatar——她被问到心情时照的就是这面镜子。
- `set_mood` 回报转移：`mood→sleepy (was happy)`。上一个 slug 可能是别的 turn 设的，对当前会话是新信息。

## 持久化

slug 镜像到 `<scoped home>/current-mood.json`，重启后头像不再无声跳回 `neutral`（用户还看着旧的那张）。写是 fire-and-forget 异步——云端 home 是 gcsfuse 挂载、全租户共享一个 event loop，为一个装饰性写操作卡住所有人的 turn 不划算；读按 scope 惰性 hydrate 一次并保持同步，因为 `current()` 在 `/events` 连接帧里被同步调用。`lisa monitor` 改读这个镜像——它原来读的 `current-mood.txt` 全仓库没人写。

## 租户隔离

不变：`load()` 走调用方的 scoped home，map 仍按 `scopedUid()` 键。`forget(uid)` 额外 unlink 镜像文件并把该 scope 标记为已 hydrate——unlink 失败也不会让已删账号的脸从磁盘复活（有测试）。

## 测试

`typecheck` + `check:api-contract` 通过，**1542 passed / 0 failed**（新增 14 个）：

- `src/mood-bus.test.ts` — 记录 when/what-kind、镜像落盘、重启 hydrate、镜像损坏回落默认脸、`forget` 不复活、`moodAgeLabel` 分桶边界与时钟回拨。
- `src/prompt.mood.test.ts` — 验收测试：prompt 里出现 slug + 年龄 + 归因；另一 surface 改 mood 会推动 fingerprint；同 slug 重设不推动。

## 没做

没改 mood bus 的 session 粒度：仍是"一个用户一张脸"，同账号多会话共享。归因标签是对它的补偿，不是替代。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
