### PR TITLE
add cloud-screencast skill — demo videos on a disposable cloud VM

### DIFF
--- a/.claude/skills/cloud-screencast/SKILL.md
+++ b/.claude/skills/cloud-screencast/SKILL.md
@@ -1,0 +1,299 @@
+---
+name: cloud-screencast
+description: >-
+  Record a clean product demo video of a web app on a disposable cloud VM —
+  provision a GCE instance, install Xvfb + Chrome + ffmpeg + real fonts, deploy the
+  app, drive the UI deterministically with Playwright over CDP while x11grab
+  records, then cut the raw take into a social-ready clip with speed ramps and
+  burned-in captions. Use when asked to record a demo / screencast / promo video,
+  produce a GIF or clip of a UI, or capture a reproducible app walkthrough — and
+  especially when the local machine is unsuitable (personal bookmarks and profile
+  chrome in frame, wrong window size, the app must start from a pristine state, or
+  the recording would tie up the user's desktop for minutes).
+allowed-tools:
+  - Read
+  - Write
+  - Edit
+  - Bash
+---
+
+# cloud-screencast — reproducible UI demo videos on a throwaway VM
+
+Records a web UI on a headless cloud box instead of the user's desktop. You get a
+pristine app state, a chosen viewport, no personal data in frame, and a scripted
+take you can re-run until it's right — none of which is true of a hand-recorded
+local screen capture.
+
+> **Cost + lifecycle:** this creates a billable VM. Always tell the user it exists,
+> and **delete it** when the recording is downloaded (§8). An e2-standard-4 left
+> running is roughly $95/month.
+
+---
+
+## Config
+
+Fill once per project, then run.
+
+```
+PROJECT   = <gcp-project-id>
+ZONE      = <zone, e.g. us-central1-a>
+VM        = <instance-name, e.g. app-record>
+APP_REPO  = <git url of the app, or an npm package name>
+APP_START = <command that serves the UI, e.g. node dist/cli.js serve --web --port 5757>
+APP_URL   = <local url the browser opens, e.g. http://127.0.0.1:5757/>
+SECRETS   = <local env file the app needs, e.g. ~/.app/config.env>
+```
+
+---
+
+## 1. Pick the geometry first
+
+Everything downstream depends on this, and getting it wrong means re-recording.
+
+Chrome's `--force-device-scale-factor=N` divides the X display into CSS pixels:
+
+```
+CSS viewport = Xvfb resolution / DSF
+```
+
+Record at **2× the delivery resolution** and downscale in post — supersampling is
+what makes small UI text look sharp in an H.264 clip.
+
+| Delivery | Xvfb | DSF | CSS viewport | Notes |
+|---|---|---|---|---|
+| 1920×1080 | 2880×1620 | 2 | 1440×810 | good default, 16:9 |
+| 1920×1080 | 2560×1440 | 2 | 1280×720 | tighter; short UIs get clipped |
+| 1080×1080 | 2160×2160 | 2 | 1080×1080 | square, better mobile in-feed |
+
+**Do not just use 1280×720.** A real user's browser window is far taller than 720
+CSS px, so a 720-tall viewport clips panels that never clip in real life — and the
+clipped part is usually the payoff (the final state, the confirm button). Probe the
+actual content height before committing (§4) and go taller if it overflows.
+
+Keep integer DSF values. Fractional scale factors make Chrome's text rendering
+noticeably softer.
+
+## 2. Provision
+
+```bash
+gcloud compute instances create <VM> --project=<PROJECT> --zone=<ZONE> \
+  --machine-type=e2-standard-4 \
+  --image-family=ubuntu-2404-lts-amd64 --image-project=ubuntu-os-cloud \
+  --boot-disk-size=50GB --boot-disk-type=pd-balanced \
+  --labels=purpose=demo-recording
+```
+
+4 vCPU is the floor — x11grab at 2880×1620/30fps plus Chrome plus the app will
+saturate 2 cores. Copy `reference/setup.sh` over and run it: it installs Xvfb,
+ffmpeg, Chrome, xdotool, ImageMagick, Node, and — critically — **fonts**.
+
+> **Fonts are the whole ballgame for "does this look right".** Most web UIs specify
+> `-apple-system, BlinkMacSystemFont, "SF Pro Text"` and `ui-monospace, "SF Mono",
+> Menlo`. None of those exist on Linux, so you get DejaVu fallback and the app looks
+> subtly wrong in a way reviewers notice but can't name. Install `fonts-inter`
+> (a near-exact SF Pro substitute, and often already in the CSS fallback chain),
+> `fonts-jetbrains-mono`, `fonts-noto-color-emoji` (UIs lean on ❤️ 🌙 ★ far more than
+> you expect), and `fonts-noto-cjk`. Then `fc-cache -f`.
+
+**`gcloud compute ssh` is flaky under load.** It intermittently dies with
+`RemoteDisconnected`. Fall back to plain SSH against the external IP with the key
+gcloud already provisioned:
+
+```bash
+ssh -i ~/.ssh/google_compute_engine -o StrictHostKeyChecking=no <user>@<EXTERNAL_IP>
+```
+
+## 3. Deploy the app + secrets
+
+Prefer building from source at the version you want to show — a published package
+often lags the current version.
+
+**Never put secrets in instance metadata or in a command line.** Metadata is
+readable by anyone with project viewer, and argv shows up in `ps` and shell
+history. Pipe them over SSH's stdin instead:
+
+```bash
+grep -E '^(API_KEY|BASE_URL)=' <SECRETS> | \
+  ssh ... "mkdir -p ~/.app && cat > ~/.app/config.env && chmod 600 ~/.app/config.env"
+```
+
+**Snapshot the pristine state before the app ever runs.** First-run flows —
+onboarding, setup wizards, a birth ritual — happen exactly once, and you will need
+three or four takes to get one good one:
+
+```bash
+cp -r ~/.app ~/.app-pristine     # BEFORE first launch
+# each retake starts with:  rm -rf ~/.app && cp -r ~/.app-pristine ~/.app
+```
+
+## 4. Bring the stack up
+
+`reference/stack.sh` does Xvfb → app → Chrome, idempotently. Chrome flags that
+matter for a clean frame:
+
+```
+--kiosk                      no tabs, no URL bar, no bookmarks
+--hide-scrollbars            scrollbars read as clutter on video
+--force-device-scale-factor  see §1
+--lang=en-US                 UIs branch on navigator.language; pin it
+--remote-debugging-port=9222 so Playwright can attach
+--user-data-dir=/tmp/...     fresh profile, no first-run bubbles
+--disable-features=Translate,TranslateUI,AutofillServerCommunication,MediaRouter
+```
+
+Also `xsetroot -solid '<app-bg-color>'` so any gap looks deliberate, and
+`xset -dpms s off s noblank` so the screen never blanks mid-take.
+
+Then **probe before recording** — check the content actually fits:
+
+```js
+await page.evaluate(() => ({
+  viewport: [innerWidth, innerHeight], dpr: devicePixelRatio,
+  overflow: document.querySelector('<container>').scrollHeight,
+  clientH:  document.querySelector('<container>').clientHeight,
+}))
+```
+
+If `scrollHeight > clientHeight` on something that shouldn't scroll, go back to §1.
+
+## 5. Drive it
+
+Attach to the running Chrome rather than letting Playwright launch its own — the
+browser then survives a script crash, so a failed drive doesn't cost you the whole
+recording:
+
+```js
+const b = await chromium.connectOverCDP('http://127.0.0.1:9222');
+const page = b.contexts()[0].pages()[0];
+```
+
+Use `playwright-core` (no bundled browser download). Rules that make takes usable:
+
+- **Print a `MARK <label> <seconds>` timeline.** The edit is driven entirely by
+  these timestamps; without them you are scrubbing a 6-minute file by hand.
+- **Record `-draw_mouse 0`.** A programmatically driven cursor never moves, so a
+  visible pointer just looks frozen.
+- **Type with `{ delay: 40-60 }`.** Instant `fill()` looks like a bug.
+- **Hold 2–3s on each payoff state.** You can always cut time out in post; you
+  cannot add a frame that was never captured.
+- **Poll for real completion**, not fixed sleeps — watch for text length going
+  stable, a class appearing, an element count changing.
+- **Scroll cinematically**: `for (i=0..N) el.scrollTop = total*i/N` with a ~50ms
+  gap reads as a deliberate camera move; a single jump reads as a glitch.
+
+## 6. Record
+
+ffmpeg runs for the whole take; you cut afterwards.
+
+```bash
+ffmpeg -y -f x11grab -draw_mouse 0 -framerate 30 -video_size <W>x<H> -i :99.0 \
+  -c:v libx264 -preset ultrafast -crf 16 -pix_fmt yuv420p /tmp/raw.mp4
+```
+
+`ultrafast` + `crf 16` keeps capture real-time on 4 vCPU; quality is recovered in
+the encode pass. Stop it with `SIGINT` (not `SIGKILL`) so the container finalizes.
+
+**Beware orphaned ffmpeg.** If the drive script dies, its ffmpeg child keeps
+recording and holds the output file — every later take then silently writes
+nowhere. Start each take with `pkill -f x11grab`.
+
+**Launch long takes detached** or the SSH session ending kills them:
+
+```bash
+ssh ... 'setsid bash ~/take.sh > ~/take.log 2>&1 < /dev/null & disown; exit 0'
+```
+
+Do not try to chain `sed`/`mv`/launch in one backgrounded compound — the `&` breaks
+the chain and you get a half-applied state that looks like it worked. Write the
+script to a file, `scp` it, run it.
+
+## 7. Cut
+
+`reference/edit.sh` turns the raw take plus the MARK timeline into a clip: extract
+each beat, apply a speed ramp, concat, burn captions, downscale.
+
+**Cut with the `trim` filter, never `-ss`/`-to`.** Both shortcuts fail silently here
+and you only notice when reviewing the output:
+
+| | what goes wrong |
+|---|---|
+| `-ss` before `-i` | seeks to the previous keyframe. An `ultrafast` screen capture has ~8s keyframe gaps, so the cut starts seconds early — on the wrong beat entirely. |
+| `-to` after `-i` | measured on the *filtered* timeline, so a `setpts` speed-up stretches the window. A 30s target came out 57s. |
+
+```
+trim=start=S:end=E,setpts=PTS-STARTPTS[,crop=W:H:X:Y],setpts=PTS/SPEED,fps=30,scale=...
+```
+
+`trim` runs on input timestamps, before `setpts` touches them.
+
+**Push in on small UI.** Full-frame desktop UI is unreadable in a phone feed. Crop
+to the element (keep it 16:9) and rescale — a 1.2–1.4× push-in is usually enough.
+**Measure the bounding box** from a full-res extracted frame first; a crop that
+misses the thing you are pointing at is invisible until you review the cut.
+
+Editorial rules for a silent autoplay feed:
+
+- **No voiceover.** Social video autoplays muted — everything must be in captions.
+- **3–5 words per caption**, ~2.5s each, bottom third, white on a subtle scrim.
+- **Speed-ramp the dead air** (network waits, model latency) 3–8×; never hold a
+  static frame.
+- **The first 2 seconds decide completion.** Open on the payoff of the first beat,
+  never on an empty screen or a loading state.
+- **End card**: what it is, the license, the URL. 2–3s.
+- Downscale with `flags=lanczos`; export `yuv420p` + `-movflags +faststart`.
+
+## 8. Music (optional)
+
+If a bed is wanted, **synthesise it** — `reference/music.sh` builds one from ffmpeg
+sine sources. Never attach a track you found online: a promo clip is a commercial
+use, and "royalty-free" pages routinely mislabel licences. Generated audio has no
+rights question at all.
+
+The recipe that sounds like music rather than a test tone: a four-chord progression
+with tight voice leading, each voice doubled by a second sine ~0.35% off for slow
+beating, then `lowpass` (warmth) → `aecho` (space) → `tremolo` (movement) →
+`loudnorm`. Put `aresample=48000` **after** `loudnorm`, which otherwise leaves the
+output at 192kHz.
+
+Verify what you can measure — `-14` to `-20` LUFS integrated, true peak under
+`-1 dBTP`, 48kHz stereo:
+
+```bash
+ffmpeg -hide_banner -i bed.wav -af ebur128 -f null - 2>&1 | tail -12
+```
+
+**Say plainly that you could not listen to it** and ask the user to audition before
+posting. Levels and format are verifiable; whether it actually sounds good is not.
+
+## 9. Tear down — required
+
+```bash
+gcloud compute scp <VM>:/tmp/final.mp4 ./ --zone=<ZONE> --project=<PROJECT>
+gcloud compute instances delete <VM> --zone=<ZONE> --project=<PROJECT> --quiet
+```
+
+Confirm the download opens locally *before* deleting. Then tell the user the VM is
+gone. If you are keeping it for retakes, say so explicitly and give them the delete
+command.
+
+---
+
+## Honesty constraints
+
+The recording is a claim about how the product behaves. So:
+
+- **Never inject CSS/JS to make the UI fit or look better.** If content clips,
+  change the viewport (§1), not the app. A viewport that matches a real user's
+  browser is the honest fix.
+- **Never fake a state the app didn't produce.** If a feature stays silent or empty
+  during the take, that is the product's real behaviour — either give it genuine
+  input that exercises it, or cut the beat.
+- Cutting and speeding up real footage is fine and expected. Staging output that
+  the app never generated is not.
+
+## Reference
+
+- `reference/setup.sh` — VM package + font install
+- `reference/stack.sh` — Xvfb + app + Chrome bring-up
+- `reference/take.mjs` — annotated Playwright drive script with the MARK timeline
+- `reference/edit.sh` — segment / speed-ramp / caption / downscale pipeline

--- a/.claude/skills/cloud-screencast/reference/edit.sh
+++ b/.claude/skills/cloud-screencast/reference/edit.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Cut a raw take into a social-ready clip.
+#
+#   RAW=/tmp/raw.mp4 OUT=/tmp/final.mp4 bash edit.sh
+#
+# Edit SEGMENTS below using the MARK timeline the drive script printed. Each row is
+#   "<start> <end> <speed> <caption>"
+# start/end are seconds into RAW; speed>1 compresses (setpts=PTS/speed).
+# Speed-ramp network + model latency hard; hold real payoff states at ~1x.
+set -euo pipefail
+
+RAW="${RAW:-/tmp/raw.mp4}"
+OUT="${OUT:-/tmp/final.mp4}"
+WORK="${WORK:-/tmp/edit}"
+OUT_W="${OUT_W:-1920}"; OUT_H="${OUT_H:-1080}"
+FONT="${FONT:-/usr/share/fonts/opentype/inter/InterDisplay-Bold.otf}"
+ENDCARD_LINE1="${ENDCARD_LINE1:-<app name>}"
+ENDCARD_LINE2="${ENDCARD_LINE2:-<tagline · license · url>}"
+
+# "start|end|speed|crop|caption"
+#   crop = "none" or W:H:X:Y — a push-in, so small UI text survives a phone feed.
+#          Keep the crop 16:9. Measure the element first (extract a full-res frame
+#          and read off its bounding box); do not guess, a crop that misses the
+#          thing you are pointing at is invisible until you review the cut.
+#   caption = empty means the UI already says it better than an overlay would.
+SEGMENTS=(
+  "0.0|17.0|3.0|2160:1215:360:202|Caption for beat one"
+  "18.5|24.0|1.6|none|Caption for beat two"
+  "25.0|38.0|1.7|none|Caption for beat three"
+  "38.0|50.0|2.0|2400:1350:240:140|Caption for beat four"
+  "112.0|126.0|1.4|none|"
+)
+
+rm -rf "$WORK"; mkdir -p "$WORK"
+
+# ── 1. extract + speed-ramp each beat ──────────────────────────────────
+i=0; : > "$WORK/list.txt"; CAPS=(); CUM=0
+for row in "${SEGMENTS[@]}"; do
+  IFS='|' read -r S E SP CROP CAP <<< "$row"
+  DUR=$(awk -v s="$S" -v e="$E" -v p="$SP" 'BEGIN{printf "%.3f", (e-s)/p}')
+  # Cut with the `trim` FILTER — NOT -ss/-to. Both shortcuts are silently wrong here:
+  #   -ss before -i  snaps to the previous keyframe. An ultrafast screen capture has
+  #                  ~8s keyframe gaps, so it starts seconds early on the wrong beat.
+  #   -to after -i   is measured on the FILTERED timeline, so a setpts speed-up
+  #                  stretches the window (a 30s cut came out 57s that way).
+  # trim runs on input timestamps, before setpts touches them.
+  FV="trim=start=$S:end=$E,setpts=PTS-STARTPTS"
+  [ "$CROP" = "none" ] || FV="$FV,crop=$CROP"
+  FV="$FV,setpts=PTS/$SP,fps=30,scale=${SRC_W:-2880}:${SRC_H:-1620}:flags=lanczos"
+  ffmpeg -v error -y -i "$RAW" -filter:v "$FV" -an \
+    -c:v libx264 -preset slow -crf 18 -pix_fmt yuv420p "$WORK/seg$i.mp4"
+  echo "file '$WORK/seg$i.mp4'" >> "$WORK/list.txt"
+  END=$(awk -v c="$CUM" -v d="$DUR" 'BEGIN{printf "%.3f", c+d}')
+  CAPS+=("$CUM|$END|$CAP")
+  CUM=$END; i=$((i+1))
+  printf "seg%d: %s->%s x%s %s = %ss cum=%s\n" $((i-1)) "$S" "$E" "$SP" "$CROP" "$DUR" "$CUM"
+done
+
+# ── 2. end card ────────────────────────────────────────────────────────
+ffmpeg -v error -y -f lavfi -i "color=c=#0b0a1a:s=${OUT_W}x${OUT_H}:d=2.6:r=30" \
+  -vf "drawtext=fontfile=$FONT:text='$ENDCARD_LINE1':fontcolor=white:fontsize=76:x=(w-tw)/2:y=(h/2)-70,
+       drawtext=fontfile=$FONT:text='$ENDCARD_LINE2':fontcolor=0xB8C0E0:fontsize=34:x=(w-tw)/2:y=(h/2)+40,
+       fade=t=in:st=0:d=0.4" \
+  -c:v libx264 -preset slow -crf 18 -pix_fmt yuv420p "$WORK/end.mp4"
+echo "file '$WORK/end.mp4'" >> "$WORK/list.txt"
+
+# ── 3. concat ──────────────────────────────────────────────────────────
+ffmpeg -v error -y -f concat -safe 0 -i "$WORK/list.txt" -c copy "$WORK/joined.mp4"
+
+# ── 4. captions + downscale ────────────────────────────────────────────
+# Captions live in the bottom third on a scrim. 3-5 words, ~2.5s each: social
+# video autoplays muted, so every bit of meaning has to survive with no audio.
+VF="scale=${OUT_W}:${OUT_H}:flags=lanczos"
+for c in "${CAPS[@]}"; do
+  IFS='|' read -r A B TXT <<< "$c"
+  ESC=$(printf '%s' "$TXT" | sed "s/'/\\\\\\\\'/g; s/:/\\\\:/g")
+  VF="$VF,drawbox=x=0:y=ih-190:w=iw:h=190:color=black@0.42:t=fill:enable='between(t,$A,$B)'"
+  VF="$VF,drawtext=fontfile=$FONT:text='$ESC':fontcolor=white:fontsize=44:x=(w-tw)/2:y=h-125:enable='between(t,$A,$B)'"
+done
+VF="$VF,fade=t=in:st=0:d=0.35"
+
+ffmpeg -v error -y -i "$WORK/joined.mp4" -vf "$VF" \
+  -c:v libx264 -preset slow -crf 19 -pix_fmt yuv420p -movflags +faststart -an "$OUT"
+
+echo "--- $OUT ---"
+ffprobe -v error -show_entries format=duration,size -show_entries stream=width,height,r_frame_rate \
+  -of default=noprint_wrappers=1 "$OUT"

--- a/.claude/skills/cloud-screencast/reference/music.sh
+++ b/.claude/skills/cloud-screencast/reference/music.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# Synthesised ambient bed — 100% generated, no sampled or licensed material, so the
+# clip is safe to publish. Am - F - G - C with close voice leading, detuned sine
+# pairs for width, lowpass + echo for warmth and space.
+set -euo pipefail
+D="${OUTDIR:-$(cd "$(dirname "$0")" && pwd)}"
+CH=9              # seconds per chord
+XF=1.5            # crossfade
+OUTDUR=30
+
+chord () {  # $1=out  $2..$5 = bass, low, mid, high (Hz)
+  local out="$1"; shift
+  local ins=() fc="" n=0
+  for f in "$@"; do
+    # each voice = two sines a few cents apart -> slow beating, not a test tone
+    ins+=(-f lavfi -i "sine=frequency=$f:duration=$CH:sample_rate=48000")
+    ins+=(-f lavfi -i "sine=frequency=$(awk -v x="$f" 'BEGIN{printf "%.4f", x*1.0035}'):duration=$CH:sample_rate=48000")
+    n=$((n+2))
+  done
+  for ((i=0;i<n;i++)); do fc="$fc[$i:a]"; done
+  # bass voice sits louder, top voice quieter -> the chord reads as one sound
+  ffmpeg -v error -y "${ins[@]}" -filter_complex \
+    "${fc}amix=inputs=$n:normalize=0,volume=0.11,afade=t=in:st=0:d=2.2,afade=t=out:st=$(awk -v c=$CH 'BEGIN{print c-2.2}'):d=2.2" \
+    -c:a pcm_s16le "$out"
+}
+
+# Am        F         G         C     (voice leading kept tight between chords)
+chord "$D/c1.wav" 110.00 220.00 261.63 329.63
+chord "$D/c2.wav"  87.31 220.00 261.63 349.23
+chord "$D/c3.wav"  98.00 196.00 246.94 293.66
+chord "$D/c4.wav"  65.41 196.00 261.63 329.63
+
+ffmpeg -v error -y -i "$D/c1.wav" -i "$D/c2.wav" -i "$D/c3.wav" -i "$D/c4.wav" \
+  -filter_complex "\
+[0][1]acrossfade=d=$XF:c1=tri:c2=tri[a];\
+[a][2]acrossfade=d=$XF:c1=tri:c2=tri[b];\
+[b][3]acrossfade=d=$XF:c1=tri:c2=tri[c];\
+[c]lowpass=f=1500,\
+aecho=0.8:0.85:420|770:0.28|0.18,\
+tremolo=f=0.18:d=0.22,\
+loudnorm=I=-20:TP=-2:LRA=7,\
+aresample=48000,\
+pan=stereo|c0=c0|c1=c0,\
+atrim=0:$OUTDUR,asetpts=N/SR/TB,\
+afade=t=in:st=0:d=1.6,afade=t=out:st=27.2:d=2.8[out]" \
+  -map "[out]" -c:a pcm_s16le -ar 48000 "$D/bed.wav"
+
+ffprobe -v error -show_entries format=duration -show_entries stream=sample_rate,channels \
+  -of default=noprint_wrappers=1 "$D/bed.wav"
+echo "--- peak / loudness ---"
+ffmpeg -v error -i "$D/bed.wav" -af "volumedetect" -f null - 2>&1 | grep -E "mean_volume|max_volume"

--- a/.claude/skills/cloud-screencast/reference/setup.sh
+++ b/.claude/skills/cloud-screencast/reference/setup.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# VM bootstrap for cloud-screencast. Run once on a fresh Ubuntu 24.04 instance.
+#   scp setup.sh <vm>:~/ && ssh <vm> 'bash ~/setup.sh'
+set -euxo pipefail
+export DEBIAN_FRONTEND=noninteractive
+
+sudo apt-get update -y
+sudo apt-get install -y --no-install-recommends \
+  xvfb x11-utils x11-xserver-utils xdotool wmctrl ffmpeg xterm \
+  git build-essential curl ca-certificates gnupg unzip imagemagick \
+  fonts-inter fonts-jetbrains-mono fonts-noto-color-emoji fonts-noto-cjk fonts-dejavu
+#   ^^^ fonts are not optional. Web UIs ask for -apple-system / SF Pro / SF Mono,
+#   none of which exist here; without Inter + JetBrains Mono you record DejaVu
+#   fallback and the app looks subtly wrong. Noto Color Emoji matters more than
+#   you expect — UI copy is full of ★ ❤️ 🌙.
+
+# Node (pin to whatever the app needs)
+curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+sudo apt-get install -y nodejs
+
+# Google Chrome stable — prefer real Chrome over Playwright's bundled chromium so
+# the recording matches what users actually see.
+curl -fsSL https://dl.google.com/linux/linux_signing_key.pub \
+  | sudo gpg --dearmor -o /usr/share/keyrings/google-chrome.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/google-chrome.gpg] https://dl.google.com/linux/chrome/deb/ stable main" \
+  | sudo tee /etc/apt/sources.list.d/google-chrome.list
+sudo apt-get update -y
+sudo apt-get install -y google-chrome-stable
+
+# CDP driver only — no browser download.
+mkdir -p ~/drive && cd ~/drive && npm init -y >/dev/null && npm i playwright-core
+
+fc-cache -f
+node -v; google-chrome --version; ffmpeg -version | head -1
+echo SETUP_DONE

--- a/.claude/skills/cloud-screencast/reference/stack.sh
+++ b/.claude/skills/cloud-screencast/reference/stack.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Bring up Xvfb -> app -> Chrome(kiosk, CDP). Idempotent: safe to re-run per take.
+#
+# Geometry: CSS viewport = W/DSF. 2880x1620 @ DSF 2 => 1440x810 CSS, and the 2x
+# oversample is what keeps UI text sharp after the downscale to 1080p.
+set -uo pipefail
+
+export DISPLAY=:99
+W=2880; H=1620; DSF=2
+CSS_W=$((W / DSF)); CSS_H=$((H / DSF))
+
+APP_DIR="${APP_DIR:-$HOME/app}"
+APP_START="${APP_START:-node dist/cli.js serve --web --port 5757}"
+APP_URL="${APP_URL:-http://127.0.0.1:5757/}"
+APP_PORT="${APP_PORT:-5757}"
+SECRETS="${SECRETS:-$HOME/.app/config.env}"
+BG="${BG:-#0b0a1a}"          # match the app background so gaps look deliberate
+
+# Orphaned ffmpeg from a crashed take will hold the output file and silently
+# swallow every later recording. Always clear it first.
+pkill -f x11grab         2>/dev/null || true
+pkill -f "Xvfb :99"      2>/dev/null || true
+pkill -f google-chrome   2>/dev/null || true
+pkill -f "$APP_START"    2>/dev/null || true
+sleep 2
+
+Xvfb :99 -screen 0 ${W}x${H}x24 -nolisten tcp +extension RANDR > ~/xvfb.log 2>&1 &
+sleep 2
+xsetroot -solid "$BG" 2>/dev/null || true
+xset -dpms s off s noblank 2>/dev/null || true
+
+[ -f "$SECRETS" ] && { set -a; . "$SECRETS"; set +a; }
+cd "$APP_DIR"
+nohup $APP_START > ~/serve.log 2>&1 &
+
+for i in $(seq 1 60); do curl -sf -o /dev/null "http://127.0.0.1:$APP_PORT/" && break; sleep 1; done
+
+rm -rf /tmp/chrome-profile
+nohup google-chrome \
+  --no-first-run --no-default-browser-check --disable-infobars \
+  --disable-features=Translate,TranslateUI,AutofillServerCommunication,MediaRouter \
+  --disable-session-crashed-bubble --disable-popup-blocking \
+  --force-device-scale-factor=$DSF \
+  --kiosk --hide-scrollbars --lang=en-US \
+  --remote-debugging-port=9222 \
+  --user-data-dir=/tmp/chrome-profile \
+  --window-position=0,0 --window-size=${CSS_W},${CSS_H} \
+  "$APP_URL" > ~/chrome.log 2>&1 &
+
+for i in $(seq 1 40); do curl -sf -o /dev/null http://127.0.0.1:9222/json/version && break; sleep 1; done
+sleep 3
+
+echo "--- geometry ---"; xdpyinfo | grep dimensions
+echo "--- css viewport --- ${CSS_W}x${CSS_H} @ ${DSF}x"
+echo STACK_UP

--- a/.claude/skills/cloud-screencast/reference/take.mjs
+++ b/.claude/skills/cloud-screencast/reference/take.mjs
@@ -1,0 +1,112 @@
+/**
+ * Drive script template for cloud-screencast.
+ *
+ *   OUT=/tmp/raw.mp4 node take.mjs
+ *
+ * Owns ffmpeg's lifetime so capture and choreography share one clock, and prints a
+ * `MARK <t> <label>` timeline — the edit is driven entirely off those timestamps.
+ * Replace the BEATS section with your app's flow.
+ */
+import { chromium } from 'playwright-core';
+import { spawn } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+
+const OUT  = process.env.OUT  || '/tmp/raw.mp4';
+const SIZE = process.env.SIZE || '2880x1620';
+
+const marks = [];
+let t0 = 0;
+const now = () => (Date.now() - t0) / 1000;
+function mark(label) {
+  const t = now();
+  marks.push({ label, t });
+  console.log(`MARK ${t.toFixed(2).padStart(8)}  ${label}`);
+}
+
+// -draw_mouse 0: a programmatically driven cursor never moves, so a visible
+// pointer just looks frozen. ultrafast+crf16 keeps capture real-time on 4 vCPU;
+// quality comes back in the edit pass.
+const ff = spawn('ffmpeg', [
+  '-y', '-f', 'x11grab', '-draw_mouse', '0', '-framerate', '30',
+  '-video_size', SIZE, '-i', ':99.0',
+  '-c:v', 'libx264', '-preset', 'ultrafast', '-crf', '16', '-pix_fmt', 'yuv420p', OUT,
+], { stdio: ['ignore', 'ignore', 'pipe'] });
+let ffTail = '';
+ff.stderr.on('data', (d) => { ffTail = (ffTail + d.toString()).slice(-1500); });
+
+await new Promise((r) => setTimeout(r, 2500));   // let ffmpeg settle before t0
+t0 = Date.now();
+mark('REC_START');
+
+// Attach to the already-running Chrome rather than launching one: the browser
+// then survives a crash in this script, so a bad drive doesn't cost the take.
+const b = await chromium.connectOverCDP('http://127.0.0.1:9222');
+const page = b.contexts()[0].pages()[0];
+const wait = (ms) => page.waitForTimeout(ms);
+
+/** Poll for real completion instead of sleeping a fixed guess. */
+async function until(fn, { every = 500, tries = 240 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    if (await page.evaluate(fn)) return true;
+    await wait(every);
+  }
+  return false;
+}
+
+/** Wait for streamed text to stop growing — the honest "is it done" signal. */
+async function untilStable(sel, { every = 500, need = 6, tries = 240 } = {}) {
+  let prev = -1, stable = 0;
+  for (let i = 0; i < tries; i++) {
+    const len = await page.evaluate((s) => document.querySelector(s)?.innerText?.length || 0, sel);
+    stable = len === prev && len > 80 ? stable + 1 : 0;
+    prev = len;
+    if (stable >= need) return true;
+    await wait(every);
+  }
+  return false;
+}
+
+// ── BEATS ──────────────────────────────────────────────────────────────
+// Hold 2-3s on every payoff state. You can cut time out in post; you cannot
+// add a frame that was never captured.
+
+mark('beat1_start');
+await until(() => !!document.querySelector('<ready-selector>'));
+mark('beat1_ready');
+await wait(2500);
+
+// Typing: {delay: 40-60} reads as human. An instant fill() looks like a bug.
+await page.click('<input-selector>');
+await page.type('<input-selector>', 'your demo prompt', { delay: 50 });
+mark('typed');
+await wait(500);
+await page.keyboard.press('Enter');
+mark('sent');
+await untilStable('<output-selector>');
+mark('reply_done');
+await wait(2800);
+
+// Cinematic scroll: a stepped scrollTop reads as a deliberate camera move,
+// a single jump reads as a glitch.
+const scrolled = await page.evaluate(async () => {
+  const el = document.querySelector('<scroll-container>');
+  if (!el) return 0;
+  const total = el.scrollHeight - el.clientHeight;
+  for (let i = 0; i <= 140; i++) {
+    el.scrollTop = (total * i) / 140;
+    await new Promise((r) => setTimeout(r, 52));
+  }
+  return total;
+});
+mark(`scrolled_${scrolled}px`);
+await wait(2000);
+
+mark('REC_END');
+// ───────────────────────────────────────────────────────────────────────
+
+await b.close();
+ff.kill('SIGINT');                                  // SIGINT, not SIGKILL — the
+await new Promise((r) => setTimeout(r, 4000));      // container must finalize
+writeFileSync('/tmp/marks.json', JSON.stringify(marks, null, 1));
+console.log('\n--- ffmpeg ---\n' + ffTail);
+console.log('\nWROTE ' + OUT);

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,12 @@ dist-release/
 .DS_Store
 .env
 .env.local
-.claude/
+# Local Claude Code state (settings.local.json, worktrees) stays out — but skills
+# are shared tooling and belong in the repo.
+.claude/*
+!.claude/skills/
 reference/
+!.claude/skills/**/reference/
 
 # Internal growth/marketing playbook — strategic docs that aren't public-friendly
 docs/GROWTH.md


### PR DESCRIPTION
Recording a product demo locally puts personal browser chrome in frame, pins the viewport to whatever window happens to be open, and ties up the desktop for minutes per take. This skill does it on a throwaway GCE instance instead: **Xvfb + Chrome + ffmpeg + real fonts**, Playwright driving the UI over CDP while `x11grab` records, then a trim / speed-ramp / caption pass down to a 1080p clip.

Built and validated end to end producing a 30s LISA demo (v0.22.0, real birth ritual → live mood switching → SOUL inspector → idle reflection), so it carries the traps that actually cost time.

### What's in it

```
.claude/skills/cloud-screencast/
  SKILL.md
  reference/setup.sh    VM packages + fonts
  reference/stack.sh    Xvfb -> app -> Chrome(kiosk, CDP)
  reference/take.mjs    annotated Playwright drive script w/ MARK timeline
  reference/edit.sh     segment / speed-ramp / caption / downscale
  reference/music.sh    synthesised ambient bed
```

### Traps it encodes

- **Viewport geometry** — CSS viewport = Xvfb resolution ÷ device-scale-factor; record at 2× the delivery resolution and downscale. A 720-tall viewport clips panels that never clip in a real browser, and the clipped part is usually the payoff.
- **Fonts** — UIs ask for `-apple-system` / SF Pro / SF Mono, none of which exist on Linux. Without `fonts-inter` + `jetbrains-mono` + `noto-color-emoji` you record DejaVu fallback and the app looks subtly wrong in a way reviewers notice but can't name.
- **Secrets** over SSH stdin — never instance metadata (project-viewer readable) or argv (shows up in `ps`).
- **Pristine snapshot** before first launch, so first-run flows can be re-recorded.
- **ffmpeg cutting: `trim` filter only.** Input-side `-ss` snaps to the previous keyframe (~8s gaps in an `ultrafast` capture) and silently starts on the wrong beat; output-side `-to` is measured post-`setpts` and stretched a 30s cut to 57s.
- **Synthesise music.** "Royalty-free" downloads are a licensing risk on a promo clip; generated audio has no rights question at all.

### Honesty constraints

The skill states them explicitly: never inject CSS/JS to make the UI fit or look better, and never stage a state the app did not produce. If content clips, fix the viewport — not the app. (This came up for real: LISA's idle run chose silence twice, which is her designed behaviour, so the cut uses the genuine idle pulse rather than a staged "while you were away" card.)

### `.gitignore`

`.claude/` was ignored wholesale. Narrowed to `.claude/*` with `!.claude/skills/` so shared tooling is tracked while `settings.local.json` and worktrees stay out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)