### PR TITLE
fix(web): identical hit area for the mail-connect modal buttons

### DIFF
--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -509,7 +509,7 @@ export const MAIN_CSS = `  :root {
   .delegate-modal .dm-task { resize: vertical; min-height: 88px; font-family: inherit; }
   .delegate-modal .dm-actions { display: flex; justify-content: flex-end; margin-top: 4px; }
   .delegate-modal .dm-start {
-    font-size: 13px; padding: 8px 16px; border-radius: 8px;
+    font-size: 13px; line-height: 1.2; padding: 8px 16px; border-radius: 8px;
     border: 1px solid var(--brand, #6ad4ff); background: rgba(106,212,255,0.16);
     color: var(--brand, #6ad4ff); cursor: pointer;
   }
@@ -535,9 +535,13 @@ export const MAIN_CSS = `  :root {
   .delegate-modal .mm-steps { margin: 0; padding-left: 18px; display: flex; flex-direction: column; gap: 4px; }
   .delegate-modal .mm-steps li { font-size: 12px; color: var(--fg-2); line-height: 1.45; }
   .delegate-modal .mm-link {
-    align-self: flex-start; font-size: 12.5px; font-weight: 500;
+    /* Match .dm-start's box exactly so the two accent buttons share a hit area:
+       same font-size + line-height + padding + border, and the same block-flow
+       box (no inline-flex — it renders an <a> 0.5px shorter than the <button>). */
+    align-self: flex-start;
+    font-size: 13px; line-height: 1.2; font-weight: 500;
     color: var(--brand, #6ad4ff); text-decoration: none;
-    border: 1px solid var(--brand, #6ad4ff); border-radius: 8px; padding: 6px 12px;
+    border: 1px solid var(--brand, #6ad4ff); border-radius: 8px; padding: 8px 16px;
     background: rgba(106,212,255,0.10);
   }
   .delegate-modal .mm-link:hover { background: rgba(106,212,255,0.20); }

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -86,10 +86,13 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: Sense social publishing host — discovered connector status, post-draft
  * list, linked-account labels, immutable approval snapshot, local approve,
  * cancel controls, and a publishing pause/resume kill switch.
+ * Then: mail connect modal — the two accent action buttons (.mm-link "Open App
+ * Passwords" and .dm-start "Connect") now share an identical hit area; .mm-link
+ * matched to .dm-start's box and both pinned to line-height:1.2 for exact parity.
  */
-const EXPECTED_LENGTH = 232129;
+const EXPECTED_LENGTH = 232412;
 const EXPECTED_SHA256 =
-  "d054604413725cbb37e979bb053d7118c43a26e8fe9b90d59b28edde93b851a5";
+  "e8ee3bf24b035276868dba640b943fb436520a9e02bb0e928082e32ce2beeafa";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);


### PR DESCRIPTION
The connect-mailbox modal has two accent action buttons — **"Open Google App
Passwords ↗"** (`.mm-link`) and **"Connect →"** (`.dm-start`) — that were
visibly different sizes, so their click/hit areas didn't match:

| | font-size | padding |
|---|---|---|
| `.mm-link` (before) | 12.5px | `6px 12px` |
| `.dm-start` | 13px | `8px 16px` |

Matched `.mm-link` to `.dm-start`'s box. Two follow-on details:

- Dropped an `inline-flex` I first added to `.mm-link` — an `<a>` renders it
  ~0.5px shorter than a `<button>` under flex cross-sizing.
- Pinned both to `line-height: 1.2` (a font-independent ratio) to erase the last
  sub-pixel `<a>`-vs-`<button>` gap. The `.dm-start` change is a ~0.1px no-op
  visually and makes its box explicit rather than UA-dependent.

## Verification

Rendered the real `MAIN_HTML` and measured both buttons in-browser:

```
before : mm-link 33.0px (12.5px / 6px 12px)  ·  dm-start 33.5px (13px / 8px 16px)
after  : both 33.59px · 13px · line-height 15.6px · padding 8px 16px · border 1px
         → IDENTICAL_HIT_AREA: true
```

`MAIN_HTML` snapshot refreshed; `tsc --noEmit` clean; full suite **1542 pass / 0 fail**.
