### PR TITLE
Session shell P2: Lisa 多 session 切换 + tab strip

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -418,10 +418,27 @@ document.addEventListener('paste', (ev) => {
 
 // Surface session id from server header on first request. The titlebar
 // shows the same id with a leading "·" separator after the "Lisa" label.
-fetch('/session').then(r => r.json()).then(s => {
-  sessionEl.textContent = s.id;
+// Session switching (PLAN_UI_SESSION_SHELL_v1.0): the active id is tracked
+// here; lisaSetActiveSession is the one entry point every switch path uses —
+// tree clicks, tab clicks, ＋New, and the session_switched SSE frame from
+// another window — so they all converge on the same reload behavior.
+let activeSessionId = null;
+function setActiveSessionUI(id) {
+  activeSessionId = id;
+  window.lisaActiveSessionId = id;
+  sessionEl.textContent = id;
   const titlebarSession = document.getElementById('titlebarSession');
-  if (titlebarSession) titlebarSession.textContent = '· ' + s.id;
+  if (titlebarSession) titlebarSession.textContent = '· ' + id;
+}
+window.lisaSetActiveSession = function (id) {
+  if (!id || id === activeSessionId) return;
+  setActiveSessionUI(id);
+  if (typeof window.lisaResetChatLog === 'function') window.lisaResetChatLog();
+  if (typeof window.lisaRenderSessionTree === 'function') window.lisaRenderSessionTree();
+};
+fetch('/session').then(r => r.json()).then(s => {
+  setActiveSessionUI(s.id);
+  if (typeof window.lisaRenderSessionTree === 'function') window.lisaRenderSessionTree();
 });
 
 // ── While-you-were-away idle note: shared card builder + localized label ──
@@ -492,6 +509,9 @@ function connectEvents() {
       // "sidebar live wiring" block). Generalized from claude_session_update
       // so codex / opencode / git / … sessions update the sidebar too.
       if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
+    } else if (ev.type === 'session_switched') {
+      // Another window (or this one) moved the active web session — converge.
+      if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(ev.session);
     } else if (ev.type === 'mail_digest_update' || ev.type === 'mail_accounts_update') {
       if (typeof window.refreshMail === 'function') window.refreshMail();
     }
@@ -765,6 +785,22 @@ loadHistoryPage();
 log.addEventListener('scroll', () => {
   if (log.scrollTop < 80) loadHistoryPage();
 });
+
+// Session switch support: wipe the log and reload page 0 for the (new) active
+// session. Bumps the chat generation so an in-flight reply stream from the
+// previous session stops touching the DOM (it keeps draining silently and the
+// server persists it into the session it started in).
+window.lisaResetChatLog = function () {
+  chatGeneration++;
+  historyPage = 0;
+  historyLoading = false;
+  historyExhausted = false;
+  currentLisaSpan = null;
+  pendingTools.clear();
+  if (thinkingEl) { thinkingEl.remove(); thinkingEl = null; }
+  log.innerHTML = '';
+  loadHistoryPage();
+};
 
 // ── mascot crossfade on mood event ──────────────────────────────────
 const mascotEl = document.getElementById('mascot');
@@ -1073,6 +1109,9 @@ if (fnSearchBtn && fnFind) {
 let currentLisaSpan = null;
 let pendingTools = new Map();
 let thinkingEl = null;
+// Bumped by lisaResetChatLog on every session switch; runChat captures the
+// value at send time and stops rendering once it goes stale.
+let chatGeneration = 0;
 
 function el(tag, cls, text) {
   const node = document.createElement(tag);
@@ -1225,6 +1264,7 @@ function showError(detail, message, filesToSend) {
 
 async function runChat(message, filesToSend) {
   sendBtn.disabled = true;
+  const gen = chatGeneration;
   currentLisaSpan = null;
   pendingTools.clear();
   thinkingEl = el('div', 'thinking', '⋯ thinking');
@@ -1232,7 +1272,7 @@ async function runChat(message, filesToSend) {
   // catch — dedupe so one failure renders exactly one error block.
   let errored = false;
   const fail = (detail) => {
-    if (errored) return;
+    if (errored || gen !== chatGeneration) return;
     errored = true;
     showError(detail, message, filesToSend);
   };
@@ -1256,6 +1296,9 @@ async function runChat(message, filesToSend) {
         const m = evRaw.match(/^data: (.*)$/m);
         if (!m) continue;
         const ev = JSON.parse(m[1]);
+        // Stale generation (the user switched sessions mid-reply): drain the
+        // stream without touching the DOM; the reply persists server-side.
+        if (gen !== chatGeneration) continue;
         if (ev.type === 'text') {
           const span = ensureLisaSpan();
           span._md = (span._md || '') + ev.text;
@@ -1479,10 +1522,11 @@ if ('serviceWorker' in navigator) {
 
   function relativeTime(iso) {
     const ms = Date.now() - new Date(iso).getTime();
-    if (ms < 30_000)   return 'just now';
-    if (ms < 60_000)   return Math.round(ms / 1000) + 's';
-    if (ms < 3600_000) return Math.round(ms / 60_000) + 'm';
-    return Math.round(ms / 3600_000) + 'h';
+    if (ms < 30_000)    return 'just now';
+    if (ms < 60_000)    return Math.round(ms / 1000) + 's';
+    if (ms < 3600_000)  return Math.round(ms / 60_000) + 'm';
+    if (ms < 86400_000) return Math.round(ms / 3600_000) + 'h';
+    return Math.round(ms / 86400_000) + 'd';
   }
 
   function setDesire(text) {
@@ -1774,13 +1818,164 @@ if ('serviceWorker' in navigator) {
     } catch {}
   }
 
+  // ── Session tree + tab strip (PLAN_UI_SESSION_SHELL_v1.0 §3.1) ──────
+  // Lisa's own sessions as the first root group of the sidebar tree; the
+  // monitored-agent groups join in the control-tree phase. Open tabs are a
+  // client-side notion (which sessions you keep at hand), persisted in
+  // localStorage; the tree is the full on-disk list.
+  let cachedSessions = [];
+  let openTabIds = [];
+  try {
+    const rawTabs = localStorage.getItem('lisaOpenSessions');
+    if (rawTabs) openTabIds = JSON.parse(rawTabs).filter(function (x) { return typeof x === 'string'; });
+  } catch (e) { openTabIds = []; }
+  function saveTabs() {
+    try { localStorage.setItem('lisaOpenSessions', JSON.stringify(openTabIds.slice(0, 12))); } catch (e) {}
+  }
+  function sessionLabel(s) {
+    const t = (s && s.lastUserMessage ? s.lastUserMessage : '').trim();
+    if (t) return t.length > 30 ? t.slice(0, 30) + '…' : t;
+    return s ? s.id : '';
+  }
+  function sessionById(id) {
+    for (let i = 0; i < cachedSessions.length; i++) {
+      if (cachedSessions[i].id === id) return cachedSessions[i];
+    }
+    return null;
+  }
+
+  let switching = false;
+  async function switchSession(id) {
+    if (switching || !id || id === window.lisaActiveSessionId) return;
+    switching = true;
+    document.body.classList.add('session-switching');
+    try {
+      const r = await fetch('/api/sessions/' + encodeURIComponent(id) + '/activate', { method: 'POST' });
+      const data = await r.json();
+      if (data && data.ok) {
+        ensureTab(data.id);
+        if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(data.id);
+      }
+    } catch (e) {}
+    document.body.classList.remove('session-switching');
+    switching = false;
+    refreshSessionsBadge();
+  }
+  async function newSession() {
+    if (switching) return;
+    switching = true;
+    document.body.classList.add('session-switching');
+    try {
+      const r = await fetch('/api/sessions', { method: 'POST' });
+      const data = await r.json();
+      if (data && data.ok) {
+        ensureTab(data.id);
+        if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(data.id);
+      }
+    } catch (e) {}
+    document.body.classList.remove('session-switching');
+    switching = false;
+    refreshSessionsBadge();
+  }
+  function ensureTab(id) {
+    if (openTabIds.indexOf(id) < 0) openTabIds.unshift(id);
+    saveTabs();
+  }
+  function closeTab(id) {
+    const idx = openTabIds.indexOf(id);
+    if (idx >= 0) openTabIds.splice(idx, 1);
+    saveTabs();
+    if (id === window.lisaActiveSessionId && openTabIds.length) {
+      switchSession(openTabIds[0]);
+      return;
+    }
+    renderSessionUI();
+  }
+
+  function renderSessionTree() {
+    const tree = document.getElementById('sessionTree');
+    if (!tree) return;
+    tree.innerHTML = '';
+    const group = document.createElement('div');
+    group.className = 'tgroup';
+    const root = document.createElement('button');
+    root.type = 'button';
+    root.className = 'tnode';
+    root.innerHTML = '<span class="twist">▾</span><span class="agent-glyph lisa">L</span><span class="tlabel">LISA</span><span class="tcount"></span>';
+    root.querySelector('.tcount').textContent = String(cachedSessions.length);
+    root.addEventListener('click', function () { group.classList.toggle('closed'); });
+    group.appendChild(root);
+    const kids = document.createElement('div');
+    kids.className = 'tchildren';
+    const MAX_LEAVES = 14;
+    cachedSessions.slice(0, MAX_LEAVES).forEach(function (s) {
+      const isActive = s.id === window.lisaActiveSessionId;
+      const leaf = document.createElement('button');
+      leaf.type = 'button';
+      leaf.className = 'tleaf' + (isActive ? ' active' : '');
+      leaf.innerHTML = '<span class="pip"></span><span class="tname"></span><span class="ttime"></span>';
+      if (isActive) leaf.querySelector('.pip').classList.add('live');
+      leaf.querySelector('.tname').textContent = sessionLabel(s);
+      leaf.querySelector('.ttime').textContent = relativeTime(s.startedAt);
+      leaf.title = s.id + ' · ' + (s.messageCount || 0) + ' msgs';
+      leaf.addEventListener('click', function () { switchSession(s.id); });
+      kids.appendChild(leaf);
+    });
+    group.appendChild(kids);
+    tree.appendChild(group);
+  }
+
+  function renderTabs() {
+    const strip = document.getElementById('tabStrip');
+    if (!strip) return;
+    strip.innerHTML = '';
+    // Drop tabs whose session vanished from disk.
+    openTabIds = openTabIds.filter(function (id) { return sessionById(id) !== null || id === window.lisaActiveSessionId; });
+    if (window.lisaActiveSessionId) ensureTab(window.lisaActiveSessionId);
+    openTabIds.slice(0, 6).forEach(function (id) {
+      const s = sessionById(id);
+      const isActive = id === window.lisaActiveSessionId;
+      const tab = document.createElement('button');
+      tab.type = 'button';
+      tab.className = 'stab' + (isActive ? ' active' : '');
+      tab.innerHTML = '<span class="pip"></span><span class="stab-name"></span><span class="stab-x" title="Close tab">×</span>';
+      if (isActive) tab.querySelector('.pip').classList.add('live');
+      tab.querySelector('.stab-name').textContent = s ? sessionLabel(s) : id;
+      tab.addEventListener('click', function (e) {
+        if (e.target && e.target.classList && e.target.classList.contains('stab-x')) {
+          e.stopPropagation();
+          closeTab(id);
+          return;
+        }
+        switchSession(id);
+      });
+      strip.appendChild(tab);
+    });
+    const plus = document.createElement('button');
+    plus.type = 'button';
+    plus.className = 'stab-new';
+    plus.title = 'New session';
+    plus.textContent = '＋';
+    plus.addEventListener('click', newSession);
+    strip.appendChild(plus);
+  }
+
+  function renderSessionUI() {
+    renderSessionTree();
+    renderTabs();
+  }
+  window.lisaRenderSessionTree = renderSessionUI;
+  const sbNewBtn = document.getElementById('sbNewSession');
+  if (sbNewBtn) sbNewBtn.addEventListener('click', newSession);
+
   async function refreshSessionsBadge() {
     try {
       const r = await fetch('/api/sessions');
       if (!r.ok) return;
       const data = await r.json();
-      const n = Array.isArray(data.sessions) ? data.sessions.length : 0;
-      sbSessionBadge.textContent = String(n);
+      cachedSessions = Array.isArray(data.sessions) ? data.sessions : [];
+      sbSessionBadge.textContent = String(cachedSessions.length);
+      renderSessionUI();
     } catch {
       // /api/sessions is optional — leave the badge as-is on failure
     }

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -732,6 +732,179 @@ export const MAIN_CSS = `  :root {
     flex-shrink: 0;
   }
 
+  /* ── Session tree (sidebar) ─────────────────────────────────────
+     Lisa's own sessions and each monitored agent kind are SIBLING root
+     groups (LISA / Claude Code / Codex … all same level). Generous type
+     per the confirmed mockup: 12.5px bold roots with 19px glyphs,
+     12px leaves, small-caps project sub-groups. */
+  .sb-sessions {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    border-top: 1px solid var(--hairline);
+    padding-top: 10px;
+    margin-top: -6px;
+  }
+  .sb-sessions-head {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 0 4px 8px;
+  }
+  .sb-sessions-head h2 {
+    margin: 0;
+    font-size: 10.5px;
+    font-weight: 700;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .new-btn {
+    border: 1px solid var(--accent-glow);
+    background: var(--accent-soft);
+    color: var(--accent);
+    font-family: inherit;
+    font-size: 10.5px;
+    padding: 2.5px 10px;
+    border-radius: 20px;
+    cursor: pointer;
+  }
+  .new-btn:hover { filter: brightness(1.15); }
+  .tree {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    scrollbar-width: thin;
+  }
+  .tree .tgroup + .tgroup { margin-top: 6px; }
+  .tnode, .tleaf {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 9px;
+    color: var(--fg-2);
+    font-family: inherit;
+    text-align: left;
+    cursor: pointer;
+    font-size: 12.5px;
+  }
+  .tnode { padding: 8px 9px; font-weight: 700; color: var(--fg); letter-spacing: 0.01em; }
+  .tnode:hover, .tleaf:hover { background: var(--bg-card); }
+  .tnode .tlabel { flex: 1; overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+  .twist {
+    width: 12px; flex: none;
+    font-size: 8px; color: var(--fg-3);
+    transition: transform 0.15s;
+    text-align: center;
+  }
+  .tgroup.closed > .tnode .twist { transform: rotate(-90deg); }
+  .tgroup.closed > .tchildren { display: none; }
+  .tsub.closed > .tchildren { display: none; }
+  .tsub.closed > .tnode .twist { transform: rotate(-90deg); }
+  .agent-glyph {
+    width: 19px; height: 19px; flex: none;
+    border-radius: 5px;
+    font-size: 10px; font-weight: 700;
+    display: flex; align-items: center; justify-content: center;
+    color: #fff;
+  }
+  .agent-glyph.lisa { background: var(--accent); color: #06202e; }
+  .agent-glyph.cc { background: var(--claude); }
+  .agent-glyph.codex { background: var(--codex); }
+  .agent-glyph.other { background: var(--fg-3); }
+  .tcount {
+    margin-left: auto;
+    font-size: 10px;
+    font-variant-numeric: tabular-nums;
+    color: var(--fg-3);
+    background: var(--bg-card);
+    border-radius: 9px;
+    padding: 1px 7px;
+  }
+  .tchildren { padding-left: 16px; }
+  .tsub .tchildren { padding-left: 13px; }
+  .tsub > .tnode {
+    font-size: 10px; padding: 5px 9px; color: var(--fg-3);
+    font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase;
+  }
+  .tleaf { padding: 7px 9px 7px 11px; }
+  .tleaf .pip {
+    width: 8px; height: 8px; flex: none;
+    border-radius: 50%;
+    background: var(--fg-faint);
+  }
+  .tleaf .pip.live { background: var(--accent); animation: breathe 2.6s ease-in-out infinite; }
+  .tleaf .pip.working { background: var(--proactive); animation: breathe 2.6s ease-in-out infinite; }
+  .tleaf .pip.waiting { background: var(--warm); animation: needsYou 2s ease-in-out infinite; }
+  .tleaf .pip.error { background: var(--err-color); }
+  .tleaf .tname {
+    flex: 1;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    font-size: 12px;
+  }
+  .tleaf .ttime { font-size: 10px; color: var(--fg-faint); flex: none; font-variant-numeric: tabular-nums; }
+  .tleaf.active {
+    background: var(--accent-soft);
+    border-color: var(--accent-glow);
+  }
+  .tleaf.active .tname { color: var(--fg); font-weight: 600; }
+  body.session-switching .tleaf, body.session-switching .stab { opacity: 0.55; pointer-events: none; }
+
+  /* ── Session tab strip (fnbar left side) ────────────────────────── */
+  .tabstrip {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-width: 0;
+    flex-shrink: 1;
+    overflow: hidden;
+  }
+  .stab {
+    display: flex;
+    align-items: center;
+    gap: 7px;
+    max-width: 200px;
+    min-width: 0;
+    padding: 6px 11px;
+    border: 1px solid var(--border-new);
+    border-radius: 9px;
+    background: transparent;
+    color: var(--fg-3);
+    font-family: inherit;
+    font-size: 11.5px;
+    cursor: pointer;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .stab .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--fg-faint); flex: none; }
+  .stab .pip.live { background: var(--accent); animation: breathe 2.6s ease-in-out infinite; }
+  .stab .stab-name { overflow: hidden; text-overflow: ellipsis; }
+  .stab:hover { background: var(--bg-card); }
+  .stab.active {
+    background: var(--bg-card-strong);
+    border-color: var(--border-strong);
+    color: var(--fg);
+  }
+  .stab .stab-x { font-size: 12px; color: var(--fg-faint); padding: 0 1px; }
+  .stab .stab-x:hover { color: var(--fg); }
+  .stab-new {
+    border: 1px dashed var(--border-strong);
+    background: transparent;
+    color: var(--fg-3);
+    width: 27px; height: 27px; flex: none;
+    border-radius: 9px;
+    font-size: 14px;
+    font-family: inherit;
+    cursor: pointer;
+  }
+  .stab-new:hover { color: var(--accent); border-color: var(--accent); }
+
   /* ── Right panel (status rail) ──────────────────────────────────
      One structured full-height panel, symmetric with the sidebar: the
      relocated sidebar lower half (wanting / agents / mail / reflection)

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -98,10 +98,20 @@ import { MAIN_HTML } from "./lisa-html.js";
  * override + chrome patches) toggled by the new fnbar #fnTheme moon/sun button
  * (persisted as localStorage "lisa-theme") beside a new #fnMail button that
  * reopens the Mail view now that the mail card can be off-screen.
+ * Then: session shell phase 2 — Lisa's own sessions become switchable: a
+ * sidebar .sb-sessions tree (#sessionTree, LISA root group + leaves from
+ * GET /api/sessions, ＋New button) and an fnbar #tabStrip of open-session
+ * tabs (localStorage "lisaOpenSessions"), both driving the new
+ * POST /api/sessions (create) and POST /api/sessions/{id}/activate (switch)
+ * endpoints, which swap the ChatCtx session/history through the turn chain
+ * and broadcast a session_switched SSE frame; lisaSetActiveSession converges
+ * every switch path onto lisaResetChatLog (log wipe + history reload) and a
+ * chatGeneration guard detaches an in-flight reply stream's DOM writes when
+ * its session is switched away mid-turn.
  */
-const EXPECTED_LENGTH = 239937;
+const EXPECTED_LENGTH = 254646;
 const EXPECTED_SHA256 =
-  "f71ab27f0ec717dca459300ef986a749228f6d219556130e92e14ef748812db4";
+  "8a43adaddd1385fe1f256b70d57de86514140b8363e553f09ba3a9efccd213e1";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -103,6 +103,17 @@ ${MAIN_CSS}
     <!-- (SOUL/SKILLS/TOOLS/PLANS → top function bar; MEMORY → rail view) -->
     <!-- (Proactive / Compact toggles moved into the Settings rail view) -->
 
+    <!-- Session tree — Lisa's own sessions as the first root group; the
+         monitored-agent groups join as sibling roots (control-tree phase).
+         Wired by the sidebar-live block (renderSessionTree). -->
+    <div class="sb-sessions">
+      <div class="sb-sessions-head">
+        <h2>Sessions</h2>
+        <button class="new-btn" id="sbNewSession" type="button" title="Start a new session">＋ New</button>
+      </div>
+      <div class="tree" id="sessionTree"></div>
+    </div>
+
     <!-- Footer: current session id -->
     <div class="sb-footer">
       <span class="session-id" id="sessionId">—</span>
@@ -116,8 +127,11 @@ ${MAIN_CSS}
     <!-- Chat view (default home) — function bar + log + attachments + composer -->
     <div class="view active" id="viewChat">
 
-    <!-- Top icon function bar (功能区): quick panels + find -->
+    <!-- Top icon function bar (功能区): session tabs (left) + quick panels
+         + find (right). #tabStrip is rendered by the sidebar-live block. -->
     <div class="fnbar" id="fnbar">
+      <div class="tabstrip" id="tabStrip"></div>
+      <span class="fbar-spacer"></span>
       <button class="fbtn" type="button" data-panel="soul" title="Soul" aria-label="Soul"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 3l2.2 6.6L21 12l-6.8 2.4L12 21l-2.2-6.6L3 12l6.8-2.4z"/></svg></button>
       <button class="fbtn" type="button" data-panel="skills" title="Skills" aria-label="Skills"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 4 14h7l-1 8 10-12h-7z"/></svg></button>
       <button class="fbtn" type="button" data-panel="tools" title="Tools" aria-label="Tools"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/></svg></button>
@@ -125,7 +139,6 @@ ${MAIN_CSS}
       <button class="fbtn" type="button" data-panel="pair" title="Pair phone" aria-label="Pair phone"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="7" y="2" width="10" height="20" rx="2"/><line x1="11" y1="18" x2="13" y2="18"/></svg></button>
       <button class="fbtn" type="button" id="fnKbSelect" title="Select messages to save to your Knowledge Base" aria-label="Save messages to knowledge base"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2 2 7l10 5 10-5-10-5Z"/><path d="m2 17 10 5 10-5"/><path d="m2 12 10 5 10-5"/></svg></button>
       <button class="fbtn" type="button" id="fnMail" title="Mail" aria-label="Mail"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-8.97 5.7a1.94 1.94 0 0 1-2.06 0L2 7"/></svg></button>
-      <span class="fbar-spacer"></span>
       <input id="fnFind" class="fn-find" type="text" placeholder="find in chat…" autocomplete="off" style="display:none">
       <button class="fbtn" type="button" id="fnSearchBtn" title="Find in conversation" aria-label="Find"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="7"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg></button>
       <button class="fbtn" type="button" id="fnTheme" title="Theme: Nebula ↔ Calm" aria-label="Toggle theme"><svg id="fnThemeMoon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg><svg id="fnThemeSun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg></button>

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3088,6 +3088,84 @@ self.addEventListener('fetch', (event) => {
       return;
     }
 
+    // ── Session switching (PLAN_UI_SESSION_SHELL_v1.0 §3.2) ──────────────
+    // Both mutations run THROUGH the ctx's turn chain: an in-flight reply
+    // always finishes — and persists via onMessagePersist → chat.session —
+    // into the session it started in before the pointer moves. chat.history
+    // is mutated in place (never reassigned): it is the same array reference
+    // the queued turns closed over.
+    const swapChatSession = async (
+      chat: ChatCtx,
+      open: () => Promise<SessionStore>,
+    ): Promise<string> => {
+      const job = chat.chain.then(async () => {
+        const s = await open();
+        const [{ messages }, reflectionSummary] = await Promise.all([
+          s.readMessagePage(0, 9999),
+          s.readLatestReflection(),
+        ]);
+        chat.session = s;
+        chat.history.length = 0;
+        chat.history.push(...messages);
+        chat.reflectionSummary = reflectionSummary;
+        chat.activity = createTenantActivityState(countUserMessages(chat.history));
+        await writeActiveWebSession(s.id);
+        if (chat === globalChat) process.env.LISA_SESSION_ID = s.id;
+      });
+      chat.chain = job.then(
+        () => {},
+        () => {},
+      );
+      await job;
+      return chat.session.id;
+    };
+
+    if (req.method === "POST" && url === "/api/sessions") {
+      // Create a fresh Lisa session and make it the active web session.
+      const runtime = await ctxForRequest();
+      try {
+        const id = await swapChatSession(runtime.value, () =>
+          SessionStore.create({ cwd: process.cwd(), model: opts.model }),
+        );
+        broadcast({ type: "session_switched", session: id });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, id }));
+      } finally {
+        runtime.release();
+      }
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      url.startsWith("/api/sessions/") &&
+      url.endsWith("/activate")
+    ) {
+      const id = url.slice("/api/sessions/".length, -"/activate".length);
+      if (!/^[A-Za-z0-9_-]+$/.test(id)) {
+        res.writeHead(400, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "bad_session_id" }));
+        return;
+      }
+      const runtime = await ctxForRequest();
+      try {
+        const active = await swapChatSession(runtime.value, () =>
+          SessionStore.open(id),
+        );
+        broadcast({ type: "session_switched", session: active });
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: true, id: active }));
+      } catch (err) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({ ok: false, error: (err as Error).message }),
+        );
+      } finally {
+        runtime.release();
+      }
+      return;
+    }
+
     if (req.method === "GET" && url === "/api/skills") {
       const { listSkills } = await import("../skills/manager.js");
       const skills = await listSkills();


### PR DESCRIPTION
Stacked PR 第二个（base = P1 #343，P1 合并后自动 retarget 到 main）。

## 内容

**后端**（`server.ts`）
- `POST /api/sessions` 新建并激活 Lisa session；`POST /api/sessions/{id}/activate` 切换到已有 session（id 白名单校验）
- 两个变更都**通过 turn chain 执行**：进行中的回复一定先在它所属的 session 里完成持久化，指针才移动；`chat.history` 原地变更（不重新赋值——排队中的 turn 闭包持有同一数组引用）
- 切换后广播 `session_switched` SSE 帧（多窗口 / island / iOS 收敛）

**前端**（`lisa-client.ts`）
- 左栏 `.sb-sessions` 树：LISA 根组 + 会话叶子（名字取首条用户消息），`＋New`；字体规格按已确认的 mockup（12.5px 加粗根行 / 19px glyph）
- fnbar 左侧 `#tabStrip`：打开的会话 tab（`localStorage("lisaOpenSessions")` 持久化），关闭活跃 tab 自动切到下一个
- 所有切换路径收敛到 `lisaSetActiveSession` → `lisaResetChatLog`（清空 log + 重载 `/api/history`）
- `chatGeneration` 守卫：切走时进行中的回复流静默排空、不再写 DOM（服务端照常持久化，切回即见）

## 验证

隔离实例实测：A 发消息得到回复 → `＋New` 建 B（log 清空、树/tab/titlebar/footer 同步）→ 切回 A 历史两条消息正确重载。全量测试 + typecheck 绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)