### PR TITLE
Session shell P3: agent 同级树 + 右栏 Inspector

### DIFF
--- a/docs/PLAN_UI_SESSION_SHELL_v1.0.md
+++ b/docs/PLAN_UI_SESSION_SHELL_v1.0.md
@@ -4,7 +4,7 @@
 > **参考**：[DouDouAI2.0 设计库](https://github.com/DiogenesModel/DouDouAI2.0)（三栏工作台范式、过程可视化=信任、静界视觉方向）；Claude Code / Codex 的 session 列表与并行任务范式。
 > **关联源码**：[src/web/lisa-html.ts](../src/web/lisa-html.ts) · [src/web/lisa-css.ts](../src/web/lisa-css.ts) · [src/web/lisa-client.ts](../src/web/lisa-client.ts) · [src/web/server.ts](../src/web/server.ts) · [src/sessions/](../src/sessions/) · [src/integrations/](../src/integrations/)
 > **Mockup**：[reference/mockups/lisa-session-shell.html](../reference/mockups/lisa-session-shell.html)（v2，交互可点：树/tab/inspector/主题切换，已与 owner 确认）
-> **编写日期**：2026-08-08 · **✅ 实现状态**：Phase 1–3 落地中（分 stacked PR），Phase 4 e2e 待跑
+> **编写日期**：2026-08-08 · **✅ 实现状态**：Phase 1–3 已实现并通过 e2e（stacked PR [#343](https://github.com/oratis/LISA/pull/343) → [#344](https://github.com/oratis/LISA/pull/344) → [#345](https://github.com/oratis/LISA/pull/345)，依序合并）；agent 过程流 tab 与 iOS 双主题为后续项（§5/§7）
 
 ---
 

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1586,135 +1586,337 @@ if ('serviceWorker' in navigator) {
     }).catch(function () {});
   }
 
+  // ── Agent roster → tree + inspector (PLAN_UI_SESSION_SHELL_v1.0 §1.3/§3.1)
+  // The right panel's row list became a single INSPECTOR card for the session
+  // selected in the sidebar tree; the roster itself now lives in the tree as
+  // per-agent root groups (LISA / Claude Code / Codex … same-level siblings),
+  // grouped agent kind → project → session.
+  let cachedAgents = [];
+  // {type:'agent', key} | {type:'lisa', id} | null (null → auto: the
+  // top-ranked live agent, else the active Lisa session).
+  let selInsp = null;
+  // Collapse state survives the 60s re-renders (keyed group → closed?).
+  const collapsedKeys = {};
+  function applyCollapsed(el, key) {
+    if (collapsedKeys[key]) el.classList.add('closed');
+  }
+  function toggleCollapsed(el, key) {
+    el.classList.toggle('closed');
+    collapsedKeys[key] = el.classList.contains('closed');
+  }
+  function agentKey(s) { return s.agent + '/' + s.sessionId; }
+  function agentByKey(key) {
+    for (let i = 0; i < cachedAgents.length; i++) {
+      if (agentKey(cachedAgents[i]) === key) return cachedAgents[i];
+    }
+    return null;
+  }
+  // Label by git branch when available (more meaningful than a worktree
+  // hash), stripping the claude/ prefix; fall back to the project name.
+  // (String ops, not a regex — a /\// here would be mangled by the outer
+  // template literal that wraps this client script.)
+  function agentLabel(s) {
+    let label = s.project;
+    if (s.activity && s.activity.gitBranch) {
+      const br = String(s.activity.gitBranch);
+      label = br.indexOf('claude/') === 0 ? br.slice(7) : br;
+    }
+    return label;
+  }
+  const AGENT_NAMES = {
+    'claude-code': 'Claude Code', codex: 'Codex', opencode: 'OpenCode',
+    aider: 'Aider', 'github-pr': 'GitHub PR', cursor: 'Cursor',
+    gemini: 'Gemini', lisa: 'LISA agents', mcp: 'MCP',
+  };
+  function agentGlyphClass(kind) {
+    if (kind === 'claude-code') return 'cc';
+    if (kind === 'codex') return 'codex';
+    return 'other';
+  }
+
   function setClaudeSessions(sessions) {
     const cutoff = Date.now() - ACTIVE_WINDOW_MS;
     const recent = sessions.filter(s => new Date(s.lastMtime).getTime() >= cutoff);
     sbClaudeCount.textContent = String(recent.length);
     // sort: errors first, then waiting, then working, then by mtime
     const rank = { error: 0, waiting: 1, working: 2, unknown: 3 };
-    const rows = recent.slice().sort((a, b) => {
+    cachedAgents = recent.slice().sort((a, b) => {
       const ra = rank[a.state] ?? 9;
       const rb = rank[b.state] ?? 9;
       if (ra !== rb) return ra - rb;
       return new Date(b.lastMtime).getTime() - new Date(a.lastMtime).getTime();
-    }).slice(0, 8);
-    while (sbClaudeRows.firstChild) sbClaudeRows.removeChild(sbClaudeRows.firstChild);
-    if (rows.length === 0) {
-      const empty = document.createElement('div');
-      empty.className = 'session-empty';
-      empty.textContent = '(idle)';
-      sbClaudeRows.appendChild(empty);
-      return;
-    }
-    for (const s of rows) {
-      const row = document.createElement('div');
-      row.className = 'session-row';
-      const pip = document.createElement('div');
-      pip.className = 'pip ' + (s.state || 'unknown');
-      const name = document.createElement('div');
-      name.className = 'name';
-      // D4a — agent-kind chip inline before the project; omitted for plain
-      // Claude so existing rows read unchanged.
-      if (s.agent && s.agent !== 'claude-code') {
-        const badge = document.createElement('span');
-        badge.className = 'agent-badge';
-        badge.textContent = s.agent;
-        badge.title = s.agent;
-        name.appendChild(badge);
-      }
-      // Label by git branch when available (more meaningful than a worktree
-      // hash), stripping the claude/ prefix; fall back to the project name.
-      // (String ops, not a regex — a /\// here would be mangled by the outer
-      // template literal that wraps this client script.)
-      let label = s.project;
-      if (s.activity && s.activity.gitBranch) {
-        const br = String(s.activity.gitBranch);
-        label = br.indexOf('claude/') === 0 ? br.slice(7) : br;
-      }
-      name.appendChild(document.createTextNode(label));
-      const when = document.createElement('div');
-      when.className = 'when';
-      when.textContent = relativeTime(s.lastMtime);
-      row.appendChild(pip);
-      row.appendChild(name);
-      row.appendChild(when);
-      // Second line: structural activity (turns/tokens/tool·file, ⚠pending, ✗err).
-      const actText = sbActivity(s);
-      if (actText) {
-        const act = document.createElement('div');
-        act.className = 'session-act';
-        act.textContent = actText;
-        act.title = actText;
-        row.appendChild(act);
-      }
-      // Controllable agents get inline controls: managed → approve/deny a pending
-      // tool, send a follow-up, cancel; pty (real CLI under a PTY) → send, view
-      // terminal output, cancel. Externally-started CLIs have no control channel
-      // (no s.controllable) → observe only.
-      const fam = s.controllable;
-      if (fam) {
-        const id = s.sessionId;
-        const ctrl = document.createElement('div');
-        ctrl.className = 'session-ctrl';
-        const pending = fam === 'managed' && s.activity && s.activity.pendingPermission;
-        if (pending) {
-          const ap = document.createElement('button');
-          ap.className = 'mc approve'; ap.textContent = '✓ approve';
-          ap.addEventListener('click', function (e) { e.stopPropagation(); agentAction('managed', id, 'approve', { allow: true }); });
-          const dn = document.createElement('button');
-          dn.className = 'mc deny'; dn.textContent = '✕ deny';
-          dn.addEventListener('click', function (e) { e.stopPropagation(); agentAction('managed', id, 'approve', { allow: false }); });
-          ctrl.appendChild(ap); ctrl.appendChild(dn);
-        } else if (s.state !== 'done') {
-          const inp = document.createElement('input');
-          inp.className = 'mc-send'; inp.type = 'text'; inp.placeholder = fam === 'pty' ? 'type into the CLI…' : 'send a follow-up…';
-          inp.addEventListener('click', function (e) { e.stopPropagation(); });
-          inp.addEventListener('keydown', function (e) {
-            // Ignore the Enter that confirms an IME candidate (see main input).
-            if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && inp.value.trim()) { e.preventDefault(); agentAction(fam, id, 'send', { text: inp.value.trim() }); inp.value = ''; }
+    });
+    renderAgentTree();
+    renderInspector();
+  }
+
+  // Sidebar tree: one root group per live agent kind, then project sub-groups,
+  // then session leaves. Idempotent — removes its own groups before rebuilding
+  // (the LISA group is owned by renderSessionTree below).
+  function renderAgentTree() {
+    const tree = document.getElementById('sessionTree');
+    if (!tree) return;
+    const olds = tree.querySelectorAll('.tgroup.agent-group');
+    for (let i = 0; i < olds.length; i++) olds[i].remove();
+    const kinds = [];
+    const byKind = {};
+    cachedAgents.forEach(function (s) {
+      if (!byKind[s.agent]) { byKind[s.agent] = []; kinds.push(s.agent); }
+      byKind[s.agent].push(s);
+    });
+    kinds.sort();
+    kinds.forEach(function (kind) {
+      const group = document.createElement('div');
+      group.className = 'tgroup agent-group';
+      applyCollapsed(group, 'agent:' + kind);
+      const root = document.createElement('button');
+      root.type = 'button';
+      root.className = 'tnode';
+      root.innerHTML = '<span class="twist">▾</span><span class="agent-glyph"></span><span class="tlabel"></span><span class="tcount"></span>';
+      const kindName = AGENT_NAMES[kind] || kind;
+      const glyph = root.querySelector('.agent-glyph');
+      glyph.classList.add(agentGlyphClass(kind));
+      glyph.textContent = (kindName.charAt(0) || 'A').toUpperCase();
+      root.querySelector('.tlabel').textContent = kindName;
+      root.querySelector('.tcount').textContent = String(byKind[kind].length);
+      root.addEventListener('click', function () { toggleCollapsed(group, 'agent:' + kind); });
+      group.appendChild(root);
+      const kids = document.createElement('div');
+      kids.className = 'tchildren';
+      const projects = [];
+      const byProject = {};
+      byKind[kind].forEach(function (s) {
+        const p = s.project || '?';
+        if (!byProject[p]) { byProject[p] = []; projects.push(p); }
+        byProject[p].push(s);
+      });
+      projects.forEach(function (p) {
+        const sub = document.createElement('div');
+        sub.className = 'tsub';
+        const subKey = 'proj:' + kind + '/' + p;
+        applyCollapsed(sub, subKey);
+        const pn = document.createElement('button');
+        pn.type = 'button';
+        pn.className = 'tnode';
+        pn.innerHTML = '<span class="twist">▾</span><span class="tlabel"></span>';
+        pn.querySelector('.tlabel').textContent = p;
+        pn.addEventListener('click', function () { toggleCollapsed(sub, subKey); });
+        sub.appendChild(pn);
+        const pkids = document.createElement('div');
+        pkids.className = 'tchildren';
+        byProject[p].forEach(function (s) {
+          const key = agentKey(s);
+          const leaf = document.createElement('button');
+          leaf.type = 'button';
+          leaf.className = 'tleaf' + (selInsp && selInsp.type === 'agent' && selInsp.key === key ? ' active' : '');
+          leaf.innerHTML = '<span class="pip"></span><span class="tname"></span><span class="ttime"></span>';
+          const st = s.state || 'unknown';
+          if (st === 'working' || st === 'waiting' || st === 'error') leaf.querySelector('.pip').classList.add(st);
+          leaf.querySelector('.tname').textContent = agentLabel(s);
+          leaf.querySelector('.ttime').textContent = relativeTime(s.lastMtime);
+          leaf.title = (s.stateReason ? s.state + ' · ' + s.stateReason : s.state) + ' · ' + s.project + ' · ' + s.sessionId;
+          leaf.addEventListener('click', function () {
+            selInsp = { type: 'agent', key: key };
+            const all = tree.querySelectorAll('.tleaf.active');
+            for (let i = 0; i < all.length; i++) all[i].classList.remove('active');
+            leaf.classList.add('active');
+            renderInspector();
           });
-          ctrl.appendChild(inp);
-        }
-        if (fam === 'pty') {
-          const out = document.createElement('button');
-          out.className = 'mc'; out.textContent = '▤'; out.title = 'View terminal output';
-          out.addEventListener('click', function (e) { e.stopPropagation(); ptyOutput(id); });
-          ctrl.appendChild(out);
-        }
-        if (s.state !== 'done') {
-          const cancel = document.createElement('button');
-          cancel.className = 'mc cancel'; cancel.textContent = '⏹'; cancel.title = 'Cancel agent';
-          cancel.addEventListener('click', function (e) { e.stopPropagation(); agentAction(fam, id, 'cancel', null); });
-          ctrl.appendChild(cancel);
-        }
-        if (ctrl.childNodes.length) row.appendChild(ctrl);
-      }
-      // Idle external claude session → adopt it: LISA resumes it under a PTY and
-      // drives the continuation (then it shows as a controllable pty row). Only
-      // offered for idle sessions; a live one can't be resumed without corrupting
-      // its transcript (the server 409s, surfaced in the modal).
-      if (s.resumable) {
-        const ctrl = document.createElement('div');
-        ctrl.className = 'session-ctrl';
-        const adopt = document.createElement('button');
-        adopt.className = 'mc adopt'; adopt.textContent = '⇲ adopt';
-        adopt.title = 'Resume this session under LISA — then send / answer / cancel / view it';
-        adopt.addEventListener('click', function (e) {
-          e.stopPropagation();
-          fetch('/api/agents/pty/start', {
-            method: 'POST', headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ agent: 'claude', resumeSessionId: s.sessionId, cwd: s.cwd || '' }),
-          }).then(function (r) {
-            if (!r.ok) { return r.text().then(function (t) { openModal('adopt', '<pre>' + escapeHtml(t) + '</pre>'); }); }
-            if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
-          }).catch(function () {});
+          pkids.appendChild(leaf);
         });
-        ctrl.appendChild(adopt);
-        row.appendChild(ctrl);
-      }
-      row.title = (s.stateReason ? s.state + ' · ' + s.stateReason : s.state) + ' · ' + s.project + ' · ' + s.sessionId;
-      sbClaudeRows.appendChild(row);
+        sub.appendChild(pkids);
+        kids.appendChild(sub);
+      });
+      group.appendChild(kids);
+      tree.appendChild(group);
+    });
+  }
+
+  // ── Inspector card builders ─────────────────────────────────────────
+  function inspRow(label, value, cls) {
+    const row = document.createElement('div');
+    row.className = 'kvrow' + (cls ? ' ' + cls : '');
+    const k = document.createElement('span');
+    k.textContent = label;
+    const v = document.createElement('code');
+    v.textContent = value;
+    v.title = value;
+    row.appendChild(k);
+    row.appendChild(v);
+    return row;
+  }
+  function inspStat(value, label) {
+    const st = document.createElement('div');
+    st.className = 'stat';
+    const b = document.createElement('b');
+    b.textContent = value;
+    b.title = value;
+    const sp = document.createElement('span');
+    sp.textContent = label;
+    st.appendChild(b);
+    st.appendChild(sp);
+    return st;
+  }
+  function inspHead(glyphCls, glyphText, name, stateCls, stateText, sub) {
+    const head = document.createElement('div');
+    head.className = 'insp-head';
+    const g = document.createElement('span');
+    g.className = 'agent-glyph ' + glyphCls;
+    g.textContent = glyphText;
+    const box = document.createElement('div');
+    box.className = 'insp-names';
+    const nm = document.createElement('div');
+    nm.className = 'insp-name';
+    const nmText = document.createElement('span');
+    nmText.className = 'nm';
+    nmText.textContent = name;
+    nmText.title = name;
+    nm.appendChild(nmText);
+    if (stateText) {
+      const chip = document.createElement('span');
+      chip.className = 'st-chip ' + stateCls;
+      chip.textContent = stateText;
+      nm.appendChild(chip);
     }
+    const subEl = document.createElement('div');
+    subEl.className = 'insp-sub';
+    subEl.textContent = sub || '';
+    subEl.title = sub || '';
+    box.appendChild(nm);
+    box.appendChild(subEl);
+    head.appendChild(g);
+    head.appendChild(box);
+    return head;
+  }
+  function fmtTokens(t) {
+    if (!t) return '—';
+    const total = (t.input || 0) + (t.output || 0);
+    return total >= 1000 ? Math.round(total / 1000) + 'k' : String(total);
+  }
+
+  function renderInspector() {
+    const box = sbClaudeRows;
+    while (box.firstChild) box.removeChild(box.firstChild);
+    let agent = null;
+    let lisaSession = null;
+    if (selInsp && selInsp.type === 'agent') agent = agentByKey(selInsp.key);
+    if (!agent && selInsp && selInsp.type === 'lisa') lisaSession = sessionById(selInsp.id);
+    if (!agent && !lisaSession) {
+      if (cachedAgents.length) agent = cachedAgents[0];
+      else lisaSession = sessionById(window.lisaActiveSessionId);
+    }
+    if (agent) { renderAgentInspector(box, agent); return; }
+    if (lisaSession) { renderLisaInspector(box, lisaSession); return; }
+    const empty = document.createElement('div');
+    empty.className = 'session-empty';
+    empty.textContent = '(idle)';
+    box.appendChild(empty);
+  }
+
+  function renderLisaInspector(box, s) {
+    const isActive = s.id === window.lisaActiveSessionId;
+    box.appendChild(inspHead('lisa', 'L', sessionLabel(s), isActive ? 'working' : 'done', isActive ? 'active' : 'idle', s.id + ' · ' + (s.cwd || '')));
+    const stats = document.createElement('div');
+    stats.className = 'stats';
+    stats.appendChild(inspStat(String(s.messageCount || 0), 'msgs'));
+    stats.appendChild(inspStat(relativeTime(s.startedAt), 'started'));
+    stats.appendChild(inspStat(String((s.cwd || '—').split('/').pop() || '—'), 'project'));
+    box.appendChild(stats);
+    const kv = document.createElement('div');
+    kv.className = 'kvrows';
+    if (s.model) kv.appendChild(inspRow('model', s.model));
+    if (s.cwd) kv.appendChild(inspRow('cwd', s.cwd));
+    box.appendChild(kv);
+    if (!isActive) {
+      const acts = document.createElement('div');
+      acts.className = 'session-ctrl insp-actions';
+      const openBtn = document.createElement('button');
+      openBtn.className = 'mc adopt';
+      openBtn.textContent = '⇱ open';
+      openBtn.title = 'Switch to this session';
+      openBtn.addEventListener('click', function () { switchSession(s.id); });
+      acts.appendChild(openBtn);
+      box.appendChild(acts);
+    }
+  }
+
+  function renderAgentInspector(box, s) {
+    const a = s.activity || {};
+    const kindName = AGENT_NAMES[s.agent] || s.agent;
+    const stateCls = s.state === 'done' ? 'done' : (s.state || 'unknown');
+    const sub = kindName + ' · ' + s.project + (a.gitBranch ? ' · ' + a.gitBranch : '');
+    box.appendChild(inspHead(agentGlyphClass(s.agent), (kindName.charAt(0) || 'A').toUpperCase(), agentLabel(s), stateCls, s.state || '?', sub));
+    const stats = document.createElement('div');
+    stats.className = 'stats';
+    stats.appendChild(inspStat(a.turnCount != null ? String(a.turnCount) : '—', 'turns'));
+    stats.appendChild(inspStat(fmtTokens(a.tokens), 'tokens'));
+    stats.appendChild(inspStat(a.filesTouched ? String(a.filesTouched.length) : '—', 'files'));
+    box.appendChild(stats);
+    const kv = document.createElement('div');
+    kv.className = 'kvrows';
+    if (a.lastCommandName) kv.appendChild(inspRow('last cmd', '$ ' + a.lastCommandName));
+    if (a.lastTools && a.lastTools.length) kv.appendChild(inspRow('tools', a.lastTools.join(' · ')));
+    if (a.filesTouched && a.filesTouched.length) {
+      const names = a.filesTouched.slice(-3).map(function (f) { return String(f).split('/').pop(); });
+      kv.appendChild(inspRow('files', names.join(' · ')));
+    }
+    if (a.pendingPermission) kv.appendChild(inspRow('pending', '⚠ ' + a.pendingPermission, 'warn'));
+    if (a.lastError) kv.appendChild(inspRow('error', a.lastError, 'err'));
+    if (s.stateReason && !a.pendingPermission && !a.lastError) kv.appendChild(inspRow('state', s.stateReason));
+    if (kv.childNodes.length) box.appendChild(kv);
+    // Controls — same surface the roster rows had, for the selected session:
+    // managed → approve/deny pending, send, cancel; pty → send, output,
+    // cancel; idle external claude → adopt. Observe-only agents get nothing.
+    const fam = s.controllable;
+    const id = s.sessionId;
+    const acts = document.createElement('div');
+    acts.className = 'session-ctrl insp-actions';
+    if (fam === 'managed' && a.pendingPermission) {
+      const ap = document.createElement('button');
+      ap.className = 'mc approve'; ap.textContent = '✓ approve';
+      ap.addEventListener('click', function () { agentAction('managed', id, 'approve', { allow: true }); });
+      const dn = document.createElement('button');
+      dn.className = 'mc deny'; dn.textContent = '✕ deny';
+      dn.addEventListener('click', function () { agentAction('managed', id, 'approve', { allow: false }); });
+      acts.appendChild(ap); acts.appendChild(dn);
+    } else if (fam && s.state !== 'done') {
+      const inp = document.createElement('input');
+      inp.className = 'mc-send'; inp.type = 'text';
+      inp.placeholder = fam === 'pty' ? 'type into the CLI…' : 'send a follow-up…';
+      inp.addEventListener('keydown', function (e) {
+        // Ignore the Enter that confirms an IME candidate (see main input).
+        if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && inp.value.trim()) { e.preventDefault(); agentAction(fam, id, 'send', { text: inp.value.trim() }); inp.value = ''; }
+      });
+      acts.appendChild(inp);
+    }
+    if (fam === 'pty') {
+      const out = document.createElement('button');
+      out.className = 'mc'; out.textContent = '▤ output'; out.title = 'View terminal output';
+      out.addEventListener('click', function () { ptyOutput(id); });
+      acts.appendChild(out);
+    }
+    if (fam && s.state !== 'done') {
+      const cancel = document.createElement('button');
+      cancel.className = 'mc cancel'; cancel.textContent = '⏹ cancel'; cancel.title = 'Cancel agent';
+      cancel.addEventListener('click', function () { agentAction(fam, id, 'cancel', null); });
+      acts.appendChild(cancel);
+    }
+    if (s.resumable) {
+      const adopt = document.createElement('button');
+      adopt.className = 'mc adopt'; adopt.textContent = '⇲ adopt';
+      adopt.title = 'Resume this session under LISA — then send / answer / cancel / view it';
+      adopt.addEventListener('click', function () {
+        fetch('/api/agents/pty/start', {
+          method: 'POST', headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ agent: 'claude', resumeSessionId: s.sessionId, cwd: s.cwd || '' }),
+        }).then(function (r) {
+          if (!r.ok) { return r.text().then(function (t) { openModal('adopt', '<pre>' + escapeHtml(t) + '</pre>'); }); }
+          if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
+        }).catch(function () {});
+      });
+      acts.appendChild(adopt);
+    }
+    if (acts.childNodes.length) box.appendChild(acts);
   }
 
   async function refreshPing() {
@@ -1898,12 +2100,13 @@ if ('serviceWorker' in navigator) {
     tree.innerHTML = '';
     const group = document.createElement('div');
     group.className = 'tgroup';
+    applyCollapsed(group, 'lisa');
     const root = document.createElement('button');
     root.type = 'button';
     root.className = 'tnode';
     root.innerHTML = '<span class="twist">▾</span><span class="agent-glyph lisa">L</span><span class="tlabel">LISA</span><span class="tcount"></span>';
     root.querySelector('.tcount').textContent = String(cachedSessions.length);
-    root.addEventListener('click', function () { group.classList.toggle('closed'); });
+    root.addEventListener('click', function () { toggleCollapsed(group, 'lisa'); });
     group.appendChild(root);
     const kids = document.createElement('div');
     kids.className = 'tchildren';
@@ -1918,11 +2121,16 @@ if ('serviceWorker' in navigator) {
       leaf.querySelector('.tname').textContent = sessionLabel(s);
       leaf.querySelector('.ttime').textContent = relativeTime(s.startedAt);
       leaf.title = s.id + ' · ' + (s.messageCount || 0) + ' msgs';
-      leaf.addEventListener('click', function () { switchSession(s.id); });
+      leaf.addEventListener('click', function () {
+        selInsp = { type: 'lisa', id: s.id };
+        renderInspector();
+        switchSession(s.id);
+      });
       kids.appendChild(leaf);
     });
     group.appendChild(kids);
     tree.appendChild(group);
+    renderAgentTree();
   }
 
   function renderTabs() {

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -956,8 +956,94 @@ export const MAIN_CSS = `  :root {
     line-height: 1.7;
     color: var(--fg-2);
   }
-  .rightbar .delegate-btn { margin: 4px 0 8px; }
+  .rightbar .delegate-btn { margin: 10px 0 0; }
   .rightbar #sbMailCard .h { cursor: pointer; }
+
+  /* Inspector card (right panel §1.3): session head + stat triplet +
+     aligned KV rows + equal-width action buttons. */
+  .insp-head { display: flex; gap: 10px; align-items: flex-start; }
+  .insp-head .agent-glyph {
+    width: 30px; height: 30px;
+    border-radius: 8px;
+    font-size: 13px;
+    margin-top: 1px;
+  }
+  .insp-names { min-width: 0; flex: 1; }
+  .insp-name {
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--fg);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    min-width: 0;
+  }
+  .insp-name .nm { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .insp-name .st-chip { flex: none; }
+  .insp-sub {
+    margin-top: 3px;
+    font-size: 10.5px;
+    color: var(--fg-3);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .rightbar .stats {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 6px;
+    margin: 13px 0 4px;
+  }
+  .rightbar .stat {
+    background: var(--bg-inset);
+    border: 1px solid var(--hairline);
+    border-radius: 9px;
+    padding: 9px 6px 7px;
+    text-align: center;
+    min-width: 0;
+  }
+  .rightbar .stat b {
+    display: block;
+    font-size: 15px;
+    font-weight: 700;
+    color: var(--fg);
+    font-variant-numeric: tabular-nums;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .rightbar .stat span {
+    display: block;
+    margin-top: 2px;
+    font-size: 8.5px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    text-transform: uppercase;
+    color: var(--fg-3);
+  }
+  .kvrows { margin-top: 6px; }
+  .kvrow {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 6.5px 0;
+    font-size: 11.5px;
+  }
+  .kvrow + .kvrow { border-top: 1px solid var(--hairline); }
+  .kvrow > span { color: var(--fg-3); flex: none; }
+  .kvrow > code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 10.5px;
+    color: var(--fg-2);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .kvrow.warn > code { color: var(--warm); }
+  .kvrow.err  > code { color: var(--err-color); }
+  .insp-actions { margin-top: 10px; }
 
   /* ── Primary nav (九宫格 3×3 tile grid in the sidebar) ────────── */
   .nav-list { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -108,10 +108,20 @@ import { MAIN_HTML } from "./lisa-html.js";
  * every switch path onto lisaResetChatLog (log wipe + history reload) and a
  * chatGeneration guard detaches an in-flight reply stream's DOM writes when
  * its session is switched away mid-turn.
+ * Then: session shell phase 3 — the monitored agents join the sidebar tree as
+ * root groups SIBLING to LISA (agent kind → project → session leaves with
+ * state pips, collapse state kept across refreshes), and the right panel's
+ * agents roster became a single INSPECTOR card (#sbClaudeRows repurposed as
+ * its body) for the tree-selected session: head + state chip, stat triplet
+ * (turns/tokens/files or msgs/started/project), aligned KV rows
+ * (last cmd/tools/files/⚠pending/error), and the same control surface the
+ * roster rows had (approve/deny/send/output/cancel/adopt) now scoped to the
+ * selected session; auto-selects the top-ranked live agent, else the active
+ * Lisa session, whose inspector offers "open" to switch.
  */
-const EXPECTED_LENGTH = 254646;
+const EXPECTED_LENGTH = 266187;
 const EXPECTED_SHA256 =
-  "8a43adaddd1385fe1f256b70d57de86514140b8363e553f09ba3a9efccd213e1";
+  "c875a2fb086c3338f144fec0aebf986a32e92a81689e953090c0a0249867efa5";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -198,18 +198,21 @@ ${MAIN_CSS}
       <p class="body-text" id="sbDesire">—</p>
     </div>
 
-    <!-- Agents monitor -->
+    <!-- Inspector — detail card for the session selected in the sidebar
+         tree (agent or Lisa session; auto-selects the top problem session).
+         #sbClaudeRows is the inspector body (id kept: setupSidebarLive
+         resolves it unguarded); the live-agent count stays in the header. -->
     <div class="rb-sec" id="sbClaudeCard">
       <div class="h">
-        <div class="left">agents</div>
-        <div class="count">▶︎ <span id="sbClaudeCount">0</span></div>
+        <div class="left">inspector</div>
+        <div class="count">▶︎ <span id="sbClaudeCount">0</span> live</div>
+      </div>
+      <div id="sbClaudeRows">
+        <div class="session-empty">(idle)</div>
       </div>
       <button id="sbDelegateBtn" class="delegate-btn" type="button" title="Start an agent">
         ＋ delegate a task
       </button>
-      <div id="sbClaudeRows">
-        <div class="session-empty">(idle)</div>
-      </div>
     </div>
 
     <!-- Mail digest (connect a mailbox → daily classified digest) -->


### PR DESCRIPTION
Stacked PR 第三个（base = P2 #344）。合并顺序：#343 → #344 → 本 PR。

## 内容

- 被监控 agent 以**与 LISA 同级的树根**加入左栏 session 树（已确认设计：LISA / Claude Code / Codex … 平级），结构 `agent 种类 → 项目 → session`：状态 pip（working 呼吸 / waiting 光晕 / error）、分支名叶子标签、折叠状态跨 60s 刷新保持
- 右栏 agents roster 变为单一 **INSPECTOR 卡**（`#sbClaudeRows` 复用为其载体，ID 不变）：会话头 + 状态 chip、stat 三联（agent: turns/tokens/files；Lisa 会话: msgs/started/project）、对齐 KV 行（last cmd / tools / files / ⚠pending / error）、以及原 roster 行的完整控制面 —— approve/deny、追问、pty output、cancel、adopt —— 作用于树中选中的会话
- 自动选中规则：error → waiting → working 的最高优先活跃 agent，否则当前 Lisa 会话；非活跃 Lisa 会话的 inspector 提供 open 切换
- 隐私边界不变：roster 面只有结构化元数据，无 prompt/回复正文

**范围说明**：mockup 中的「agent 只读过程流 tab」需要新的 turn 级步骤端点（parser 目前只保留聚合活动），按设计文档 §5 的裁剪原则列为后续项；pty 会话的实时输出仍走现有 `▤ output`。

## 验证

隔离实例实测：5 个真实 claude-code 会话按项目分组入树、点击叶子 inspector 联动、Control 视图无回归、双主题可读。全量 1542 通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)