### PR TITLE
Session shell v1.1 F1: agent 只读过程流

### DIFF
--- a/src/integrations/claude-code/observer.ts
+++ b/src/integrations/claude-code/observer.ts
@@ -26,6 +26,9 @@ function toAgentSession(info: ClaudeSessionInfo): AgentSession {
     stateReason: info.stateReason,
     lastMtime: info.lastMtime,
     activity: info.activity,
+    // Server-internal file handle for the step-timeline endpoint;
+    // agentSessionsResponse strips it before serialization.
+    jsonlPath: info.jsonlPath,
   };
 }
 

--- a/src/integrations/claude-code/parser-steps.test.ts
+++ b/src/integrations/claude-code/parser-steps.test.ts
@@ -1,0 +1,113 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { parseSessionSteps } from "./parser.js";
+
+/**
+ * parseSessionSteps privacy + shape tests (PLAN_UI_SESSION_SHELL_v1.1 F1).
+ *
+ * Same secret-planting technique as parser.test.ts: a unique marker is
+ * embedded in every content-bearing position (user text, assistant text,
+ * tool_result payload, full Bash command, parent DIRECTORY of a file path)
+ * and must never appear in the parsed output. Step targets are file
+ * basenames / Bash argv[0] only.
+ */
+
+const SECRET = "S3CR3T-ne-pas-fuir-9f2d";
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj) + "\n";
+}
+
+async function withSession(jsonl: string, fn: (file: string) => Promise<void>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-steps-"));
+  const file = path.join(dir, "abc.jsonl");
+  await fs.writeFile(file, jsonl);
+  try {
+    await fn(file);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("parseSessionSteps: ordered structural steps, no content leakage", async () => {
+  const jsonl =
+    line({
+      type: "user",
+      timestamp: "2026-08-08T01:00:00Z",
+      message: { role: "user", content: [{ type: "text", text: SECRET + " please fix the bug" }] },
+    }) +
+    line({
+      type: "assistant",
+      timestamp: "2026-08-08T01:00:05Z",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "Read", input: { file_path: "/Users/x/" + SECRET + "-dir/notes.md" } },
+        ],
+      },
+    }) +
+    // tool_result envelope (type:user but NOT a human turn) carrying an error
+    line({
+      type: "user",
+      is_error: true,
+      message: { role: "user", content: [{ type: "tool_result", content: SECRET }] },
+    }) +
+    line({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [{ type: "tool_use", name: "Bash", input: { command: "grep " + SECRET + " -r ." } }],
+      },
+    }) +
+    line({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: "done: " + SECRET }] },
+    }) +
+    line({
+      type: "user",
+      timestamp: "2026-08-08T01:01:00Z",
+      message: { role: "user", content: [{ type: "text", text: "next " + SECRET }] },
+    });
+
+  await withSession(jsonl, async (file) => {
+    const steps = await parseSessionSteps(file);
+
+    // Order + turn attribution: user(1) → Read → Bash → assistant → user(2)
+    assert.equal(steps.length, 5);
+    assert.equal(steps[0]!.kind, "user");
+    assert.equal(steps[0]!.turn, 1);
+    assert.equal(steps[0]!.ts, "2026-08-08T01:00:00Z");
+
+    const read = steps.find((s) => s.tool === "Read");
+    assert.ok(read, "Read tool step present");
+    assert.equal(read!.target, "notes.md"); // basename only — directory (with secret) stripped
+    assert.equal(read!.turn, 1);
+    assert.equal(read!.isError, true); // is_error tool_result attributed to latest tool
+
+    const bash = steps.find((s) => s.tool === "Bash");
+    assert.ok(bash, "Bash tool step present");
+    assert.equal(bash!.target, "$ grep"); // argv[0] only
+
+    const assistants = steps.filter((s) => s.kind === "assistant");
+    assert.equal(assistants.length, 1); // tool_use-only assistant lines are not text markers
+
+    assert.equal(steps[steps.length - 1]!.kind, "user");
+    assert.equal(steps[steps.length - 1]!.turn, 2);
+
+    // The privacy assertion: the planted secret appears nowhere.
+    assert.ok(!JSON.stringify(steps).includes(SECRET), "secret leaked into steps output");
+  });
+});
+
+test("parseSessionSteps: empty / missing / malformed files return []", async () => {
+  assert.deepEqual(await parseSessionSteps("/nonexistent/file.jsonl"), []);
+  await withSession("", async (file) => {
+    assert.deepEqual(await parseSessionSteps(file), []);
+  });
+  await withSession("not json\n{broken\n", async (file) => {
+    assert.deepEqual(await parseSessionSteps(file), []);
+  });
+});

--- a/src/integrations/claude-code/parser.ts
+++ b/src/integrations/claude-code/parser.ts
@@ -392,3 +392,150 @@ function dedupeKeepRecent(items: string[], max: number): string[] {
   }
   return out.slice(-max);
 }
+
+// ── F1 (PLAN_UI_SESSION_SHELL_v1.1): ordered structural step timeline ────────
+//
+// SAME PRIVACY BOUNDARY as parseSessionActivity (block comment above), one
+// notch tighter: step targets are file BASENAMES / Bash argv[0] only — never
+// full paths, text blocks, full commands, or edit payloads. Tested in
+// parser-steps.test.ts with the same secret-planting technique.
+
+/** One structural step in a session's tail — powers the read-only stream tab. */
+export interface AgentStep {
+  /** ISO timestamp when the jsonl line carried one. */
+  ts?: string;
+  kind: "user" | "assistant" | "tool";
+  /** tool_use name (kind === "tool" only). */
+  tool?: string;
+  /** File basename or Bash argv[0] (kind === "tool" only). */
+  target?: string;
+  /** Turn ordinal within the parsed tail — increments on each real user turn. */
+  turn: number;
+  /** A tool error observed at (or right after) this step. */
+  isError?: boolean;
+}
+
+const MAX_STEPS = 200;
+
+export async function parseSessionSteps(filePath: string): Promise<AgentStep[]> {
+  let size: number;
+  try {
+    const st = await fsp.stat(filePath);
+    if (!st.isFile() || st.size === 0) return [];
+    size = st.size;
+  } catch {
+    return [];
+  }
+
+  let tail: string;
+  try {
+    const fd = await fsp.open(filePath, "r");
+    try {
+      const length = Math.min(ACTIVITY_TAIL_BYTES, size);
+      const buf = Buffer.alloc(length);
+      await fd.read(buf, 0, length, size - length);
+      tail = buf.toString("utf8");
+    } finally {
+      await fd.close();
+    }
+  } catch {
+    return [];
+  }
+
+  const lines = tail.split("\n").filter(Boolean);
+  if (size > ACTIVITY_TAIL_BYTES && lines.length > 0) lines.shift();
+
+  const steps: AgentStep[] = [];
+  let turn = 0;
+
+  const basenameOf = (p: string): string => {
+    const parts = p.split("/").filter(Boolean);
+    return parts.length ? parts[parts.length - 1]! : p;
+  };
+
+  for (const line of lines) {
+    let e: unknown;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!e || typeof e !== "object") continue;
+    const obj = e as Record<string, unknown>;
+
+    const type = readString(obj.type);
+    if (type && META_TYPES.has(type)) continue;
+    const ts = readString(obj.timestamp);
+
+    const msg = obj.message;
+    const m = msg && typeof msg === "object" ? (msg as Record<string, unknown>) : null;
+    const content = m ? m.content : null;
+
+    // Structural classification only — block TYPES are inspected, block
+    // text never is.
+    let hasText = false;
+    let hasToolResult = false;
+    const toolBlocks: Array<Record<string, unknown>> = [];
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== "object") continue;
+        const b = block as Record<string, unknown>;
+        if (b.type === "text") hasText = true;
+        else if (b.type === "tool_result") hasToolResult = true;
+        else if (b.type === "tool_use") toolBlocks.push(b);
+      }
+    } else if (typeof content === "string") {
+      hasText = content.length > 0;
+    }
+
+    if (type === "user") {
+      if (hasToolResult) {
+        // A tool_result envelope, not a human turn — attribute errors to
+        // the most recent tool step.
+        if (obj.is_error === true || obj.error === true) {
+          for (let i = steps.length - 1; i >= 0; i--) {
+            if (steps[i]!.kind === "tool") {
+              steps[i]!.isError = true;
+              break;
+            }
+          }
+        }
+      } else if (hasText) {
+        turn++;
+        steps.push({ ts, kind: "user", turn });
+      }
+      continue;
+    }
+
+    if (type === "assistant") {
+      for (const b of toolBlocks) {
+        const name = readString(b.name);
+        if (!name) continue;
+        let target: string | undefined;
+        const input = b.input;
+        if (input && typeof input === "object") {
+          const inp = input as Record<string, unknown>;
+          for (const k of PATH_KEYS) {
+            const p = inp[k];
+            if (typeof p === "string" && p) {
+              target = basenameOf(p);
+              break;
+            }
+          }
+          if (!target && name.toLowerCase() === "bash") {
+            const cmd = inp.command;
+            if (typeof cmd === "string" && cmd.trim()) {
+              target = "$ " + cmd.trim().split(/\s+/)[0];
+            }
+          }
+        }
+        steps.push({ ts, kind: "tool", turn, tool: name, target });
+      }
+      if (toolBlocks.length === 0 && hasText) {
+        steps.push({ ts, kind: "assistant", turn });
+      }
+    }
+  }
+
+  return steps.slice(-MAX_STEPS);
+}

--- a/src/integrations/claude-code/watcher.ts
+++ b/src/integrations/claude-code/watcher.ts
@@ -116,6 +116,12 @@ export interface ClaudeSessionInfo {
    * Privacy: structural metadata only — never conversation content.
    */
   activity?: SessionActivity;
+  /**
+   * Absolute path of the session's jsonl. Server-internal — the step
+   * timeline endpoint (PLAN_UI_SESSION_SHELL_v1.1 F1) resolves the file
+   * through this; it is STRIPPED from the wire by agentSessionsResponse.
+   */
+  jsonlPath?: string;
 }
 
 export interface ClaudeSessionUpdate {
@@ -356,6 +362,7 @@ export class ClaudeCodeWatcher extends EventEmitter {
       stateReason: derived.stateReason,
       cwd,
       activity: derived.activity,
+      jsonlPath: filePath,
     };
   }
 

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -92,6 +92,12 @@ export interface AgentSession {
   /** When a controllable PTY is a resume-adopt, the real claude sessionId it
    *  continues — lets the roster drop the observe-only duplicate of that session. */
   adoptedSessionId?: string;
+  /**
+   * SERVER-INTERNAL: absolute path of the session's transcript file, set by
+   * adapters that can serve a structural step timeline (claude-code). Never
+   * serialized — agentSessionsResponse strips it before the wire.
+   */
+  jsonlPath?: string;
 }
 
 /** Visibility tier — how deeply LISA may inspect a session. See plan §3. */

--- a/src/web/api-contract.ts
+++ b/src/web/api-contract.ts
@@ -49,14 +49,19 @@ export function agentSessionsResponse(
   liveClaudeSessions: ReadonlySet<string>,
 ): AgentSessionsResponse {
   return {
-    sessions: sessions.map((session) => ({
-      ...session,
-      lastMtime: new Date(session.lastMtime).toISOString(),
-      ...(session.agent === "claude-code" &&
-      !session.controllable &&
-      !liveClaudeSessions.has(session.sessionId)
-        ? { resumable: true }
-        : {}),
-    })),
+    sessions: sessions.map((session) => {
+      // jsonlPath is a server-internal file handle (step-timeline endpoint);
+      // it must never reach the wire (it leaks the local home directory).
+      const { jsonlPath: _jsonlPath, ...rest } = session;
+      return {
+        ...rest,
+        lastMtime: new Date(session.lastMtime).toISOString(),
+        ...(session.agent === "claude-code" &&
+        !session.controllable &&
+        !liveClaudeSessions.has(session.sessionId)
+          ? { resumable: true }
+          : {}),
+      };
+    }),
   };
 }

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1668,6 +1668,9 @@ if ('serviceWorker' in navigator) {
     });
     renderSessionTree();
     renderInspector();
+    // Live refresh for an open stream tab (head/perm/foot reflect the
+    // newest snapshot; steps repoll on their own timer too).
+    if (currentAgentTab) renderStreamView();
   }
 
   // ── Tree view mode (F3): group by agent kind (default) or by project ──
@@ -1707,7 +1710,9 @@ if ('serviceWorker' in navigator) {
     leaf.addEventListener('click', function () {
       selInsp = { type: 'lisa', id: s.id };
       renderInspector();
-      switchSession(s.id);
+      closeStreamView();
+      if (s.id === window.lisaActiveSessionId) renderSessionUI();
+      else switchSession(s.id);
     });
     return leaf;
   }
@@ -1975,6 +1980,15 @@ if ('serviceWorker' in navigator) {
     const id = s.sessionId;
     const acts = document.createElement('div');
     acts.className = 'session-ctrl insp-actions';
+    // F1 — every agent session gets a read-only step stream tab.
+    const streamBtn = document.createElement('button');
+    streamBtn.className = 'mc';
+    streamBtn.textContent = '▤ stream';
+    streamBtn.title = 'Open the read-only step stream';
+    streamBtn.addEventListener('click', function () {
+      if (window.lisaOpenAgentStream) window.lisaOpenAgentStream(s);
+    });
+    acts.appendChild(streamBtn);
     if (fam === 'managed' && a.pendingPermission) {
       const ap = document.createElement('button');
       ap.className = 'mc approve'; ap.textContent = '✓ approve';
@@ -2130,13 +2144,21 @@ if ('serviceWorker' in navigator) {
   // client-side notion (which sessions you keep at hand), persisted in
   // localStorage; the tree is the full on-disk list.
   let cachedSessions = [];
+  // Open tabs: 'sessionId' strings (Lisa sessions) or {t:'agent', agent, id,
+  // label} objects (read-only agent stream tabs, F1). Old string-only
+  // payloads load unchanged.
   let openTabIds = [];
   try {
     const rawTabs = localStorage.getItem('lisaOpenSessions');
-    if (rawTabs) openTabIds = JSON.parse(rawTabs).filter(function (x) { return typeof x === 'string'; });
+    if (rawTabs) openTabIds = JSON.parse(rawTabs).filter(function (x) {
+      return typeof x === 'string' || (x && x.t === 'agent' && typeof x.agent === 'string' && typeof x.id === 'string');
+    });
   } catch (e) { openTabIds = []; }
   function saveTabs() {
     try { localStorage.setItem('lisaOpenSessions', JSON.stringify(openTabIds.slice(0, 12))); } catch (e) {}
+  }
+  function tabKeyOf(entry) {
+    return typeof entry === 'string' ? entry : entry.agent + '/' + entry.id;
   }
   function sessionLabel(s) {
     // F2 auto-naming: the FIRST user message is the session's name (the
@@ -2173,6 +2195,7 @@ if ('serviceWorker' in navigator) {
   async function newSession() {
     if (switching) return;
     switching = true;
+    closeStreamView();
     document.body.classList.add('session-switching');
     try {
       const r = await fetch('/api/sessions', { method: 'POST' });
@@ -2187,14 +2210,19 @@ if ('serviceWorker' in navigator) {
     refreshSessionsBadge();
   }
   function ensureTab(id) {
-    if (openTabIds.indexOf(id) < 0) openTabIds.unshift(id);
+    if (!openTabIds.some(function (x) { return tabKeyOf(x) === id; })) openTabIds.unshift(id);
     saveTabs();
   }
-  function closeTab(id) {
-    const idx = openTabIds.indexOf(id);
+  function closeTab(key) {
+    const idx = openTabIds.findIndex(function (x) { return tabKeyOf(x) === key; });
     if (idx >= 0) openTabIds.splice(idx, 1);
     saveTabs();
-    if (id === window.lisaActiveSessionId && openTabIds.length) {
+    if (currentAgentTab && tabKeyOf(currentAgentTab) === key) {
+      closeStreamView();
+      renderSessionUI();
+      return;
+    }
+    if (key === window.lisaActiveSessionId && openTabIds.length && typeof openTabIds[0] === 'string') {
       switchSession(openTabIds[0]);
       return;
     }
@@ -2231,25 +2259,50 @@ if ('serviceWorker' in navigator) {
     const strip = document.getElementById('tabStrip');
     if (!strip) return;
     strip.innerHTML = '';
-    // Drop tabs whose session vanished from disk.
-    openTabIds = openTabIds.filter(function (id) { return sessionById(id) !== null || id === window.lisaActiveSessionId; });
+    // Drop Lisa tabs whose session vanished from disk; agent tabs persist
+    // (their sessions may simply be outside the 30-min active window).
+    openTabIds = openTabIds.filter(function (x) {
+      if (typeof x !== 'string') return true;
+      return sessionById(x) !== null || x === window.lisaActiveSessionId;
+    });
     if (window.lisaActiveSessionId) ensureTab(window.lisaActiveSessionId);
-    openTabIds.slice(0, 6).forEach(function (id) {
-      const s = sessionById(id);
-      const isActive = id === window.lisaActiveSessionId;
+    openTabIds.slice(0, 6).forEach(function (entry) {
+      const key = tabKeyOf(entry);
+      const isAgent = typeof entry !== 'string';
+      const isActive = isAgent
+        ? !!(currentAgentTab && tabKeyOf(currentAgentTab) === key)
+        : (!currentAgentTab && entry === window.lisaActiveSessionId);
       const tab = document.createElement('button');
       tab.type = 'button';
       tab.className = 'stab' + (isActive ? ' active' : '');
-      tab.innerHTML = '<span class="pip"></span><span class="stab-name"></span><span class="stab-x" title="Close tab">×</span>';
-      if (isActive) tab.querySelector('.pip').classList.add('live');
-      tab.querySelector('.stab-name').textContent = s ? sessionLabel(s) : id;
+      tab.innerHTML = '<span class="pip"></span>' + (isAgent ? '<span class="agent-glyph mini"></span>' : '') + '<span class="stab-name"></span><span class="stab-x" title="Close tab">×</span>';
+      if (isAgent) {
+        const s = agentByKey(key);
+        const g = tab.querySelector('.agent-glyph');
+        const kindName = AGENT_NAMES[entry.agent] || entry.agent;
+        g.classList.add(agentGlyphClass(entry.agent));
+        g.textContent = (kindName.charAt(0) || 'A').toUpperCase();
+        const st = s ? (s.state || 'unknown') : 'unknown';
+        if (st === 'working' || st === 'waiting' || st === 'error') tab.querySelector('.pip').classList.add(st);
+        tab.querySelector('.stab-name').textContent = s ? agentLabel(s) : (entry.label || entry.id);
+      } else {
+        const s = sessionById(entry);
+        if (isActive) tab.querySelector('.pip').classList.add('live');
+        tab.querySelector('.stab-name').textContent = s ? sessionLabel(s) : entry;
+      }
       tab.addEventListener('click', function (e) {
         if (e.target && e.target.classList && e.target.classList.contains('stab-x')) {
           e.stopPropagation();
-          closeTab(id);
+          closeTab(key);
           return;
         }
-        switchSession(id);
+        if (isAgent) {
+          openStreamTab(entry);
+        } else {
+          closeStreamView();
+          if (entry === window.lisaActiveSessionId) renderSessionUI();
+          else switchSession(entry);
+        }
       });
       strip.appendChild(tab);
     });
@@ -2260,6 +2313,201 @@ if ('serviceWorker' in navigator) {
     plus.textContent = '＋';
     plus.addEventListener('click', newSession);
     strip.appendChild(plus);
+  }
+
+  // ── F1: read-only agent stream tab ─────────────────────────────────
+  // An agent tab swaps the chat surface for a structural step timeline
+  // (GET /api/agents/steps; PTY sessions stream their terminal tail over
+  // the existing SSE endpoint instead). 4s visibility-gated polling, plus
+  // refresh on agent_session_update via setClaudeSessions.
+  let currentAgentTab = null;
+  let streamTimer = null;
+  let ptyStream = null;
+  function ensureAgentTab(s) {
+    const key = agentKey(s);
+    if (!openTabIds.some(function (x) { return tabKeyOf(x) === key; })) {
+      openTabIds.unshift({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
+      saveTabs();
+    }
+  }
+  window.lisaOpenAgentStream = function (s) {
+    ensureAgentTab(s);
+    openStreamTab({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
+  };
+  function openStreamTab(entry) {
+    if (ptyStream) { ptyStream.close(); ptyStream = null; }
+    currentAgentTab = entry;
+    document.body.classList.add('agent-tab-active');
+    if (window.lisaShowView) window.lisaShowView('chat');
+    renderSessionUI();
+    renderStreamView();
+    if (streamTimer) clearInterval(streamTimer);
+    streamTimer = setInterval(function () {
+      if (currentAgentTab && !document.hidden) refreshStreamSteps();
+    }, 4000);
+  }
+  function closeStreamView() {
+    if (!currentAgentTab) return;
+    currentAgentTab = null;
+    document.body.classList.remove('agent-tab-active');
+    if (streamTimer) { clearInterval(streamTimer); streamTimer = null; }
+    if (ptyStream) { ptyStream.close(); ptyStream = null; }
+  }
+  function streamSession() {
+    return currentAgentTab ? agentByKey(tabKeyOf(currentAgentTab)) : null;
+  }
+  function renderStreamView() {
+    if (!currentAgentTab) return;
+    const head = document.getElementById('asHead');
+    const perm = document.getElementById('asPerm');
+    const foot = document.getElementById('asFoot');
+    if (!head || !perm || !foot) return;
+    const s = streamSession();
+    head.innerHTML = '';
+    const kindName = AGENT_NAMES[currentAgentTab.agent] || currentAgentTab.agent;
+    const g = document.createElement('span');
+    g.className = 'agent-glyph ' + agentGlyphClass(currentAgentTab.agent);
+    g.textContent = (kindName.charAt(0) || 'A').toUpperCase();
+    head.appendChild(g);
+    const nameEl = document.createElement('b');
+    nameEl.textContent = s ? agentLabel(s) : (currentAgentTab.label || currentAgentTab.id);
+    head.appendChild(nameEl);
+    const meta = document.createElement('span');
+    meta.className = 'meta';
+    if (s) {
+      const a = s.activity || {};
+      const bits = [kindName, s.project];
+      if (a.gitBranch) bits.push(a.gitBranch);
+      if (a.turnCount != null) bits.push(a.turnCount + ' turns');
+      if (a.tokens) bits.push(fmtTokens(a.tokens) + ' tok');
+      meta.textContent = bits.join(' · ');
+    } else {
+      meta.textContent = kindName + ' · (outside the active window)';
+    }
+    head.appendChild(meta);
+    const badge = document.createElement('span');
+    badge.className = 'ro-badge';
+    badge.textContent = s && s.controllable ? s.controllable : 'observing';
+    head.appendChild(badge);
+    perm.style.display = 'none';
+    perm.innerHTML = '';
+    if (s && s.controllable === 'managed' && s.activity && s.activity.pendingPermission) {
+      perm.style.display = '';
+      const label = document.createElement('span');
+      label.textContent = '⚠ pending';
+      perm.appendChild(label);
+      const code = document.createElement('code');
+      code.textContent = s.activity.pendingPermission;
+      perm.appendChild(code);
+      const grow = document.createElement('span');
+      grow.className = 'grow';
+      perm.appendChild(grow);
+      const ap = document.createElement('button');
+      ap.className = 'mc approve'; ap.textContent = '✓ approve';
+      ap.addEventListener('click', function () { agentAction('managed', s.sessionId, 'approve', { allow: true }); });
+      const dn = document.createElement('button');
+      dn.className = 'mc deny'; dn.textContent = '✕ deny';
+      dn.addEventListener('click', function () { agentAction('managed', s.sessionId, 'approve', { allow: false }); });
+      perm.appendChild(ap);
+      perm.appendChild(dn);
+    }
+    foot.innerHTML = '';
+    if (s && s.controllable && s.state !== 'done') {
+      const inp = document.createElement('input');
+      inp.type = 'text';
+      inp.placeholder = s.controllable === 'pty' ? 'type into the CLI…' : 'send a follow-up…';
+      inp.addEventListener('keydown', function (e) {
+        if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && inp.value.trim()) {
+          e.preventDefault();
+          agentAction(s.controllable, s.sessionId, 'send', { text: inp.value.trim() });
+          inp.value = '';
+        }
+      });
+      foot.appendChild(inp);
+      const cancel = document.createElement('button');
+      cancel.className = 'mc cancel'; cancel.textContent = '⏹ cancel';
+      cancel.addEventListener('click', function () { agentAction(s.controllable, s.sessionId, 'cancel', null); });
+      foot.appendChild(cancel);
+    } else if (s && s.resumable) {
+      const note = document.createElement('span');
+      note.style.cssText = 'font-size:11px;color:var(--fg-3);align-self:center;';
+      note.textContent = 'observe-only — adopt it from the inspector to take control';
+      foot.appendChild(note);
+    }
+    refreshStreamSteps();
+  }
+  function refreshStreamSteps() {
+    if (!currentAgentTab) return;
+    const stepsEl = document.getElementById('asSteps');
+    if (!stepsEl) return;
+    const s = streamSession();
+    // PTY sessions: live terminal tail over the existing SSE endpoint.
+    if (s && s.controllable === 'pty') {
+      if (!ptyStream) {
+        stepsEl.innerHTML = '';
+        const pre = document.createElement('pre');
+        pre.className = 'pty-tail';
+        stepsEl.appendChild(pre);
+        ptyStream = new EventSource('/api/agents/pty/' + encodeURIComponent(s.sessionId) + '/stream');
+        ptyStream.onmessage = function (e) {
+          try {
+            const ev = JSON.parse(e.data);
+            if (ev.type === 'snapshot') pre.textContent = ev.text || '';
+            else if (ev.type === 'chunk') pre.textContent += ev.text || '';
+            else if (ev.type === 'end') { if (ptyStream) { ptyStream.close(); ptyStream = null; } }
+            stepsEl.scrollTop = stepsEl.scrollHeight;
+          } catch (err) {}
+        };
+        ptyStream.onerror = function () { if (ptyStream) { ptyStream.close(); ptyStream = null; } };
+      }
+      return;
+    }
+    fetch('/api/agents/steps?agent=' + encodeURIComponent(currentAgentTab.agent) + '&id=' + encodeURIComponent(currentAgentTab.id))
+      .then(function (r) { return r.ok ? r.json() : null; })
+      .then(function (d) {
+        if (!d || !currentAgentTab) return;
+        renderSteps(stepsEl, d.steps || []);
+      })
+      .catch(function () {});
+  }
+  function stepIcon(tool) {
+    const t = (tool || '').toLowerCase();
+    if (t === 'read') return '📖';
+    if (t === 'edit' || t === 'write' || t === 'notebookedit') return '✏️';
+    if (t === 'bash') return '🖥';
+    if (t === 'grep' || t === 'glob') return '🔎';
+    return '⚙';
+  }
+  function renderSteps(stepsEl, steps) {
+    const atBottom = stepsEl.scrollHeight - stepsEl.scrollTop - stepsEl.clientHeight < 60;
+    stepsEl.innerHTML = '';
+    if (!steps.length) {
+      const empty = document.createElement('div');
+      empty.className = 'session-empty';
+      empty.textContent = '(no structural steps in the recent tail — metadata-only visibility, or a quiet session)';
+      stepsEl.appendChild(empty);
+      return;
+    }
+    steps.forEach(function (st) {
+      const row = document.createElement('div');
+      if (st.kind === 'user') {
+        row.className = 'srow turn';
+        row.innerHTML = '<span class="sic">💬</span><span></span><span class="stime"></span>';
+        row.children[1].textContent = 'turn ' + st.turn;
+      } else if (st.kind === 'assistant') {
+        row.className = 'srow';
+        row.innerHTML = '<span class="sic">💭</span><span>reply</span><span class="stime"></span>';
+      } else {
+        row.className = 'srow' + (st.isError ? ' err' : '');
+        row.innerHTML = '<span class="sic"></span><span></span><span class="sdetail"></span><span class="stime"></span>';
+        row.querySelector('.sic').textContent = stepIcon(st.tool);
+        row.children[1].textContent = st.tool || '';
+        row.querySelector('.sdetail').textContent = st.target || '';
+      }
+      if (st.ts) row.querySelector('.stime').textContent = relativeTime(st.ts);
+      stepsEl.appendChild(row);
+    });
+    if (atBottom) stepsEl.scrollTop = stepsEl.scrollHeight;
   }
 
   function renderSessionUI() {

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -931,6 +931,135 @@ export const MAIN_CSS = `  :root {
   }
   .stab-new:hover { color: var(--accent); border-color: var(--accent); }
 
+  /* ── Agent read-only stream (F1) — swaps in for the chat surface while
+     an agent tab is active (body.agent-tab-active). ─────────────── */
+  body.agent-tab-active #viewChat.view.active { grid-template-rows: auto 1fr; }
+  body.agent-tab-active #log,
+  body.agent-tab-active #attachPreview,
+  body.agent-tab-active #form { display: none !important; }
+  #agentStream { display: none; }
+  body.agent-tab-active #agentStream {
+    display: flex;
+    flex-direction: column;
+    min-height: 0;
+    overflow: hidden;
+    padding: 10px 22px 16px;
+    gap: 10px;
+  }
+  .as-head {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    border-radius: 12px;
+    font-size: 12px;
+    flex: none;
+  }
+  .as-head .agent-glyph { width: 22px; height: 22px; font-size: 11px; border-radius: 6px; }
+  .as-head b { font-size: 12.5px; color: var(--fg); }
+  .as-head .meta {
+    color: var(--fg-3);
+    font-size: 11px;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+    flex: 1;
+  }
+  .ro-badge {
+    flex: none;
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    color: var(--claude);
+    background: var(--claude-soft);
+    border: 1px solid var(--claude-soft);
+    padding: 2px 9px;
+    border-radius: 20px;
+  }
+  .as-perm {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 14px;
+    background: var(--warm-soft);
+    border: 1px solid var(--warm);
+    border-radius: 9px;
+    font-size: 12px;
+    color: var(--fg);
+    flex: none;
+  }
+  .as-perm code {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    background: var(--bg-hover, rgba(255,255,255,.05));
+    padding: 1px 6px;
+    border-radius: 4px;
+  }
+  .as-perm .grow { flex: 1; }
+  .as-steps {
+    flex: 1;
+    min-height: 0;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    scrollbar-width: thin;
+  }
+  .as-steps pre.pty-tail {
+    margin: 0;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    color: var(--fg-2);
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .srow {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 5px 12px;
+    border-radius: 8px;
+    font-size: 12px;
+    color: var(--fg-2);
+    flex: none;
+  }
+  .srow:hover { background: var(--bg-card); }
+  .srow .sic { width: 16px; text-align: center; flex: none; font-size: 12px; }
+  .srow .sdetail {
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 11px;
+    color: var(--fg-3);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .srow .stime { margin-left: auto; flex: none; font-size: 10px; color: var(--fg-faint); }
+  .srow.turn {
+    color: var(--fg);
+    font-weight: 600;
+    margin-top: 7px;
+    border-left: 2px solid var(--accent);
+    border-radius: 0 8px 8px 0;
+  }
+  .srow.err .sdetail, .srow.err { color: var(--err-color); }
+  .as-foot { display: flex; gap: 8px; flex: none; }
+  .as-foot input {
+    flex: 1;
+    background: var(--bg-card-strong);
+    border: 1px solid var(--border-strong);
+    border-radius: 9px;
+    padding: 9px 13px;
+    color: var(--fg);
+    font-family: inherit;
+    font-size: 12.5px;
+    outline: none;
+  }
+  .as-foot .mc { font-size: 11.5px; padding: 6px 14px; }
+
   /* ── Right panel (status rail) ──────────────────────────────────
      One structured full-height panel, symmetric with the sidebar: the
      relocated sidebar lower half (wanting / agents / mail / reflection)

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -125,10 +125,19 @@ import { MAIN_HTML } from "./lisa-html.js";
  * source glyphs; localStorage "lisaTreeMode", per-mode collapse keys); and a
  * new fnbar #fnPanel button collapses the right panel (body.rb-collapsed +
  * localStorage "lisaRightbar"), independent of the ≤1180px auto-hide.
+ * Then: v1.1 F1 — the read-only agent stream: an #agentStream surface inside
+ * #viewChat (head card / pending-permission banner / turn-separated step
+ * rows / control footer) that swaps in for the chat surface while an agent
+ * tab is active (body.agent-tab-active); agent tabs join the tab strip
+ * ({t:'agent',…} entries in "lisaOpenSessions", back-compat with the old
+ * string-only payload); the inspector gains a "▤ stream" action. Steps come
+ * from the new GET /api/agents/steps (parseSessionSteps — basenames/argv[0]
+ * only, tier-gated), and PTY sessions render their live terminal tail from
+ * the existing /api/agents/pty/{id}/stream SSE instead.
  */
-const EXPECTED_LENGTH = 272187;
+const EXPECTED_LENGTH = 287343;
 const EXPECTED_SHA256 =
-  "fa81e8ecc01fc79ac0ade89bb9ae286dbdb93f119fd36afac8f0abbef64076c4";
+  "c46a802e9f05f24b31531b1651691ed86a6e6d8010d0b9342c4433b59e3a3863";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -148,6 +148,15 @@ ${MAIN_CSS}
       <button class="fbtn" type="button" id="fnTheme" title="Theme: Nebula ↔ Calm" aria-label="Toggle theme"><svg id="fnThemeMoon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg><svg id="fnThemeSun" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/></svg></button>
     </div>
 
+    <!-- Agent read-only stream (F1) — swaps in for the chat surface while
+         an agent tab is active; wired by the sidebar-live block. -->
+    <div id="agentStream">
+      <div class="as-head" id="asHead"></div>
+      <div class="as-perm" id="asPerm" style="display:none"></div>
+      <div class="as-steps" id="asSteps"></div>
+      <div class="as-foot" id="asFoot"></div>
+    </div>
+
     <!-- Chat log (messages, tool blocks, idle blocks injected here) -->
     <div id="log"></div>
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -2901,6 +2901,34 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // F1 (PLAN_UI_SESSION_SHELL_v1.1) — structural step timeline for one
+    // observed session, powering the read-only stream tab. Same tier gate
+    // as activity (no activity ⇒ empty) and a TIGHTER privacy contract:
+    // parseSessionSteps emits file basenames / Bash argv[0] only.
+    if (req.method === "GET" && url.startsWith("/api/agents/steps")) {
+      const q = new URL(url, "http://localhost").searchParams;
+      const agent = q.get("agent") ?? "";
+      const id = q.get("id") ?? "";
+      const session = hub
+        .list()
+        .find((s) => s.agent === agent && s.sessionId === id);
+      if (!session) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "unknown_session" }));
+        return;
+      }
+      let steps: unknown[] = [];
+      if (session.activity && session.jsonlPath) {
+        const { parseSessionSteps } = await import(
+          "../integrations/claude-code/parser.js"
+        );
+        steps = await parseSessionSteps(session.jsonlPath);
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ steps }));
+      return;
+    }
+
     // L6 — cross-agent "while you were away" recap, synthesized from the
     // journal. ?sinceMinutes=N (default 120) bounds the window.
     if (req.method === "GET" && url.startsWith("/api/agents/recap")) {


### PR DESCRIPTION
v1.1 F1（base = p4）。mockup pane B 的正式落地。

- **parser**：`parseSessionSteps` 保序解析 64KB tail——user turn / assistant 文本标记 / tool 步骤；隐私比 activity 更紧：target 只有文件 **basename** / Bash **argv[0]**；tool_result 信封只做结构识别（error 归因），永不读内容。新增 secret 种植测试
- **管道**：`AgentSession.jsonlPath`（服务端内部字段，补上 sessionId→文件的缺失一环）；`agentSessionsResponse` 出线前剥离；新端点 `GET /api/agents/steps` 与 activity 同档门禁
- **前端**：agent 会话可开成 tab（tab 模型向后兼容旧 string[]）；tab 激活时 #viewChat 换成过程流面——头卡 + 待批准横幅（approve/deny）+ turn 分隔步骤行 + 控制底条；4s 可见性门控轮询 + SSE 触发；pty 会话直接渲染既有 SSE 终端 tail

实测：对本 worktree 的真实 Claude Code 会话开流，实时看到它自己的 Edit/Bash/浏览器工具步骤。

🤖 Generated with [Claude Code](https://claude.com/claude-code)