### PR TITLE
Session shell v1.1 F5: island 深链到主窗树节点

### DIFF
--- a/src/web/island.ts
+++ b/src/web/island.ts
@@ -1006,6 +1006,28 @@ ${MD_RENDER_CSS}
     const cwd = s.cwd || '';
     const hasCwd = cwd.startsWith('/');
 
+    // F5 deep link — select this session in the main shell's tree/inspector.
+    // The SSE focus_session frame reaches any open shell; the bridge message
+    // additionally raises the main window (existing open_full_gui path).
+    const focusBtn = document.createElement('button');
+    focusBtn.type = 'button';
+    focusBtn.textContent = '⇱ Open in Lisa';
+    focusBtn.title = 'Select this session in the main window';
+    focusBtn.addEventListener('click', (e) => {
+      e.stopPropagation();
+      fetch('/api/island/focus-session', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agent: s.agent || 'claude-code', sessionId: s.sessionId }),
+      }).catch(() => {});
+      if (window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.island) {
+        window.webkit.messageHandlers.island.postMessage({ type: 'open_full_gui', prefill: '' });
+      } else {
+        window.open('/#agent=' + encodeURIComponent(s.agent || 'claude-code') + '/' + encodeURIComponent(s.sessionId), '_blank');
+      }
+    });
+    container.appendChild(focusBtn);
+
     const openBtn = document.createElement('button');
     openBtn.type = 'button';
     openBtn.textContent = '📁 Open folder';

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -512,6 +512,9 @@ function connectEvents() {
     } else if (ev.type === 'session_switched') {
       // Another window (or this one) moved the active web session — converge.
       if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(ev.session);
+    } else if (ev.type === 'focus_session') {
+      // F5 island deep link — select an agent session in the tree/inspector.
+      if (typeof window.lisaFocusAgent === 'function') window.lisaFocusAgent(ev.agent, ev.session);
     } else if (ev.type === 'mail_digest_update' || ev.type === 'mail_accounts_update') {
       if (typeof window.refreshMail === 'function') window.refreshMail();
     }
@@ -1666,6 +1669,8 @@ if ('serviceWorker' in navigator) {
       if (ra !== rb) return ra - rb;
       return new Date(b.lastMtime).getTime() - new Date(a.lastMtime).getTime();
     });
+    // First roster snapshot: honor a #agent=kind/id deep link (F5).
+    if (typeof window.lisaHandleAgentHashOnce === 'function') window.lisaHandleAgentHashOnce();
     renderSessionTree();
     renderInspector();
     // Live refresh for an open stream tab (head/perm/foot reflect the
@@ -2515,6 +2520,28 @@ if ('serviceWorker' in navigator) {
     renderTabs();
   }
   window.lisaRenderSessionTree = renderSessionUI;
+
+  // ── F5: focus an agent session from outside (island SSE / #agent= hash) ──
+  window.lisaFocusAgent = function (agent, id) {
+    if (!agent || !id) return;
+    selInsp = { type: 'agent', key: agent + '/' + id };
+    if (window.lisaShowView) window.lisaShowView('chat');
+    renderInspector();
+    renderSessionUI();
+  };
+  let agentHashHandled = false;
+  function handleAgentHash() {
+    const h = (location.hash || '').replace('#', '');
+    if (h.indexOf('agent=') !== 0) return;
+    const parts = decodeURIComponent(h.slice(6)).split('/');
+    if (parts.length >= 2) window.lisaFocusAgent(parts[0], parts.slice(1).join('/'));
+  }
+  window.addEventListener('hashchange', handleAgentHash);
+  window.lisaHandleAgentHashOnce = function () {
+    if (agentHashHandled) return;
+    agentHashHandled = true;
+    handleAgentHash();
+  };
   const sbNewBtn = document.getElementById('sbNewSession');
   if (sbNewBtn) sbNewBtn.addEventListener('click', newSession);
 

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -134,10 +134,15 @@ import { MAIN_HTML } from "./lisa-html.js";
  * from the new GET /api/agents/steps (parseSessionSteps — basenames/argv[0]
  * only, tier-gated), and PTY sessions render their live terminal tail from
  * the existing /api/agents/pty/{id}/stream SSE instead.
+ * Then: v1.1 F5 — island deep link: a focus_session SSE case + a
+ * lisaFocusAgent global (selects an agent session in the tree/inspector)
+ * plus #agent=kind/id hash handling (on hashchange and once after the first
+ * roster snapshot), driven by the island's new "⇱ Open in Lisa" row action
+ * via POST /api/island/focus-session.
  */
-const EXPECTED_LENGTH = 287343;
+const EXPECTED_LENGTH = 288566;
 const EXPECTED_SHA256 =
-  "c46a802e9f05f24b31531b1651691ed86a6e6d8010d0b9342c4433b59e3a3863";
+  "9881f146e861021219af539def60a6433827acc478cb68a3875e87289cd0e1f4";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -2271,6 +2271,39 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // F5 (PLAN_UI_SESSION_SHELL_v1.1) — island deep link: ask any open main
+    // shell to select this agent session in its tree/inspector. Fire-and-
+    // forget broadcast; the island separately raises the main window via its
+    // existing open_full_gui bridge message.
+    if (req.method === "POST" && url === "/api/island/focus-session") {
+      const fBody = await readRequestText(req, res);
+      if (fBody === null) return;
+      let fPayload: { agent?: unknown; sessionId?: unknown };
+      try {
+        fPayload = JSON.parse(fBody || "{}");
+      } catch {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("bad json");
+        return;
+      }
+      if (
+        typeof fPayload.agent !== "string" ||
+        typeof fPayload.sessionId !== "string"
+      ) {
+        res.writeHead(400, { "content-type": "text/plain" });
+        res.end("agent and sessionId required");
+        return;
+      }
+      broadcast({
+        type: "focus_session",
+        agent: fPayload.agent,
+        session: fPayload.sessionId,
+      });
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ ok: true }));
+      return;
+    }
+
     // ✕ on an advisor suggestion: persist the dismissal so the category
     // down-weights over time ("learns to shut up"), and drop it from the
     // cached card so a refreshed island doesn't resurrect it.


### PR DESCRIPTION
v1.1 F5（base = p5）。

- island agent 行新增「⇱ Open in Lisa」：POST 新端点 `/api/island/focus-session` → 广播 `focus_session` SSE 帧，任何开着的主 shell 选中该会话（树 + Inspector）；bridge 场景经既有 `open_full_gui` 消息拉起主窗，无 bridge 时回退 `window.open('/#agent=<kind>/<id>')`
- 主 shell 支持 `#agent=kind/id` hash 深链（加载后首个 roster 快照时 + hashchange），unknown id 回落自动选择

实测：hash 直达选中目标会话；POST 广播帧实时改选。

🤖 Generated with [Claude Code](https://claude.com/claude-code)