### PR TITLE
Session shell v1.1 F7: iOS Calm 主题 + 树形 roster

### DIFF
--- a/docs/PLAN_UI_SESSION_SHELL_v1.1.md
+++ b/docs/PLAN_UI_SESSION_SHELL_v1.1.md
@@ -2,7 +2,7 @@
 
 > **定位**：承接 [PLAN_UI_SESSION_SHELL_v1.0](PLAN_UI_SESSION_SHELL_v1.0.md)（三栏 shell + 双主题 + session 树 + Inspector，PR #343–#345）落地时登记的全部后续项：agent 只读过程流、会话自动命名、树按项目视图、右栏手动折叠、island 深链、iOS 双主题与树形 roster、以及 v1.0 辩论 D3 悬置的 **Lisa 本体真并发**。
 > **关联源码**：[src/integrations/claude-code/](../src/integrations/claude-code/) · [src/web/server.ts](../src/web/server.ts) · [src/web/lisa-client.ts](../src/web/lisa-client.ts) · [src/web/island.ts](../src/web/island.ts) · [src/sessions/list.ts](../src/sessions/list.ts) · [packaging/ios-companion/](../packaging/ios-companion/)
-> **编写日期**：2026-08-08 · **✅ 实现状态**：F1–F7 分 stacked PR 落地中（基于 #345 的分支续排）
+> **编写日期**：2026-08-08 · **✅ 实现状态**：F1–F7 已实现并通过 e2e（stacked PR [#346](https://github.com/oratis/LISA/pull/346) F2-F4 → [#347](https://github.com/oratis/LISA/pull/347) F1 → [#348](https://github.com/oratis/LISA/pull/348) F5 → [#349](https://github.com/oratis/LISA/pull/349) F6 → [#350](https://github.com/oratis/LISA/pull/350) F7，接在 v1.0 的 #343→#344→#345 之后依序合并）
 
 ---
 

--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -30,7 +30,12 @@ struct RootView: View {
                 .tabItem { Label("Settings", systemImage: "gearshape") }.tag(3)
         }
         .tint(Theme.accent)                                  // cyan active tab + links + controls
-        .preferredColorScheme(.dark)                         // force the console dark look
+        // Appearance follows the Settings picker: Nebula (dark, default) ·
+        // Calm (light) · Auto (system). Theme.* colors are trait-aware.
+        .preferredColorScheme(
+            app.appearance == "calm" ? .light
+            : app.appearance == "auto" ? nil
+            : .dark)
         .toolbarBackground(Theme.panel, for: .tabBar)
         .toolbarBackground(.visible, for: .tabBar)
         .onOpenURL { app.handleDeepLink($0) }

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -38,6 +38,9 @@ final class AppState: ObservableObject {
     /// Optional Face ID / passcode gate over the app (token grants full control).
     @Published var biometricLockEnabled: Bool
     @Published var locked: Bool
+    /// Appearance: "nebula" (dark, default) · "calm" (light) · "auto" (system).
+    /// Mirrors the web shell's theme pair (PLAN_UI_SESSION_SHELL_v1.1 F7).
+    @Published var appearance: String
     /// Last APNs registration outcome, shown in Settings.
     @Published var pushStatus = ""
     /// Drives the first-run onboarding cover (docs/PLAN_IOS_ONBOARDING_v1.0.md).
@@ -84,6 +87,7 @@ final class AppState: ObservableObject {
         self.config = cfg
         self.client = LisaClient(config: cfg)
         self.connectionMode = ConnectionMode(rawValue: d.string(forKey: "lisa.mode") ?? "") ?? .mac
+        self.appearance = d.string(forKey: "lisa.appearance") ?? "nebula"
         let lockOn = d.bool(forKey: "lisa.biometricLock")
         self.biometricLockEnabled = lockOn
         self.locked = lockOn && cfg.token != nil  // require unlock at launch when armed
@@ -152,6 +156,12 @@ final class AppState: ObservableObject {
     /// unreachable; surface the R3 banner.
     var lanUnreachableOnCellular: Bool {
         config.isConfigured && config.isPrivateLAN && onCellular
+    }
+
+    /// Persist the appearance choice ("nebula" | "calm" | "auto").
+    func setAppearance(_ value: String) {
+        appearance = value
+        UserDefaults.standard.set(value, forKey: "lisa.appearance")
     }
 
     func update(host: String, port: Int, token: String?, scheme: String = "http") {

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -197,13 +197,15 @@ struct RosterView: View {
         app.pendingSession = nil
     }
 
-    /// Needs-you-first sections (redesign): blocked/errored/waiting agents float to
-    /// the top as action cards (inline approve/deny), running ones are a compact
-    /// list, and idle/done collapse behind a disclosure.
+    /// Tree-shaped roster (PLAN_UI_SESSION_SHELL_v1.1 F7) mirroring the Mac
+    /// shell's session tree: needs-you action cards stay on top, then one
+    /// section per agent kind (Claude Code / Codex / …) with that kind's
+    /// sessions grouped by project (mini project headers when a kind spans
+    /// more than one project). Row order inside a project keeps the model's
+    /// problem-first sort.
     private var agentSections: some View {
         let needs = model.sessions.filter(needsYou)
-        let running = model.sessions.filter { $0.state == "working" && !needsYou($0) }
-        let resting = model.sessions.filter { !needsYou($0) && $0.state != "working" }
+        let kinds = groupByKindAndProject(model.sessions.filter { !needsYou($0) })
         return List {
             if !needs.isEmpty {
                 Section {
@@ -213,20 +215,21 @@ struct RosterView: View {
                     }
                 } header: { Text("Needs you · \(needs.count)").foregroundStyle(Theme.waiting) }
             }
-            if !running.isEmpty {
-                Section("Running · \(running.count)") {
-                    ForEach(running) { s in
-                        NavigationLink(value: s) { RosterRow(session: s) }.listRowBackground(Theme.card)
-                    }
-                }
-            }
-            if !resting.isEmpty {
+            ForEach(kinds, id: \.kind) { group in
                 Section {
-                    DisclosureGroup("Idle & done · \(resting.count)") {
-                        ForEach(resting) { s in
+                    ForEach(group.projects, id: \.name) { proj in
+                        if kinds.count > 1 || group.projects.count > 1 {
+                            Text(proj.name.uppercased())
+                                .font(.caption2.weight(.semibold))
+                                .foregroundStyle(Theme.tertiary)
+                                .listRowBackground(Theme.panel)
+                        }
+                        ForEach(proj.rows) { s in
                             NavigationLink(value: s) { RosterRow(session: s) }.listRowBackground(Theme.card)
                         }
                     }
+                } header: {
+                    Text("\(agentDisplayName(group.kind)) · \(group.count)")
                 }
             }
         }
@@ -235,6 +238,55 @@ struct RosterView: View {
 
     private func needsYou(_ s: AgentSession) -> Bool {
         s.activity?.pendingPermission != nil || s.state == "waiting" || s.state == "error"
+    }
+}
+
+// ── Tree grouping (v1.1 F7) — pure, unit-testable ────────────────────
+
+struct ProjectGroup: Equatable {
+    var name: String
+    var rows: [AgentSession]
+}
+
+struct KindGroup: Equatable {
+    var kind: String
+    var projects: [ProjectGroup]
+    var count: Int { projects.reduce(0) { $0 + $1.rows.count } }
+}
+
+/// Group sessions agent kind → project (both alphabetical), preserving the
+/// incoming row order (the model's problem-first sort) within a project.
+func groupByKindAndProject(_ sessions: [AgentSession]) -> [KindGroup] {
+    var kindOrder: [String] = []
+    var byKind: [String: [AgentSession]] = [:]
+    for s in sessions {
+        if byKind[s.agent] == nil { kindOrder.append(s.agent) }
+        byKind[s.agent, default: []].append(s)
+    }
+    kindOrder.sort()
+    return kindOrder.map { kind in
+        var projOrder: [String] = []
+        var byProj: [String: [AgentSession]] = [:]
+        for s in byKind[kind] ?? [] {
+            let p = s.project.isEmpty ? "?" : s.project
+            if byProj[p] == nil { projOrder.append(p) }
+            byProj[p, default: []].append(s)
+        }
+        projOrder.sort()
+        return KindGroup(kind: kind, projects: projOrder.map { ProjectGroup(name: $0, rows: byProj[$0] ?? []) })
+    }
+}
+
+func agentDisplayName(_ kind: String) -> String {
+    switch kind {
+    case "claude-code": return "Claude Code"
+    case "codex": return "Codex"
+    case "opencode": return "OpenCode"
+    case "aider": return "Aider"
+    case "github-pr": return "GitHub PR"
+    case "cursor": return "Cursor"
+    case "gemini": return "Gemini"
+    default: return kind
     }
 }
 

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -139,6 +139,18 @@ struct SettingsView: View {
                     Text("Change these on the Mac (localhost only).").font(.caption).foregroundStyle(.secondary)
                 }
 
+                Section("Appearance") {
+                    Picker("Theme", selection: Binding(
+                        get: { app.appearance },
+                        set: { app.setAppearance($0) })) {
+                        Text("Nebula (dark)").tag("nebula")
+                        Text("Calm (light)").tag("calm")
+                        Text("Auto (system)").tag("auto")
+                    }
+                    Text("Mirrors the Mac shell's Nebula / Calm theme pair.")
+                        .font(.caption).foregroundStyle(.secondary)
+                }
+
                 Section("Autonomy") {
                     Toggle("Proactive mode", isOn: Binding(
                         get: { app.proactiveEnabled },

--- a/packaging/ios-companion/Sources/Theme.swift
+++ b/packaging/ios-companion/Sources/Theme.swift
@@ -1,24 +1,32 @@
 import SwiftUI
 
-/// Agent-console palette — mirrors the web shell tokens (src/web/lisa-css.ts):
-/// cyan accent, gold Lisa identity, green "proactive / live", dark card UI.
-/// Defined once so views reference `Theme.*` instead of ad-hoc semantic colors.
+/// Agent-console palette — mirrors the web shell tokens (src/web/lisa-css.ts,
+/// token table: docs/PLAN_UI_SESSION_SHELL_v1.0.md §2): each color carries a
+/// dark ("Nebula") and light ("Calm") variant, resolved by the trait
+/// environment — the appearance picker in Settings drives
+/// `.preferredColorScheme` at the root, and every `Theme.*` follows.
 enum Theme {
     // Surfaces
-    static let bgDeep = Color(hex: 0x0A0E22)   // app background
-    static let panel  = Color(hex: 0x0F1430)   // tab/nav bars, grouped lists
-    static let card   = Color(hex: 0x161C3C)   // rows, cards, banners
-    static let border = Color.white.opacity(0.08)
+    static let bgDeep = Color(dark: 0x0A0E22, light: 0xF6F7F9)   // app background
+    static let panel  = Color(dark: 0x0F1430, light: 0xFFFFFF)   // tab/nav bars, grouped lists
+    static let card   = Color(dark: 0x161C3C, light: 0xFFFFFF)   // rows, cards, banners
+    static let border = Color.primary.opacity(0.08)              // hairline (trait-aware)
+    /// Sunken code/log wells (CodeBlock) — deep in Nebula, faint in Calm.
+    static let sunken = Color(UIColor { t in
+        t.userInterfaceStyle == .light
+            ? UIColor.black.withAlphaComponent(0.05)
+            : UIColor.black.withAlphaComponent(0.25)
+    })
 
     // Text
-    static let text      = Color(hex: 0xE8EAFF)
-    static let secondary = Color(hex: 0x9AA3C8)
-    static let tertiary  = Color(hex: 0x6B7299)
+    static let text      = Color(dark: 0xE8EAFF, light: 0x1B2430)
+    static let secondary = Color(dark: 0x9AA3C8, light: 0x4D5666)
+    static let tertiary  = Color(dark: 0x6B7299, light: 0x8A919F)
 
     // Identity / accents
-    static let accent = Color(hex: 0x6AD4FF)   // cyan — nav / active / links
-    static let gold   = Color(hex: 0xFFD066)   // Lisa identity
-    static let green  = Color(hex: 0x3DDC97)   // proactive / live / done
+    static let accent = Color(dark: 0x6AD4FF, light: 0x4F5BD5)   // cyan / calm indigo
+    static let gold   = Color(dark: 0xFFD066, light: 0xD97706)   // Lisa identity
+    static let green  = Color(dark: 0x3DDC97, light: 0x1F9D6B)   // proactive / live / done
 
     // Status pips — defined in Shared/GlanceColors so the widget extension (which
     // can't see Theme) renders identical status colors (review I1/B23).
@@ -58,7 +66,7 @@ struct CodeBlock: View {
                 .padding(10)
         }
         .frame(maxHeight: maxHeight)
-        .background(Color.black.opacity(0.25), in: RoundedRectangle(cornerRadius: 8))
+        .background(Theme.sunken, in: RoundedRectangle(cornerRadius: 8))
         .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Theme.border, lineWidth: Theme.hairline))
     }
 }
@@ -71,6 +79,19 @@ extension Color {
                   green: Double((hex >> 8) & 0xFF) / 255,
                   blue:  Double(hex & 0xFF) / 255,
                   opacity: 1)
+    }
+
+    /// Trait-aware token: one hex per appearance (Nebula dark / Calm light),
+    /// resolved live by UIKit's trait environment.
+    init(dark: UInt32, light: UInt32) {
+        self.init(UIColor { traits in
+            let hex = traits.userInterfaceStyle == .light ? light : dark
+            return UIColor(
+                red:   CGFloat((hex >> 16) & 0xFF) / 255,
+                green: CGFloat((hex >> 8) & 0xFF) / 255,
+                blue:  CGFloat(hex & 0xFF) / 255,
+                alpha: 1)
+        })
     }
 }
 


### PR DESCRIPTION
v1.1 F7（base = p7，本波次最后一个）。

- **Calm 主题**：Theme.swift 全 token 变 trait-aware 双值（Nebula 深 / Calm 浅，来源 v1.0 §2 token 表，新 `Color(dark:light:)`）；Settings › Appearance 三选（Nebula / Calm / Auto，`lisa.appearance` 持久化）驱动根部 `preferredColorScheme`；Store/Onboarding 维持品牌深色
- **树形 roster**：镜像 Mac shell 的会话树 —— needs-you 卡置顶，之后每个 agent 种类一个 Section、内部按项目分组（跨多项目时插 mini 项目标头）；纯函数 `groupByKindAndProject` 可测

模拟器构建绿（./build.sh）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)