### PR TITLE
Session shell v1.1 收尾: codex/aider 过程流 + 合约收编 + iOS 补全

### DIFF
--- a/contracts/lisa-api-v1.openapi.json
+++ b/contracts/lisa-api-v1.openapi.json
@@ -201,6 +201,80 @@
           }
         }
       }
+    },
+    "/api/sessions": {
+      "get": {
+        "operationId": "listLisaSessions",
+        "responses": {
+          "200": {
+            "description": "Lisa's own chat sessions on disk, newest first (PLAN_UI_SESSION_SHELL_v1.1). The on-disk file path is server-internal and never serialized.",
+            "headers": {
+              "X-Lisa-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LisaSessionsResponse"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "operationId": "createLisaSession",
+        "responses": {
+          "200": {
+            "description": "Creates a fresh Lisa session and makes it the active web session.",
+            "headers": {
+              "X-Lisa-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LisaSessionMutation"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/sessions/{id}/activate": {
+      "post": {
+        "operationId": "activateLisaSession",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Switches the active web session to an existing one.",
+            "headers": {
+              "X-Lisa-API-Version": {
+                "$ref": "#/components/headers/ApiVersion"
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LisaSessionMutation"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -545,6 +619,73 @@
         },
         "additionalProperties": true,
         "description": "Open event envelope. Clients must ignore unknown types and additive fields; known v1 types include agent_session_update, claude_session_update, mood, chat_start, chat_delta, chat_end, idle_message, advisor_suggestions, screen_suggestion, sense_event, reflect_done and error."
+      },
+      "LisaSession": {
+        "type": "object",
+        "required": [
+          "id",
+          "startedAt",
+          "cwd",
+          "model",
+          "messageCount"
+        ],
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "model": {
+            "type": "string"
+          },
+          "messageCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "lastUserMessage": {
+            "type": "string"
+          },
+          "firstUserMessage": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
+      },
+      "LisaSessionsResponse": {
+        "type": "object",
+        "required": [
+          "sessions"
+        ],
+        "properties": {
+          "sessions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/LisaSession"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "LisaSessionMutation": {
+        "type": "object",
+        "required": [
+          "ok",
+          "id"
+        ],
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          },
+          "id": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": true
       }
     }
   }

--- a/packaging/ios-companion/Sources/App.swift
+++ b/packaging/ios-companion/Sources/App.swift
@@ -32,10 +32,7 @@ struct RootView: View {
         .tint(Theme.accent)                                  // cyan active tab + links + controls
         // Appearance follows the Settings picker: Nebula (dark, default) ·
         // Calm (light) · Auto (system). Theme.* colors are trait-aware.
-        .preferredColorScheme(
-            app.appearance == "calm" ? .light
-            : app.appearance == "auto" ? nil
-            : .dark)
+        .preferredColorScheme(app.preferredScheme)
         .toolbarBackground(Theme.panel, for: .tabBar)
         .toolbarBackground(.visible, for: .tabBar)
         .onOpenURL { app.handleDeepLink($0) }

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -164,6 +164,11 @@ final class AppState: ObservableObject {
         UserDefaults.standard.set(value, forKey: "lisa.appearance")
     }
 
+    /// The SwiftUI color scheme for the chosen appearance (nil = follow system).
+    var preferredScheme: ColorScheme? {
+        appearance == "calm" ? .light : appearance == "auto" ? nil : .dark
+    }
+
     func update(host: String, port: Int, token: String?, scheme: String = "http") {
         let cfg = ServerConfig(host: host, port: port, token: token, scheme: scheme)
         config = cfg

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -363,6 +363,13 @@ final class LisaClient {
 
     // ── read ──
     func sessions() async throws -> [AgentSession] { try await decode("/api/agents/sessions", as: SessionsResponse.self).sessions }
+    /// Lisa's own chat sessions — the roster's LISA group (v1.1).
+    func lisaSessions() async throws -> [LisaSessionInfo] { try await decode("/api/sessions", as: LisaSessionsResponse.self).sessions }
+    /// Switch the Mac's active web session (the Chat tab follows it).
+    func activateSession(_ id: String) async throws -> LisaSessionMutation {
+        let enc = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        return try await decode("/api/sessions/\(enc)/activate", method: "POST", as: LisaSessionMutation.self)
+    }
     func dispatchList() async throws -> [DispatchView] { try await decode("/api/dispatch/list", as: DispatchListResponse.self).dispatches }
     func dispatchStatus(id: String) async throws -> DispatchStatus {
         let enc = id.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? id

--- a/packaging/ios-companion/Sources/Models.swift
+++ b/packaging/ios-companion/Sources/Models.swift
@@ -273,3 +273,20 @@ struct DeviceInfo: Codable, Identifiable {
     var lastSeenAt: Double?
 }
 struct DevicesResponse: Codable { var devices: [DeviceInfo] }
+
+// ── Lisa's own chat sessions (/api/sessions — contract: LisaSessionsResponse,
+// PLAN_UI_SESSION_SHELL_v1.1). The on-disk path never reaches the wire. ──
+struct LisaSessionInfo: Codable, Identifiable, Hashable {
+    var id: String
+    var startedAt: String
+    var cwd: String
+    var model: String
+    var messageCount: Int
+    var lastUserMessage: String?
+    var firstUserMessage: String?
+    /// Display name mirrors the web tree: the opening request, else the
+    /// latest one, else the raw id (F2 auto-naming).
+    var displayName: String { firstUserMessage ?? lastUserMessage ?? id }
+}
+struct LisaSessionsResponse: Codable { var sessions: [LisaSessionInfo] }
+struct LisaSessionMutation: Codable { var ok: Bool; var id: String }

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -24,7 +24,7 @@ struct OnboardingFlow: View {
             Theme.bgDeep.ignoresSafeArea()
             content
         }
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(app.preferredScheme)
         .tint(Theme.accent)
         .sheet(isPresented: $showManual) {
             OnboardingManualEntry(mode: manualMode) {
@@ -378,7 +378,7 @@ struct OnboardingManualEntry: View {
                 ToolbarItem(placement: .cancellationAction) { Button("Cancel") { dismiss() } }
             }
         }
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(app.preferredScheme)
     }
 
     // ── Cloud: the shared account sign-in form (SIWA / email / advanced token

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -119,6 +119,8 @@ struct RosterView: View {
     @State private var path: [AgentSession] = []
     @State private var showDelegate = false
     @State private var policy: ControlPolicy?
+    /// LISA root group (v1.1): Lisa's own chat sessions, tap to activate.
+    @State private var lisaSessions: [LisaSessionInfo] = []
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -165,7 +167,13 @@ struct RosterView: View {
             .sheet(isPresented: $showDelegate) {
                 DelegateSheet(client: app.client) { Task { await model.load(app.client) } }
             }
-            .refreshable { await model.load(app.client) }
+            .refreshable {
+                await model.load(app.client)
+                lisaSessions = (try? await app.client.lisaSessions()) ?? lisaSessions
+            }
+            .task(id: app.config) {
+                lisaSessions = (try? await app.client.lisaSessions()) ?? []
+            }
             .task(id: app.config) {
                 await model.load(app.client)
                 await app.loadProactive()
@@ -214,6 +222,38 @@ struct RosterView: View {
                             .listRowBackground(Theme.card)
                     }
                 } header: { Text("Needs you · \(needs.count)").foregroundStyle(Theme.waiting) }
+            }
+            // LISA root group (v1.1) — same-level sibling of the agent kinds,
+            // mirroring the web tree. Tap = make it the active web session.
+            if !lisaSessions.isEmpty {
+                Section {
+                    ForEach(lisaSessions.prefix(8)) { s in
+                        Button {
+                            Task {
+                                do {
+                                    _ = try await app.client.activateSession(s.id)
+                                    app.notify("Switched Lisa to that session")
+                                    app.selectedTab = 1
+                                } catch {
+                                    app.notify("Couldn't switch session", ok: false)
+                                }
+                            }
+                        } label: {
+                            HStack(spacing: 10) {
+                                StatusDot(color: Theme.accent, size: 8)
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(s.displayName)
+                                        .font(.subheadline).foregroundStyle(Theme.text).lineLimit(1)
+                                    Text("\(s.messageCount) msgs")
+                                        .font(.caption2).foregroundStyle(Theme.tertiary)
+                                }
+                                Spacer()
+                                Image(systemName: "arrow.right.circle").foregroundStyle(Theme.tertiary)
+                            }
+                        }
+                        .listRowBackground(Theme.card)
+                    }
+                } header: { Text("LISA · \(lisaSessions.count)") }
             }
             ForEach(kinds, id: \.kind) { group in
                 Section {

--- a/packaging/ios-companion/Sources/StoreView.swift
+++ b/packaging/ios-companion/Sources/StoreView.swift
@@ -135,7 +135,7 @@ struct PaywallSheet: View {
             }
             .task { await store.loadProducts() }
         }
-        .preferredColorScheme(.dark)
+        .preferredColorScheme(app.preferredScheme)
     }
 
     private func bonusLabel(_ id: String) -> String {

--- a/src/integrations/aider/observer.ts
+++ b/src/integrations/aider/observer.ts
@@ -34,6 +34,7 @@ import type {
   AgentObserver,
   AgentSession,
   AgentSessionState,
+  AgentStep,
   SessionActivity,
 } from "../types.js";
 
@@ -227,6 +228,8 @@ interface AiderSessionInfo {
   state: AgentSessionState;
   stateReason: string;
   activity?: SessionActivity;
+  /** History-file path — server-internal (step timeline); stripped from the wire. */
+  jsonlPath?: string;
 }
 
 export class AiderObserver extends EventEmitter implements AgentObserver {
@@ -316,6 +319,7 @@ export class AiderObserver extends EventEmitter implements AgentObserver {
         state,
         stateReason: reason,
         activity: this.computeActivity ? parseAiderActivity(tail) : undefined,
+        jsonlPath: full,
       });
     } catch {
       this.sessions.delete(full);
@@ -333,7 +337,69 @@ function toAgentSession(i: AiderSessionInfo): AgentSession {
     stateReason: i.stateReason,
     lastMtime: i.lastMtime,
     activity: i.activity,
+    jsonlPath: i.jsonlPath,
   };
+}
+
+// ── F1 follow-up (PLAN_UI_SESSION_SHELL_v1.1): turn-boundary steps ──────────
+//
+// Aider's history is a Markdown TRANSCRIPT — its "> " tool lines are prose
+// (e.g. "> Applied edit to …") and extracting names from them would mean
+// reading transcript text, which this adapter's privacy contract forbids.
+// So the step timeline is STRUCTURAL MARKERS ONLY: user turns ("#### "),
+// collapsed aider-tool runs ("> " blocks), and assistant prose blocks.
+
+const STEPS_TAIL_BYTES = 64 * 1024;
+const MAX_STEPS = 200;
+
+export async function parseAiderSteps(filePath: string): Promise<AgentStep[]> {
+  let size: number;
+  try {
+    const st = await fsp.stat(filePath);
+    if (!st.isFile() || st.size === 0) return [];
+    size = st.size;
+  } catch {
+    return [];
+  }
+
+  let tail: string;
+  try {
+    const fd = await fsp.open(filePath, "r");
+    try {
+      const length = Math.min(STEPS_TAIL_BYTES, size);
+      const buf = Buffer.alloc(length);
+      await fd.read(buf, 0, length, size - length);
+      tail = buf.toString("utf8");
+    } finally {
+      await fd.close();
+    }
+  } catch {
+    return [];
+  }
+
+  const steps: AgentStep[] = [];
+  let turn = 0;
+  // Collapse runs: many consecutive "> " lines are one tool phase; many
+  // consecutive prose lines are one assistant block.
+  let last: "user" | "assistant" | "tool" | null = null;
+  for (const rawLine of tail.split("\n")) {
+    const line = rawLine.trimEnd();
+    if (!line) continue;
+    if (line.startsWith("#### ")) {
+      turn++;
+      steps.push({ kind: "user", turn });
+      last = "user";
+    } else if (line.startsWith("# aider chat started")) {
+      last = null;
+    } else if (line.startsWith("> ")) {
+      if (last !== "tool") steps.push({ kind: "tool", turn, tool: "aider" });
+      last = "tool";
+    } else {
+      if (last !== "assistant") steps.push({ kind: "assistant", turn });
+      last = "assistant";
+    }
+  }
+  return steps.slice(-MAX_STEPS);
 }
 
 registerIntegration("aider", (cfg) => new AiderObserver(cfg));

--- a/src/integrations/aider/steps.test.ts
+++ b/src/integrations/aider/steps.test.ts
@@ -1,0 +1,43 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { parseAiderSteps } from "./observer.js";
+
+/**
+ * Aider step-timeline: STRUCTURAL MARKERS ONLY — user turns, collapsed tool
+ * runs, assistant blocks. No transcript text may reach the output.
+ */
+
+const SECRET = "A1DER-S3CR3T-42kq";
+
+test("parseAiderSteps: turn boundaries only, no transcript leakage", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-aider-steps-"));
+  const file = path.join(dir, ".aider.chat.history.md");
+  const md = [
+    "# aider chat started at 2026-08-08 03:00:00",
+    "> Aider v0.86 " + SECRET,
+    "> Added foo.py to the chat.",
+    "#### fix the bug in " + SECRET + ".py",
+    "Looking at the file, the bug is " + SECRET,
+    "more prose",
+    "> Applied edit to " + SECRET + ".py",
+    "#### thanks, now add tests",
+    "Sure — adding tests. " + SECRET,
+  ].join("\n");
+  await fs.writeFile(file, md);
+
+  const steps = await parseAiderSteps(file);
+  // tool(收尾 header block) → user(1) → assistant → tool → user(2) → assistant
+  const kinds = steps.map((s) => s.kind);
+  assert.deepEqual(kinds, ["tool", "user", "assistant", "tool", "user", "assistant"]);
+  assert.equal(steps[1]!.turn, 1);
+  assert.equal(steps[4]!.turn, 2);
+  for (const s of steps) {
+    if (s.kind === "tool") assert.equal(s.tool, "aider");
+    assert.equal(s.target, undefined); // never a name/path from prose
+  }
+  assert.ok(!JSON.stringify(steps).includes(SECRET), "transcript text leaked");
+  await fs.rm(dir, { recursive: true, force: true });
+});

--- a/src/integrations/claude-code/parser-transcript.test.ts
+++ b/src/integrations/claude-code/parser-transcript.test.ts
@@ -1,0 +1,96 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { parseSessionTranscript } from "./parser.js";
+import { parseCodexTranscript } from "../codex/observer.js";
+
+/**
+ * Transcript privacy tests (确认轮三). The transcript IS allowed to carry
+ * user/assistant message text — that is its purpose (owner's local view,
+ * loopback-only endpoint). What must STILL never leak: tool inputs (full
+ * commands, edit payloads), tool_result contents, and full paths. A tool
+ * secret is planted in all of those; a message marker must come through.
+ */
+
+const TOOL_SECRET = "T00L-S3CR3T-91fe";
+const USER_TEXT = "please fix the login bug";
+const AGENT_TEXT = "Done — the fix is in `auth.ts`.";
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj) + "\n";
+}
+
+async function withFile(name: string, data: string, fn: (file: string) => Promise<void>) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-transcript-"));
+  const file = path.join(dir, name);
+  await fs.writeFile(file, data);
+  try {
+    await fn(file);
+  } finally {
+    await fs.rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("claude-code transcript: message text present, tool payloads absent", async () => {
+  const jsonl =
+    line({
+      type: "user",
+      timestamp: "2026-08-08T01:00:00Z",
+      message: { role: "user", content: [{ type: "text", text: USER_TEXT }] },
+    }) +
+    line({
+      type: "assistant",
+      message: {
+        role: "assistant",
+        content: [
+          { type: "tool_use", name: "Edit", input: { file_path: "/Users/x/" + TOOL_SECRET + "-dir/auth.ts", old_string: TOOL_SECRET, new_string: TOOL_SECRET } },
+          { type: "tool_use", name: "Bash", input: { command: "git commit -m " + TOOL_SECRET } },
+        ],
+      },
+    }) +
+    line({
+      type: "user",
+      is_error: true,
+      message: { role: "user", content: [{ type: "tool_result", content: TOOL_SECRET }] },
+    }) +
+    line({
+      type: "assistant",
+      message: { role: "assistant", content: [{ type: "text", text: AGENT_TEXT }] },
+    });
+
+  await withFile("abc.jsonl", jsonl, async (file) => {
+    const entries = await parseSessionTranscript(file);
+    const kinds = entries.map((e) => e.kind);
+    assert.deepEqual(kinds, ["user", "tool", "tool", "assistant"]);
+    assert.equal(entries[0]!.text, USER_TEXT);
+    assert.equal(entries[0]!.turn, 1);
+    assert.equal(entries[1]!.tool, "Edit");
+    assert.equal(entries[1]!.target, "auth.ts"); // basename only
+    assert.equal(entries[2]!.target, "$ git"); // argv[0] only
+    assert.equal(entries[2]!.isError, true); // error attributed to the LATEST tool
+    assert.equal(entries[3]!.text, AGENT_TEXT);
+    assert.ok(!JSON.stringify(entries).includes(TOOL_SECRET), "tool payload leaked");
+  });
+});
+
+test("codex transcript: message text present, arguments/output absent", async () => {
+  const jsonl =
+    line({ type: "user", timestamp: "2026-08-08T02:00:00Z", message: { role: "user", content: USER_TEXT } }) +
+    line({ type: "function_call", name: "shell", arguments: JSON.stringify({ command: "echo " + TOOL_SECRET }) }) +
+    line({ type: "function_call_output", is_error: true, output: TOOL_SECRET }) +
+    line({ type: "response", message: { role: "assistant", content: [{ type: "output_text", text: AGENT_TEXT }] } });
+
+  await withFile("rollout-x.jsonl", jsonl, async (file) => {
+    const entries = await parseCodexTranscript(file);
+    const kinds = entries.map((e) => e.kind);
+    assert.deepEqual(kinds, ["user", "tool", "assistant"]);
+    assert.equal(entries[0]!.text, USER_TEXT);
+    assert.equal(entries[1]!.tool, "shell");
+    assert.equal(entries[1]!.target, "$ echo");
+    assert.equal(entries[1]!.isError, true);
+    assert.equal(entries[2]!.text, AGENT_TEXT);
+    assert.ok(!JSON.stringify(entries).includes(TOOL_SECRET), "tool payload leaked");
+  });
+});

--- a/src/integrations/claude-code/parser.ts
+++ b/src/integrations/claude-code/parser.ts
@@ -41,7 +41,9 @@
  */
 
 import fsp from "node:fs/promises";
-import type { SessionActivity } from "../types.js";
+import type { AgentStep, SessionActivity } from "../types.js";
+
+export type { AgentStep } from "../types.js";
 
 export type ClaudeSessionState = "working" | "waiting" | "error" | "unknown";
 
@@ -399,21 +401,7 @@ function dedupeKeepRecent(items: string[], max: number): string[] {
 // notch tighter: step targets are file BASENAMES / Bash argv[0] only — never
 // full paths, text blocks, full commands, or edit payloads. Tested in
 // parser-steps.test.ts with the same secret-planting technique.
-
-/** One structural step in a session's tail — powers the read-only stream tab. */
-export interface AgentStep {
-  /** ISO timestamp when the jsonl line carried one. */
-  ts?: string;
-  kind: "user" | "assistant" | "tool";
-  /** tool_use name (kind === "tool" only). */
-  tool?: string;
-  /** File basename or Bash argv[0] (kind === "tool" only). */
-  target?: string;
-  /** Turn ordinal within the parsed tail — increments on each real user turn. */
-  turn: number;
-  /** A tool error observed at (or right after) this step. */
-  isError?: boolean;
-}
+// (AgentStep lives in ../types.ts so the codex/aider adapters share it.)
 
 const MAX_STEPS = 200;
 

--- a/src/integrations/claude-code/parser.ts
+++ b/src/integrations/claude-code/parser.ts
@@ -41,9 +41,9 @@
  */
 
 import fsp from "node:fs/promises";
-import type { AgentStep, SessionActivity } from "../types.js";
+import type { AgentStep, AgentTranscriptEntry, SessionActivity } from "../types.js";
 
-export type { AgentStep } from "../types.js";
+export type { AgentStep, AgentTranscriptEntry } from "../types.js";
 
 export type ClaudeSessionState = "working" | "waiting" | "error" | "unknown";
 
@@ -526,4 +526,149 @@ export async function parseSessionSteps(filePath: string): Promise<AgentStep[]> 
   }
 
   return steps.slice(-MAX_STEPS);
+}
+
+// ── Transcript (确认轮三): the OWNER's local conversation view ──────────────
+//
+// Unlike steps, entries may carry MESSAGE TEXT — but ONLY from user /
+// assistant `text` content blocks. Tool inputs stay structural (basename /
+// argv[0], same extraction as steps) and tool_result payloads are never
+// read. The serving endpoint is LOOPBACK-ONLY; this shape must not cross a
+// remote surface. Privacy test: parser-transcript.test.ts.
+
+const TRANSCRIPT_TAIL_BYTES = 256 * 1024;
+const MAX_TRANSCRIPT_ENTRIES = 160;
+const MAX_TEXT_CHARS = 4000;
+
+export async function parseSessionTranscript(
+  filePath: string,
+): Promise<AgentTranscriptEntry[]> {
+  let size: number;
+  try {
+    const st = await fsp.stat(filePath);
+    if (!st.isFile() || st.size === 0) return [];
+    size = st.size;
+  } catch {
+    return [];
+  }
+
+  let tail: string;
+  try {
+    const fd = await fsp.open(filePath, "r");
+    try {
+      const length = Math.min(TRANSCRIPT_TAIL_BYTES, size);
+      const buf = Buffer.alloc(length);
+      await fd.read(buf, 0, length, size - length);
+      tail = buf.toString("utf8");
+    } finally {
+      await fd.close();
+    }
+  } catch {
+    return [];
+  }
+
+  const lines = tail.split("\n").filter(Boolean);
+  if (size > TRANSCRIPT_TAIL_BYTES && lines.length > 0) lines.shift();
+
+  const entries: AgentTranscriptEntry[] = [];
+  let turn = 0;
+
+  const basenameOf = (p: string): string => {
+    const parts = p.split("/").filter(Boolean);
+    return parts.length ? parts[parts.length - 1]! : p;
+  };
+  const textOfBlocks = (content: unknown): string => {
+    if (typeof content === "string") return content;
+    if (!Array.isArray(content)) return "";
+    const parts: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+      // ONLY text blocks — never tool_use input or tool_result payloads.
+      if (b.type === "text" && typeof b.text === "string") parts.push(b.text);
+    }
+    return parts.join("\n");
+  };
+
+  for (const line of lines) {
+    let e: unknown;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!e || typeof e !== "object") continue;
+    const obj = e as Record<string, unknown>;
+
+    const type = readString(obj.type);
+    if (type && META_TYPES.has(type)) continue;
+    const ts = readString(obj.timestamp);
+
+    const msg = obj.message;
+    const m = msg && typeof msg === "object" ? (msg as Record<string, unknown>) : null;
+    const content = m ? m.content : null;
+
+    let hasToolResult = false;
+    const toolBlocks: Array<Record<string, unknown>> = [];
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (!block || typeof block !== "object") continue;
+        const b = block as Record<string, unknown>;
+        if (b.type === "tool_result") hasToolResult = true;
+        else if (b.type === "tool_use") toolBlocks.push(b);
+      }
+    }
+
+    if (type === "user") {
+      if (hasToolResult) {
+        if (obj.is_error === true || obj.error === true) {
+          for (let i = entries.length - 1; i >= 0; i--) {
+            if (entries[i]!.kind === "tool") {
+              entries[i]!.isError = true;
+              break;
+            }
+          }
+        }
+        continue;
+      }
+      const text = textOfBlocks(content).trim();
+      if (text) {
+        turn++;
+        entries.push({ ts, kind: "user", turn, text: text.slice(0, MAX_TEXT_CHARS) });
+      }
+      continue;
+    }
+
+    if (type === "assistant") {
+      for (const b of toolBlocks) {
+        const name = readString(b.name);
+        if (!name) continue;
+        let target: string | undefined;
+        const input = b.input;
+        if (input && typeof input === "object") {
+          const inp = input as Record<string, unknown>;
+          for (const k of PATH_KEYS) {
+            const p = inp[k];
+            if (typeof p === "string" && p) {
+              target = basenameOf(p);
+              break;
+            }
+          }
+          if (!target && name.toLowerCase() === "bash") {
+            const cmd = inp.command;
+            if (typeof cmd === "string" && cmd.trim()) {
+              target = "$ " + cmd.trim().split(/\s+/)[0];
+            }
+          }
+        }
+        entries.push({ ts, kind: "tool", turn, tool: name, target });
+      }
+      const text = textOfBlocks(content).trim();
+      if (text) {
+        entries.push({ ts, kind: "assistant", turn, text: text.slice(0, MAX_TEXT_CHARS) });
+      }
+    }
+  }
+
+  return entries.slice(-MAX_TRANSCRIPT_ENTRIES);
 }

--- a/src/integrations/codex/observer.ts
+++ b/src/integrations/codex/observer.ts
@@ -33,6 +33,7 @@ import type {
   AgentObserver,
   AgentSession,
   AgentSessionState,
+  AgentStep,
   SessionActivity,
 } from "../types.js";
 
@@ -55,6 +56,8 @@ interface CodexSessionInfo {
   stateReason: string;
   /** Tier-2 structural activity; present only when visibility ≥ "activity". */
   activity?: SessionActivity;
+  /** Rollout file path — server-internal (step timeline); stripped from the wire. */
+  jsonlPath?: string;
 }
 
 export class CodexObserver extends EventEmitter implements AgentObserver {
@@ -166,6 +169,7 @@ export class CodexObserver extends EventEmitter implements AgentObserver {
         state,
         stateReason: reason,
         activity,
+        jsonlPath: full,
       });
     } catch {
       this.sessions.delete(full);
@@ -183,6 +187,7 @@ function toAgentSession(i: CodexSessionInfo): AgentSession {
     stateReason: i.stateReason,
     lastMtime: i.lastMtime,
     activity: i.activity,
+    jsonlPath: i.jsonlPath,
   };
 }
 
@@ -473,6 +478,110 @@ function dedupeKeepRecent(items: string[], max: number): string[] {
     }
   }
   return out.slice(-max);
+}
+
+// ── F1 follow-up (PLAN_UI_SESSION_SHELL_v1.1): ordered step timeline ────────
+//
+// Same privacy contract as parseCodexActivity, one notch TIGHTER: targets are
+// file BASENAMES / shell argv[0] only. `arguments` is parsed ONLY to look up
+// the known path/command keys — the raw string never leaves this function.
+
+const MAX_STEPS = 200;
+
+export async function parseCodexSteps(filePath: string): Promise<AgentStep[]> {
+  let size: number;
+  try {
+    const st = await fsp.stat(filePath);
+    if (!st.isFile() || st.size === 0) return [];
+    size = st.size;
+  } catch {
+    return [];
+  }
+
+  let tail: string;
+  try {
+    const fd = await fsp.open(filePath, "r");
+    try {
+      const length = Math.min(ACTIVITY_TAIL_BYTES, size);
+      const buf = Buffer.alloc(length);
+      await fd.read(buf, 0, length, size - length);
+      tail = buf.toString("utf8");
+    } finally {
+      await fd.close();
+    }
+  } catch {
+    return [];
+  }
+
+  const lines = tail.split("\n").filter(Boolean);
+  if (size > ACTIVITY_TAIL_BYTES && lines.length > 0) lines.shift();
+
+  const steps: AgentStep[] = [];
+  let turn = 0;
+
+  for (const line of lines) {
+    let e: unknown;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!e || typeof e !== "object") continue;
+    const obj = e as Record<string, unknown>;
+
+    const type = readString(obj.type);
+    const ts = readString(obj.timestamp);
+    const msg = obj.message;
+    const role =
+      readString(obj.role) ??
+      (msg && typeof msg === "object"
+        ? readString((msg as Record<string, unknown>).role)
+        : undefined);
+
+    if (type === "function_call") {
+      const name = readString(obj.name);
+      if (!name) continue;
+      let target: string | undefined;
+      const args = parseArguments(obj.arguments);
+      if (args) {
+        for (const k of PATH_KEYS) {
+          const p = args[k];
+          if (typeof p === "string" && p) {
+            const parts = p.split("/").filter(Boolean);
+            target = parts.length ? parts[parts.length - 1] : p;
+            break;
+          }
+        }
+        if (!target && SHELL_NAME_RE.test(name)) {
+          const argv0 = shellArgv0(args.command);
+          if (argv0) target = "$ " + argv0;
+        }
+      }
+      steps.push({ ts, kind: "tool", turn, tool: name, target });
+      continue;
+    }
+    if (type === "function_call_output") {
+      if (obj.is_error === true || obj.error === true) {
+        for (let i = steps.length - 1; i >= 0; i--) {
+          if (steps[i]!.kind === "tool") {
+            steps[i]!.isError = true;
+            break;
+          }
+        }
+      }
+      continue;
+    }
+    if (role === "user" || type === "user") {
+      turn++;
+      steps.push({ ts, kind: "user", turn });
+      continue;
+    }
+    if (role === "assistant" || type === "assistant" || type === "response") {
+      steps.push({ ts, kind: "assistant", turn });
+    }
+  }
+
+  return steps.slice(-MAX_STEPS);
 }
 
 registerIntegration("codex", (cfg) => new CodexObserver(cfg));

--- a/src/integrations/codex/observer.ts
+++ b/src/integrations/codex/observer.ts
@@ -34,6 +34,7 @@ import type {
   AgentSession,
   AgentSessionState,
   AgentStep,
+  AgentTranscriptEntry,
   SessionActivity,
 } from "../types.js";
 
@@ -582,6 +583,139 @@ export async function parseCodexSteps(filePath: string): Promise<AgentStep[]> {
   }
 
   return steps.slice(-MAX_STEPS);
+}
+
+// ── Transcript (确认轮三): the OWNER's local conversation view ──────────────
+//
+// Entries may carry MESSAGE TEXT from user/assistant message content ONLY —
+// function_call `arguments` stay structural (basename / argv[0], same as
+// steps) and function_call_output payloads are never read. Served by a
+// LOOPBACK-ONLY endpoint. Privacy test: transcript.test.ts.
+
+const TRANSCRIPT_TAIL_BYTES = 256 * 1024;
+const MAX_TRANSCRIPT_ENTRIES = 160;
+const MAX_TEXT_CHARS = 4000;
+
+export async function parseCodexTranscript(
+  filePath: string,
+): Promise<AgentTranscriptEntry[]> {
+  let size: number;
+  try {
+    const st = await fsp.stat(filePath);
+    if (!st.isFile() || st.size === 0) return [];
+    size = st.size;
+  } catch {
+    return [];
+  }
+
+  let tail: string;
+  try {
+    const fd = await fsp.open(filePath, "r");
+    try {
+      const length = Math.min(TRANSCRIPT_TAIL_BYTES, size);
+      const buf = Buffer.alloc(length);
+      await fd.read(buf, 0, length, size - length);
+      tail = buf.toString("utf8");
+    } finally {
+      await fd.close();
+    }
+  } catch {
+    return [];
+  }
+
+  const lines = tail.split("\n").filter(Boolean);
+  if (size > TRANSCRIPT_TAIL_BYTES && lines.length > 0) lines.shift();
+
+  const entries: AgentTranscriptEntry[] = [];
+  let turn = 0;
+
+  const textOfContent = (content: unknown): string => {
+    if (typeof content === "string") return content;
+    if (!Array.isArray(content)) return "";
+    const parts: string[] = [];
+    for (const block of content) {
+      if (!block || typeof block !== "object") continue;
+      const b = block as Record<string, unknown>;
+      // Codex block spellings vary by version — text-ish blocks only.
+      if (
+        (b.type === "text" || b.type === "input_text" || b.type === "output_text") &&
+        typeof b.text === "string"
+      ) {
+        parts.push(b.text);
+      }
+    }
+    return parts.join("\n");
+  };
+
+  for (const line of lines) {
+    let e: unknown;
+    try {
+      e = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (!e || typeof e !== "object") continue;
+    const obj = e as Record<string, unknown>;
+
+    const type = readString(obj.type);
+    const ts = readString(obj.timestamp);
+    const msg = obj.message;
+    const m = msg && typeof msg === "object" ? (msg as Record<string, unknown>) : null;
+    const role =
+      readString(obj.role) ?? (m ? readString(m.role) : undefined);
+
+    if (type === "function_call") {
+      const name = readString(obj.name);
+      if (!name) continue;
+      let target: string | undefined;
+      const args = parseArguments(obj.arguments);
+      if (args) {
+        for (const k of PATH_KEYS) {
+          const pv = args[k];
+          if (typeof pv === "string" && pv) {
+            const parts = pv.split("/").filter(Boolean);
+            target = parts.length ? parts[parts.length - 1] : pv;
+            break;
+          }
+        }
+        if (!target && SHELL_NAME_RE.test(name)) {
+          const argv0 = shellArgv0(args.command);
+          if (argv0) target = "$ " + argv0;
+        }
+      }
+      entries.push({ ts, kind: "tool", turn, tool: name, target });
+      continue;
+    }
+    if (type === "function_call_output") {
+      if (obj.is_error === true || obj.error === true) {
+        for (let i = entries.length - 1; i >= 0; i--) {
+          if (entries[i]!.kind === "tool") {
+            entries[i]!.isError = true;
+            break;
+          }
+        }
+      }
+      continue;
+    }
+
+    const content = (m ? m.content : undefined) ?? obj.content;
+    if (role === "user" || type === "user") {
+      const text = textOfContent(content).trim();
+      if (text) {
+        turn++;
+        entries.push({ ts, kind: "user", turn, text: text.slice(0, MAX_TEXT_CHARS) });
+      }
+      continue;
+    }
+    if (role === "assistant" || type === "assistant" || type === "response") {
+      const text = textOfContent(content).trim();
+      if (text) {
+        entries.push({ ts, kind: "assistant", turn, text: text.slice(0, MAX_TEXT_CHARS) });
+      }
+    }
+  }
+
+  return entries.slice(-MAX_TRANSCRIPT_ENTRIES);
 }
 
 registerIntegration("codex", (cfg) => new CodexObserver(cfg));

--- a/src/integrations/codex/steps.test.ts
+++ b/src/integrations/codex/steps.test.ts
@@ -1,0 +1,41 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { parseCodexSteps } from "./observer.js";
+
+/** Codex step-timeline privacy + shape (PLAN_UI_SESSION_SHELL_v1.1 收尾). */
+
+const SECRET = "C0DEX-S3CR3T-77ab";
+
+function line(obj: unknown): string {
+  return JSON.stringify(obj) + "\n";
+}
+
+test("parseCodexSteps: ordered structural steps, no content leakage", async () => {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-codex-steps-"));
+  const file = path.join(dir, "rollout-x.jsonl");
+  const jsonl =
+    line({ type: "user", timestamp: "2026-08-08T03:00:00Z", message: { role: "user", content: SECRET + " do the thing" } }) +
+    line({ type: "function_call", name: "read_file", arguments: JSON.stringify({ file_path: "/Users/x/" + SECRET + "-dir/notes.md" }) }) +
+    line({ type: "function_call_output", is_error: true, output: SECRET }) +
+    line({ type: "function_call", name: "shell", arguments: JSON.stringify({ command: "grep " + SECRET + " -r ." }) }) +
+    line({ type: "response", message: { role: "assistant", content: "done " + SECRET } }) +
+    line({ type: "user", message: { role: "user", content: "next " + SECRET } });
+  await fs.writeFile(file, jsonl);
+
+  const steps = await parseCodexSteps(file);
+  assert.equal(steps[0]!.kind, "user");
+  assert.equal(steps[0]!.turn, 1);
+  const read = steps.find((s) => s.tool === "read_file");
+  assert.ok(read, "read_file step present");
+  assert.equal(read!.target, "notes.md"); // basename only
+  assert.equal(read!.isError, true); // function_call_output error attributed
+  const shell = steps.find((s) => s.tool === "shell");
+  assert.equal(shell!.target, "$ grep"); // argv[0] only
+  assert.equal(steps[steps.length - 1]!.kind, "user");
+  assert.equal(steps[steps.length - 1]!.turn, 2);
+  assert.ok(!JSON.stringify(steps).includes(SECRET), "secret leaked");
+  await fs.rm(dir, { recursive: true, force: true });
+});

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -119,6 +119,24 @@ export interface AgentStep {
   isError?: boolean;
 }
 
+/**
+ * One transcript entry — an AgentStep that may carry MESSAGE TEXT (user /
+ * assistant turns only). Serves the owner's LOCAL view of an observed
+ * session (loopback-only endpoint): tool inputs/outputs stay structural
+ * (basename / argv[0]) exactly like AgentStep, and this shape must never
+ * cross a remote surface (island / iOS / channels keep steps).
+ */
+export interface AgentTranscriptEntry {
+  ts?: string;
+  kind: "user" | "assistant" | "tool";
+  /** Message text — user/assistant entries only, length-capped. */
+  text?: string;
+  tool?: string;
+  target?: string;
+  turn: number;
+  isError?: boolean;
+}
+
 /** Visibility tier — how deeply LISA may inspect a session. See plan §3. */
 export type VisibilityTier = "off" | "metadata" | "activity" | "intent";
 

--- a/src/integrations/types.ts
+++ b/src/integrations/types.ts
@@ -100,6 +100,25 @@ export interface AgentSession {
   jsonlPath?: string;
 }
 
+/**
+ * One structural step in a session's tail — powers the read-only stream tab
+ * (PLAN_UI_SESSION_SHELL_v1.1 F1). Same privacy contract as SessionActivity,
+ * one notch tighter: targets are file BASENAMES / command argv[0] only.
+ */
+export interface AgentStep {
+  /** ISO timestamp when the source line carried one. */
+  ts?: string;
+  kind: "user" | "assistant" | "tool";
+  /** Tool name (kind === "tool" only). */
+  tool?: string;
+  /** File basename or "$ argv[0]" (kind === "tool" only). */
+  target?: string;
+  /** Turn ordinal within the parsed tail — increments on each user turn. */
+  turn: number;
+  /** A tool error observed at (or right after) this step. */
+  isError?: boolean;
+}
+
 /** Visibility tier — how deeply LISA may inspect a session. See plan §3. */
 export type VisibilityTier = "off" | "metadata" | "activity" | "intent";
 

--- a/src/web/api-contract.test.ts
+++ b/src/web/api-contract.test.ts
@@ -11,6 +11,7 @@ import {
   agentSessionsResponse,
   applyApiVersionHeader,
   isVersionedApiSurface,
+  lisaSessionsResponse,
 } from "./api-contract.js";
 
 interface Schema {
@@ -170,6 +171,43 @@ describe("actual server DTOs conform to OpenAPI v1", () => {
     const response = agentSessionsResponse(sessions, new Set());
     assert.equal(response.sessions[0]?.resumable, true);
     assertContract("SessionsResponse", response);
+  });
+
+  test("agent session serializer strips the server-internal jsonlPath", () => {
+    const response = agentSessionsResponse(
+      [
+        {
+          agent: "claude-code",
+          sessionId: "s1",
+          project: "lisa",
+          state: "working",
+          stateReason: "tool_use",
+          lastMtime: Date.parse("2026-08-08T10:00:00.000Z"),
+          jsonlPath: "/Users/someone/.claude/projects/x/s1.jsonl",
+        },
+      ],
+      new Set(["s1"]),
+    );
+    assert.ok(!JSON.stringify(response).includes(".claude/projects"));
+    assertContract("SessionsResponse", response);
+  });
+
+  test("lisa session serializer strips the on-disk path (LisaSessionsResponse)", () => {
+    const response = lisaSessionsResponse([
+      {
+        id: "20260808-001950-d50b69",
+        path: "/Users/someone/.lisa/sessions/20260808-001950-d50b69.jsonl",
+        startedAt: "2026-08-08T00:19:50.000Z",
+        cwd: "/work/lisa",
+        model: "claude-fable-5",
+        messageCount: 4,
+        lastUserMessage: "switch it",
+        firstUserMessage: "restyle the shell",
+      },
+    ]);
+    assert.ok(!JSON.stringify(response).includes(".lisa/sessions"));
+    assertContract("LisaSessionsResponse", response);
+    assertContract("LisaSessionMutation", { ok: true, id: "20260808-001950-d50b69" });
   });
 
   test("dispatch and island/error/event fixtures conform", () => {

--- a/src/web/api-contract.ts
+++ b/src/web/api-contract.ts
@@ -1,5 +1,6 @@
 import type http from "node:http";
 import type { AgentSession } from "../integrations/types.js";
+import type { SessionInfo } from "../sessions/list.js";
 import {
   LISA_API_VERSION,
   LISA_API_VERSION_HEADER,
@@ -31,7 +32,7 @@ export function applyApiVersionHeader(
   }
 }
 
-export type ApiAgentSession = Omit<AgentSession, "lastMtime"> & {
+export type ApiAgentSession = Omit<AgentSession, "lastMtime" | "jsonlPath"> & {
   lastMtime: string;
   resumable?: boolean;
 };
@@ -62,6 +63,29 @@ export function agentSessionsResponse(
           ? { resumable: true }
           : {}),
       };
+    }),
+  };
+}
+
+/** Wire shape of a Lisa chat session — the on-disk `path` never serializes. */
+export type ApiLisaSession = Omit<SessionInfo, "path">;
+
+export interface LisaSessionsResponse {
+  sessions: ApiLisaSession[];
+}
+
+/**
+ * Canonical REST serialization for GET /api/sessions (contract:
+ * LisaSessionsResponse). Strips the absolute on-disk file path — it leaks
+ * the local home directory and no client needs it.
+ */
+export function lisaSessionsResponse(
+  sessions: readonly SessionInfo[],
+): LisaSessionsResponse {
+  return {
+    sessions: sessions.map((s) => {
+      const { path: _path, ...rest } = s;
+      return rest;
     }),
   };
 }

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -2540,13 +2540,65 @@ if ('serviceWorker' in navigator) {
       }
       return;
     }
-    fetch('/api/agents/steps?agent=' + encodeURIComponent(currentAgentTab.agent) + '&id=' + encodeURIComponent(currentAgentTab.id))
+    // 确认轮三: prefer the full local transcript (user/assistant text +
+    // structural tool markers — loopback-only endpoint); fall back to the
+    // structural steps when it comes back empty (remote access, other
+    // agent kinds, or a quiet tail).
+    const q = 'agent=' + encodeURIComponent(currentAgentTab.agent) + '&id=' + encodeURIComponent(currentAgentTab.id);
+    fetch('/api/agents/transcript?' + q)
       .then(function (r) { return r.ok ? r.json() : null; })
       .then(function (d) {
-        if (!d || !currentAgentTab) return;
-        renderSteps(stepsEl, d.steps || []);
+        if (!currentAgentTab) return null;
+        if (d && d.entries && d.entries.length) {
+          renderTranscript(stepsEl, d.entries);
+          return null;
+        }
+        return fetch('/api/agents/steps?' + q)
+          .then(function (r) { return r.ok ? r.json() : null; })
+          .then(function (sd) {
+            if (!sd || !currentAgentTab) return;
+            renderSteps(stepsEl, sd.steps || []);
+          });
       })
       .catch(function () {});
+  }
+  function renderTranscript(stepsEl, entries) {
+    const atBottom = stepsEl.scrollHeight - stepsEl.scrollTop - stepsEl.clientHeight < 60;
+    stepsEl.innerHTML = '';
+    entries.forEach(function (en) {
+      if (en.kind === 'tool') {
+        const row = document.createElement('div');
+        row.className = 'srow' + (en.isError ? ' err' : '');
+        row.innerHTML = '<span class="sic"></span><span></span><span class="sdetail"></span><span class="stime"></span>';
+        row.querySelector('.sic').textContent = stepIcon(en.tool);
+        row.children[1].textContent = en.tool || '';
+        row.querySelector('.sdetail').textContent = en.target || '';
+        if (en.ts) row.querySelector('.stime').textContent = relativeTime(en.ts);
+        stepsEl.appendChild(row);
+        return;
+      }
+      const msg = document.createElement('div');
+      msg.className = 'as-msg ' + (en.kind === 'user' ? 'user' : 'assistant');
+      const role = document.createElement('div');
+      role.className = 'as-role';
+      role.textContent = en.kind === 'user' ? 'USER' : 'AGENT';
+      if (en.ts) {
+        const t = document.createElement('span');
+        t.className = 'stime';
+        t.textContent = relativeTime(en.ts);
+        role.appendChild(t);
+      }
+      msg.appendChild(role);
+      const body = document.createElement('div');
+      body.className = 'as-text';
+      // Agent replies are Markdown → render; the user's own text as-is
+      // (same rule as Lisa's chat history).
+      if (en.kind === 'assistant' && typeof renderMarkdown === 'function') body.innerHTML = renderMarkdown(en.text || '');
+      else body.textContent = en.text || '';
+      msg.appendChild(body);
+      stepsEl.appendChild(msg);
+    });
+    if (atBottom) stepsEl.scrollTop = stepsEl.scrollHeight;
   }
   function stepIcon(tool) {
     const t = (tool || '').toLowerCase();

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1731,26 +1731,22 @@ if ('serviceWorker' in navigator) {
       const pend = s.activity && s.activity.pendingPermission;
       row.querySelector('.nr-sub').textContent = pend ? ('⚠ ' + pend) : (s.stateReason || s.state);
       row.title = (AGENT_NAMES[s.agent] || s.agent) + ' · ' + s.project + ' · ' + s.sessionId;
-      row.addEventListener('click', function () {
-        selInsp = { type: 'agent', key: agentKey(s) };
-        renderInspector();
-        // Same as a tree click: straight into the conversation.
-        openStreamTab({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
-      });
+      row.setAttribute('data-agent', s.agent);
+      row.setAttribute('data-session', s.sessionId);
       const acts = document.createElement('span');
       acts.className = 'session-ctrl nr-acts';
       if (s.controllable === 'managed' && pend) {
         const ap = document.createElement('button');
         ap.className = 'mc approve'; ap.textContent = '✓'; ap.title = 'Approve';
-        ap.addEventListener('click', function (e) { e.stopPropagation(); agentAction('managed', s.sessionId, 'approve', { allow: true }); });
+        ap.setAttribute('data-act', 'approve');
         const dn = document.createElement('button');
         dn.className = 'mc deny'; dn.textContent = '✕'; dn.title = 'Deny';
-        dn.addEventListener('click', function (e) { e.stopPropagation(); agentAction('managed', s.sessionId, 'approve', { allow: false }); });
+        dn.setAttribute('data-act', 'deny');
         acts.appendChild(ap); acts.appendChild(dn);
       } else {
         const open = document.createElement('button');
         open.className = 'mc'; open.textContent = '▤'; open.title = 'Open the read-only stream';
-        open.addEventListener('click', function (e) { e.stopPropagation(); if (window.lisaOpenAgentStream) window.lisaOpenAgentStream(s); });
+        open.setAttribute('data-act', 'stream');
         acts.appendChild(open);
       }
       row.appendChild(acts);
@@ -1782,6 +1778,10 @@ if ('serviceWorker' in navigator) {
 
   // Shared leaf builders (both tree modes). withGlyph adds a mini source
   // glyph in project view where Lisa and agent sessions sit side by side.
+  // NOTE (真实E2E修复): tree/needs/inspector rebuild on every roster tick,
+  // so per-node listeners kept landing real clicks on freshly-replaced dead
+  // elements. All click handling is DELEGATED to the stable containers —
+  // nodes only carry data-* attributes.
   function makeLisaLeaf(s, withGlyph) {
     const isActive = s.id === window.lisaActiveSessionId;
     const leaf = document.createElement('button');
@@ -1792,13 +1792,7 @@ if ('serviceWorker' in navigator) {
     leaf.querySelector('.tname').textContent = sessionLabel(s);
     leaf.querySelector('.ttime').textContent = relativeTime(s.startedAt);
     leaf.title = s.id + ' · ' + (s.messageCount || 0) + ' msgs';
-    leaf.addEventListener('click', function () {
-      selInsp = { type: 'lisa', id: s.id };
-      renderInspector();
-      closeStreamView();
-      if (s.id === window.lisaActiveSessionId) renderSessionUI();
-      else switchSession(s.id);
-    });
+    leaf.setAttribute('data-lisa-id', s.id);
     return leaf;
   }
   function makeAgentLeaf(s, withGlyph) {
@@ -1818,17 +1812,8 @@ if ('serviceWorker' in navigator) {
     leaf.querySelector('.tname').textContent = agentLabel(s);
     leaf.querySelector('.ttime').textContent = relativeTime(s.lastMtime);
     leaf.title = (s.stateReason ? s.state + ' · ' + s.stateReason : s.state) + ' · ' + s.project + ' · ' + s.sessionId;
-    leaf.addEventListener('click', function () {
-      selInsp = { type: 'agent', key: key };
-      const tree = document.getElementById('sessionTree');
-      const all = tree ? tree.querySelectorAll('.tleaf.active') : [];
-      for (let i = 0; i < all.length; i++) all[i].classList.remove('active');
-      leaf.classList.add('active');
-      renderInspector();
-      // 确认轮三: clicking an agent session OPENS its conversation directly
-      // (transcript stream pane) — same mental model as a Lisa session.
-      openStreamTab({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
-    });
+    leaf.setAttribute('data-agent', s.agent);
+    leaf.setAttribute('data-session', s.sessionId);
     return leaf;
   }
 
@@ -1855,7 +1840,7 @@ if ('serviceWorker' in navigator) {
       root.innerHTML = '<span class="twist">▾</span><span class="tlabel"></span><span class="tcount"></span>';
       root.querySelector('.tlabel').textContent = p;
       root.querySelector('.tcount').textContent = String(byProject[p].lisa.length + byProject[p].agents.length);
-      root.addEventListener('click', function () { toggleCollapsed(group, key); });
+      root.setAttribute('data-toggle', key);
       group.appendChild(root);
       const kids = document.createElement('div');
       kids.className = 'tchildren';
@@ -1895,7 +1880,7 @@ if ('serviceWorker' in navigator) {
       glyph.textContent = (kindName.charAt(0) || 'A').toUpperCase();
       root.querySelector('.tlabel').textContent = kindName;
       root.querySelector('.tcount').textContent = String(byKind[kind].length);
-      root.addEventListener('click', function () { toggleCollapsed(group, 'agent:' + kind); });
+      root.setAttribute('data-toggle', 'agent:' + kind);
       group.appendChild(root);
       const kids = document.createElement('div');
       kids.className = 'tchildren';
@@ -1916,7 +1901,7 @@ if ('serviceWorker' in navigator) {
         pn.className = 'tnode';
         pn.innerHTML = '<span class="twist">▾</span><span class="tlabel"></span>';
         pn.querySelector('.tlabel').textContent = p;
-        pn.addEventListener('click', function () { toggleCollapsed(sub, subKey); });
+        pn.setAttribute('data-toggle', subKey);
         sub.appendChild(pn);
         const pkids = document.createElement('div');
         pkids.className = 'tchildren';
@@ -2033,7 +2018,8 @@ if ('serviceWorker' in navigator) {
       openBtn.className = 'mc adopt';
       openBtn.textContent = '⇱ open';
       openBtn.title = 'Switch to this session';
-      openBtn.addEventListener('click', function () { switchSession(s.id); });
+      openBtn.setAttribute('data-act', 'open-lisa');
+      openBtn.setAttribute('data-lisa-id', s.id);
       acts.appendChild(openBtn);
       box.appendChild(acts);
     }
@@ -2070,58 +2056,48 @@ if ('serviceWorker' in navigator) {
     const id = s.sessionId;
     const acts = document.createElement('div');
     acts.className = 'session-ctrl insp-actions';
+    acts.setAttribute('data-fam', fam || '');
+    acts.setAttribute('data-agent', s.agent);
+    acts.setAttribute('data-session', id);
+    acts.setAttribute('data-cwd', s.cwd || '');
     // F1 — every agent session gets a read-only step stream tab.
     const streamBtn = document.createElement('button');
     streamBtn.className = 'mc';
     streamBtn.textContent = '▤ stream';
     streamBtn.title = 'Open the read-only step stream';
-    streamBtn.addEventListener('click', function () {
-      if (window.lisaOpenAgentStream) window.lisaOpenAgentStream(s);
-    });
+    streamBtn.setAttribute('data-act', 'stream');
     acts.appendChild(streamBtn);
     if (fam === 'managed' && a.pendingPermission) {
       const ap = document.createElement('button');
       ap.className = 'mc approve'; ap.textContent = '✓ approve';
-      ap.addEventListener('click', function () { agentAction('managed', id, 'approve', { allow: true }); });
+      ap.setAttribute('data-act', 'approve');
       const dn = document.createElement('button');
       dn.className = 'mc deny'; dn.textContent = '✕ deny';
-      dn.addEventListener('click', function () { agentAction('managed', id, 'approve', { allow: false }); });
+      dn.setAttribute('data-act', 'deny');
       acts.appendChild(ap); acts.appendChild(dn);
     } else if (fam && s.state !== 'done') {
       const inp = document.createElement('input');
       inp.className = 'mc-send'; inp.type = 'text';
       inp.placeholder = fam === 'pty' ? 'type into the CLI…' : 'send a follow-up…';
-      inp.addEventListener('keydown', function (e) {
-        // Ignore the Enter that confirms an IME candidate (see main input).
-        if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && inp.value.trim()) { e.preventDefault(); agentAction(fam, id, 'send', { text: inp.value.trim() }); inp.value = ''; }
-      });
       acts.appendChild(inp);
     }
     if (fam === 'pty') {
       const out = document.createElement('button');
       out.className = 'mc'; out.textContent = '▤ output'; out.title = 'View terminal output';
-      out.addEventListener('click', function () { ptyOutput(id); });
+      out.setAttribute('data-act', 'output');
       acts.appendChild(out);
     }
     if (fam && s.state !== 'done') {
       const cancel = document.createElement('button');
       cancel.className = 'mc cancel'; cancel.textContent = '⏹ cancel'; cancel.title = 'Cancel agent';
-      cancel.addEventListener('click', function () { agentAction(fam, id, 'cancel', null); });
+      cancel.setAttribute('data-act', 'cancel');
       acts.appendChild(cancel);
     }
     if (s.resumable) {
       const adopt = document.createElement('button');
       adopt.className = 'mc adopt'; adopt.textContent = '⇲ adopt';
       adopt.title = 'Resume this session under LISA — then send / answer / cancel / view it';
-      adopt.addEventListener('click', function () {
-        fetch('/api/agents/pty/start', {
-          method: 'POST', headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ agent: 'claude', resumeSessionId: s.sessionId, cwd: s.cwd || '' }),
-        }).then(function (r) {
-          if (!r.ok) { return r.text().then(function (t) { openModal('adopt', '<pre>' + escapeHtml(t) + '</pre>'); }); }
-          if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
-        }).catch(function () {});
-      });
+      adopt.setAttribute('data-act', 'adopt');
       acts.appendChild(adopt);
     }
     if (acts.childNodes.length) box.appendChild(acts);
@@ -2394,7 +2370,7 @@ if ('serviceWorker' in navigator) {
     root.className = 'tnode';
     root.innerHTML = '<span class="twist">▾</span><span class="agent-glyph lisa">L</span><span class="tlabel">LISA</span><span class="tcount"></span>';
     root.querySelector('.tcount').textContent = String(cachedSessions.length);
-    root.addEventListener('click', function () { toggleCollapsed(group, 'lisa'); });
+    root.setAttribute('data-toggle', 'lisa');
     group.appendChild(root);
     const kids = document.createElement('div');
     kids.className = 'tchildren';
@@ -2428,10 +2404,7 @@ if ('serviceWorker' in navigator) {
       const st = s ? (s.state || 'unknown') : 'unknown';
       if (st === 'working' || st === 'waiting' || st === 'error') chip.querySelector('.pip').classList.add(st);
       chip.querySelector('.ctx-name').textContent = s ? agentLabel(s) : (currentAgentTab.label || currentAgentTab.id);
-      chip.querySelector('.ctx-x').addEventListener('click', function () {
-        closeStreamView();
-        renderSessionUI();
-      });
+      chip.querySelector('.ctx-x').setAttribute('data-act', 'close-stream');
     } else {
       chip.innerHTML = '<span class="pip live"></span><span class="ctx-name"></span><span class="ctx-meta"></span>';
       const s = sessionById(window.lisaActiveSessionId);
@@ -2520,31 +2493,28 @@ if ('serviceWorker' in navigator) {
       const grow = document.createElement('span');
       grow.className = 'grow';
       perm.appendChild(grow);
+      perm.setAttribute('data-session', s.sessionId);
       const ap = document.createElement('button');
       ap.className = 'mc approve'; ap.textContent = '✓ approve';
-      ap.addEventListener('click', function () { agentAction('managed', s.sessionId, 'approve', { allow: true }); });
+      ap.setAttribute('data-act', 'approve');
       const dn = document.createElement('button');
       dn.className = 'mc deny'; dn.textContent = '✕ deny';
-      dn.addEventListener('click', function () { agentAction('managed', s.sessionId, 'approve', { allow: false }); });
+      dn.setAttribute('data-act', 'deny');
       perm.appendChild(ap);
       perm.appendChild(dn);
     }
     foot.innerHTML = '';
     if (s && s.controllable && s.state !== 'done') {
+      foot.setAttribute('data-fam', s.controllable);
+      foot.setAttribute('data-session', s.sessionId);
       const inp = document.createElement('input');
       inp.type = 'text';
+      inp.className = 'mc-send';
       inp.placeholder = s.controllable === 'pty' ? 'type into the CLI…' : 'send a follow-up…';
-      inp.addEventListener('keydown', function (e) {
-        if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && inp.value.trim()) {
-          e.preventDefault();
-          agentAction(s.controllable, s.sessionId, 'send', { text: inp.value.trim() });
-          inp.value = '';
-        }
-      });
       foot.appendChild(inp);
       const cancel = document.createElement('button');
       cancel.className = 'mc cancel'; cancel.textContent = '⏹ cancel';
-      cancel.addEventListener('click', function () { agentAction(s.controllable, s.sessionId, 'cancel', null); });
+      cancel.setAttribute('data-act', 'cancel');
       foot.appendChild(cancel);
     } else if (s && s.resumable) {
       const note = document.createElement('span');
@@ -3013,6 +2983,138 @@ if ('serviceWorker' in navigator) {
     sbMailHead.title = 'Open Mail';
     sbMailHead.addEventListener('click', function () {
       if (typeof window.lisaShowView === 'function') window.lisaShowView('mail');
+    });
+  }
+
+  // ── Delegated wiring (真实E2E修复) ───────────────────────────────────
+  // The tree / needs-you / inspector / stream controls REBUILD on every
+  // roster tick (SSE fires every few seconds while agents are active), so
+  // per-node listeners kept landing real clicks on freshly-replaced dead
+  // elements — "I clicked and nothing happened". One listener per STABLE
+  // container; nodes carry data-* attributes.
+  function selectAgentAndStream(agent, sid) {
+    selInsp = { type: 'agent', key: agent + '/' + sid };
+    renderInspector();
+    const found = agentByKey(agent + '/' + sid);
+    openStreamTab({ t: 'agent', agent: agent, id: sid, label: found ? agentLabel(found) : sid });
+  }
+  function runDelegatedAction(act, fam, agent, sid, cwd, sendText) {
+    if (act === 'stream') { selectAgentAndStream(agent, sid); return; }
+    if (act === 'approve') { agentAction('managed', sid, 'approve', { allow: true }); return; }
+    if (act === 'deny') { agentAction('managed', sid, 'approve', { allow: false }); return; }
+    if (act === 'cancel') { agentAction(fam, sid, 'cancel', null); return; }
+    if (act === 'output') { ptyOutput(sid); return; }
+    if (act === 'send') { agentAction(fam, sid, 'send', { text: sendText }); return; }
+    if (act === 'adopt') {
+      fetch('/api/agents/pty/start', {
+        method: 'POST', headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ agent: 'claude', resumeSessionId: sid, cwd: cwd || '' }),
+      }).then(function (r) {
+        if (!r.ok) { return r.text().then(function (t) { openModal('adopt', '<pre>' + escapeHtml(t) + '</pre>'); }); }
+        if (typeof refreshClaudeSessions === 'function') refreshClaudeSessions();
+      }).catch(function () {});
+    }
+  }
+  const treeEl = document.getElementById('sessionTree');
+  if (treeEl) treeEl.addEventListener('click', function (e) {
+    const t = e.target;
+    if (!t || !t.closest) return;
+    const leaf = t.closest('.tleaf');
+    if (leaf && treeEl.contains(leaf)) {
+      const lisaId = leaf.getAttribute('data-lisa-id');
+      if (lisaId) {
+        selInsp = { type: 'lisa', id: lisaId };
+        renderInspector();
+        closeStreamView();
+        if (lisaId === window.lisaActiveSessionId) renderSessionUI();
+        else switchSession(lisaId);
+        return;
+      }
+      const agent = leaf.getAttribute('data-agent');
+      const sid = leaf.getAttribute('data-session');
+      if (agent && sid) {
+        const all = treeEl.querySelectorAll('.tleaf.active');
+        for (let i = 0; i < all.length; i++) all[i].classList.remove('active');
+        leaf.classList.add('active');
+        selectAgentAndStream(agent, sid);
+      }
+      return;
+    }
+    const node = t.closest('.tnode');
+    if (node && treeEl.contains(node)) {
+      const tkey = node.getAttribute('data-toggle');
+      if (tkey && node.parentElement) toggleCollapsed(node.parentElement, tkey);
+    }
+  });
+  const stripEl = document.getElementById('tabStrip');
+  if (stripEl) stripEl.addEventListener('click', function (e) {
+    const t = e.target;
+    if (!t || !t.closest) return;
+    const btn = t.closest('[data-act]');
+    if (btn && btn.getAttribute('data-act') === 'close-stream') {
+      closeStreamView();
+      renderSessionUI();
+    }
+  });
+  const needsEl = document.getElementById('sbNeedsRows');
+  if (needsEl) needsEl.addEventListener('click', function (e) {
+    const t = e.target;
+    if (!t || !t.closest) return;
+    const row = t.closest('.needs-row');
+    if (!row) return;
+    const agent = row.getAttribute('data-agent');
+    const sid = row.getAttribute('data-session');
+    const btn = t.closest('[data-act]');
+    if (btn) { runDelegatedAction(btn.getAttribute('data-act'), 'managed', agent, sid, ''); return; }
+    if (agent && sid) selectAgentAndStream(agent, sid);
+  });
+  const inspEl = document.getElementById('sbClaudeRows');
+  if (inspEl) {
+    inspEl.addEventListener('click', function (e) {
+      const t = e.target;
+      if (!t || !t.closest) return;
+      const btn = t.closest('[data-act]');
+      if (!btn) return;
+      const act = btn.getAttribute('data-act');
+      if (act === 'open-lisa') { switchSession(btn.getAttribute('data-lisa-id')); return; }
+      const acts = t.closest('.insp-actions');
+      if (!acts) return;
+      runDelegatedAction(act, acts.getAttribute('data-fam'), acts.getAttribute('data-agent'), acts.getAttribute('data-session'), acts.getAttribute('data-cwd'));
+    });
+    inspEl.addEventListener('keydown', function (e) {
+      const t = e.target;
+      if (!t || !t.classList || !t.classList.contains('mc-send')) return;
+      if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && t.value.trim()) {
+        e.preventDefault();
+        const acts = t.closest('.insp-actions');
+        if (acts) runDelegatedAction('send', acts.getAttribute('data-fam'), acts.getAttribute('data-agent'), acts.getAttribute('data-session'), '', t.value.trim());
+        t.value = '';
+      }
+    });
+  }
+  const permEl = document.getElementById('asPerm');
+  if (permEl) permEl.addEventListener('click', function (e) {
+    const t = e.target;
+    if (!t || !t.closest) return;
+    const btn = t.closest('[data-act]');
+    if (btn) runDelegatedAction(btn.getAttribute('data-act'), 'managed', '', permEl.getAttribute('data-session'), '');
+  });
+  const footEl = document.getElementById('asFoot');
+  if (footEl) {
+    footEl.addEventListener('click', function (e) {
+      const t = e.target;
+      if (!t || !t.closest) return;
+      const btn = t.closest('[data-act]');
+      if (btn) runDelegatedAction(btn.getAttribute('data-act'), footEl.getAttribute('data-fam'), '', footEl.getAttribute('data-session'), '');
+    });
+    footEl.addEventListener('keydown', function (e) {
+      const t = e.target;
+      if (!t || !t.classList || !t.classList.contains('mc-send')) return;
+      if (e.key === 'Enter' && !e.isComposing && e.keyCode !== 229 && t.value.trim()) {
+        e.preventDefault();
+        runDelegatedAction('send', footEl.getAttribute('data-fam'), '', footEl.getAttribute('data-session'), '', t.value.trim());
+        t.value = '';
+      }
     });
   }
 

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -2312,42 +2312,78 @@ if ('serviceWorker' in navigator) {
     return null;
   }
 
+  // e2e 加固: switch/new used to swallow failures (empty catch, no finally)
+  // — one hung POST left the switching flag stuck forever and every later
+  // ＋New / tree click silently no-oped. Now: 8s timeout, finally-reset, a
+  // visible console error, and the composer LOCKS during the swap so a
+  // message can never be typed into a session that's about to be switched
+  // away (the "sent but nothing happened" race).
   let switching = false;
+  function setComposerLocked(on) {
+    try {
+      input.disabled = on;
+      sendBtn.disabled = on;
+      input.placeholder = on
+        ? 'switching session…'
+        : 'Talk to Lisa…  (Enter to send · Shift+Enter for newline)';
+    } catch (e) {}
+  }
+  async function postSessionMutation(url) {
+    const ctrl = new AbortController();
+    const timer = setTimeout(function () { ctrl.abort(); }, 8000);
+    try {
+      const r = await fetch(url, { method: 'POST', signal: ctrl.signal });
+      return await r.json();
+    } finally {
+      clearTimeout(timer);
+    }
+  }
   async function switchSession(id) {
     if (switching || !id || id === window.lisaActiveSessionId) return;
     switching = true;
     document.body.classList.add('session-switching');
+    setComposerLocked(true);
     try {
-      const r = await fetch('/api/sessions/' + encodeURIComponent(id) + '/activate', { method: 'POST' });
-      const data = await r.json();
-      if (data && data.ok) {
-        if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(data.id);
+      const data = await postSessionMutation('/api/sessions/' + encodeURIComponent(id) + '/activate');
+      if (data && data.ok && typeof window.lisaSetActiveSession === 'function') {
+        window.lisaSetActiveSession(data.id);
       }
-    } catch (e) {}
-    document.body.classList.remove('session-switching');
-    switching = false;
-    refreshSessionsBadge();
+    } catch (e) {
+      console.error('[sessions] switch failed:', e);
+    } finally {
+      document.body.classList.remove('session-switching');
+      setComposerLocked(false);
+      switching = false;
+      refreshSessionsBadge();
+    }
   }
   async function newSession() {
     if (switching) return;
     switching = true;
     closeStreamView();
     document.body.classList.add('session-switching');
+    setComposerLocked(true);
     try {
-      const r = await fetch('/api/sessions', { method: 'POST' });
-      const data = await r.json();
-      if (data && data.ok) {
-        if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(data.id);
+      const data = await postSessionMutation('/api/sessions');
+      if (data && data.ok && typeof window.lisaSetActiveSession === 'function') {
+        window.lisaSetActiveSession(data.id);
       }
-    } catch (e) {}
-    document.body.classList.remove('session-switching');
-    switching = false;
-    refreshSessionsBadge();
+    } catch (e) {
+      console.error('[sessions] new session failed:', e);
+    } finally {
+      document.body.classList.remove('session-switching');
+      setComposerLocked(false);
+      switching = false;
+      refreshSessionsBadge();
+    }
   }
 
   function renderSessionTree() {
     const tree = document.getElementById('sessionTree');
     if (!tree) return;
+    // Rendering with no Lisa sessions means the list fetch hasn't landed or
+    // failed — kick it (in-flight guard + retry make this loop-safe).
+    if (!cachedSessions.length) refreshSessionsBadge();
     tree.innerHTML = '';
     if (treeMode === 'project') { buildProjectTree(tree); return; }
     const group = document.createElement('div');
@@ -2689,10 +2725,19 @@ if ('serviceWorker' in navigator) {
   const sbNewBtn = document.getElementById('sbNewSession');
   if (sbNewBtn) sbNewBtn.addEventListener('click', newSession);
 
+  // e2e 加固: a failed/slow session-list fetch used to stay broken for the
+  // whole 5-minute interval while the roster SSE kept rebuilding the tree —
+  // Lisa's sessions "vanished" until the next tick. Now: in-flight guard +
+  // 5s retry, and renderSessionTree triggers a fetch whenever it finds
+  // itself rendering with an empty list.
+  let sessionsFetchInFlight = false;
+  let sessionsRetryTimer = null;
   async function refreshSessionsBadge() {
+    if (sessionsFetchInFlight) return;
+    sessionsFetchInFlight = true;
     try {
       const r = await fetch('/api/sessions');
-      if (!r.ok) return;
+      if (!r.ok) throw new Error('http ' + r.status);
       const data = await r.json();
       cachedSessions = Array.isArray(data.sessions) ? data.sessions : [];
       sbSessionBadge.textContent = String(cachedSessions.length);
@@ -2701,8 +2746,14 @@ if ('serviceWorker' in navigator) {
       // only resolve once this list (and /session) has landed, so re-render
       // here too or a fresh page shows "(idle)" until the next roster tick.
       renderInspector();
-    } catch {
-      // /api/sessions is optional — leave the badge as-is on failure
+    } catch (e) {
+      if (sessionsRetryTimer) clearTimeout(sessionsRetryTimer);
+      sessionsRetryTimer = setTimeout(function () {
+        sessionsRetryTimer = null;
+        refreshSessionsBadge();
+      }, 5000);
+    } finally {
+      sessionsFetchInFlight = false;
     }
   }
 

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1576,6 +1576,7 @@ if ('serviceWorker' in navigator) {
 
   function setDesire(text) {
     sbDesire.textContent = text || '(nothing actively pursued)';
+    sbDesire.title = text || '';
   }
 
   window.updateReflection = function (text) {
@@ -1694,10 +1695,66 @@ if ('serviceWorker' in navigator) {
     // First roster snapshot: honor a #agent=kind/id deep link (F5).
     if (typeof window.lisaHandleAgentHashOnce === 'function') window.lisaHandleAgentHashOnce();
     renderSessionTree();
+    renderNeeds();
     renderInspector();
     // Live refresh for an open stream tab (head/perm/foot reflect the
     // newest snapshot; steps repoll on their own timer too).
     if (currentAgentTab) renderStreamView();
+  }
+
+  // ── "Needs you" rail section (确认轮二) — every agent decision waiting
+  // on the user, actionable inline: approve/deny a pending permission, or
+  // jump straight into the read-only stream of a waiting/errored session.
+  function renderNeeds() {
+    const rows = document.getElementById('sbNeedsRows');
+    const count = document.getElementById('sbNeedsCount');
+    if (!rows) return;
+    rows.innerHTML = '';
+    const needs = cachedAgents.filter(function (s) {
+      return (s.activity && s.activity.pendingPermission) || s.state === 'waiting' || s.state === 'error';
+    });
+    if (count) count.textContent = needs.length ? String(needs.length) : '';
+    if (!needs.length) {
+      const ok = document.createElement('div');
+      ok.className = 'session-empty';
+      ok.textContent = 'all clear ✓';
+      rows.appendChild(ok);
+      return;
+    }
+    needs.slice(0, 6).forEach(function (s) {
+      const row = document.createElement('div');
+      row.className = 'needs-row';
+      row.innerHTML = '<span class="pip"></span><span class="nr-main"><span class="nr-name"></span><span class="nr-sub"></span></span>';
+      const st = s.state || 'unknown';
+      if (st === 'working' || st === 'waiting' || st === 'error') row.querySelector('.pip').classList.add(st);
+      row.querySelector('.nr-name').textContent = agentLabel(s);
+      const pend = s.activity && s.activity.pendingPermission;
+      row.querySelector('.nr-sub').textContent = pend ? ('⚠ ' + pend) : (s.stateReason || s.state);
+      row.title = (AGENT_NAMES[s.agent] || s.agent) + ' · ' + s.project + ' · ' + s.sessionId;
+      row.addEventListener('click', function () {
+        selInsp = { type: 'agent', key: agentKey(s) };
+        renderInspector();
+        renderSessionUI();
+      });
+      const acts = document.createElement('span');
+      acts.className = 'session-ctrl nr-acts';
+      if (s.controllable === 'managed' && pend) {
+        const ap = document.createElement('button');
+        ap.className = 'mc approve'; ap.textContent = '✓'; ap.title = 'Approve';
+        ap.addEventListener('click', function (e) { e.stopPropagation(); agentAction('managed', s.sessionId, 'approve', { allow: true }); });
+        const dn = document.createElement('button');
+        dn.className = 'mc deny'; dn.textContent = '✕'; dn.title = 'Deny';
+        dn.addEventListener('click', function (e) { e.stopPropagation(); agentAction('managed', s.sessionId, 'approve', { allow: false }); });
+        acts.appendChild(ap); acts.appendChild(dn);
+      } else {
+        const open = document.createElement('button');
+        open.className = 'mc'; open.textContent = '▤'; open.title = 'Open the read-only stream';
+        open.addEventListener('click', function (e) { e.stopPropagation(); if (window.lisaOpenAgentStream) window.lisaOpenAgentStream(s); });
+        acts.appendChild(open);
+      }
+      row.appendChild(acts);
+      rows.appendChild(row);
+    });
   }
 
   // ── Tree view mode (F3): group by agent kind (default) or by project ──
@@ -1937,9 +1994,11 @@ if ('serviceWorker' in navigator) {
     let lisaSession = null;
     if (selInsp && selInsp.type === 'agent') agent = agentByKey(selInsp.key);
     if (!agent && selInsp && selInsp.type === 'lisa') lisaSession = sessionById(selInsp.id);
+    // Default context = the ACTIVE Lisa session (确认轮二: no more
+    // auto-picking a random agent — the Needs-you section carries the
+    // agent-attention case now).
     if (!agent && !lisaSession) {
-      if (cachedAgents.length) agent = cachedAgents[0];
-      else lisaSession = sessionById(window.lisaActiveSessionId);
+      lisaSession = sessionById(window.lisaActiveSessionId);
     }
     if (agent) { renderAgentInspector(box, agent); return; }
     if (lisaSession) { renderLisaInspector(box, lisaSession); return; }
@@ -2230,22 +2289,10 @@ if ('serviceWorker' in navigator) {
   // client-side notion (which sessions you keep at hand), persisted in
   // localStorage; the tree is the full on-disk list.
   let cachedSessions = [];
-  // Open tabs: 'sessionId' strings (Lisa sessions) or {t:'agent', agent, id,
-  // label} objects (read-only agent stream tabs, F1). Old string-only
-  // payloads load unchanged.
-  let openTabIds = [];
-  try {
-    const rawTabs = localStorage.getItem('lisaOpenSessions');
-    if (rawTabs) openTabIds = JSON.parse(rawTabs).filter(function (x) {
-      return typeof x === 'string' || (x && x.t === 'agent' && typeof x.agent === 'string' && typeof x.id === 'string');
-    });
-  } catch (e) { openTabIds = []; }
-  function saveTabs() {
-    try { localStorage.setItem('lisaOpenSessions', JSON.stringify(openTabIds.slice(0, 12))); } catch (e) {}
-  }
-  function tabKeyOf(entry) {
-    return typeof entry === 'string' ? entry : entry.agent + '/' + entry.id;
-  }
+  // (确认轮二) Multi-tab strip removed: creating/switching lives in the
+  // sidebar tree only, and the strip renders a single CONTEXT CHIP for
+  // what the main pane is showing — the active Lisa session, or the
+  // observed agent while the stream pane is open.
   function sessionLabel(s) {
     // F2 auto-naming: the FIRST user message is the session's name (the
     // opening request describes the task); fall back to the latest one,
@@ -2270,7 +2317,6 @@ if ('serviceWorker' in navigator) {
       const r = await fetch('/api/sessions/' + encodeURIComponent(id) + '/activate', { method: 'POST' });
       const data = await r.json();
       if (data && data.ok) {
-        ensureTab(data.id);
         if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(data.id);
       }
     } catch (e) {}
@@ -2287,32 +2333,12 @@ if ('serviceWorker' in navigator) {
       const r = await fetch('/api/sessions', { method: 'POST' });
       const data = await r.json();
       if (data && data.ok) {
-        ensureTab(data.id);
         if (typeof window.lisaSetActiveSession === 'function') window.lisaSetActiveSession(data.id);
       }
     } catch (e) {}
     document.body.classList.remove('session-switching');
     switching = false;
     refreshSessionsBadge();
-  }
-  function ensureTab(id) {
-    if (!openTabIds.some(function (x) { return tabKeyOf(x) === id; })) openTabIds.unshift(id);
-    saveTabs();
-  }
-  function closeTab(key) {
-    const idx = openTabIds.findIndex(function (x) { return tabKeyOf(x) === key; });
-    if (idx >= 0) openTabIds.splice(idx, 1);
-    saveTabs();
-    if (currentAgentTab && tabKeyOf(currentAgentTab) === key) {
-      closeStreamView();
-      renderSessionUI();
-      return;
-    }
-    if (key === window.lisaActiveSessionId && openTabIds.length && typeof openTabIds[0] === 'string') {
-      switchSession(openTabIds[0]);
-      return;
-    }
-    renderSessionUI();
   }
 
   function renderSessionTree() {
@@ -2341,64 +2367,38 @@ if ('serviceWorker' in navigator) {
     renderAgentTree();
   }
 
+  // Single context chip: what the main pane is showing right now — the
+  // active Lisa session, or the observed agent while the stream pane is
+  // open (with an × back to chat). NOT a switcher: creation and switching
+  // live in the sidebar tree only (确认轮二).
   function renderTabs() {
     const strip = document.getElementById('tabStrip');
     if (!strip) return;
     strip.innerHTML = '';
-    // Drop Lisa tabs whose session vanished from disk; agent tabs persist
-    // (their sessions may simply be outside the 30-min active window).
-    openTabIds = openTabIds.filter(function (x) {
-      if (typeof x !== 'string') return true;
-      return sessionById(x) !== null || x === window.lisaActiveSessionId;
-    });
-    if (window.lisaActiveSessionId) ensureTab(window.lisaActiveSessionId);
-    openTabIds.slice(0, 6).forEach(function (entry) {
-      const key = tabKeyOf(entry);
-      const isAgent = typeof entry !== 'string';
-      const isActive = isAgent
-        ? !!(currentAgentTab && tabKeyOf(currentAgentTab) === key)
-        : (!currentAgentTab && entry === window.lisaActiveSessionId);
-      const tab = document.createElement('button');
-      tab.type = 'button';
-      tab.className = 'stab' + (isActive ? ' active' : '') + (!isAgent && window.lisaIsUnread && window.lisaIsUnread(key) ? ' unread' : '');
-      tab.innerHTML = '<span class="pip"></span>' + (isAgent ? '<span class="agent-glyph mini"></span>' : '') + '<span class="stab-name"></span><span class="stab-x" title="Close tab">×</span>';
-      if (isAgent) {
-        const s = agentByKey(key);
-        const g = tab.querySelector('.agent-glyph');
-        const kindName = AGENT_NAMES[entry.agent] || entry.agent;
-        g.classList.add(agentGlyphClass(entry.agent));
-        g.textContent = (kindName.charAt(0) || 'A').toUpperCase();
-        const st = s ? (s.state || 'unknown') : 'unknown';
-        if (st === 'working' || st === 'waiting' || st === 'error') tab.querySelector('.pip').classList.add(st);
-        tab.querySelector('.stab-name').textContent = s ? agentLabel(s) : (entry.label || entry.id);
-      } else {
-        const s = sessionById(entry);
-        if (isActive) tab.querySelector('.pip').classList.add('live');
-        tab.querySelector('.stab-name').textContent = s ? sessionLabel(s) : entry;
-      }
-      tab.addEventListener('click', function (e) {
-        if (e.target && e.target.classList && e.target.classList.contains('stab-x')) {
-          e.stopPropagation();
-          closeTab(key);
-          return;
-        }
-        if (isAgent) {
-          openStreamTab(entry);
-        } else {
-          closeStreamView();
-          if (entry === window.lisaActiveSessionId) renderSessionUI();
-          else switchSession(entry);
-        }
+    const chip = document.createElement('div');
+    chip.className = 'ctx-chip';
+    if (currentAgentTab) {
+      chip.classList.add('agent');
+      chip.innerHTML = '<span class="pip"></span><span class="agent-glyph mini"></span><span class="ctx-name"></span><span class="ctx-meta">observing</span><button type="button" class="ctx-x" title="Back to chat">×</button>';
+      const s = agentByKey(currentAgentTab.agent + '/' + currentAgentTab.id);
+      const kindName = AGENT_NAMES[currentAgentTab.agent] || currentAgentTab.agent;
+      const g = chip.querySelector('.agent-glyph');
+      g.classList.add(agentGlyphClass(currentAgentTab.agent));
+      g.textContent = (kindName.charAt(0) || 'A').toUpperCase();
+      const st = s ? (s.state || 'unknown') : 'unknown';
+      if (st === 'working' || st === 'waiting' || st === 'error') chip.querySelector('.pip').classList.add(st);
+      chip.querySelector('.ctx-name').textContent = s ? agentLabel(s) : (currentAgentTab.label || currentAgentTab.id);
+      chip.querySelector('.ctx-x').addEventListener('click', function () {
+        closeStreamView();
+        renderSessionUI();
       });
-      strip.appendChild(tab);
-    });
-    const plus = document.createElement('button');
-    plus.type = 'button';
-    plus.className = 'stab-new';
-    plus.title = 'New session';
-    plus.textContent = '＋';
-    plus.addEventListener('click', newSession);
-    strip.appendChild(plus);
+    } else {
+      chip.innerHTML = '<span class="pip live"></span><span class="ctx-name"></span><span class="ctx-meta"></span>';
+      const s = sessionById(window.lisaActiveSessionId);
+      chip.querySelector('.ctx-name').textContent = s ? sessionLabel(s) : (window.lisaActiveSessionId || '—');
+      chip.querySelector('.ctx-meta').textContent = s ? String(s.messageCount || 0) + ' msgs' : '';
+    }
+    strip.appendChild(chip);
   }
 
   // ── F1: read-only agent stream tab ─────────────────────────────────
@@ -2409,15 +2409,7 @@ if ('serviceWorker' in navigator) {
   let currentAgentTab = null;
   let streamTimer = null;
   let ptyStream = null;
-  function ensureAgentTab(s) {
-    const key = agentKey(s);
-    if (!openTabIds.some(function (x) { return tabKeyOf(x) === key; })) {
-      openTabIds.unshift({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
-      saveTabs();
-    }
-  }
   window.lisaOpenAgentStream = function (s) {
-    ensureAgentTab(s);
     openStreamTab({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
   };
   function openStreamTab(entry) {
@@ -2440,7 +2432,7 @@ if ('serviceWorker' in navigator) {
     if (ptyStream) { ptyStream.close(); ptyStream = null; }
   }
   function streamSession() {
-    return currentAgentTab ? agentByKey(tabKeyOf(currentAgentTab)) : null;
+    return currentAgentTab ? agentByKey(currentAgentTab.agent + '/' + currentAgentTab.id) : null;
   }
   function renderStreamView() {
     if (!currentAgentTab) return;
@@ -2662,6 +2654,11 @@ if ('serviceWorker' in navigator) {
     if (!body) return;
     while (body.firstChild) body.removeChild(body.firstChild);
     const hasAccounts = accounts && accounts.length > 0;
+    // 确认轮二: an unconnected mail section is pure noise — hide the whole
+    // card until a mailbox exists (the fnbar Mail button stays the entry
+    // point for connecting one).
+    const mailCard = document.getElementById('sbMailCard');
+    if (mailCard) mailCard.style.display = hasAccounts ? '' : 'none';
     if (connectBtn) connectBtn.textContent = hasAccounts ? '＋ add mailbox' : '＋ connect mailbox';
     if (!hasAccounts) {
       const empty = document.createElement('div');

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1734,7 +1734,8 @@ if ('serviceWorker' in navigator) {
       row.addEventListener('click', function () {
         selInsp = { type: 'agent', key: agentKey(s) };
         renderInspector();
-        renderSessionUI();
+        // Same as a tree click: straight into the conversation.
+        openStreamTab({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
       });
       const acts = document.createElement('span');
       acts.className = 'session-ctrl nr-acts';
@@ -1824,6 +1825,9 @@ if ('serviceWorker' in navigator) {
       for (let i = 0; i < all.length; i++) all[i].classList.remove('active');
       leaf.classList.add('active');
       renderInspector();
+      // 确认轮三: clicking an agent session OPENS its conversation directly
+      // (transcript stream pane) — same mental model as a Lisa session.
+      openStreamTab({ t: 'agent', agent: s.agent, id: s.sessionId, label: agentLabel(s) });
     });
     return leaf;
   }
@@ -2693,6 +2697,10 @@ if ('serviceWorker' in navigator) {
       cachedSessions = Array.isArray(data.sessions) ? data.sessions : [];
       sbSessionBadge.textContent = String(cachedSessions.length);
       renderSessionUI();
+      // The inspector's default target is the active Lisa session — it can
+      // only resolve once this list (and /session) has landed, so re-render
+      // here too or a fresh page shows "(idle)" until the next roster tick.
+      renderInspector();
     } catch {
       // /api/sessions is optional — leave the badge as-is on failure
     }

--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -516,6 +516,9 @@ function connectEvents() {
     } else if (ev.type === 'focus_session') {
       // F5 island deep link — select an agent session in the tree/inspector.
       if (typeof window.lisaFocusAgent === 'function') window.lisaFocusAgent(ev.agent, ev.session);
+    } else if (ev.type === 'chat_end') {
+      // A turn just finished (any window/session) — the ledger moved.
+      if (typeof window.refreshTokens === 'function') window.refreshTokens();
     } else if (ev.type === 'mail_digest_update' || ev.type === 'mail_accounts_update') {
       if (typeof window.refreshMail === 'function') window.refreshMail();
     }
@@ -2073,6 +2076,65 @@ if ('serviceWorker' in navigator) {
     } catch {}
   }
 
+  // ── Token source + usage (right-rail bottom section) ────────────────
+  // Source = the selected coding plan (plan://…) else the configured API
+  // key; usage = the local billing ledger's today/12h aggregates plus any
+  // per-plan window stats the plan detector reports.
+  function fmtUsd(microUSD) {
+    if (!microUSD) return '$0';
+    const usd = microUSD / 1e6;
+    return usd >= 1 ? '$' + usd.toFixed(2) : '$' + usd.toFixed(3);
+  }
+  function fmtCount(n) {
+    if (!n) return '0';
+    return n >= 1000 ? Math.round(n / 1000) + 'k' : String(n);
+  }
+  async function refreshTokens() {
+    const statsEl = document.getElementById('sbTokenStats');
+    const rowsEl = document.getElementById('sbTokenRows');
+    const modelEl = document.getElementById('sbTokenModel');
+    if (!statsEl || !rowsEl || !modelEl) return;
+    let model = '';
+    let usage = null;
+    let plansData = null;
+    try {
+      const r = await fetch('/session');
+      if (r.ok) { const d = await r.json(); model = d.model || ''; }
+    } catch (e) {}
+    try {
+      const r = await fetch('/api/billing/usage');
+      if (r.ok) usage = await r.json();
+    } catch (e) {}
+    try {
+      const r = await fetch('/api/plans');
+      if (r.ok) plansData = await r.json();
+    } catch (e) {}
+    modelEl.textContent = model;
+    modelEl.title = model;
+    statsEl.innerHTML = '';
+    rowsEl.innerHTML = '';
+    const today = usage && usage.today ? usage.today : null;
+    const win = usage && usage.window12h ? usage.window12h : null;
+    if (today) {
+      statsEl.appendChild(inspStat(fmtCount((today.inputTokens || 0) + (today.outputTokens || 0)), 'tokens'));
+      statsEl.appendChild(inspStat(String(today.turns || 0), 'turns'));
+      statsEl.appendChild(inspStat(fmtUsd(today.microUSD), 'today'));
+    }
+    let source = 'API key';
+    const plans = plansData && Array.isArray(plansData.plans) ? plansData.plans : [];
+    for (let i = 0; i < plans.length; i++) {
+      if (plans[i].selected) { source = String(plans[i].label || plans[i].id); break; }
+    }
+    rowsEl.appendChild(inspRow('source', source));
+    if (win) {
+      rowsEl.appendChild(inspRow('12h window', fmtCount((win.inputTokens || 0) + (win.outputTokens || 0)) + ' tok · ' + fmtUsd(win.microUSD)));
+    }
+    plans.forEach(function (p) {
+      if (p && p.available && p.usage) rowsEl.appendChild(inspRow(String(p.id || 'plan'), String(p.usage)));
+    });
+  }
+  window.refreshTokens = refreshTokens;
+
   // Exposed so the SSE handler above can call this on
   // agent_session_update events without redeclaring the helper. D4a — the
   // multi-agent snapshot (all agents), not just Claude Code.
@@ -2853,6 +2915,7 @@ if ('serviceWorker' in navigator) {
   window.refreshMail();
   refreshIdentity();
   refreshSessionsBadge();
+  refreshTokens();
   setInterval(refreshPing, 30_000);
   // Resolve refreshClaudeSessions at call time (arrow), not now: setupConsole
   // later wraps window.refreshClaudeSessions to re-render the active console
@@ -2860,6 +2923,8 @@ if ('serviceWorker' in navigator) {
   setInterval(() => window.refreshClaudeSessions(), 60_000);
   setInterval(window.refreshMail, 5 * 60_000);
   setInterval(refreshSessionsBadge, 5 * 60_000);
+  // Cheap resync for the tokens section; chat_end gives the fast path.
+  setInterval(refreshTokens, 5 * 60_000);
 })();
 
 // ════════════════════════════════════════════════════════════════════

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -1185,6 +1185,7 @@ export const MAIN_CSS = `  :root {
     color: var(--fg-3);
   }
   .kvrows { margin-top: 6px; }
+  .rightbar .stats:empty, .rightbar .kvrows:empty { display: none; margin: 0; }
   .kvrow {
     display: flex;
     align-items: center;
@@ -2204,6 +2205,10 @@ export const MAIN_CSS = `  :root {
     transition: background 120ms ease, color 120ms ease;
     min-height: 44px;
     padding: 0;
+    /* Identical hit areas: #recordBtn is a grid item (36px column) but
+       #plusBtn sits INSIDE .plus-wrap — without an explicit width it
+       shrank to its 19px icon. 100% = the 36px cell in both cases. */
+    width: 100%;
   }
   /* Line-style icons matching the .fbtn function bar above. */
   #plusBtn svg, #recordBtn svg { width: 19px; height: 19px; display: block; }

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -862,8 +862,11 @@ export const MAIN_CSS = `  :root {
     border-radius: 9px;
     padding: 1px 7px;
   }
-  .tchildren { padding-left: 16px; }
-  .tsub .tchildren { padding-left: 13px; }
+  /* Leaves sit flush with the group header column: the 8px pip centers
+     under the 12px twist, so the tree reads as aligned rows rather than
+     a deep indent (确认轮四 style pass). */
+  .tchildren { padding-left: 0; }
+  .tsub .tchildren { padding-left: 0; }
   .tsub > .tnode {
     font-size: 10px; padding: 5px 9px; color: var(--fg-3);
     font-weight: 700; letter-spacing: 0.09em; text-transform: uppercase;

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -298,6 +298,17 @@ export const MAIN_CSS = `  :root {
     background: var(--accent);
     box-shadow: 0 0 6px var(--accent-glow);
   }
+  /* Lisa's current pursuit, two lines max (moved out of the right rail). */
+  .identity .identity-desire {
+    margin: 5px 0 0;
+    font-size: 10.5px;
+    color: var(--fg-3);
+    line-height: 1.45;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
 
   /* Sidebar plain text section ("currently wanting") */
   .sb-section { display: flex; flex-direction: column; gap: 6px; }
@@ -790,8 +801,8 @@ export const MAIN_CSS = `  :root {
     border-color: var(--accent-glow);
     color: var(--accent);
   }
-  /* Mini source glyph on leaves in project view (Lisa + agents mixed). */
-  .tleaf .agent-glyph.mini {
+  /* Mini source glyph (project-view leaves, the context chip). */
+  .agent-glyph.mini {
     width: 14px; height: 14px;
     border-radius: 4px;
     font-size: 8px;
@@ -889,7 +900,9 @@ export const MAIN_CSS = `  :root {
     vertical-align: 2px;
   }
 
-  /* ── Session tab strip (fnbar left side) ────────────────────────── */
+  /* ── Context chip (fnbar left) — what the main pane is showing:
+     the active Lisa session, or the observed agent while the stream
+     pane is open. A status readout, not a switcher (确认轮二). ─── */
   .tabstrip {
     display: flex;
     align-items: center;
@@ -898,45 +911,41 @@ export const MAIN_CSS = `  :root {
     flex-shrink: 1;
     overflow: hidden;
   }
-  .stab {
+  .ctx-chip {
     display: flex;
     align-items: center;
-    gap: 7px;
-    max-width: 200px;
+    gap: 8px;
+    max-width: 460px;
     min-width: 0;
-    padding: 6px 11px;
+    padding: 6px 12px;
     border: 1px solid var(--border-new);
     border-radius: 9px;
-    background: transparent;
-    color: var(--fg-3);
-    font-family: inherit;
+    background: var(--bg-card);
+    color: var(--fg);
     font-size: 11.5px;
-    cursor: pointer;
     overflow: hidden;
     white-space: nowrap;
   }
-  .stab .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--fg-faint); flex: none; }
-  .stab .pip.live { background: var(--accent); animation: breathe 2.6s ease-in-out infinite; }
-  .stab .stab-name { overflow: hidden; text-overflow: ellipsis; }
-  .stab:hover { background: var(--bg-card); }
-  .stab.active {
-    background: var(--bg-card-strong);
-    border-color: var(--border-strong);
-    color: var(--fg);
-  }
-  .stab .stab-x { font-size: 12px; color: var(--fg-faint); padding: 0 1px; }
-  .stab .stab-x:hover { color: var(--fg); }
-  .stab-new {
-    border: 1px dashed var(--border-strong);
-    background: transparent;
+  .ctx-chip .pip { width: 7px; height: 7px; border-radius: 50%; background: var(--fg-faint); flex: none; }
+  .ctx-chip .pip.live { background: var(--accent); animation: breathe 2.6s ease-in-out infinite; }
+  .ctx-chip .pip.working { background: var(--proactive); animation: breathe 2.6s ease-in-out infinite; }
+  .ctx-chip .pip.waiting { background: var(--warm); animation: needsYou 2s ease-in-out infinite; }
+  .ctx-chip .pip.error { background: var(--err-color); }
+  .ctx-chip .ctx-name { overflow: hidden; text-overflow: ellipsis; font-weight: 600; min-width: 0; }
+  .ctx-chip .ctx-meta { flex: none; font-size: 10px; color: var(--fg-3); }
+  .ctx-chip.agent .ctx-meta { color: var(--claude); }
+  .ctx-chip .ctx-x {
+    flex: none;
+    background: none;
+    border: none;
     color: var(--fg-3);
-    width: 27px; height: 27px; flex: none;
-    border-radius: 9px;
-    font-size: 14px;
-    font-family: inherit;
     cursor: pointer;
+    font-size: 13px;
+    font-family: inherit;
+    padding: 0 2px;
+    line-height: 1;
   }
-  .stab-new:hover { color: var(--accent); border-color: var(--accent); }
+  .ctx-chip .ctx-x:hover { color: var(--fg); }
 
   /* ── Agent read-only stream (F1) — swaps in for the chat surface while
      an agent tab is active (body.agent-tab-active). ─────────────── */
@@ -1207,6 +1216,41 @@ export const MAIN_CSS = `  :root {
   .kvrow.warn > code { color: var(--warm); }
   .kvrow.err  > code { color: var(--err-color); }
   .insp-actions { margin-top: 10px; }
+
+  /* "Needs you" rows — actionable agent decisions (确认轮二). */
+  .needs-row {
+    display: flex;
+    align-items: center;
+    gap: 9px;
+    padding: 7px 0;
+    font-size: 11.5px;
+    cursor: pointer;
+  }
+  .needs-row + .needs-row { border-top: 1px solid var(--hairline); }
+  .needs-row .pip { width: 8px; height: 8px; border-radius: 50%; background: var(--fg-faint); flex: none; }
+  .needs-row .pip.working { background: var(--proactive); animation: breathe 2.6s ease-in-out infinite; }
+  .needs-row .pip.waiting { background: var(--warm); animation: needsYou 2s ease-in-out infinite; }
+  .needs-row .pip.error { background: var(--err-color); }
+  .needs-row .nr-main { flex: 1; min-width: 0; }
+  .needs-row .nr-name {
+    display: block;
+    color: var(--fg);
+    font-weight: 600;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .needs-row .nr-sub {
+    display: block;
+    margin-top: 1px;
+    font-size: 10.5px;
+    color: var(--fg-3);
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .needs-row .nr-acts { margin-top: 0; flex: none; }
 
   /* ── Primary nav (九宫格 3×3 tile grid in the sidebar) ────────── */
   .nav-list { display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px; }

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -1062,6 +1062,41 @@ export const MAIN_CSS = `  :root {
     border-radius: 0 8px 8px 0;
   }
   .srow.err .sdetail, .srow.err { color: var(--err-color); }
+  /* Transcript bubbles (确认轮三) — the owner's local conversation view of
+     an observed session; tool markers keep the .srow structural style. */
+  .as-msg {
+    flex: none;
+    padding: 8px 12px;
+    border-radius: 10px;
+    background: var(--bg-card);
+    border: 1px solid var(--border-new);
+    margin: 4px 0;
+    max-width: 86%;
+    align-self: flex-start;
+  }
+  .as-msg.user {
+    align-self: flex-end;
+    background: var(--accent-soft);
+    border-color: var(--accent-glow);
+  }
+  .as-msg .as-role {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.08em;
+    color: var(--fg-3);
+    margin-bottom: 4px;
+  }
+  .as-msg .as-role .stime { margin-left: auto; font-size: 9px; color: var(--fg-faint); }
+  .as-msg .as-text {
+    font-size: 12.5px;
+    line-height: 1.6;
+    color: var(--fg);
+    overflow-wrap: anywhere;
+  }
+
   .as-foot { display: flex; gap: 8px; flex: none; }
   .as-foot input {
     flex: 1;
@@ -1933,38 +1968,38 @@ export const MAIN_CSS = `  :root {
      lisa-html.ts). The base .msg keeps white-space:pre-wrap for the user's
      plain-text bubble; the block children below reset to normal flow and carry
      the hierarchy. Scoped to both so idle "★" notes render the same way. */
-  :is(.msg, .idle-block) > :first-child { margin-top: 0; }
-  :is(.msg, .idle-block) > :last-child { margin-bottom: 0; }
-  :is(.msg, .idle-block) :is(h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, table, td, th) { white-space: normal; }
-  :is(.msg, .idle-block) p { margin: 0 0 0.6em; }
-  :is(.msg, .idle-block) :is(h1, h2, h3, h4, h5, h6) {
+  :is(.msg, .idle-block, .as-text) > :first-child { margin-top: 0; }
+  :is(.msg, .idle-block, .as-text) > :last-child { margin-bottom: 0; }
+  :is(.msg, .idle-block, .as-text) :is(h1, h2, h3, h4, h5, h6, p, ul, ol, li, blockquote, table, td, th) { white-space: normal; }
+  :is(.msg, .idle-block, .as-text) p { margin: 0 0 0.6em; }
+  :is(.msg, .idle-block, .as-text) :is(h1, h2, h3, h4, h5, h6) {
     margin: 1em 0 0.5em;
     line-height: 1.3;
     font-weight: 650;
     color: var(--fg);
     letter-spacing: 0.01em;
   }
-  :is(.msg, .idle-block) h1 { font-size: 18px; }
-  :is(.msg, .idle-block) h2 {
+  :is(.msg, .idle-block, .as-text) h1 { font-size: 18px; }
+  :is(.msg, .idle-block, .as-text) h2 {
     font-size: 15.5px;
     padding-bottom: 5px;
     border-bottom: 1px solid var(--border-new);
   }
-  :is(.msg, .idle-block) h3 { font-size: 13.5px; color: #cfe9ff; }
-  :is(.msg, .idle-block) :is(h4, h5, h6) { font-size: 13px; color: var(--fg-2); }
-  :is(.msg, .idle-block) strong { font-weight: 680; color: #fff; }
-  :is(.msg, .idle-block) em { font-style: italic; color: var(--fg-2); }
-  :is(.msg, .idle-block) a {
+  :is(.msg, .idle-block, .as-text) h3 { font-size: 13.5px; color: #cfe9ff; }
+  :is(.msg, .idle-block, .as-text) :is(h4, h5, h6) { font-size: 13px; color: var(--fg-2); }
+  :is(.msg, .idle-block, .as-text) strong { font-weight: 680; color: #fff; }
+  :is(.msg, .idle-block, .as-text) em { font-style: italic; color: var(--fg-2); }
+  :is(.msg, .idle-block, .as-text) a {
     color: var(--accent);
     text-decoration: none;
     border-bottom: 1px solid rgba(106, 212, 255, 0.35);
   }
-  :is(.msg, .idle-block) a:hover { border-bottom-color: var(--accent); }
-  :is(.msg, .idle-block) :is(ul, ol) { margin: 0 0 0.6em; padding-left: 1.4em; }
-  :is(.msg, .idle-block) li { margin: 0.18em 0; }
-  :is(.msg, .idle-block) li::marker { color: var(--accent); }
-  :is(.msg, .idle-block) :is(ul, ol) :is(ul, ol) { margin: 0.18em 0 0; }
-  :is(.msg, .idle-block) blockquote {
+  :is(.msg, .idle-block, .as-text) a:hover { border-bottom-color: var(--accent); }
+  :is(.msg, .idle-block, .as-text) :is(ul, ol) { margin: 0 0 0.6em; padding-left: 1.4em; }
+  :is(.msg, .idle-block, .as-text) li { margin: 0.18em 0; }
+  :is(.msg, .idle-block, .as-text) li::marker { color: var(--accent); }
+  :is(.msg, .idle-block, .as-text) :is(ul, ol) :is(ul, ol) { margin: 0.18em 0 0; }
+  :is(.msg, .idle-block, .as-text) blockquote {
     margin: 0 0 0.6em;
     padding: 0.35em 0 0.35em 0.9em;
     border-left: 3px solid var(--accent);
@@ -1973,13 +2008,13 @@ export const MAIN_CSS = `  :root {
     font-style: italic;
     background: linear-gradient(90deg, var(--accent-soft), transparent 80%);
   }
-  :is(.msg, .idle-block) hr {
+  :is(.msg, .idle-block, .as-text) hr {
     border: 0;
     height: 1px;
     margin: 0.9em 0;
     background: linear-gradient(90deg, transparent, var(--border-strong), transparent);
   }
-  :is(.msg, .idle-block) :not(pre) > code {
+  :is(.msg, .idle-block, .as-text) :not(pre) > code {
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
     font-size: 0.86em;
     background: rgba(106, 212, 255, 0.10);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -153,10 +153,21 @@ import { MAIN_HTML } from "./lisa-html.js";
  * selected coding plan else API key from /api/plans, a 12h-window row, and
  * per-plan usage rows), refreshed on boot, every 5 minutes, and on the SSE
  * chat_end frame.
+ * Then: 确认轮二 — the multi-tab strip became a single CONTEXT CHIP (the
+ * active session's name/status, or the observed agent + "observing" + an ×
+ * back to chat; creating/switching lives in the sidebar tree only, and the
+ * lisaOpenSessions tab persistence is gone), and the right rail was
+ * re-anchored on core value: a new NEEDS-YOU section on top (waiting/error/
+ * pending-permission agents with inline approve/deny/open-stream), the
+ * inspector defaults to the ACTIVE Lisa session instead of auto-picking an
+ * agent, "currently wanting" compressed into the identity card (#sbDesire
+ * moved, 2-line clamp + tooltip), the mail card hides entirely until a
+ * mailbox is connected, and the reflection section is retitled "while you
+ * were away".
  */
-const EXPECTED_LENGTH = 293906;
+const EXPECTED_LENGTH = 297244;
 const EXPECTED_SHA256 =
-  "f42776661e43de2aec63839df82fcfc1cf3f3ad5ce385fb49b15501bc78fbebe";
+  "86687fde816a22f296b781f4026dff914e9fee6f8e97f05a1716689f8f137b49";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -188,10 +188,19 @@ import { MAIN_HTML } from "./lisa-html.js";
  * refreshSessionsBadge gained an in-flight guard + 5s retry and
  * renderSessionTree kicks it whenever it renders with an empty session
  * list (the "sessions vanished after refresh" flash).
+ * Then: 真实E2E — the tree / needs-you / inspector actions / stream
+ * perm+foot / context-chip × all rebuild on every roster tick, so their
+ * per-node listeners kept landing REAL clicks on freshly-replaced dead
+ * elements ("clicked and nothing happened"). All of them moved to
+ * DELEGATED listeners on the stable containers (#sessionTree,
+ * #sbNeedsRows, #sbClaudeRows click+keydown, #asPerm, #asFoot,
+ * #tabStrip); nodes now carry data-* attributes only
+ * (runDelegatedAction dispatches approve/deny/send/output/cancel/adopt/
+ * stream/open-lisa/close-stream).
  */
-const EXPECTED_LENGTH = 303662;
+const EXPECTED_LENGTH = 307402;
 const EXPECTED_SHA256 =
-  "30cb05fec303e3c582e49909a8502be89ae6130ef909bed6a7cadf0e156dec65";
+  "8c08d262b17ca6251b05e0430c06fd54482d2803482e317cad59a29bdc9590af";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -180,10 +180,18 @@ import { MAIN_HTML } from "./lisa-html.js";
  * Then: tree style pass (确认轮四) — .tchildren indents dropped to 0 so
  * session leaves sit flush with their group header column (the 8px pip
  * centers under the 12px twist) instead of a deep nested indent.
+ * Then: e2e hardening — session switch/new gained an 8s abort timeout,
+ * finally-reset of the switching flag (one hung POST used to lock every
+ * later ＋New/switch into a silent no-op), a console error on failure, and
+ * a composer LOCK while switching (typing into a session about to be
+ * switched away was the "sent but nothing happened" race);
+ * refreshSessionsBadge gained an in-flight guard + 5s retry and
+ * renderSessionTree kicks it whenever it renders with an empty session
+ * list (the "sessions vanished after refresh" flash).
  */
-const EXPECTED_LENGTH = 301558;
+const EXPECTED_LENGTH = 303662;
 const EXPECTED_SHA256 =
-  "b2108dcfa86bb2e10879b657d09c3ca692f828e2da5f5f5e3e3c2b8aa4057463";
+  "30cb05fec303e3c582e49909a8502be89ae6130ef909bed6a7cadf0e156dec65";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -171,10 +171,16 @@ import { MAIN_HTML } from "./lisa-html.js";
  * .as-text — with the structural tool markers interleaved as .srow rows)
  * and falls back to the structural steps when it's empty (remote access,
  * other agent kinds, quiet tail).
+ * Then: clicking an agent session in the tree (or a needs-you row) opens its
+ * conversation DIRECTLY — the leaf click now calls openStreamTab instead of
+ * only selecting the inspector (the "▤ stream" button remains as a secondary
+ * entry); and refreshSessionsBadge re-renders the inspector once the session
+ * list lands, fixing the "(idle)" inspector on a fresh page load (the roster
+ * used to win the race before /api/sessions and nothing re-rendered).
  */
-const EXPECTED_LENGTH = 300753;
+const EXPECTED_LENGTH = 301378;
 const EXPECTED_SHA256 =
-  "48db3b8ed4da067c019dc929dd410e5264d2855f9166b7277804833a0af9c0cf";
+  "e08761ff04a7cca87f2cc3f1f22749837a025fc222487df818781f6e43e93219";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -177,10 +177,13 @@ import { MAIN_HTML } from "./lisa-html.js";
  * entry); and refreshSessionsBadge re-renders the inspector once the session
  * list lands, fixing the "(idle)" inspector on a fresh page load (the roster
  * used to win the race before /api/sessions and nothing re-rendered).
+ * Then: tree style pass (确认轮四) — .tchildren indents dropped to 0 so
+ * session leaves sit flush with their group header column (the 8px pip
+ * centers under the 12px twist) instead of a deep nested indent.
  */
-const EXPECTED_LENGTH = 301378;
+const EXPECTED_LENGTH = 301558;
 const EXPECTED_SHA256 =
-  "e08761ff04a7cca87f2cc3f1f22749837a025fc222487df818781f6e43e93219";
+  "b2108dcfa86bb2e10879b657d09c3ca692f828e2da5f5f5e3e3c2b8aa4057463";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -164,10 +164,17 @@ import { MAIN_HTML } from "./lisa-html.js";
  * moved, 2-line clamp + tooltip), the mail card hides entirely until a
  * mailbox is connected, and the reflection section is retitled "while you
  * were away".
+ * Then: 确认轮三 — the stream pane loads the observed session's CHAT
+ * TRANSCRIPT: it first fetches the new loopback-only
+ * GET /api/agents/transcript (user/assistant message text as bubbles —
+ * agent replies markdown-rendered, the md style scope widened to include
+ * .as-text — with the structural tool markers interleaved as .srow rows)
+ * and falls back to the structural steps when it's empty (remote access,
+ * other agent kinds, quiet tail).
  */
-const EXPECTED_LENGTH = 297244;
+const EXPECTED_LENGTH = 300753;
 const EXPECTED_SHA256 =
-  "86687fde816a22f296b781f4026dff914e9fee6f8e97f05a1716689f8f137b49";
+  "48db3b8ed4da067c019dc929dd410e5264d2855f9166b7277804833a0af9c0cf";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -145,10 +145,18 @@ import { MAIN_HTML } from "./lisa-html.js";
  * session was switched away refreshes the log if the user is back on it,
  * else marks the session unread (lisaMarkUnread → ● dot on the tree leaf +
  * tab, cleared by lisaSetActiveSession).
+ * Then: composer-button hit parity + a TOKENS rail section — #plusBtn gets
+ * width:100% so its hit area matches #recordBtn's full 36px grid cell (it
+ * used to shrink to its 19px icon inside .plus-wrap); and the right rail
+ * gains a bottom #sbTokens section (model chip in the header, today
+ * tokens/turns/cost stat triplet from /api/billing/usage, source row =
+ * selected coding plan else API key from /api/plans, a 12h-window row, and
+ * per-plan usage rows), refreshed on boot, every 5 minutes, and on the SSE
+ * chat_end frame.
  */
-const EXPECTED_LENGTH = 290465;
+const EXPECTED_LENGTH = 293906;
 const EXPECTED_SHA256 =
-  "6e1035711ee27fec30547a3deefb56449f75eedd488613c3ad1bde920e0386b0";
+  "f42776661e43de2aec63839df82fcfc1cf3f3ad5ce385fb49b15501bc78fbebe";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -83,6 +83,9 @@ ${MAIN_CSS}
         <h1>Lisa</h1>
         <p class="sub" id="identitySub">—</p>
         <div class="mood" id="mascotTag">neutral</div>
+        <!-- Lisa's current autonomous pursuit, compressed to two lines
+             (moved out of the right rail — full text in the tooltip). -->
+        <p class="identity-desire" id="sbDesire" title="">—</p>
       </div>
     </div>
 
@@ -203,12 +206,17 @@ ${MAIN_CSS}
        working (setupSidebarLive resolves them unguarded). -->
   <aside class="rightbar">
 
-    <!-- Currently wanting -->
-    <div class="rb-sec">
+    <!-- Needs you — every agent decision waiting on the user, actionable
+         inline (approve/deny/open). The rail's top slot: this is the
+         multi-agent console's highest-value surface. -->
+    <div class="rb-sec" id="sbNeeds">
       <div class="h">
-        <div class="left">currently wanting</div>
+        <div class="left">needs you</div>
+        <div class="count" id="sbNeedsCount"></div>
       </div>
-      <p class="body-text" id="sbDesire">—</p>
+      <div id="sbNeedsRows">
+        <div class="session-empty">all clear ✓</div>
+      </div>
     </div>
 
     <!-- Inspector — detail card for the session selected in the sidebar
@@ -242,10 +250,11 @@ ${MAIN_CSS}
       </button>
     </div>
 
-    <!-- Last reflection (collapsed pointer to the most recent ★) -->
+    <!-- While you were away — Lisa's latest idle reflection. Hidden until
+         one exists (same label as the chat's idle cards). -->
     <div class="rb-sec" id="sbReflection" style="display:none;">
       <div class="h">
-        <div class="left">★ last reflection</div>
+        <div class="left">★ while you were away</div>
       </div>
       <p class="body-text" id="sbReflectionBody"></p>
     </div>

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -250,6 +250,16 @@ ${MAIN_CSS}
       <p class="body-text" id="sbReflectionBody"></p>
     </div>
 
+    <!-- Token source + usage (bottom of the rail; wired in setupSidebarLive) -->
+    <div class="rb-sec" id="sbTokens">
+      <div class="h">
+        <div class="left">tokens</div>
+        <div class="count" id="sbTokenModel"></div>
+      </div>
+      <div class="stats" id="sbTokenStats"></div>
+      <div class="kvrows" id="sbTokenRows"></div>
+    </div>
+
   </aside>
 </div>
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3008,10 +3008,22 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       }
       let steps: unknown[] = [];
       if (session.activity && session.jsonlPath) {
-        const { parseSessionSteps } = await import(
-          "../integrations/claude-code/parser.js"
-        );
-        steps = await parseSessionSteps(session.jsonlPath);
+        if (agent === "claude-code") {
+          const { parseSessionSteps } = await import(
+            "../integrations/claude-code/parser.js"
+          );
+          steps = await parseSessionSteps(session.jsonlPath);
+        } else if (agent === "codex") {
+          const { parseCodexSteps } = await import(
+            "../integrations/codex/observer.js"
+          );
+          steps = await parseCodexSteps(session.jsonlPath);
+        } else if (agent === "aider") {
+          const { parseAiderSteps } = await import(
+            "../integrations/aider/observer.js"
+          );
+          steps = await parseAiderSteps(session.jsonlPath);
+        }
       }
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ steps }));
@@ -3211,12 +3223,14 @@ self.addEventListener('fetch', (event) => {
     }
 
     if (req.method === "GET" && url === "/api/sessions") {
-      // Lisa's own chat sessions on disk — drives the sidebar footer count
-      // badge. (Was missing → the badge fetch 404'd and stayed a placeholder.)
+      // Lisa's own chat sessions on disk — the session tree/tabs + the iOS
+      // roster's LISA group. Contract: LisaSessionsResponse (the on-disk
+      // path is stripped by the serializer).
       const { listSessionsOnDisk } = await import("../sessions/list.js");
+      const { lisaSessionsResponse } = await import("./api-contract.js");
       const sessions = await listSessionsOnDisk();
       res.writeHead(200, { "content-type": "application/json" });
-      res.end(JSON.stringify({ sessions }));
+      res.end(JSON.stringify(lisaSessionsResponse(sessions)));
       return;
     }
 

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -3030,6 +3030,53 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       return;
     }
 
+    // 确认轮三 — the OWNER's local transcript view of an observed session:
+    // user/assistant message text plus the structural tool markers. STRICTLY
+    // LOOPBACK-ONLY (defence in depth like /api/config/save): unlike steps,
+    // message content must never leave this machine — island / iOS / remote
+    // callers keep the structural surfaces.
+    if (req.method === "GET" && url.startsWith("/api/agents/transcript")) {
+      const tRemote = req.socket.remoteAddress ?? "";
+      if (!isLoopbackAddress(tRemote)) {
+        res.writeHead(403, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            ok: false,
+            error: "transcript is only served to localhost",
+          }),
+        );
+        return;
+      }
+      const q = new URL(url, "http://localhost").searchParams;
+      const agent = q.get("agent") ?? "";
+      const id = q.get("id") ?? "";
+      const session = hub
+        .list()
+        .find((s) => s.agent === agent && s.sessionId === id);
+      if (!session) {
+        res.writeHead(404, { "content-type": "application/json" });
+        res.end(JSON.stringify({ ok: false, error: "unknown_session" }));
+        return;
+      }
+      let entries: unknown[] = [];
+      if (session.activity && session.jsonlPath) {
+        if (agent === "claude-code") {
+          const { parseSessionTranscript } = await import(
+            "../integrations/claude-code/parser.js"
+          );
+          entries = await parseSessionTranscript(session.jsonlPath);
+        } else if (agent === "codex") {
+          const { parseCodexTranscript } = await import(
+            "../integrations/codex/observer.js"
+          );
+          entries = await parseCodexTranscript(session.jsonlPath);
+        }
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify({ entries }));
+      return;
+    }
+
     // L6 — cross-agent "while you were away" recap, synthesized from the
     // journal. ?sinceMinutes=N (default 120) bounds the window.
     if (req.method === "GET" && url.startsWith("/api/agents/recap")) {


### PR DESCRIPTION
v1.1 波次的遗留清零（base = p8，整条链的最后一个）。合并顺序：#343→#344→#345→#346→#347→#348→#349→#350→本 PR。

## 内容

**其余 agent 的过程流**
- `AgentStep` 上移到 `integrations/types.ts` 共享
- codex：`parseCodexSteps`（与其 activity 解析同一 128KB tail 遍历；target 只有文件 basename / shell argv[0]，`arguments` 只查已知键、原串永不外流）
- aider：`parseAiderSteps` —— 其历史是 Markdown 正文，按隐私约定**只做结构标记**（user turn / 折叠的工具段 / assistant 块），不从 prose 提取任何名字
- 两个 observer 补 `jsonlPath`；steps 端点按 agent 种类分发；两份 secret 种植测试

**合约收编（顺带修一个隐私泄漏）**
- `GET/POST /api/sessions`、`POST /api/sessions/{id}/activate` 进 OpenAPI 合约（LisaSession* schemas）
- 新 `lisaSessionsResponse` 序列化器把绝对磁盘路径从 wire 上剥掉（之前 `/api/sessions` 一直在泄漏本机 home 目录路径）；`agentSessionsResponse` 的 `jsonlPath` 剥离也补了类型与测试

**iOS 补全**
- roster 增加 **LISA 根组**（走新收编的端点；tap = 在 Mac 上激活该会话并跳到 Chat tab）—— 至此 iOS 与 web 树同构
- Store / Onboarding 不再强制深色，跟随 Appearance 选择（共享 `AppState.preferredScheme`）

## 验证

全量 1548 通过 / 0 失败；`check:api-contract` 绿；模拟器构建绿。

🤖 Generated with [Claude Code](https://claude.com/claude-code)