### PR TITLE
docs: DeepSeek Harness 调研引入 + LISA 对齐计划 v1.0

### DIFF
--- a/docs/PLAN_HARNESS_ALIGNMENT_v1.0.md
+++ b/docs/PLAN_HARNESS_ALIGNMENT_v1.0.md
@@ -140,21 +140,25 @@ LISA 的会话 JSONL **已经**记录了 `tool_use` / `tool_result`（它们是 
 
 ### 做法（分两步，第一步很便宜）
 
-**Step 1（低成本，先做）**：新增两类日志条目
-- `{type:"prompt", ts, fingerprint, text}` — 会话开始时写一次全文；
-- `{type:"prompt_rebuilt", ts, fingerprint, text}` — 每次热重载写一次全文。
+**Step 1（低成本，先做）**：新增一类日志条目 `{type:"prompt", ts, fingerprint, text, reason}`，`reason` 区分 `initial`（本次运行的开局提示词）与 `rebuilt`（中途热重载）。
 
-`getPromptFingerprint` 已存在（[prompt.ts:237](../src/prompt.ts)），热重载点也已存在（`agent.ts:228` 的 `if (next.fingerprint !== currentFingerprint)`），改动面很小。体积可控：一份系统提示词几 KB，一次会话通常个位数次重载。若嫌大，只在 fingerprint 变化时写全文，其余写 fingerprint 引用。
+`getPromptFingerprint` 已存在（[prompt.ts:237](../src/prompt.ts)），热重载点也已存在（`agent.ts:228` 的 `if (next.fingerprint !== currentFingerprint)`），改动面很小。体积可控：一份系统提示词几 KB，一次会话通常个位数次重载。`fingerprint` 用正文的内容哈希、连续相同不重复写，所以"第 N 条时生效的提示词"= 最近的前一条 prompt 条目，从不自我修改的长对话只花一条。
 
 **Step 2（可选，之后再说）**：把 `SessionStore` 从"消息日志"推向"事件日志"，加一条运行时断言——任何进入 `provider.runTurn` 的输入都必须能从日志重建。这是 dsh 的完整形态，成本高，**不是 1.0 必需**。
 
 **明确不做**：不抄 `assistant/chunk` 级别的流式保真（LISA 的 UI 不需要逐 chunk 回放），不引入 SQLite 持久化（JSONL 够用，projection cache 等有性能问题再说）。
 
+### 实现中发现的边界（Step 1 已落地，见 PR #357）
+
+`systemPrompt` 是**逐字精确**的。但 `messages` 只是会话正典全量，**不等于每轮真正发出去的消息窗口**：web 表层把 `modelContext.history`（历史的有界后缀）传给 `runAgent`，而会话文件保留完整历史（[web/server.ts:4060](../src/web/server.ts) 的注释自己写明了这点）；CLI 与渠道表层不做窗口，两者一致。
+
+也就是说 H3 的不变量目前对**提示词**成立、对**消息窗口**不成立。做 token 级精确重放的调用方需自行处理；做"她被告知自己是谁"分析的不受影响——而后者正是本项的目的。补上窗口边界记录属于 **Step 2**。
+
 ### 验收
 
-- [ ] 会话 JSONL 含 `prompt` / `prompt_rebuilt` 条目，`SessionHeader.version` 同步升级；
-- [ ] 写一个离线脚本：读一条历史会话 → 完整重建每一轮的 `(system, messages)` 输入；
-- [ ] 该脚本成为 Reve drift 指标与论文实验的取数入口（这是本项的真实交付物，不是日志本身）。
+- [x] 会话 JSONL 含 `prompt` 条目，`SessionHeader.version` 同步升级（v1 → v2，旧会话仍可读）；
+- [x] 写一个离线脚本：读一条历史会话 → 重建每一轮的 `(system, messages)` 输入（`src/sessions/replay.ts` + `scripts/replay-session.ts`，随 #357 落地）；
+- [ ] 该脚本成为 Reve drift 指标与论文实验的取数入口（这是本项的真实交付物，不是日志本身）——**还没接上，是下一步**。
 
 ---
 
@@ -166,15 +170,33 @@ dsh 是**目前唯一一个既有本地会话文件、又有 headless CLI、还�
 
 **两个层级，按成本**：
 
-1. **L1 OBSERVE（约 1 天）**：写 `src/integrations/dsh/observer.ts`，读 `$DSH_HOME` 下的会话 JSONL，映射到 `AgentSession`。**做之前先确认 dsh 的磁盘格式** —— README 明示 `SESSION_FORMAT_VERSION = 0` 不给兼容承诺，所以适配器必须对未知字段宽容、对格式变更优雅失败（这一点写进适配器注释）。
-2. **L3 COMMAND（约 1 天，L1 之后）**：`dispatch_agent` 增加 `dsh` 后端，用 `dsh --profile headless "job"` 拉起一次性运行。这是 dsh 最稳定的接口（无服务器、跑完退出），比接 ACP/SDK 风险低得多。
+1. **L1 OBSERVE**：写 `src/integrations/dsh/observer.ts`，读 dsh 的会话日志映射到 `AgentSession`。
+2. **L3 COMMAND（L1 之后）**：`dispatch_agent` 增加 `dsh` 后端，用 `dsh --profile headless "job"` 拉起一次性运行。这是 dsh 最稳定的接口（无服务器、跑完退出），比接 ACP/SDK 风险低得多。
 
 **不做**：不接 ACP、不接 dsh SDK、不做 resume-adopt（同 codex 的理由，见 [PTY_AGENTS.md](./PTY_AGENTS.md)）。
 
+### ⚠ 格式核查结果（2026-08-14）：L1 比预估贵得多，**暂缓**
+
+本节原估 L1「约 1 天」，并注明「做之前先确认 dsh 的磁盘格式」。核查做了（读 `deepseek-ai/deepseek-harness` 的 `packages/session/session-persistence-jsonl/src/{format,index}.ts` 与 `docs/subsystems/persistence.md`），**结论推翻了估算**：
+
+| 核查项 | 实际 | 对适配器的影响 |
+|---|---|---|
+| 物理编码 | **默认 Zstandard**（`session.jsonl.zstd`），且 header 单独占一个可独立解码的首帧；dsh 自带 `zstd-*-decoder.ts` | 不是"读一个 JSONL"。要么实现兼容其分帧约定的 zstd 解码，要么只支持用户显式配了 `compression: 'none'` 的部署 |
+| 日志根目录 | `root` 是**必填插件配置、无默认值**（他们明确拒绝默认 `process.cwd()`） | 没有 `~/.claude/projects` 那样的公知路径可监听。适配器得解析当前 profile 的 `cordis.patch.yml` 才知道去哪找 |
+| 事件行 | `packChunks` **默认 true**，delta 会被打包成 `text-chunks`/`reasoning-chunks`/`tool-call-chunks` 行，需 `decodeStorageRecord` | 第二层解码 |
+| 目录布局 | `<root>/--<cwd 转义>--/<会话 id 转义>/session.jsonl[.zstd]`，转义规则自定义（`~XXXX`） | 可实现，但要照抄两套转义函数 |
+| 版本 | `SESSION_FORMAT_VERSION`，遇到不认识的版本主动拒绝，且 README 不给兼容承诺 | 每次 dsh 升版都可能要跟 |
+
+**决定：L1 暂缓，不写投机适配器。** 在本机没有装 dsh、无法对真实产物验证的情况下照着源码猜一个解析器，正是 [OBSERVER_FIDELITY.md](./OBSERVER_FIDELITY.md) 记录过的那类问题——单测能证明解析逻辑对得上 fixture，证明不了 fixture 对得上真实工具写出来的东西。
+
+**重新排期**：
+- **先做 L3**（`dispatch_agent` 的 dsh 后端）。它依赖的是 README 明文承诺的 CLI 契约（`dsh --profile headless "job"` → 跑完打印最终答案退出），面比磁盘格式窄得多、也稳定得多，而且不需要先有 L1。原文把 L1 排在 L3 前面是错的。
+- **L1 的前置条件**：本机装一个真实 dsh、跑出几个会话、按 `scripts/verify-observers.ts` 的路子对真实产物核对字段。没有这一步就不要开工。
+
 ### 验收
-- [ ] `lisa` 能在 hub 里列出正在跑的 dsh 会话，字段深度对齐 Tier-2 基线；
-- [ ] `dispatch_agent(backend:"dsh")` 能跑通一个真实任务并回收输出；
-- [ ] dsh 未安装 / 格式变更时适配器降级为"不可见"，不报错、不崩 hub。
+- [ ] （L3）`dispatch_agent(backend:"dsh")` 能跑通一个真实任务并回收输出；dsh 未安装时给出清晰错误而非崩溃；
+- [ ] （L1，前置满足后）`lisa` 能在 hub 里列出正在跑的 dsh 会话，字段深度对齐 Tier-2 基线；
+- [ ] （L1）dsh 未安装 / 格式变更时适配器降级为"不可见"，不报错、不崩 hub。
 
 ---
 
@@ -193,20 +215,28 @@ dsh 是**目前唯一一个既有本地会话文件、又有 headless CLI、还�
 
 ## 7. 排期
 
-| 优先级 | 项 | 规模 | 服务的支柱 |
-|---|---|---|---|
-| **P0** | H1 能力 seam（fs + shell，local 提供方） | 中（纯重构，行为零变化） | Dispatch / Cloud / 测试 |
-| **P0** | H2 沙箱三档 + fail-closed + 会话级固定 | 中（依赖 H1） | Dispatch / Sense / Foundations |
-| **P0** | H3 Step 1 提示词入日志 + 离线重建脚本 | **小** | Reve / **论文** |
-| **P1** | I1 L1 dsh observer | 小 | Dispatch |
-| **P1** | `AGENTS.md` / `CLAUDE.md` 指令链加载 | 小 | 生态兼容 |
-| **P1** | Skills 加项目级目录 + 热监听 | 小 | 生态兼容 |
-| **P2** | I1 L3 dsh dispatch 后端 | 小 | Dispatch |
-| **P2** | 工具结果 pruner + spill store | 中 | 成本 |
-| **P2** | `session_search` 模型可见工具 | 小（依赖 H3） | 记忆 |
-| **缓** | Code Mode / 用户可编辑 preset | 大 | — |
+状态列更新于 2026-08-14。
+
+| 优先级 | 项 | 规模 | 服务的支柱 | 状态 |
+|---|---|---|---|---|
+| **P0** | H3 Step 1 提示词入日志 + 离线重建脚本 | **小** | Reve / **论文** | ✅ #357 |
+| **P0** | H1 能力 seam（fs + shell，local 提供方） | 中（纯重构，行为零变化） | Dispatch / Cloud / 测试 | ✅ #358 |
+| **P0** | H2 沙箱三档 + fail-closed + 会话级固定 | 中（依赖 H1） | Dispatch / Sense / Foundations | ✅ #359（栈在 #358 上） |
+| **P1** | `AGENTS.md` / `CLAUDE.md` 指令链加载 | 小 | 生态兼容 | ✅ #360 |
+| **P1** | Skills 加项目级目录 | 小 | 生态兼容 | ✅ #360 |
+| ~~P1~~ | ~~Skills 热监听~~ | — | — | ❌ 不做：skills 本来就经提示词指纹每轮重读，加 chokidar 依赖是纯冗余 |
+| **P1** | H3 的取数入口接进 Reve drift 指标 / 论文实验 | 小 | **论文** | 待做（H3 的真实交付物） |
+| **P1** | I1 **L3** dsh dispatch 后端 | 小 | Dispatch | 待做（**已提到 L1 前面**，见 §5 的格式核查） |
+| **P2** | 按 surface 收紧无人值守沙箱默认值（§3 的表） | 小 | Foundations | 待做（会改行为，单独一步） |
+| **P2** | H3 Step 2：记录消息窗口边界 | 中 | 论文精确性 | 待做（见 §4 的边界说明） |
+| **P2** | 工具结果 pruner + spill store | 中 | 成本 | 待做 |
+| **P2** | `session_search` 模型可见工具 | 小（依赖 H3） | 记忆 | 待做 |
+| **暂缓** | I1 **L1** dsh observer | **大**（原估"小"，核查后推翻） | Dispatch | ⛔ 前置未满足，见 §5 |
+| **缓** | Code Mode / 用户可编辑 preset | 大 | — | — |
 
 **建议起手**：**H3 Step 1**。它最小、最独立（不依赖 H1/H2）、且直接产出论文要用的测量工具——先拿到"能离线重建每一轮模型输入"这个能力，后面的 drift/coherence 实验才有地基。然后做 H1，H2 自然长在 H1 上。
+
+*（回看：这个顺序是对的。H3 独立落地，H1 是纯重构、行为零变化，H2 只是在 H1 的 seam 上加一个提供方——如果先做 H2，那三个洞就得在七个工具里各补一遍。）*
 
 ---
 

--- a/docs/PLAN_HARNESS_ALIGNMENT_v1.0.md
+++ b/docs/PLAN_HARNESS_ALIGNMENT_v1.0.md
@@ -1,0 +1,231 @@
+# LISA × DeepSeek Harness 对齐计划 v1.0
+
+> 依据：[RESEARCH_DEEPSEEK_HARNESS.md](./RESEARCH_DEEPSEEK_HARNESS.md)（2026-08-13 调研，2026-08-14 引入本仓）
+> 日期：2026-08-14 · 基线：v0.23.0（`9cfe2a3`）· 关联：[ROADMAP_v1.0.md](./ROADMAP_v1.0.md)、[PLAN_FOUNDATIONS_v1.0.md](./PLAN_FOUNDATIONS_v1.0.md)、[PLAN_DISPATCH_v1.0.md](./PLAN_DISPATCH_v1.0.md)、[PLAN_CLOUD_v1.0.md](./PLAN_CLOUD_v1.0.md)
+> 文中行号以当前树为准，后续修改会漂移。
+
+## 0. 结论先行
+
+对 LISA 而言，dsh **不是引擎候选，是一面镜子 + 一个新的被指挥对象**。
+
+1. **生态兼容层无事可做。** dsh 花大力气建的兼容面（多提供方 + `apiKeyEnv` 引用、Claude Code `hooks.json`、`SKILL.md`、`mcp__<server>__<tool>` 命名、把 Claude Code / Codex CLI 当子代理），LISA **已经全部有了，部分还更全**。这一层照抄没有增量。
+2. **真差距只有三处**，且每一处恰好卡在 1.0 的一条主线上：
+   - **H1 能力 seam** — 工具直接 `import fs` / `spawn`，没有可替换的执行世界 → 卡住 Dispatch 的远程执行与 Cloud 的多租户隔离；
+   - **H2 权限与沙箱** — 默认关、只包 `bash`、非 macOS 静默降级 → 卡住 Dispatch「闭合本地命令回路」的安全地板与 Sense 的隐私地板；
+   - **H3 会话日志的真源地位** — 系统提示词一个字节都不进日志 → 卡住 Reve 的 drift/coherence 度量，也卡住论文的测量工具。
+3. **唯一值得写代码"接入"的**：把 `dsh` 加成 `src/integrations/` 的第 11 个 observer / dispatch 目标。既有注册表天然支持，成本一天，收益直接落在 Dispatch 支柱上。
+4. **明确不做**：不 fork、不把 dsh 当执行引擎、不引入 Cordis、不做 Code Mode（暂缓）。
+
+一句话：**dsh 免费化的是 harness 管道，而 LISA 的护城河从来不是管道，是 soul / desire / mood / KB / Reve 这一层持久身份——dsh 这一层是零。** 这次调研对 LISA 的价值是"体检报告"，不是"选型报告"。
+
+---
+
+## 1. 逐项对照（现状盘点）
+
+| dsh 概念 | LISA 现状 | 差距 | 结论 |
+|---|---|---|---|
+| 能力 seam（`ctx.fs` / `ctx.shell` / `ctx.subprocess` / `ctx.sandbox`） | `ToolContext = { cwd, signal, log, onObjection? }`（[types.ts:24](../src/types.ts)）；工具各自 `import fs from "node:fs"` / `spawn` | **大** | **H1 抄** |
+| 权限：`sandbox/mode` ×3 + `approval/policy` ×2 + preset，fail-closed | `LISA_SANDBOX` 布尔且默认关（[sandbox.ts:50](../src/sandbox/sandbox.ts)）；只有 `bash` 走沙箱（[bash.ts:34](../src/tools/bash.ts)）；非 macOS **静默降级**（[sandbox.ts:46](../src/sandbox/sandbox.ts)）；`--approval` 默认 `auto`（[cli-args.ts:81](../src/cli-args.ts)） | **大** | **H2 抄** |
+| 会话日志唯一真源 / 模型可见 ⟺ 已记录 | JSONL 只写 header / message / reflection（[sessions/store.ts](../src/sessions/store.ts)）；`tool_use`/`tool_result` 在 message 的 content block 里**已在**；但**系统提示词不在**，且中途会热重载（[agent.ts:225](../src/agent.ts)） | **中** | **H3 抄** |
+| Agent Preset（用户可复制修改的模式） | 编译期 subset 函数：`readOnlySubset` / `autonomousSubset` / `remoteSafeSubset` / `cloudSafeSubset` / `desireReviewSubset`（[tools/registry.ts:128–306](../src/tools/registry.ts)） | 中 | **P2 缓**（见 §5） |
+| 多提供方 + 凭据只存引用 | `OPENAI_COMPAT_PRESETS` 20+ 家含 DeepSeek，`apiKeyEnv` 引用制（[providers/registry.ts:38+](../src/providers/registry.ts)） | **无（LISA 更全）** | 不动 |
+| Claude Code `hooks.json` | 已支持同形状 6 事件（[plugins/types.ts:27](../src/plugins/types.ts)、[hooks/runner.ts](../src/hooks/runner.ts)） | 无 | 不动 |
+| `SKILL.md` | 已支持；但只有单层 `~/.lisa/skills`（[skills/manager.ts](../src/skills/manager.ts)），无项目级、无热监听 | 小 | **P1 小补** |
+| MCP `mcp__<server>__<tool>` | 已同形状（[mcp/client.ts:76](../src/mcp/client.ts)） | 无 | 不动 |
+| 把别家 CLI 当子代理 | `src/agents/pty.ts` + `managed.ts` + `dispatch_agent` 已可拉起/接管 claude / codex | **无（等价能力已有）** | 不动 |
+| `AGENTS.md` / `CLAUDE.md` 指令链 | **无**（全仓无加载逻辑） | 小 | **P1 小补** |
+| goal 三件套（跨轮次目标 + 人类根权限） | `soul/desires` + `desire_progress/revise/close` + `autonomy/runs` | **无（LISA 更强：desire 是人格化长期目标，不只是任务）** | 不动 |
+| `session_search` / `session_trace` 模型可见 | 无会话检索工具；有 `memory_search` / `kb_search` | 小 | **P2 缓**（依赖 H3） |
+| 压缩：pruner + spill store | `--compact` 直接开 Anthropic 原生 context management（[providers/anthropic.ts:85](../src/providers/anthropic.ts)） | 中 | **P2 缓** |
+| Code Mode（`run_code`） | 无 | — | **不做**（见 §4） |
+| ACP / SDK 程序化入口 | web server + `contracts/` API contract | 小 | 不动 |
+| 桌面 / 移动 / 语音 / 常驻感知 | Mac Island、iOS Pocket、voice、Sense observers | **无（dsh 完全没有）** | 不动 |
+
+**读法**：右侧只有三行写着"大/中 + 抄"。这就是本计划的全部实质。
+
+---
+
+## 2. H1 — 能力 seam：把 `ToolContext` 扩成能力容器
+
+### 问题
+
+LISA 的工具直接 `import fs from "node:fs/promises"`、直接 `spawn`。后果有三个，都已经在路线图上咬人：
+
+- **Dispatch** 想把执行搬到远程/容器里，就得给每个工具写第二份实现；
+- **Cloud** 的多租户隔离目前靠 `homeScope` AsyncLocalStorage 兜住 `lisaHome()`（[paths.ts:20](../src/paths.ts)），但 `write` / `edit` / `bash` 的 `ctx.cwd` 不受它管——所以云端只能用 `cloudSafeSubset` 白名单硬砍掉这些工具（[tools/registry.ts:283](../src/tools/registry.ts)）。**白名单是补丁，seam 才是解**；
+- **测试**只能靠真实文件系统，没有内存实现。
+
+dsh 的答案：`ctx.fs` / `ctx.shell` / `ctx.subprocess` 是接口，`local` / `sandbox` / `e2b` 是可换的提供方，工具只消费接口。**换提供方 = 换整个执行世界，一行工具代码都不改。**
+
+### 做法（最小可行）
+
+```ts
+// src/types.ts — 扩 ToolContext，不改现有字段
+export interface ToolContext {
+  cwd: string;
+  signal: AbortSignal;
+  log: (msg: string) => void;
+  onObjection?: (o: {...}) => void;
+  /** 执行世界。缺省 = local 提供方（现行为，逐字等价）。 */
+  caps?: Capabilities;
+}
+
+export interface Capabilities {
+  fs: FsCapability;        // readFile/writeFile/stat/readdir/rm，带根目录约束
+  shell: ShellCapability;  // run(cmd) → {stdout, stderr, code}
+}
+```
+
+- **第一步只做 `fs` 与 `shell` 两个 seam**，提供方只做 `local`；
+- 迁移顺序：`read` / `write` / `edit` / `apply_patch` / `ls` / `grep` / `bash` 七个工具改成 `ctx.caps.fs` / `ctx.caps.shell`；其余工具（soul / memory / kb / github / …）**不动**——它们操作的是 LISA 自己的 home，本来就该走 `lisaHome()`；
+- `caps` 可选、缺省注入 local 提供方，所以**这一步对外行为零变化**，是纯重构。
+
+### 为什么值得
+
+它同时解锁 H2（沙箱提供方 = 换一个 `fs`/`shell` 实现，而不是在每个工具里加 if）、Cloud 的真隔离（per-uid 根目录的 fs 提供方，白名单可以退回成纵深防御而不是唯一防线）、以及远程执行（Dispatch 的容器化目标）。**一次重构，三条主线受益**——这是整份计划里性价比最高的一项。
+
+### 验收
+
+- [ ] `ToolContext.caps` 落地，local 提供方通过全部现有测试且无行为变化；
+- [ ] 七个 fs/shell 工具不再直接 `import node:fs` / `node:child_process`（留一条 lint/grep 断言防回归）；
+- [ ] 新增一个内存 fs 提供方，至少 3 个工具测试用它跑，不落盘。
+
+---
+
+## 3. H2 — 权限与沙箱：三档 + fail-closed + 会话级固定
+
+### 问题（按严重度排序）
+
+1. **`write` / `edit` / `apply_patch` 完全不受沙箱约束。** `wrapForSandbox` 唯一调用点是 `bash.ts:34`；三个写工具都是 `path.resolve(ctx.cwd, input.path)`（[write.ts:24](../src/tools/write.ts)、[edit.ts:33](../src/tools/edit.ts)、[apply_patch.ts:58](../src/tools/apply_patch.ts)），绝对路径与 `../` 一律照收。即使 `LISA_SANDBOX=1`，`bash` 被关进 cwd 而 `write` 能写满盘——正是 dsh 明确要避免的「bash 与 fs 限制到不同的根目录」。（对照：KB 写工具是路径 jail 的，[kb/tool.ts:5](../src/kb/tool.ts)——说明这个模式在本仓已被证明可行。）
+2. **非 macOS 静默降级成不受限 `/bin/bash -lc`**（[sandbox.ts:46](../src/sandbox/sandbox.ts)）。dsh 的规矩是 `SANDBOX_UNAVAILABLE` 直接拒绝执行。**"以为开了沙箱其实没开"比"没有沙箱"更危险。**
+3. **默认全关**：`LISA_SANDBOX` 不设 = 无沙箱，`--approval` 默认 `auto` = 无审批。本地 attended REPL 这样没问题（和 Claude Code 同一姿态），但 1.0 要闭合的是**本地 agent 命令回路**——dispatch 出去的是**无人值守**的运行，那时"默认全关"就不再是合理默认。
+
+### 做法
+
+- **三档 `sandboxMode`**（对齐 dsh 词汇，别自造）：`read-only` / `workspace-write` / `danger-full-access`；
+- **在 H1 的 seam 上实现**：`fs-sandbox` 与 `shell-sandbox` 两个提供方共享同一份根目录策略，天然保证两者边界一致；
+- **fail-closed**：`workspace-write` 在无可用强制机制的平台（Linux 无 bwrap/Landlock、Windows）**报错拒绝**，不降级。想在这些平台跑，用户须显式选 `danger-full-access`；
+- **会话级固定**：模式写进 `SessionHeader`，会话创建时定死，中途改配置不影响进行中的会话；
+- **默认值按 surface 分层**（LISA 已有 surface 概念，只是没连到沙箱）：
+  | surface | sandboxMode 默认 | approval 默认 |
+  |---|---|---|
+  | 本地 attended REPL / Island | `danger-full-access` | `auto`（现状不变） |
+  | dispatch / 无人值守运行 | `workspace-write` | `auto` |
+  | idle / heartbeat（Reve） | `read-only` | `auto`（已有 `autonomousSubset` 兜底） |
+  | 渠道（remote-origin） | `read-only` | `auto`（已有 `remoteSafeSubset` 兜底） |
+  | cloud | 不适用（无 fs/shell 工具） | — |
+
+  注意最后三行**已经有工具级边界了**——加沙箱是把"能不能拿到工具"的单层防御，变成"拿到了也出不去"的纵深防御。
+
+### 验收
+
+- [ ] `write`/`edit`/`apply_patch` 在 `workspace-write` 下拒绝写出根目录（含 `../` 与符号链接逃逸），有测试；
+- [ ] Linux 无 bwrap/Landlock 时 `workspace-write` 抛 `SANDBOX_UNAVAILABLE`，**不**静默降级，有测试；
+- [ ] `SessionHeader` 记录 `sandboxMode`，`version` 升到 2 且旧会话可读；
+- [ ] `docs/FOOTPRINT.md` / README 的安全叙事同步更新（1.0 判定标准第 2 条：叙事 = 代码）。
+
+---
+
+## 4. H3 — 会话日志成为唯一真源（论文的测量工具）
+
+### 问题
+
+LISA 的会话 JSONL **已经**记录了 `tool_use` / `tool_result`（它们是 `StoredMessage` 的 content block），这点比预想的好。真正缺的是**系统提示词**：
+
+- 系统提示词由 soul + memory + skills + mood + KB 摘要动态构建（[prompt.ts:66](../src/prompt.ts)）；
+- 而且**会话中途会热重载**——`soul_patch` / `memory` 写入后，下一轮就换了一份系统提示词（[agent.ts:225–242](../src/agent.ts)），只发一个 `system_prompt_rebuilt` 事件，**不落盘**；
+- 结果：**拿着一条历史会话，无法重建当时模型看到的东西**。dsh 的不变量「模型可见 ⟺ 已记录」在 LISA 这里对消息成立、对提示词不成立。
+
+这不是洁癖。ROADMAP §1.0 判定标准第 4 条要求「可复现的自主性度量：Reve 能产出 drift / coherence 指标」，而 drift 的定义就是"她的自我描述随时间怎么变"——**如果日志里没有当时的自我描述，这个指标根本无法离线复算**。同一条也直接卡住论文：长时程连贯性的任何测量，都要求知道每个时点模型看到的 persona 是什么。
+
+### 做法（分两步，第一步很便宜）
+
+**Step 1（低成本，先做）**：新增两类日志条目
+- `{type:"prompt", ts, fingerprint, text}` — 会话开始时写一次全文；
+- `{type:"prompt_rebuilt", ts, fingerprint, text}` — 每次热重载写一次全文。
+
+`getPromptFingerprint` 已存在（[prompt.ts:237](../src/prompt.ts)），热重载点也已存在（`agent.ts:228` 的 `if (next.fingerprint !== currentFingerprint)`），改动面很小。体积可控：一份系统提示词几 KB，一次会话通常个位数次重载。若嫌大，只在 fingerprint 变化时写全文，其余写 fingerprint 引用。
+
+**Step 2（可选，之后再说）**：把 `SessionStore` 从"消息日志"推向"事件日志"，加一条运行时断言——任何进入 `provider.runTurn` 的输入都必须能从日志重建。这是 dsh 的完整形态，成本高，**不是 1.0 必需**。
+
+**明确不做**：不抄 `assistant/chunk` 级别的流式保真（LISA 的 UI 不需要逐 chunk 回放），不引入 SQLite 持久化（JSONL 够用，projection cache 等有性能问题再说）。
+
+### 验收
+
+- [ ] 会话 JSONL 含 `prompt` / `prompt_rebuilt` 条目，`SessionHeader.version` 同步升级；
+- [ ] 写一个离线脚本：读一条历史会话 → 完整重建每一轮的 `(system, messages)` 输入；
+- [ ] 该脚本成为 Reve drift 指标与论文实验的取数入口（这是本项的真实交付物，不是日志本身）。
+
+---
+
+## 5. I1 — 唯一的"接入"：dsh 成为第 11 个 Dispatch 目标
+
+LISA 的 `src/integrations/` 已有 10 个内建 observer（claude-code / codex / github-pr / opencode / aider / git / shell / takoapi / managed / pty，见 [integrations/registry.ts:52](../src/integrations/registry.ts)），`AgentKind` 是开放字符串联合（[integrations/types.ts:14](../src/integrations/types.ts)），加一种不用改类型。
+
+dsh 是**目前唯一一个既有本地会话文件、又有 headless CLI、还带 star 势能的新 harness**。把它接成 LISA 能观察和指挥的对象，直接服务 Dispatch 支柱「用户跟 LISA 对话即可指挥本机全部其它 agent」。
+
+**两个层级，按成本**：
+
+1. **L1 OBSERVE（约 1 天）**：写 `src/integrations/dsh/observer.ts`，读 `$DSH_HOME` 下的会话 JSONL，映射到 `AgentSession`。**做之前先确认 dsh 的磁盘格式** —— README 明示 `SESSION_FORMAT_VERSION = 0` 不给兼容承诺，所以适配器必须对未知字段宽容、对格式变更优雅失败（这一点写进适配器注释）。
+2. **L3 COMMAND（约 1 天，L1 之后）**：`dispatch_agent` 增加 `dsh` 后端，用 `dsh --profile headless "job"` 拉起一次性运行。这是 dsh 最稳定的接口（无服务器、跑完退出），比接 ACP/SDK 风险低得多。
+
+**不做**：不接 ACP、不接 dsh SDK、不做 resume-adopt（同 codex 的理由，见 [PTY_AGENTS.md](./PTY_AGENTS.md)）。
+
+### 验收
+- [ ] `lisa` 能在 hub 里列出正在跑的 dsh 会话，字段深度对齐 Tier-2 基线；
+- [ ] `dispatch_agent(backend:"dsh")` 能跑通一个真实任务并回收输出；
+- [ ] dsh 未安装 / 格式变更时适配器降级为"不可见"，不报错、不崩 hub。
+
+---
+
+## 6. 明确不做
+
+| 项 | 理由 |
+|---|---|
+| fork dsh 主干 | Developer Preview + 219 包 + 每文件 100% 覆盖率门禁；LISA 是单人维护 |
+| 把 dsh 当 LISA 的执行引擎 | LISA **自己就是 harness**，不是需要引擎的产品壳。接进来等于两套工具层 + soul/memory 状态被劈成两半，是净负债 |
+| 引入 Cordis | 元框架的收益在"219 个包要解耦"时才兑现；LISA 32 个 `src/` 模块、单人维护，收益 < 认知成本。**只抄 seam 这一个概念，不抄框架** |
+| Code Mode（`run_code`） | 省 token 是真的，但它要求工具管线可重入 + worker vm 沙箱，前置是 H1+H2 全做完。**H1/H2 落地后再评估**，不进 1.0 |
+| 抄 Agent Preset 的完整形态 | LISA 的 subset 函数已经覆盖了核心用例，且**安全边界写在代码里比写在用户可编辑的 yml 里更难被绕过**。用户可编辑的 preset 是 2.0 话题 |
+| 追 dsh 的 rc 版本 | 观察 1–2 个月的破坏性变更频率，再决定 I1 的适配器要不要加固 |
+
+---
+
+## 7. 排期
+
+| 优先级 | 项 | 规模 | 服务的支柱 |
+|---|---|---|---|
+| **P0** | H1 能力 seam（fs + shell，local 提供方） | 中（纯重构，行为零变化） | Dispatch / Cloud / 测试 |
+| **P0** | H2 沙箱三档 + fail-closed + 会话级固定 | 中（依赖 H1） | Dispatch / Sense / Foundations |
+| **P0** | H3 Step 1 提示词入日志 + 离线重建脚本 | **小** | Reve / **论文** |
+| **P1** | I1 L1 dsh observer | 小 | Dispatch |
+| **P1** | `AGENTS.md` / `CLAUDE.md` 指令链加载 | 小 | 生态兼容 |
+| **P1** | Skills 加项目级目录 + 热监听 | 小 | 生态兼容 |
+| **P2** | I1 L3 dsh dispatch 后端 | 小 | Dispatch |
+| **P2** | 工具结果 pruner + spill store | 中 | 成本 |
+| **P2** | `session_search` 模型可见工具 | 小（依赖 H3） | 记忆 |
+| **缓** | Code Mode / 用户可编辑 preset | 大 | — |
+
+**建议起手**：**H3 Step 1**。它最小、最独立（不依赖 H1/H2）、且直接产出论文要用的测量工具——先拿到"能离线重建每一轮模型输入"这个能力，后面的 drift/coherence 实验才有地基。然后做 H1，H2 自然长在 H1 上。
+
+---
+
+## 8. 风险
+
+| 风险 | 说明 | 处置 |
+|---|---|---|
+| H1 重构面广 | 七个高频工具 + 全部相关测试 | 分两个 PR：先加 `caps` 与 local 提供方（不改工具），再逐个迁移工具；每步跑全量测试 |
+| H2 收紧默认值会破坏现有用户流程 | dispatch / idle 收到 `read-only` 后可能失败 | 本地 attended 姿态**保持不变**；只对无人值守 surface 收紧，且先出一版只 warn 不 enforce |
+| H3 日志体积 | 每次热重载写全文系统提示词 | 只在 fingerprint 变化时写；观察实际体积，超标再改为 fingerprint 引用 + 单独的 prompt 内容池 |
+| dsh 磁盘格式变更 | `SESSION_FORMAT_VERSION = 0`，无兼容承诺 | I1 适配器对未知字段宽容、解析失败降级为"不可见"；不把 hub 的稳定性押在它上面 |
+| 被"抄 dsh"带偏节奏 | ROADMAP 的核心诊断是"每版加一个新大件而不打深" | 本计划的 P0 三项**全部是把已声称的能力做实**（沙箱、隔离、可复现度量），没有一项是新大件。I1 是唯一新增，且落在既有注册表里 |
+
+---
+
+## 9. 与论文的衔接
+
+用户的论文方向是**长时程连贯性（主线）+ soul 稳定性机制（消融）**，目标 COLM/ICLR 2027。本计划里与之直接相关的只有一项，但很关键：
+
+**H3 = 论文的测量工具。** 没有"每一轮模型看到的 persona 是什么"的完整记录，drift 与 coherence 都只能在线测、无法离线复算、无法对同一批会话跑多种指标、无法做消融。H3 Step 1 是几百行的改动，却是把 LISA 的纵向部署数据从"日志"变成"数据集"的那一步。
+
+其余各项（H1/H2/I1）是工程债与产品能力，与论文无关——**不要为了论文去做它们，也不要用论文当它们的理由**。

--- a/docs/RESEARCH_DEEPSEEK_HARNESS.md
+++ b/docs/RESEARCH_DEEPSEEK_HARNESS.md
@@ -1,0 +1,396 @@
+# DeepSeek Harness（dsh）源码与架构调研
+
+> 更新：2026-08-13 · 状态：调研完成
+>
+> **引入说明（2026-08-14）**：本文原产于另一个项目（逗逗AI 2.0）的 `docs/research/deepseek-harness.md`，
+> 原样引入本仓作为外部 harness 的一手调研底本。§1–§4、§6 是与产品无关的客观调研，可直接引用；
+> **§5 是源项目的结论，不是 LISA 的结论**，其中的相对链接指向源仓库、在本仓不可解析，已改为纯文本。
+> LISA 侧的对照分析、取舍与排期见 [PLAN_HARNESS_ALIGNMENT_v1.0.md](./PLAN_HARNESS_ALIGNMENT_v1.0.md)。
+
+## TL;DR
+
+- **DeepSeek 亲自下场做 harness 层**：2026-08-13 开源 [deepseek-ai/deepseek-harness](https://github.com/deepseek-ai/deepseek-harness)（`dsh`），MIT 协议、TypeScript、Developer Preview。开源当天 GitHub 星标 26,995、fork 1,974（抓取时点数据）——这是 agent 框架层近期最大的一次事件，直接改变了「多模型 hub」类产品的竞争前提。
+- **核心主张是「一切皆插件」**：底座是 Cordis 元框架，模型适配器、工具注册表、会话日志、甚至 agent loop 本身都是插件，没有需要打补丁的特权内核。扩展方式是「把插件挂在别的插件旁边」，所有注册都是可撤销的副作用。
+- **工程体量极大**：packages/ 下 219 个 workspace 包、约 52 万行 TS/TSX、2,355 个 md 文档（中英成对）、684 篇 Agent Note（其中 506 篇已实现）、PR 编号已到 #2521。内部研发从 2026-06-11 起算，约两个月做到这个规模——本身就是「AI 造 AI 工具」的样本。
+- **面向模型的能力已经很完整**：24 个工具包、52 个模型可见工具，含 bash/PTY 终端、fs 读写编辑、glob/grep、LSP、web 搜索抓取、todo、plan mode、goal（跨轮次目标）、subagent（6 种后端）、workflow（模型写脚本编排子代理）、ralph（全新 agent 循环）、schedule、session 检索、jobs 后台任务、skill、MCP。
+- **兼容主流生态是明确策略**：读 Claude Code 与 Codex 的 `hooks.json`、读 `AGENTS.md`/`CLAUDE.md` 指令链、用 `SKILL.md` 技能格式、MCP 工具沿用 `mcp__<server>__<tool>` 命名，甚至能把 **Claude Code CLI 和 Codex CLI 当作 subagent 后端挂进来**。
+- **表层（surface）只有三类**：Web UI（本地 React 应用，默认 `127.0.0.1:3080`）、headless 一次性运行、程序化接口（ACP server / TypeScript SDK / Python SDK）。**没有 TUI、没有桌面壳、没有移动端、没有任何实时语音能力**——游戏陪玩方向从这个仓库拿不到东西。
+- **对逗逗 2.0 的判断**：不建议整仓 fork（Developer Preview + 明确的破坏性变更声明 + 219 包的维护面），但**架构范式、能力清单、权限沙箱方案、模型接入方案（对应 D05）可以大量借鉴**，并且 dsh 的 SDK / ACP / subagent seam 提供了「把 dsh 当成办公模式的一个后端引擎」这条低成本路径。
+
+## 一、基本事实
+
+| 项 | 值 |
+| --- | --- |
+| 仓库 | `deepseek-ai/deepseek-harness`，描述 "DeepSeek Harness: Everything is a Plugin." |
+| 许可 | MIT（Copyright (c) 2026 DeepSeek） |
+| 语言 / 运行时 | TypeScript（ESM only），Node `^22.19.0 \|\| >=24`，pnpm 11 workspaces |
+| 状态 | Developer Preview，README 明示「THERE WILL BE COMPATIBILITY-BREAKING CHANGES」 |
+| 版本 | 仓库 master `0.1.0-rc.5`；npm `@deepseek-ai/dsh` 最新 `0.1.0-rc.6` |
+| npm 首发 | 2026-08-10（`0.0.1-rc.1`），2026-08-13 公开发布到 npm public |
+| GitHub 创建 | 2026-08-13T11:56:32Z |
+| 关注度 | star 26,995 / fork 1,974 / watch 91（2026-08-13 抓取，实时变动） |
+| 官网 | https://deepseek.com/harness |
+| 社区 | GitHub Discussions、Discord、企微群 + 微信公众号（中文社区单独运营）；插件用 `dsh-plugin` topic 发现 |
+| 上手 | `npx @deepseek-ai/dsh web` → 浏览器打开 `http://127.0.0.1:3080` |
+
+规模指标（本地统计）：
+
+| 指标 | 数量 |
+| --- | --- |
+| workspace 包 | 219 |
+| TS/TSX 行数（packages + apps，含测试） | ≈ 520,000 |
+| Markdown 文档 | 2,355（中英成对维护） |
+| Agent Note | 684（implemented 506 / archived 142 / proposed 25 / rejected 11） |
+| 模型可见工具 | 52（分布在 24 个工具包） |
+| 能力 seam（`ctx.*` 服务键） | ≈ 55 |
+
+## 二、架构：一切皆插件
+
+### 2.1 Cordis 与「没有特权内核」
+
+dsh 的底座是 [Cordis](https://github.com/cordiverse/cordis)（vendored 在 `vendor/cordis`），其设计论文是《A Programming Paradigm for Spatiotemporal Composability》。核心约定：
+
+- 插件向共享 `ctx` 贡献**服务**、**类型化事件**和**可逆副作用**；
+- 「注册即副作用」——每次 `ctx.effect()` / `ctx.on()` 都返回 disposer，插件卸载时自动撤销；
+- 产品的每一部分都是插件，**包括 agent loop 本身**，所以每一部分都能从配置里替换掉；
+- 支持 HMR：改配置项触发插件重挂载，不用重启进程（MCP server 的断连重连、客户端 bundle 热替换都走这条路）。
+
+这解决了 harness 类产品最典型的架构病：核心循环写死 → 想改行为只能加 if / 打补丁 / fork。
+
+### 2.2 Profile / Bundle / Patch 三层组装
+
+运行中的 `dsh` 是一棵插件树，按顺序叠出来：
+
+```
+空配置根
+  ← 按 profile 的 bundles 顺序应用每个组合包的 cordis.patch.yml
+  ← profile 自己的 cordis.patch.yml
+  ← $DSH_HOME/cordis.patch.yml
+  ← 命令行 --patch overlay
+```
+
+- **bundle（组合包）**：Cordis 配置项 + 挂载代码的分发格式。随发行版交付三个：`dsh-base`（模型适配器、工具、持久化、沙箱与审批策略、settings、凭据、遥测）、`dsh-web-app`（浏览器应用层）、`dsh-headless`（一次性运行器，完全不带服务器）。
+- **profile**：Harness home 里的具名组装，列出自己叠哪些 bundle、装了哪些树外插件、以及用户自己的 patch。
+- **patch**：按 id 定位某个配置项，**整体替换其 config**（没有深度合并），或插入新项。
+- `dsh --profile web --dump-config` 打印实际启动的整棵树——**打印出来的任何一行都可以被用户 patch 掉**。
+
+命令行入口只有四种形态：
+
+| 命令 | 用途 |
+| --- | --- |
+| `dsh --profile <name>` | 启动指定 profile |
+| `dsh --profile headless "job"` | 跑一个持久化会话、打印最终答案、退出 |
+| `dsh web` | `--profile web` 的别名 |
+| `dsh plugin --profile <name> <pnpm args>` | 转发 pnpm 管理该 profile 的树外插件 |
+
+### 2.3 能力 seam（capability seam）
+
+这是全仓最值得抄的概念。一个 seam = **三种角色的完整能力**：
+
+- **Service Definition**：声明接口、拥有 `ctx.<key>` 和词汇类型；
+- **Service Provider**：一个或多个实现；
+- **Consumer**：使用者（通常是面向模型的工具）。
+
+术语表明确规定「seam 是完整能力，绝不是其中一个角色」。范例是 shell：`dsh-shell`（定义）+ `dsh-bash-local` / `dsh-bash-sandbox` / `dsh-pwsh-local`（实现）+ `dsh-tool-bash`（消费）。
+
+**seam 正是「换一个提供方就换掉整个产品」的原因**：文件系统与进程提供方共享同一个执行世界，所以把它们指向远程沙箱（如内置的 E2B 适配器），Bash、PTY、LSP 就一并搬过去了，不需要为远程场景 fork 一份工具实现。
+
+主要 seam 一览（节选）：
+
+| ctx 键 | 能力 | 已有实现 |
+| --- | --- | --- |
+| `ctx.llm` | 模型流式推理 | `llm-deepseek`（官方直连）、`llm-pi-ai`（多提供方）、`llm-replay`（测试回放） |
+| `ctx.tools` | 工具注册表 + 执行流水线 | core |
+| `ctx.sessions` | 仅追加会话事件日志 | core |
+| `ctx.sessionPersistence` | 会话持久化 | JSONL / SQLite |
+| `ctx.sessionQuery` | 会话检索 | SQLite（全文 + 游标） |
+| `ctx.fs` | 文件系统 | local / sandbox / e2b |
+| `ctx.shell` | shell 执行 | bash-local / bash-sandbox / pwsh-local |
+| `ctx.subprocess` | 进程 spawn / 进程树 | local / e2b |
+| `ctx.terminals` | 持久 PTY | terminal-bash |
+| `ctx.sandbox` | 进程沙箱 | sandbox-local（bwrap/Landlock/Seatbelt/Windows ACL） |
+| `ctx.subagents` | 子代理 | 6 种后端（见 §3.4） |
+| `ctx.workflowEngine` | 工作流脚本引擎 | worker-thread |
+| `ctx.codeRuntime` | Code Mode 程序执行 | worker-thread |
+| `ctx.skills` | 技能目录 | filesystem / badge |
+| `ctx.compaction` | 上下文压缩 | compaction-basic + tool-result-pruner |
+| `ctx.spillStore` | 超大工具输出外溢 | spill-local |
+| `ctx.web` | 联网 | DeepSeek / Exa / Perplexity 搜索 + HTTP 抓取 |
+| `ctx.lsp` | 语言服务 | lsp-stdio |
+| `ctx.credentials` | 凭据引用解析 | credentials-local（env / .env） |
+| `ctx.settings` | 用户设置分层 | settings-file |
+| `ctx.approval` / `ctx.permissionPresets` | 审批与权限预设 | ACP 桥接 / 预设表 |
+| `ctx.jobs` | 后台任务 | jobs-local |
+| `ctx.goals` | 跨轮次目标 | core |
+| `ctx.sessionTelemetry` | 遥测 | OpenTelemetry |
+
+### 2.4 轮次流程与「模型可见即已记录」
+
+一个**步骤（step）** = 一次模型请求 + 它调用的工具；一个**轮次（turn）** = 零个或多个步骤。
+
+```
+turn/start
+  领取 next-step 输入 + 一条排队消息
+  组装提示词片段 + 工具 schema
+  -> agent/pre-step                   reject | enter(messages)
+     step/start
+     追加消息 → 从日志推导模型历史
+     agent/request -> llm/stream -> assistant/chunk* -> assistant/message
+     tool/call* -> tools/pre-execute -> tools/execute -> tools/post-execute -> tool/result*
+     step/end
+  -> agent/turn-stopping
+turn/end
+```
+
+三类扩展点分工清晰：**会话事件**（持久事实，重载后仍在）、**agent 事件**（观察/拦截进行中的工作）、**能力事件**（向 seam 附加策略与适配器）。其中 `agent/pre-step`、`agent/request`、`llm/stream`、三个 `tools/*` 是**瀑布式事件**（监听器必须调 `next()` 才能委托下去，不调就短路）。
+
+最关键的一条运行时不变量：
+
+> **模型可见 ⟺ 已记录。** 抵达模型请求的一切都必须能从会话日志重建，并由运行时不变量断言这一点。因此，新增一项模型可见输入就必须新增一个会话事件。
+
+会话日志是唯一真源：`deriveMessages()` 从中投影模型历史，原始 `assistant/chunk` 保证回放与 UI 保真；fork、恢复、transcript、遥测、持久化全部派生自这条事件流。
+
+## 三、能力盘点（对标视角）
+
+### 3.1 模型可见工具（52 个）
+
+| 类别 | 工具 |
+| --- | --- |
+| Shell / 终端 | `bash`（支持 `run_in_background`）、`pwsh`（Windows）、`bash`（持久 PTY 版）、`terminal_open/read/send/close/list/signal` |
+| 文件 | `read`、`write`、`edit`、`read_image`、`str_replace_editor` |
+| 检索 | `glob`、`grep`（内置 ripgrep，不经 shell）、`web_search`、`web_fetch`、`lsp` |
+| 任务与计划 | `todo_write`、`exit_plan_mode`、`create_goal` / `get_goal` / `update_goal` |
+| 委派与编排 | `subagent`、`subagent_fork`、`send_message`、`interrupt_agent`、`list_agents`、`report`、`workflow`、`ralph` |
+| 后台 | `job_list`、`job_output`、`job_kill`、`schedule_create/list/delete` |
+| 会话自省 | `session_search`、`session_trace`、`session_event_read/search/trace` |
+| 其他 | `skill`、`ask_user_question`、`run_code`（Code Mode）、`cordis_*`（自省与自我改造，需显式启用） |
+
+值得注意的几个：
+
+- **`ask_user_question`**：工具调用会**挂起**直到 UI 侧返回人类答案——把「向用户提问」做成了一等能力而不是提示词约定。
+- **`goal` 三件套**：附着在会话上的持久完成目标，有 `active/paused/blocked/complete` 阶段和 **Goal Round 上限**；create/edit/pause/resume **要求直接来自人类的根权限**，模型不能自己给自己续命。
+- **`ralph`**：每个 Round 起一个**全新子代理**（看不到父会话和之前的子会话），共享工作区当长期记忆，Round 之间只传一份有界的结构化交接报告。适合「长时间自动迭代」而不被上下文污染。
+- **`session_*` 五件套**：模型可以检索、追踪自己和历史会话的事件流——这是「记忆」的另一条路径（检索而非摘要）。
+- **`cordis_*`**：模型可以在运行时定义、挂载、停止自己的插件，**运行中的插件可以注册额外的模型可见工具**。默认不在任何发行树里，需显式启用。
+
+### 3.2 Code Mode（`run_code`）
+
+工具注册表有 `mode: tool | code | both`。在 `code` 模式下，模型不再逐个发工具调用，而是**写一段 TypeScript 程序**，程序里的工具是异步 binding 函数：
+
+- 程序在 worker thread 的 vm 上下文里跑，顶层 `await`/`return` 可用，返回值经无损 JSON 边界回传；
+- 每个嵌套调用**重新进入完整且受守卫保护的工具流水线**（审批、沙箱、策略一个不少），并关联到外层结果；
+- 并发按原生约定调度，`maxParallelSubCalls` 限流。
+
+这就是官方 preset 里的 **「PTC 模式」**。价值：多步操作合并成一次模型请求，省 token、省往返。
+
+### 3.3 Agent Preset（模式切换机制）
+
+一个 preset = 一个目录 + 一份 `agent.cordis.yml`；roster 在进程内**只挂载一次**（常驻 scope），命名它的每个会话把自己的 scope key 认父到该挂载。查找按 `agent → preset → global` 解析，近者遮蔽远者。
+
+随 CLI 交付四个 preset：
+
+| id | 名称 | 内容 |
+| --- | --- | --- |
+| `standard` | 标准模式 | 完整编码 agent：fs、shell、检索、skills、plan、goal、subagent、workflow、todo、web、压缩 |
+| `code` | PTC 模式 | 标准模式全部能力，但工具以 Code Mode SDK 呈现（`mode: code`） |
+| `minimal` | 极简模式 | 只有持久 `bash` + `str_replace_editor`，persona 即完整系统提示词，**无压缩、无运行时上下文** |
+| `cordis` | 创造模式 | 标准 + 运行时自省 + 插件实验 + preset 创作指导（自带两个 SKILL.md） |
+
+**用户可以复制、修改、删除 preset**，`ctx.agentPresets` 提供 list/resolve/mount/copy/remove/recompose 全套 API，UI 侧有 `ui-agent-preset` 模块。
+
+### 3.4 Subagent：六种后端，含 Claude Code 与 Codex
+
+`ctx.subagents` 是唯一允许**同一上下文中多个提供方并存**的 seam（按名称注册）：
+
+| 提供方 | 说明 |
+| --- | --- |
+| `subagent-spawn-in-process` | 进程内新建子 agent |
+| `subagent-fork-in-process` | 从当前会话 fork |
+| `subagent-acp` | 通过 ACP 协议连外部 agent |
+| `subagent-claude-code` | **把 Claude Code CLI 当子代理**（base bundle 默认加载但休眠） |
+| `subagent-codex` | **把 Codex CLI 当子代理**（同上） |
+| `subagent-dsh-sdk` | 通过 dsh SDK 连另一个 dsh 运行时 |
+
+能力按静态描述符声明（`outputSchema` / `depthLimit` / `toolFilter` / `persona`），请求依赖提供方没有的能力时**明确拒绝，绝不接受后静默忽略**。
+
+还支持**可继续子代理**：持久化子会话 + 至多一个进程内 Activation，可执行多个 FIFO 轮次、支持冷恢复；父子之间用 `send_message` / `report` 双向通信。
+
+### 3.5 生态兼容层
+
+| 兼容对象 | 机制 |
+| --- | --- |
+| `AGENTS.md` / `CLAUDE.md` | `dsh-agent-instructions`：从 `$DSH_HOME/AGENTS.md` 到项目根到 cwd 逐层加载，内容完全一致时折叠去重；工具写文件后**自动检测新增/变更/删除并注入**；以 `<system-reminder>` 包裹注入为持久 user 消息 |
+| Claude Code hooks | `dsh-hooks-claude-code`：读现有 `hooks.json`，支持 `${CLAUDE_PLUGIN_ROOT}`/`${CLAUDE_PROJECT_DIR}` 替换，映射 SessionStart / UserPromptSubmit / PreToolUse / PostToolUse / Stop 到 harness 的类型化决策 |
+| Codex hooks | `dsh-hooks-codex`：10 个 hook 点中的 5 个，snake_case payload |
+| Skills（`SKILL.md`） | 六级 rank 发现：`<project>/.dsh/skills`(100) → `<project>/.agents/skills`(200) → 自定义目录(300) → `<dshHome>/skills`(400) → `<agentsHome>/skills`(500) → 随包目录(600)；chokidar 热监听 |
+| MCP | `dsh-mcp-client`，一个 server 一个插件实例，stdio / streamable-http；工具名 `mcp__<server>__<tool>`（与 Claude Code、Codex 同形状）；HMR 热替换 |
+| ACP | `dsh-acp` 提供 JSON-RPC stdio 的 Agent Client Protocol 服务器（仅自动化，不含 UI 集成） |
+
+两个 hook 桥接的 README 都明确写着：**原生 Cordis 插件功能更强、有类型化返回、没有序列化边界，桥接只是兼容路径**。定位很清楚——用兼容性接住存量用户，用原生扩展点承接真正的定制。
+
+### 3.6 权限与沙箱
+
+分两层，且两层都是持久会话状态：
+
+- **`sandbox/mode`**（机制层）：`read-only` / `workspace-write` / `danger-full-access`。执行由操作系统强制：Linux 优先 `bwrap`、否则 Landlock（自研 `@deepseek-ai/node-addon-landlock-run`）；macOS 用 Seatbelt；Windows 用 **ACL 受限令牌**（每个「会话 × 工作区」分配随机私有临时目录 + 独立 SID + 可撤销 ACE）。**不受支持的平台直接以 `SANDBOX_UNAVAILABLE` 拒绝执行，绝不静默回退到不受限。**
+- **`approval/policy`**（交互层）：一次性权限决策通过 `approval/request` 瀑布事件分派，没有回答方时**以 unavailable 关闭失败**（fail closed）。
+- **`permissionPresets`**：把两者打包成用户可见的单个选择器，默认两档 `workspace-write`（+ ask）与 `danger-full-access`（+ never）。切换写入 `permissionPresets/preset` 事件；**权限在会话创建时固定，之后改设置不影响已存在会话**。
+
+`fs` 侧同样受 `ctx.sandboxPolicy` 约束（`fs-sandbox`），保证「bash 与 fs 不会限制到不同的根目录」。
+
+### 3.7 模型接入
+
+两个适配器并存，对应两种诉求：
+
+**`llm-deepseek`**（官方直连，路由名 `deepseek-official`）
+- 直接 fetch + SSE，只支持流式；
+- 默认公布 `deepseek-v4-flash` / `deepseek-v4-pro`，**上下文窗口均为 1,000,000 token**，默认输出上限 `maxTokens: 256000`；
+- 未列出的 model id **原样透传**，所以换模型不需要改代码；
+- 推理强度三档 `off / high / max`（默认 high），可按会话步骤替换；带工具调用的轮次把 `reasoning_content` 回传历史，不带工具调用的丢弃以省 token；
+- **连接事实不在加载时冻结**：baseURL、catalog、请求默认值、密钥都在下一次请求时重读，改设置不用重启（首次上手流程就是「浏览模型 → 存密钥 → 再发提示」）；
+- 请求带匿名用户 id（`x-deepseek-harness-user-id`）与会话 id 标头。
+
+**`llm-pi-ai`**（多提供方，基于 `@earendil-works/pi-ai`）
+- 一个插件实例持有一份「路由 → 提供方 profile」字典，每个请求用 `provider` 选路由；
+- 点名了已安装 pi-ai 提供方的路由继承其端点/协议/模型 catalog，逐字段覆盖；pi-ai 没有的路由可整体声明；
+- **接 OpenAI 兼容网关、自建服务、比 catalog 更新的模型，全部属于配置而非改代码**；
+- 凭据只存 `apiKeyEnv` **引用**，密钥不进配置文件；配置了却解析不出值 → `MISSING_CREDENTIAL` 失败（而不是拿环境里恰好存在的别的 key 蒙混过关）。
+
+### 3.8 上下文与持久化
+
+- **持久化**：`session-persistence-jsonl`（默认）/ `-sqlite`；`session-query-sqlite` 提供全文检索与游标；`session-projection` + `session-projection-cache` 让列表读取不必加载完整日志（缓存行 + 持久化尾部回放）。
+- **压缩**：`compaction-basic` 消费步骤后的 token 压力事件与请求错误恢复事件；`compaction-tool-result-pruner` 在摘要压缩**之前**用可回放的单节点替换改写过大的工具结果；`/compact` 用户命令。压缩调用带 `x-deepseek-harness-compact: 1` 标头，方便宿主把压缩流量与会话流量分开计费。
+- **spill**：超大工具输出落到 `ctx.spillStore`，内联结果替换为有界预览 + 取回定位信息。
+- **guard**：`repeat-tool-reminder`（重复工具调用提醒）+ `timeout-policy`（单次调用截止时间）。
+- **session title**：可选 LLM 生成，强制禁用思考模式以省 token。
+
+### 3.9 表层与接入方式
+
+| 表层 | 形态 |
+| --- | --- |
+| Web UI | 本地 node:http 服务 + React 前端（`apps/web`，Vite 构建），默认 `127.0.0.1:3080`；客户端本身也是插件体系（`packages/client/ui-*` 约 30 个模块 + slot 机制 + HMR） |
+| headless | `dsh --profile headless "job"`，跑一个持久化会话打印答案退出，完全不带服务器 |
+| ACP | JSON-RPC stdio 的 Agent Client Protocol 服务器，供程序化客户端驱动 |
+| TypeScript SDK | `packages/sdk`（protocol / client / server），从另一进程驱动运行时 |
+| Python SDK | `pip install deepseek-harness-sdk`，自带平台 wheel 的单文件运行时 `dsh-jsonrpc-agent`，`with DeepSeekHarness() as h: h.run("...")` |
+
+**明确没有的**：TUI（相关 Agent Note 已归档 = 已退役）、桌面应用外壳、移动端、语音 / 实时音频、任何游戏相关能力。
+
+Web UI 的设置界面已有：模型与提供方配置（含自定义 OpenAI 兼容端点表单）、插件清单、权限预设、工作区选择器、agent preset 选择器、skill 面板、subagent 面板、workflow run 面板、goal 面板、jobs 面板、trajectory（轨迹）视图、消息反馈。
+
+## 四、工程流程（同样值得学）
+
+这个仓库本身是「用 agent 造 agent 工具」的样本，规矩写在 `AGENTS.md`（root 的 `CLAUDE.md` 是它的软链接）：
+
+- **Agent Note 制度**：非平凡改动**必须**在同一个 PR 里附一篇 Agent Note，按 `implemented / proposed / rejected / archived` × `architecture / feature / bug-fix / simplification / process / testing` 二维归档；归档的笔记**冻结**，不得编辑也不得当作现行权威。目前 684 篇。
+- **文档即门禁**：`pnpm run doc-sync` 下挂十几个校验器——工具 schema 目录自动生成并验证新鲜度（真启动每个工具插件读 `ctx.tools.schemas()`，而非静态分析）、中英文档配对校验、链接校验、字数预算校验、Agent Note 格式与分类校验、mermaid 校验。
+- **测试**：CI 覆盖率门禁是 **`packages/*/*/src` 每文件 100%**；另有 e2e（真实 API）、snapshot（无密钥回放，比对 ACP/headless 输出）、web 性能与压力测试、Windows/wine 矩阵。
+- **写作规范**：「禁止比喻」「不要复述代码」「`contract` 只用于前置/后置条件与兼容承诺」这类要求写进了强制规范，还配了 `dsh-prose-standard` 技能。
+- **仓库自带 11 个 `.agents/skills/`**：pre-push 检查、代码审查、找简化点、翻译文档、归档笔记、合并 stacked PR、裁剪 CoT 泄漏等——**团队自己的研发流程也被写成了 skill**。
+- **预发布姿态**：README 直言「没有外部消费者，优先正确的地基而非兼容垫片」，`SESSION_FORMAT_VERSION` 保持 `0` 且不给兼容承诺，后端直接拒绝旧的磁盘格式。
+
+## 五、原文对逗逗AI 2.0 的启示（源项目结论，存档保留）
+
+> 本节是源项目的判断，**不是 LISA 的结论**。相对链接指向源仓库，已改为纯文本。
+> LISA 的对照分析见 [PLAN_HARNESS_ALIGNMENT_v1.0.md](./PLAN_HARNESS_ALIGNMENT_v1.0.md)。
+
+### 5.1 竞争格局：harness 层被免费化了
+
+DeepSeek 用 MIT 协议放出一个**能力矩阵接近 Claude Code、且天然绑定自家 1M 上下文模型**的完整 harness。这意味着：
+
+1. **「做一个多模型 agent 工作台」本身不再是壁垒**——它现在是 `npx` 一行命令就能得到的东西。逗逗 2.0 办公模式的差异化必须落在**桌宠人格、跨模式记忆资产、面向非程序员白领的任务表达**上，而不是 harness 管道本身。参见 产品定位（源仓 `docs/design/product-positioning.md`）、办公模式设计（源仓 `docs/design/work-mode.md`）。
+2. **反过来这是重大利好**：地基可以不自己造。逗逗把精力放在「上层体验 + 人格 + 商业化」，底层能力可以借。
+3. **对 D05 模型接入策略（源仓 `docs/decisions/d05-model-access-strategy.md`）的直接印证**：`llm-pi-ai` 证明了「BYOK + OpenAI 兼容网关 + 官方直连」三条路径可以在**同一个配置文件**里共存，凭据只存引用、按请求解析、热更新不重启。D05 结论无需修改，但实现方案可以直接照抄这个分层（credentials seam ↔ settings seam ↔ adapter thunk）。
+
+### 5.2 可直接借鉴的四个架构决策
+
+| 借鉴项 | 为什么值得抄 | 逗逗的对应场景 |
+| --- | --- | --- |
+| **能力 seam 三角色** | 换提供方 = 换产品形态，不需要 fork 消费方 | 办公模式的「本地执行 / 云端沙箱」切换、模型「云端 / 本地 / BYOK」切换 |
+| **Agent Preset = 常驻 scope 挂载** | 同一引擎装配出多套工具/人格组合，进程内只挂一次 | **办公模式 / 游戏模式 / 桌宠模式就是三个 preset**，而不是三套代码；用户还能自己复制修改 |
+| **会话日志唯一真源 + 模型可见⟺已记录** | 回放、fork、恢复、UI 保真、遥测全部免费得到 | 逗逗的「记忆与资产长期累积」需要的正是这条不变量；1.0 若是散状态存储，2.0 应重构为追加日志 + 投影 |
+| **投影缓存（projection cache）** | 列表读取不加载完整日志 | 会话列表、任务面板、桌宠状态条的性能地基 |
+
+### 5.3 权限与沙箱是办公模式的准入门槛
+
+逗逗 2.0 办公模式要读写用户文件、跑命令。dsh 给出的是**操作系统级**答案而非提示词答案：
+
+- 三档 `sandbox/mode` + 两档 `approval/policy`，打包成用户可见的**单个权限预设选择器**；
+- Linux/macOS/Windows 各有真实的强制机制，**不支持的平台直接拒绝执行，绝不静默降级**；
+- 权限在会话创建时固定，后续改设置不影响进行中的会话（避免「改了设置导致跑着的任务突然越权」）。
+
+**建议**：逗逗 2.0 办公模式的权限设计直接对齐这三档 + 会话级固定语义；macOS 用 Seatbelt、Windows 用受限令牌 ACL 的方案可以照搬（Landlock addon 本身就是 MIT 的独立 npm 包）。这是 C 端桌面产品建立信任的必需品，也是 1.0 完全没有的东西。
+
+### 5.4 兼容存量生态 = 低成本获客
+
+dsh 的做法很值得学：**不发明新格式，全部读别人的**——`AGENTS.md`/`CLAUDE.md`、`SKILL.md`、`hooks.json`（CC 与 Codex 两种方言）、MCP 的 `mcp__server__tool` 命名。
+
+对逗逗的含义：
+
+- 办公模式的「规则/技能/工具」配置**直接兼容 `AGENTS.md` + `SKILL.md` + MCP**，用户从 Claude Code/Codex/Cursor 迁移零成本；
+- 更进一步：dsh 的 `subagent-claude-code` / `subagent-codex` 证明了**把别家 CLI 当子代理挂进来**是可行且已实现的工程方案。逗逗如果做「多模型 hub」，这是比自己实现每家 harness 更省的路径。
+
+### 5.5 是否直接采用 dsh 作为办公模式引擎
+
+**结论：不整仓 fork，但值得作为可选后端接入，并大量借鉴。**
+
+支持接入的理由：
+- MIT 协议，商用无碍；
+- 已有 headless / ACP / TS SDK / **Python SDK** 四条程序化接入路径，桌面壳（Electron/Tauri）可以直接把它当子进程驱动；
+- 一次性接入即获得 52 个工具 + 沙箱 + 压缩 + MCP + skills 的完整能力面。
+
+不建议 fork 主干的理由：
+- **Developer Preview**，README 明示会有破坏性变更，`SESSION_FORMAT_VERSION = 0` 不给兼容承诺，后端直接拒绝旧磁盘格式；
+- 219 个包 + 每文件 100% 覆盖率门禁 + 十几个文档门禁，**维护面远超逗逗团队规模**；
+- 依赖 Node ^22.19 || >=24 运行时，前端 dist 必须预构建，桌面打包体积与冷启动需实测；
+- bundle patch 是**整行 config 替换**（无深度合并），跟随上游更新时冲突面不小。
+
+**建议的落地路径**（按成本从低到高）：
+1. **P0 借鉴层**：把 §5.2 的四个架构决策、§5.3 的权限模型写进逗逗 2.0 的技术设计；
+2. **P1 兼容层**：办公模式支持 `AGENTS.md` + `SKILL.md` + MCP，先接生态；
+3. **P2 后端层**：把 dsh 以 headless/SDK 形式作为办公模式的**一个可选执行引擎**（与自研引擎并存，用能力 seam 的思路隔离），先在内部验证稳定性再考虑对外；
+4. **不做**：不 fork 主干、不追 rc 版本、不把产品命脉压在 Developer Preview 上。
+
+### 5.6 游戏模式：这里什么都拿不到
+
+dsh 没有任何语音、实时音频、屏幕感知、游戏相关能力，表层也不含桌面壳与移动端。游戏模式设计（源仓 `docs/design/game-mode.md`）的技术方案需完全另寻来源，不要因为「办公模式用了 dsh」而假设游戏模式能复用同一条链路——两者唯一应该共享的是**会话日志/记忆层**，而那一层的设计恰好可以借鉴 dsh。
+
+### 5.7 团队研发流程：Agent Note 制度可以立刻用
+
+684 篇 Agent Note、11 个仓库自带 skill、文档门禁——这套东西让一个两个月的项目做到 52 万行仍然可被 agent 理解和修改。逗逗团队若要用 AI 大规模参与研发，最低成本的两条：
+
+1. **非平凡改动必须附一篇决策笔记**，按 implemented/proposed/rejected 归档，归档后冻结；
+2. **文档校验进 CI**（链接、目录索引、中英配对），否则 AI 写的文档必然漂移。
+
+源仓现有的 CLAUDE.md 三层结构已经是同一思路的轻量版，可以按上面两条继续加固。
+
+## 六、风险与待验证
+
+| 项 | 说明 | 验证方式 |
+| --- | --- | --- |
+| 版本稳定性 | Developer Preview，两周内已从 `0.0.1-rc.1` 迭代到 `0.1.0-rc.6` | 观察 1–2 个月的破坏性变更频率再决定是否接入 |
+| 桌面打包可行性 | Node 22/24 运行时 + 预构建前端 dist + 原生 addon（landlock）与 SQLite | 实测 Electron/Tauri 打包体积、冷启动时间、跨平台原生依赖 |
+| 中文生态与文档质量 | 中英成对维护，中文文档质量高，社区有企微群 | 已确认，无风险 |
+| 数据外发 | 官方适配器默认向 DeepSeek 端点发送匿名用户 id 与会话 id 标头 | 若作为后端使用，需评估是否改走自有网关（`baseURL` 可配） |
+| 模型绑定 | 默认组合绑 DeepSeek V4 系列；多提供方需挂 `llm-pi-ai` | 已有解法，属配置项 |
+| 许可与合规 | MIT，第三方依赖清单在 `THIRD_PARTY_NOTICES.md` | 接入前完整过一遍依赖许可 |
+
+## 来源
+
+- 仓库主页：https://github.com/deepseek-ai/deepseek-harness
+- README（中文）：https://github.com/deepseek-ai/deepseek-harness/blob/master/README.zh.md
+- AGENTS.md（工程约定）：https://github.com/deepseek-ai/deepseek-harness/blob/master/AGENTS.md
+- 架构文档：https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/architecture.zh.md
+- 术语表：https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/glossary.zh.md
+- 工具 schema 目录：https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/tool-catalog.zh.md
+- 能力 seam 图：https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/capability-seams.zh.md
+- 子系统文档目录：https://github.com/deepseek-ai/deepseek-harness/tree/master/docs/subsystems
+- Web UI 使用指南：https://github.com/deepseek-ai/deepseek-harness/blob/master/docs/user/guide/index.zh.md
+- Python SDK：https://github.com/deepseek-ai/deepseek-harness/blob/master/python/sdk/README.zh.md
+- 官方产品页：https://www.deepseek.com/harness/en/
+- 官方发布公告（X）：https://x.com/deepseek_ai/status/2087887408440164663
+- npm 包 `@deepseek-ai/dsh`：https://registry.npmjs.org/@deepseek-ai/dsh （版本与发布时间取自 registry 元数据）
+- GitHub 仓库元数据（star/fork/创建时间）：https://api.github.com/repos/deepseek-ai/deepseek-harness （2026-08-13 抓取，实时变动）
+- Cordis 框架：https://github.com/cordiverse/cordis ；设计论文：https://github.com/cordiverse/paper
+- 第三方报道：https://cryptobriefing.com/deepseek-harness-open-source-developer-preview/
+- 代码规模、包数、Agent Note 数、工具数为源项目本地 clone 统计（commit `47f9438`，2026-08-13）


### PR DESCRIPTION
## 做了什么

把 DeepSeek Harness（`dsh`，MIT，2026-08-13 开源）的一手调研引入本仓，并逐项对着当前树（v0.23.0 / `9cfe2a3`）审计出 LISA 侧的真实差距与取舍。

| 文件 | 内容 |
|---|---|
| `docs/RESEARCH_DEEPSEEK_HARNESS.md` | 原文照收（来自 DouDouAI 仓），加引入说明。**§5 是源项目的结论而非 LISA 的**，指向源仓的相对链接已改纯文本 |
| `docs/PLAN_HARNESS_ALIGNMENT_v1.0.md` | LISA 侧的逐项对照、取舍、排期与验收清单（新写） |

## 核心结论

**dsh 对 LISA 不是引擎候选，是体检报告。**

dsh 花大力气建的生态兼容层，LISA 已经追平或更全 —— 20+ provider 预设且是 `apiKeyEnv` 引用制、Claude Code `hooks.json` 同形状、`SKILL.md`、`mcp__server__tool` 命名、PTY/managed 已能把 claude+codex CLI 当受控子代理。这一层照抄零增量。反过来 dsh 完全没有 soul/desire/mood/KB/Reve 这层持久身份。

**真差距只有三处**，每处恰好卡在 1.0 的一条主线上：

1. **H1 能力 seam** — `ToolContext` 只有 `{cwd, signal, log, onObjection}`，工具各自 `import fs`/`spawn`；Cloud 多租户只能靠 `cloudSafeSubset` 白名单硬砍 fs/shell 工具（白名单是补丁，seam 才是解）
2. **H2 权限沙箱三个洞** — `wrapForSandbox` 唯一调用点是 `bash.ts:34`，`write`/`edit`/`apply_patch` 完全绕过；非 macOS **静默降级**成无沙箱；默认全关
3. **H3 会话日志不是真源** — `tool_use`/`tool_result` 其实都在，但**系统提示词一个字节都不进日志**且会话中途热重载 → 拿一条历史会话重建不出当时模型看到的 persona，drift/coherence 无法离线复算

唯一值得写代码接入的：把 `dsh` 加成 `src/integrations/` 的第 11 个 observer + `dispatch_agent` 后端。

**明确不做**：不 fork、不当执行引擎、不引 Cordis、Code Mode 缓到 seam+沙箱落地后再评估（理由见计划 §6）。

## 后续 PR

本 PR 只含文档。实现按计划 §7 的优先级拆成独立 PR 跟进（H3 → H1 → H2 → dsh observer → 生态小补）。

## 验证

- 两个文档里的全部相对链接（含 `../src/*.ts` 与 `./PLAN_*.md`）均已脚本校验可解析
- 计划中的每条现状断言都带 `file:line`，取自当前树

🤖 Generated with [Claude Code](https://claude.com/claude-code)