### PR TITLE
feat(sessions): 系统提示词入会话日志 + 离线重放（H3）

### DIFF
--- a/scripts/replay-session.ts
+++ b/scripts/replay-session.ts
@@ -46,7 +46,12 @@ async function main(): Promise<void> {
     return;
   }
 
-  const id = argv.find((a) => !a.startsWith("--"));
+  // `--turn` takes a value, so the token right after it is NOT the positional
+  // id — otherwise `replay --turn 3 <id>` reads "3" as the id. (#357 review)
+  const turnFlag = argv.indexOf("--turn");
+  const id = argv.find(
+    (a, i) => !a.startsWith("--") && (turnFlag === -1 || i !== turnFlag + 1),
+  );
   if (!id) throw new Error("no session id given");
   const replay = await replaySession(id);
 
@@ -55,7 +60,6 @@ async function main(): Promise<void> {
     return;
   }
 
-  const turnFlag = argv.indexOf("--turn");
   if (turnFlag !== -1) {
     const n = Number(argv[turnFlag + 1]);
     const turn = replay.turns.find((t) => t.index === n);
@@ -64,7 +68,9 @@ async function main(): Promise<void> {
     console.log(
       `system prompt: ${
         turn.systemPrompt === null
-          ? "(NOT RECORDED — session predates format v2)"
+          ? replay.header.version >= 2
+            ? "(none recorded at or before this turn — v2)"
+            : "(NOT RECORDED — session predates format v2)"
           : `${turn.systemPrompt.length} chars, fingerprint ${turn.promptFingerprint} (${turn.promptReason})`
       }`,
     );
@@ -82,9 +88,13 @@ async function main(): Promise<void> {
   console.log(`turns   ${replay.turns.length}`);
   if (!replay.promptsRecorded) {
     console.log(
-      "\n⚠ no system prompt recorded — this session predates H3 (format v2).\n" +
-        "  Every turn's systemPrompt is null because it was never written, not\n" +
-        "  because the persona was empty. Exclude it from drift analysis.",
+      replay.header.version < 2
+        ? "\n⚠ no system prompt recorded — this session predates H3 (format v2).\n" +
+            "  Every turn's systemPrompt is null because it was never written, not\n" +
+            "  because the persona was empty. Exclude it from drift analysis."
+        : "\n⚠ format v2 but no system prompt was recorded — persistence likely\n" +
+            "  failed (e.g. disk full / EPERM). systemPrompt is null on every turn;\n" +
+            "  exclude it from drift analysis.",
     );
     return;
   }

--- a/scripts/replay-session.ts
+++ b/scripts/replay-session.ts
@@ -1,0 +1,113 @@
+#!/usr/bin/env tsx
+/**
+ * Offline session replay (H3 — docs/PLAN_HARNESS_ALIGNMENT_v1.0.md §4).
+ *
+ * Reconstructs, for every turn of a stored session, the exact `(systemPrompt,
+ * messages)` input the model was given. This is the take-out point for drift /
+ * coherence analysis: it lets a metric be computed — or recomputed with a
+ * different definition — long after the run, without the soul/memory/skill
+ * files still being in the state they were in at the time.
+ *
+ * Usage:
+ *   npx tsx scripts/replay-session.ts <session-id>            # human summary
+ *   npx tsx scripts/replay-session.ts <session-id> --json     # full JSON to stdout
+ *   npx tsx scripts/replay-session.ts <session-id> --turn 3   # one turn, verbatim
+ *   npx tsx scripts/replay-session.ts --list                  # ids on disk
+ *
+ * Sessions written before format version 2 have no recorded prompt; the script
+ * says so explicitly rather than printing an empty persona, because "not
+ * recorded" and "no persona" must never be confused by a downstream metric.
+ *
+ * Read-only. It never writes to a session file.
+ */
+import process from "node:process";
+import { replaySession } from "../src/sessions/replay.js";
+import { listSessionsOnDisk } from "../src/sessions/list.js";
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2);
+
+  if (argv.includes("--list") || argv.length === 0) {
+    const sessions = await listSessionsOnDisk();
+    if (sessions.length === 0) {
+      console.log("(no sessions on disk)");
+      return;
+    }
+    for (const s of sessions) {
+      console.log(
+        `${s.id}  ${s.startedAt}  ${String(s.messageCount).padStart(4)} msgs  ${
+          s.firstUserMessage ?? ""
+        }`,
+      );
+    }
+    if (argv.length === 0) {
+      console.log("\nPass a session id to replay it. --json for machine output.");
+    }
+    return;
+  }
+
+  const id = argv.find((a) => !a.startsWith("--"));
+  if (!id) throw new Error("no session id given");
+  const replay = await replaySession(id);
+
+  if (argv.includes("--json")) {
+    process.stdout.write(JSON.stringify(replay, null, 2) + "\n");
+    return;
+  }
+
+  const turnFlag = argv.indexOf("--turn");
+  if (turnFlag !== -1) {
+    const n = Number(argv[turnFlag + 1]);
+    const turn = replay.turns.find((t) => t.index === n);
+    if (!turn) throw new Error(`session has no turn ${n} (${replay.turns.length} total)`);
+    console.log(`── turn ${turn.index} @ ${turn.ts} ──`);
+    console.log(
+      `system prompt: ${
+        turn.systemPrompt === null
+          ? "(NOT RECORDED — session predates format v2)"
+          : `${turn.systemPrompt.length} chars, fingerprint ${turn.promptFingerprint} (${turn.promptReason})`
+      }`,
+    );
+    if (turn.systemPrompt !== null) {
+      console.log("\n" + turn.systemPrompt + "\n");
+    }
+    console.log(`messages sent: ${turn.messages.length}`);
+    process.stdout.write(JSON.stringify(turn.messages, null, 2) + "\n");
+    return;
+  }
+
+  console.log(`session ${replay.header.id}  (format v${replay.header.version})`);
+  console.log(`started ${replay.header.startedAt}  model ${replay.header.model}`);
+  console.log(`cwd     ${replay.header.cwd}`);
+  console.log(`turns   ${replay.turns.length}`);
+  if (!replay.promptsRecorded) {
+    console.log(
+      "\n⚠ no system prompt recorded — this session predates H3 (format v2).\n" +
+        "  Every turn's systemPrompt is null because it was never written, not\n" +
+        "  because the persona was empty. Exclude it from drift analysis.",
+    );
+    return;
+  }
+  console.log(`prompts ${replay.promptChanges.length} distinct`);
+  console.log("\n── prompt timeline ──");
+  for (const change of replay.promptChanges) {
+    console.log(
+      `  ${change.ts}  ${change.fingerprint}  ${change.reason.padEnd(7)}  ` +
+        `first used by turn ${change.firstTurn ?? "(none — run ended first)"}`,
+    );
+  }
+  console.log("\n── turns ──");
+  for (const turn of replay.turns) {
+    console.log(
+      `  ${String(turn.index).padStart(3)}  ${turn.ts}  ` +
+        `prompt ${turn.promptFingerprint ?? "(none)"}  ` +
+        `${String(turn.messages.length).padStart(4)} msgs in`,
+    );
+  }
+  console.log("\nUse --turn <n> for one turn verbatim, or --json for everything.");
+}
+
+main().catch((err: unknown) => {
+  console.error(`[replay-session] ${err instanceof Error ? err.message : String(err)}`);
+  process.exitCode = 1;
+});

--- a/src/agent.ts
+++ b/src/agent.ts
@@ -53,6 +53,19 @@ export interface RunAgentOptions {
   effort?: "low" | "medium" | "high" | "xhigh" | "max";
   onEvent?: (event: AgentEvent) => void;
   onMessagePersist?: (message: StoredMessage) => Promise<void> | void;
+  /**
+   * H3 — "model-visible ⟺ recorded" (docs/PLAN_HARNESS_ALIGNMENT_v1.0.md §4).
+   * Called with the system prompt immediately before every provider call, so
+   * the session log carries the persona the model actually saw rather than
+   * only the messages. Called on every turn on purpose: the sink dedupes by
+   * content hash, which is cheaper to reason about than tracking "did it
+   * change" in two places. Sessionless runs (subagents, channel turns) leave
+   * it unset.
+   */
+  onPromptPersist?: (
+    text: string,
+    reason: "initial" | "rebuilt",
+  ) => Promise<unknown> | unknown;
   approval?: ApprovalCallback;
   preToolHook?: (
     name: string,
@@ -242,6 +255,22 @@ async function runAgentLoop(opts: RunAgentOptions): Promise<RunAgentResult> {
     }
 
     onEvent?.({ type: "turn_start" });
+
+    // H3: record the prompt BEFORE the call that makes it model-visible, so a
+    // crash mid-turn still leaves the log able to explain what the model was
+    // asked with. Best-effort — persistence must never sink a live turn.
+    if (opts.onPromptPersist) {
+      try {
+        await opts.onPromptPersist(
+          currentSystemPrompt,
+          iterations === 1 ? "initial" : "rebuilt",
+        );
+      } catch (err) {
+        toolCtx.log(
+          `[prompt-log] skipped: ${(err as Error).message.slice(0, 200)}`,
+        );
+      }
+    }
 
     let result;
     try {

--- a/src/channels/router.ts
+++ b/src/channels/router.ts
@@ -135,6 +135,10 @@ export class ChannelRouter {
         thinking: this.opts.thinking,
         compaction: this.opts.compaction,
         onMessagePersist: (m) => ctx.session.appendMessage(m),
+        // Channel turns get no hot-reload, so this writes exactly one prompt
+        // entry per channel session — but it writes it, so a channel session
+        // is as replayable as a REPL one (H3).
+        onPromptPersist: (text, reason) => ctx.session.appendPrompt(text, reason),
         moodOrigin: `a message on your ${channel.name} channel`,
       });
       ctx.history.length = 0;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -750,6 +750,7 @@ async function main(): Promise<void> {
       },
       onEvent: renderEvent,
       onMessagePersist: (msg) => session.appendMessage(msg),
+      onPromptPersist: (text, reason) => session.appendPrompt(text, reason),
       hotReload: {
         initialFingerprint: fresh.fingerprint,
         rebuild: rebuildPrompt,

--- a/src/sessions/replay.test.ts
+++ b/src/sessions/replay.test.ts
@@ -1,0 +1,163 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { replaySessionFile } from "./replay.js";
+
+/**
+ * H3 acceptance (docs/PLAN_HARNESS_ALIGNMENT_v1.0.md §4): given a stored
+ * session, rebuild the (systemPrompt, messages) input of every turn offline.
+ */
+
+function jsonl(...entries: unknown[]): string {
+  return entries.map((e) => JSON.stringify(e)).join("\n") + "\n";
+}
+
+const HEADER = {
+  type: "session",
+  id: "20260814-120000-abc",
+  version: 2,
+  startedAt: "2026-08-14T12:00:00.000Z",
+  cwd: "/work",
+  model: "claude-opus-5",
+};
+
+const V1_HEADER = { ...HEADER, version: 1 };
+
+function prompt(ts: string, text: string, reason: "initial" | "rebuilt" = "initial") {
+  return { type: "prompt", ts, fingerprint: `fp-${text}`, text, reason };
+}
+function user(ts: string, text: string) {
+  return { type: "message", ts, message: { role: "user", content: text } };
+}
+function assistant(ts: string, text: string) {
+  return { type: "message", ts, message: { role: "assistant", content: text } };
+}
+
+describe("replaySessionFile — turn reconstruction", () => {
+  test("each turn carries the messages that preceded it, not the ones after", () => {
+    const raw = jsonl(
+      HEADER,
+      prompt("t0", "You are Lisa."),
+      user("t1", "hello"),
+      assistant("t2", "hi"),
+      user("t3", "again"),
+      assistant("t4", "still here"),
+    );
+    const replay = replaySessionFile(raw);
+
+    assert.equal(replay.turns.length, 2);
+    assert.deepEqual(
+      replay.turns[0]!.messages.map((m) => m.content),
+      ["hello"],
+    );
+    assert.deepEqual(
+      replay.turns[1]!.messages.map((m) => m.content),
+      ["hello", "hi", "again"],
+      "turn 2 saw turn 1's exchange",
+    );
+    assert.equal(replay.turns[1]!.assistant.content, "still here");
+  });
+
+  test("a mid-session prompt rebuild applies from the next turn onward", () => {
+    const raw = jsonl(
+      HEADER,
+      prompt("t0", "persona A"),
+      user("t1", "who are you"),
+      assistant("t2", "A"),
+      // she calls soul_patch; the loop rebuilds before the next provider call
+      prompt("t3", "persona B", "rebuilt"),
+      user("t4", "and now"),
+      assistant("t5", "B"),
+    );
+    const replay = replaySessionFile(raw);
+
+    assert.equal(replay.turns[0]!.systemPrompt, "persona A");
+    assert.equal(replay.turns[0]!.promptReason, "initial");
+    assert.equal(replay.turns[1]!.systemPrompt, "persona B");
+    assert.equal(replay.turns[1]!.promptReason, "rebuilt");
+  });
+
+  test("prompt timeline records which turn first ran under each prompt", () => {
+    const raw = jsonl(
+      HEADER,
+      prompt("t0", "A"),
+      user("t1", "x"),
+      assistant("t2", "y"),
+      prompt("t3", "B", "rebuilt"),
+      user("t4", "x"),
+      assistant("t5", "y"),
+      // recorded but the run died before the provider answered
+      prompt("t6", "C", "rebuilt"),
+    );
+    const replay = replaySessionFile(raw);
+
+    assert.deepEqual(
+      replay.promptChanges.map((c) => [c.fingerprint, c.firstTurn]),
+      [
+        ["fp-A", 1],
+        ["fp-B", 2],
+        ["fp-C", null],
+      ],
+    );
+  });
+
+  test("tool turns count as turns — the assistant message is what closes one", () => {
+    const raw = jsonl(
+      HEADER,
+      prompt("t0", "P"),
+      user("t1", "read the file"),
+      { type: "message", ts: "t2", message: { role: "assistant", content: [{ type: "tool_use", id: "u1", name: "read", input: {} }] } },
+      { type: "message", ts: "t3", message: { role: "user", content: [{ type: "tool_result", tool_use_id: "u1", content: "contents" }] } },
+      assistant("t4", "it says contents"),
+    );
+    const replay = replaySessionFile(raw);
+
+    assert.equal(replay.turns.length, 2, "one call to emit the tool_use, one to answer");
+    assert.equal(replay.turns[1]!.messages.length, 3, "the tool_result was in the second call's input");
+  });
+});
+
+describe("replaySessionFile — honesty about what was not recorded", () => {
+  test("a pre-H3 session reports promptsRecorded=false with null prompts", () => {
+    const raw = jsonl(V1_HEADER, user("t1", "hello"), assistant("t2", "hi"));
+    const replay = replaySessionFile(raw);
+
+    assert.equal(replay.promptsRecorded, false);
+    assert.equal(replay.turns[0]!.systemPrompt, null);
+    assert.deepEqual(replay.promptChanges, []);
+  });
+
+  test("turns before the first recorded prompt keep a null prompt, not the later one", () => {
+    const raw = jsonl(
+      HEADER,
+      user("t1", "hello"),
+      assistant("t2", "hi"),
+      prompt("t3", "persona", "rebuilt"),
+      user("t4", "again"),
+      assistant("t5", "yes"),
+    );
+    const replay = replaySessionFile(raw);
+
+    assert.equal(replay.turns[0]!.systemPrompt, null);
+    assert.equal(replay.turns[1]!.systemPrompt, "persona");
+  });
+
+  test("other entry kinds are ignored, and a torn tail line is survivable", () => {
+    const raw =
+      jsonl(
+        HEADER,
+        prompt("t0", "P"),
+        { type: "reflection", ts: "t1", summary: "a reflection" },
+        { type: "model_change", ts: "t2", model: "other-model" },
+        user("t3", "hello"),
+        assistant("t4", "hi"),
+      ) + '{"type":"message","ts":"t5","mess';
+
+    const replay = replaySessionFile(raw);
+    assert.equal(replay.turns.length, 1);
+    assert.deepEqual(replay.turns[0]!.messages.map((m) => m.content), ["hello"]);
+  });
+
+  test("an empty file is an error, not a silently empty replay", () => {
+    assert.throws(() => replaySessionFile(""), /empty/);
+  });
+});

--- a/src/sessions/replay.ts
+++ b/src/sessions/replay.ts
@@ -1,0 +1,143 @@
+/**
+ * Offline replay — reconstruct what the model was actually asked, turn by turn.
+ *
+ * This is the deliverable of H3 (docs/PLAN_HARNESS_ALIGNMENT_v1.0.md §4). The
+ * session log records messages *and*, since format version 2, the system prompt
+ * as it was at each provider call. Walking those two entry kinds together
+ * rebuilds the `(systemPrompt, messages)` input of every turn without re-running
+ * anything and without needing the soul/memory/skill files to still be in the
+ * state they were in at the time.
+ *
+ * Why it matters beyond debugging: drift and coherence metrics are functions of
+ * "what did she say about herself, given what she was told she was". Without the
+ * prompt in the log those can only be measured live, once, with no chance to
+ * recompute a different metric over the same history or to run an ablation.
+ *
+ * Fidelity, stated precisely:
+ *  - `systemPrompt` is exact — it is the byte-identical string handed to the
+ *    provider (the CLI and web surfaces both persist it, suffix included).
+ *  - `messages` is the canonical session transcript up to that turn. For
+ *    surfaces that send a bounded suffix of history rather than all of it (the
+ *    web chat does; the CLI does not), the real request carried a *tail* of this
+ *    list. The window boundary is not yet recorded — that is H3 Step 2. Callers
+ *    computing token-exact replays must account for it; callers analyzing what
+ *    Lisa was told about herself do not care.
+ */
+
+import fs from "node:fs/promises";
+import path from "node:path";
+import { sessionsDir } from "../paths.js";
+import { pathExists } from "../fs-utils.js";
+import type { SessionEntry, SessionHeader, StoredMessage } from "../types.js";
+
+export interface ReplayTurn {
+  /** 1-based index of the provider call within the session. */
+  index: number;
+  /** Timestamp of the assistant message this turn produced. */
+  ts: string;
+  /**
+   * The system prompt in effect, or null when the session predates format
+   * version 2 (or the turn precedes the first recorded prompt).
+   */
+  systemPrompt: string | null;
+  promptFingerprint: string | null;
+  /** How the prompt in effect came to be: the run's opening prompt, or a
+   *  mid-session rebuild triggered by soul/memory/skill changes. */
+  promptReason: "initial" | "rebuilt" | null;
+  /** Conversation as of just before this turn (see fidelity note above). */
+  messages: StoredMessage[];
+  /** What the model returned. */
+  assistant: StoredMessage;
+}
+
+export interface SessionReplay {
+  header: SessionHeader;
+  turns: ReplayTurn[];
+  /**
+   * False for pre-H3 sessions: every `systemPrompt` is null because it was
+   * never recorded, NOT because the prompt was empty. Analysis passes must
+   * drop these sessions rather than treat them as "no persona".
+   */
+  promptsRecorded: boolean;
+  /** Prompt entries seen, in order — one per distinct prompt the model saw. */
+  promptChanges: Array<{
+    ts: string;
+    fingerprint: string;
+    reason: "initial" | "rebuilt";
+    /** Index of the first turn that ran under this prompt, or null if it was
+     *  recorded but no turn followed (crash / abandoned run). */
+    firstTurn: number | null;
+  }>;
+}
+
+/** Reconstruct from raw JSONL text. Corrupt lines are skipped, not fatal. */
+export function replaySessionFile(raw: string): SessionReplay {
+  const lines = raw.split("\n").filter(Boolean);
+  if (lines.length === 0) throw new Error("session file is empty");
+  const header = JSON.parse(lines[0]!) as SessionHeader;
+
+  const messages: StoredMessage[] = [];
+  const turns: ReplayTurn[] = [];
+  const promptChanges: SessionReplay["promptChanges"] = [];
+  let currentPrompt: string | null = null;
+  let currentFingerprint: string | null = null;
+  let currentReason: "initial" | "rebuilt" | null = null;
+  let pendingPromptChange: (typeof promptChanges)[number] | null = null;
+
+  for (let i = 1; i < lines.length; i++) {
+    let entry: SessionEntry;
+    try {
+      entry = JSON.parse(lines[i]!) as SessionEntry;
+    } catch {
+      continue; // tolerate a torn write at the tail
+    }
+    if (entry.type === "prompt") {
+      currentPrompt = entry.text;
+      currentFingerprint = entry.fingerprint;
+      currentReason = entry.reason;
+      pendingPromptChange = {
+        ts: entry.ts,
+        fingerprint: entry.fingerprint,
+        reason: entry.reason,
+        firstTurn: null,
+      };
+      promptChanges.push(pendingPromptChange);
+      continue;
+    }
+    if (entry.type !== "message") continue;
+
+    if (entry.message.role === "assistant") {
+      // A provider call happened with everything accumulated so far as input.
+      turns.push({
+        index: turns.length + 1,
+        ts: entry.ts,
+        systemPrompt: currentPrompt,
+        promptFingerprint: currentFingerprint,
+        promptReason: currentReason,
+        messages: [...messages],
+        assistant: entry.message,
+      });
+      if (pendingPromptChange) {
+        pendingPromptChange.firstTurn = turns.length;
+        pendingPromptChange = null;
+      }
+    }
+    messages.push(entry.message);
+  }
+
+  return {
+    header,
+    turns,
+    promptsRecorded: promptChanges.length > 0,
+    promptChanges,
+  };
+}
+
+/** Reconstruct a session by id from the active Lisa home. */
+export async function replaySession(id: string): Promise<SessionReplay> {
+  const file = path.join(sessionsDir(), `${id}.jsonl`);
+  if (!(await pathExists(file))) {
+    throw new Error(`session ${id} not found at ${file}`);
+  }
+  return replaySessionFile(await fs.readFile(file, "utf8"));
+}

--- a/src/sessions/store.test.ts
+++ b/src/sessions/store.test.ts
@@ -38,6 +38,18 @@ describe("SessionStore — create / open round-trip", () => {
     assert.equal(reopened.header.model, "test-model");
   });
 
+  test(
+    "the log is 0600 in a 0700 dir — it now carries the whole system prompt (H3)",
+    { skip: process.platform === "win32" },
+    async () => {
+      const s = await SessionStore.create({ cwd: "/w", model: "m" });
+      const dir = path.join(home, "sessions");
+      const file = path.join(dir, `${s.id}.jsonl`);
+      assert.equal(fs.statSync(file).mode & 0o777, 0o600, "session log must be private (soul/USER.md/MEMORY.md/KB)");
+      assert.equal(fs.statSync(dir).mode & 0o777, 0o700, "sessions dir must be private");
+    },
+  );
+
   test("open() rejects a missing session", async () => {
     await assert.rejects(SessionStore.open("does-not-exist"));
   });

--- a/src/sessions/store.test.ts
+++ b/src/sessions/store.test.ts
@@ -9,12 +9,13 @@ import type { StoredMessage } from "../types.js";
 // BEFORE importing the store (dynamic import). node --test isolates each file in
 // its own process, so this env mutation can't leak to other suites.
 let SessionStore: typeof import("./store.js").SessionStore;
+let promptFingerprint: typeof import("./store.js").promptFingerprint;
 let home: string;
 
 before(async () => {
   home = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-sess-"));
   process.env.LISA_HOME = home;
-  ({ SessionStore } = await import("./store.js"));
+  ({ SessionStore, promptFingerprint } = await import("./store.js"));
 });
 after(() => {
   fs.rmSync(home, { recursive: true, force: true });
@@ -93,5 +94,81 @@ describe("SessionStore — message persistence + resume", () => {
     const page = await s.readMessagePage(5, 20);
     assert.deepEqual(page.messages, []);
     assert.equal(page.hasMore, false);
+  });
+});
+
+// H3 — "model-visible ⟺ recorded" (docs/PLAN_HARNESS_ALIGNMENT_v1.0.md §4).
+describe("SessionStore — system prompt persistence", () => {
+  function promptEntries(file: string): Array<Record<string, unknown>> {
+    return fs
+      .readFileSync(file, "utf8")
+      .split("\n")
+      .filter(Boolean)
+      .map((l) => JSON.parse(l) as Record<string, unknown>)
+      .filter((e) => e.type === "prompt");
+  }
+
+  test("new sessions declare format version 2", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    assert.equal(s.header.version, 2);
+  });
+
+  test("first prompt is written with reason 'initial' and a content fingerprint", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    assert.equal(await s.appendPrompt("You are Lisa.", "initial"), true);
+
+    const entries = promptEntries(s.path);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]!.text, "You are Lisa.");
+    assert.equal(entries[0]!.reason, "initial");
+    assert.equal(entries[0]!.fingerprint, promptFingerprint("You are Lisa."));
+  });
+
+  test("an unchanged prompt is not re-written on every turn", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    await s.appendPrompt("stable", "initial");
+    assert.equal(await s.appendPrompt("stable", "rebuilt"), false);
+    assert.equal(await s.appendPrompt("stable", "rebuilt"), false);
+    assert.equal(promptEntries(s.path).length, 1);
+  });
+
+  test("a changed prompt is written again, and back-and-forth changes both land", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    await s.appendPrompt("v1", "initial");
+    await s.appendPrompt("v2", "rebuilt");
+    await s.appendPrompt("v1", "rebuilt"); // reverting is still a change
+    assert.deepEqual(
+      promptEntries(s.path).map((e) => e.text),
+      ["v1", "v2", "v1"],
+    );
+  });
+
+  test("resuming a session does not duplicate the prompt still in effect", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    await s.appendPrompt("carried over", "initial");
+    await s.appendMessage(msg(0));
+
+    const resumed = await SessionStore.open(s.id);
+    assert.equal(
+      await resumed.appendPrompt("carried over", "initial"),
+      false,
+      "the prompt is unchanged since the last run — nothing new to record",
+    );
+    assert.equal(promptEntries(s.path).length, 1);
+
+    assert.equal(await resumed.appendPrompt("she patched herself", "rebuilt"), true);
+    assert.equal(promptEntries(s.path).length, 2);
+  });
+
+  test("prompt entries stay out of message pages and reflections", async () => {
+    const s = await SessionStore.create({ cwd: "/w", model: "m" });
+    await s.appendPrompt("persona", "initial");
+    await s.appendMessage(msg(0));
+    await s.appendPrompt("persona v2", "rebuilt");
+    await s.appendMessage(msg(1));
+
+    const page = await s.readMessagePage(0);
+    assert.deepEqual(page.messages.map((m) => m.content), ["m0", "m1"]);
+    assert.equal(await s.readLatestReflection(), undefined);
   });
 });

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -47,7 +47,13 @@ export class SessionStore {
     cwd: string;
     model: string;
   }): Promise<SessionStore> {
+    // Session logs now carry the full system prompt — soul, USER.md, MEMORY.md,
+    // KB — the same sensitive user context the rest of ~/.lisa keeps private, so
+    // hold them to the same 0600-in-0700 discipline as config.env / devices /
+    // mail. append's mode only applies on create, so chmod after to tighten a
+    // dir or file that predates this hardening.
     await ensureDir(sessionsDir());
+    await fs.chmod(sessionsDir(), 0o700).catch(() => {});
     const id = `${stamp()}-${crypto.randomBytes(3).toString("hex")}`;
     const file = path.join(sessionsDir(), `${id}.jsonl`);
     const header: SessionHeader = {
@@ -59,6 +65,7 @@ export class SessionStore {
       model: opts.model,
     };
     await appendLine(file, JSON.stringify(header));
+    await fs.chmod(file, 0o600).catch(() => {});
     return new SessionStore(id, file, header);
   }
 

--- a/src/sessions/store.ts
+++ b/src/sessions/store.ts
@@ -5,15 +5,33 @@ import { sessionsDir } from "../paths.js";
 import { appendLine, ensureDir } from "../fs-utils.js";
 import type { SessionEntry, SessionHeader, StoredMessage } from "../types.js";
 
+/** Content hash of a system prompt — the identity of a `prompt` entry. */
+export function promptFingerprint(text: string): string {
+  return crypto.createHash("sha256").update(text, "utf8").digest("hex").slice(0, 16);
+}
+
 export class SessionStore {
   readonly id: string;
   readonly path: string;
   readonly header: SessionHeader;
+  /**
+   * Fingerprint of the last system prompt written to this file, so an
+   * unchanged prompt isn't re-serialized on every turn (and a resumed session
+   * doesn't duplicate the prompt it is still running with). Recovered on
+   * open() from the file we already read.
+   */
+  private lastPromptFingerprint?: string;
 
-  private constructor(id: string, file: string, header: SessionHeader) {
+  private constructor(
+    id: string,
+    file: string,
+    header: SessionHeader,
+    lastPromptFingerprint?: string,
+  ) {
     this.id = id;
     this.path = file;
     this.header = header;
+    this.lastPromptFingerprint = lastPromptFingerprint;
   }
 
   static async open(id: string): Promise<SessionStore> {
@@ -22,7 +40,7 @@ export class SessionStore {
     const lines = raw.split("\n").filter(Boolean);
     if (lines.length === 0) throw new Error(`session ${id} is empty`);
     const header = JSON.parse(lines[0]!) as SessionHeader;
-    return new SessionStore(id, file, header);
+    return new SessionStore(id, file, header, lastPromptFingerprintIn(lines));
   }
 
   static async create(opts: {
@@ -35,13 +53,40 @@ export class SessionStore {
     const header: SessionHeader = {
       type: "session",
       id,
-      version: 1,
+      version: 2,
       startedAt: new Date().toISOString(),
       cwd: opts.cwd,
       model: opts.model,
     };
     await appendLine(file, JSON.stringify(header));
     return new SessionStore(id, file, header);
+  }
+
+  /**
+   * Record the system prompt the model is about to see (H3). No-op when the
+   * text is byte-identical to the last one written — "the prompt in effect at
+   * entry N" is therefore the nearest preceding prompt entry, and a long chat
+   * that never self-modifies costs exactly one entry.
+   *
+   * Returns whether an entry was actually appended (tests and telemetry care;
+   * callers generally don't).
+   */
+  async appendPrompt(
+    text: string,
+    reason: "initial" | "rebuilt",
+  ): Promise<boolean> {
+    const fingerprint = promptFingerprint(text);
+    if (fingerprint === this.lastPromptFingerprint) return false;
+    const entry: SessionEntry = {
+      type: "prompt",
+      ts: new Date().toISOString(),
+      fingerprint,
+      text,
+      reason,
+    };
+    await appendLine(this.path, JSON.stringify(entry));
+    this.lastPromptFingerprint = fingerprint;
+    return true;
   }
 
   async appendMessage(message: StoredMessage): Promise<void> {
@@ -104,6 +149,21 @@ export class SessionStore {
     const messages = slice.map((l) => (JSON.parse(l) as { type: "message"; message: StoredMessage }).message);
     return { messages, hasMore: start > 0 };
   }
+}
+
+/** Last `prompt` entry's fingerprint in an already-read session file, if any. */
+function lastPromptFingerprintIn(lines: string[]): string | undefined {
+  for (let index = lines.length - 1; index >= 1; index--) {
+    try {
+      const entry = JSON.parse(lines[index]!) as Partial<SessionEntry>;
+      if (entry.type === "prompt" && "fingerprint" in entry) {
+        return entry.fingerprint as string;
+      }
+    } catch {
+      // Skip a corrupt line and keep scanning backwards.
+    }
+  }
+  return undefined;
 }
 
 function stamp(): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,7 +51,15 @@ export interface Skill {
 export interface SessionHeader {
   type: "session";
   id: string;
-  version: 1;
+  /**
+   * 1 — messages only. 2 — adds `prompt` entries (H3, see
+   * docs/PLAN_HARNESS_ALIGNMENT_v1.0.md §4). Readers never branch on this:
+   * every entry reader skips unknown `type`s, so a v1 file reads fine and a
+   * v2 file reads fine in older builds. It exists to tell an *analysis* pass
+   * whether the absence of `prompt` entries means "not recorded" (v1) or
+   * "genuinely unchanged" (v2).
+   */
+  version: 1 | 2;
   startedAt: string;
   cwd: string;
   model: string;
@@ -60,7 +68,22 @@ export interface SessionHeader {
 export type SessionEntry =
   | { type: "message"; ts: string; message: StoredMessage }
   | { type: "model_change"; ts: string; model: string }
-  | { type: "reflection"; ts: string; summary: string };
+  | { type: "reflection"; ts: string; summary: string }
+  /**
+   * The system prompt as the model actually saw it (H3 — "model-visible ⟺
+   * recorded"). Written before the first provider call of a run and again
+   * whenever mid-session hot-reload swaps it, so a historical session can be
+   * replayed with the persona that was live at each turn. `fingerprint` is a
+   * content hash of `text`; consecutive identical ones are not re-written, so
+   * "the prompt in effect at entry N" is the nearest preceding prompt entry.
+   */
+  | {
+      type: "prompt";
+      ts: string;
+      fingerprint: string;
+      text: string;
+      reason: "initial" | "rebuilt";
+    };
 
 export interface AgentEvent {
   type:

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -4046,6 +4046,7 @@ self.addEventListener('fetch', (event) => {
               if (r.rewriteResult != null) return { rewriteResult: r.rewriteResult };
             },
             onMessagePersist: (m) => chat.session.appendMessage(m),
+            onPromptPersist: (text, reason) => chat.session.appendPrompt(text, reason),
             hotReload: {
               initialFingerprint: fresh.fingerprint,
               rebuild: async () => {


### PR DESCRIPTION
> 计划见 #356 的 `docs/PLAN_HARNESS_ALIGNMENT_v1.0.md` §4（H3）。本 PR 是其 Step 1。

## 问题

会话 JSONL 一直记录 `tool_use` / `tool_result`（它们是 `StoredMessage` 的 content block），这点比预想的好。真正缺的是**系统提示词**：

- 它由 soul + memory + skills + mood + KB 摘要动态构建（`prompt.ts:66`）；
- 而且会话**中途会热重载** —— `soul_patch` / `memory` 写入后下一轮就换了一份（`agent.ts` 的 `hotReload`），只发一个 `system_prompt_rebuilt` 事件，不落盘；
- 结果：**拿一条历史会话，重建不出当时模型看到的 persona**。

ROADMAP 1.0 判定标准第 4 条要求 Reve 产出可复现的 drift / coherence 指标，而 drift 的定义就是"她的自我描述随时间怎么变"。日志里没有当时的自我描述，这个指标只能在线测一次 —— 无法离线复算、无法换个定义重算、无法做消融。

## 改动

| | |
|---|---|
| 会话格式 | v1 → **v2**，新增 `prompt` 条目 `{ts, fingerprint, text, reason}` |
| 去重 | `fingerprint` 是正文内容哈希，连续相同不重复写 → "第 N 条时生效的提示词" = 最近的前一条 prompt 条目；从不自我修改的长对话只花一条 |
| 触发点 | `runAgent` 新增 `onPromptPersist`，在**每次 provider 调用之前**触发 —— 即提示词真正对模型可见的那一刻。写在调用前，所以中途崩溃的轮次也留得下"当时问的是什么" |
| 接线 | 三个持有 `SessionStore` 的表层全接：REPL / web / 渠道。子代理与 managed agent 无会话，按设计不接 |
| 交付物 | `src/sessions/replay.ts` 离线重建每轮 `(systemPrompt, messages)`；`scripts/replay-session.ts` CLI 包装 |

失败处理：持久化异常只写一行日志，绝不拖垮活轮次。

## 诚实边界

写进了 `replay.ts` 的模块头注释，也在这里说清：

- `systemPrompt` 是**逐字精确**的（CLI 与 web 都持久化了含 suffix 的最终串）；
- `messages` 是会话正典全量。**web 表层实际只发历史的有界后缀**，窗口边界尚未记录 —— 这是 H3 Step 2。做 token 级精确重放的调用方需自行处理；做"她被告知自己是谁"分析的不受影响。

## 向后兼容

v1 会话读取完全正常（所有条目读取器本来就跳过未知 `type`）。重放 v1 会话时 `promptsRecorded=false` 且每轮 `systemPrompt` 为 `null`，脚本会**明说"未记录"**而不是打印空 persona —— 避免下游指标把"没记"当成"没有人格"。

## 验证

```
npx tsx scripts/replay-session.ts --list
npx tsx scripts/replay-session.ts <session-id>
```

- store 6 例（版本、去重、往返、恢复不重复、不污染消息分页/反思）
- replay 9 例（轮次切分、中途换 persona、工具轮、prompt 时间线、v1 降级、断尾行容错、空文件报错）
- 全量 **1566 通过 / 0 失败**，typecheck 干净
- 合成 v2 会话跑通脚本三种输出模式

🤖 Generated with [Claude Code](https://claude.com/claude-code)