### PR TITLE
obs(cloud): dedupe redactEmail, classify mailer + startup logs

### DIFF
--- a/deploy/entrypoint.sh
+++ b/deploy/entrypoint.sh
@@ -11,18 +11,30 @@
 # otherwise each cold start re-births a fresh demo soul.
 set -e
 
+# Match the app's log discipline (src/log.ts): on Cloud Run (K_SERVICE) emit
+# one-line JSON so Cloud Logging lifts the severity instead of filing these as
+# unclassified; plain text anywhere else. Messages here are fixed strings with
+# no quotes or backslashes, so no JSON escaping is needed.
+log_line() {
+  if [ -n "$K_SERVICE" ]; then
+    printf '{"severity":"%s","message":"%s"}\n' "$1" "$2"
+  else
+    echo "$2"
+  fi
+}
+
 export LISA_HOME="${LISA_HOME:-/data}"
 mkdir -p "$LISA_HOME"
 
 # Born? isBorn() resolves true once the soul seed exists under $LISA_HOME.
 if node -e "import('./dist/soul/store.js').then(m=>m.isBorn()).then(b=>process.exit(b?0:1)).catch(e=>{console.error(e);process.exit(1)})"; then
-  echo "[cloud] soul already present — skipping birth"
+  log_line INFO "[cloud] soul already present — skipping birth"
 else
-  echo "[cloud] birthing the demo soul (model ${LISA_MODEL:-default})…"
+  log_line INFO "[cloud] birthing the demo soul (model ${LISA_MODEL:-default})…"
   # `lisa birth` validates that a provider key for the model is configured (any of
   # ANTHROPIC_API_KEY / ZHIPU_API_KEY / OPENAI_API_KEY / … per the model). If none
   # is set it exits non-zero and the first web visitor gets the birth ritual.
-  node dist/cli.js birth || echo "[cloud] birth skipped/failed — first visitor will see the birth ritual"
+  node dist/cli.js birth || log_line WARNING "[cloud] birth skipped/failed — first visitor will see the birth ritual"
 fi
 
 exec node dist/cli.js serve --web --port "${PORT:-8080}" --host 0.0.0.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@ import { dirname, resolve as resolvePath } from "node:path";
 // in ~/.lisa/config.env.
 import { configureProxyFromEnv } from "./proxy-bootstrap.js";
 configureProxyFromEnv({ log: (m) => console.error(m) });
+import { logInfo } from "./log.js";
 import { runAgent } from "./agent.js";
 import { buildApprovalCallback, DEFAULT_MUTATING_TOOLS, DEFAULT_MUTATING_ACTIONS } from "./approval.js";
 import { CONFIG_ENV_PATH, loadConfigEnv } from "./env.js";
@@ -570,9 +571,9 @@ async function main(): Promise<void> {
       // Print the real bind address — this used to claim "localhost" while
       // Node was actually listening on every interface.
       const display = isLoopbackAddress(args.host) ? "localhost" : args.host;
-      console.error(`Lisa web UI listening on http://${display}:${args.port} (bound to ${args.host})`);
+      logInfo(`Lisa web UI listening on http://${display}:${args.port} (bound to ${args.host})`);
       if (!isLoopbackAddress(args.host)) {
-        console.error(
+        logInfo(
           `[web] non-loopback bind: requests from other machines must present LISA_WEB_TOKEN ` +
             `(open http://${args.host}:${args.port}/?token=<value> once per device)`,
         );

--- a/src/log.test.ts
+++ b/src/log.test.ts
@@ -16,8 +16,11 @@ test("redactId keeps a prefix+suffix for correlation, never the middle", () => {
   assert.equal(redactId(""), "");
 });
 
-test("redactEmail keeps first char + domain only", () => {
-  assert.equal(redactEmail("alice@example.com"), "a***@example.com");
-  assert.equal(redactEmail("not-an-address"), "…");
-  assert.equal(redactEmail("@nouser.com"), "…");
+test("redactEmail drops the identifying local part, keeps the domain", () => {
+  assert.equal(redactEmail("alice.smith@example.com"), "al***@example.com");
+  assert.equal(redactEmail("a@b.co"), "a***@b.co");
+  // Anything that isn't an address must not fall through as-is.
+  assert.equal(redactEmail("not-an-address"), "***");
+  assert.equal(redactEmail("@nouser.com"), "***");
+  assert.equal(redactEmail("trailing@"), "***");
 });

--- a/src/log.ts
+++ b/src/log.ts
@@ -60,9 +60,13 @@ export function redactId(id: string): string {
   return `${id.slice(0, 4)}…${id.slice(-4)}`;
 }
 
-/** `alice@example.com` → `a***@example.com`; a non-address becomes `…`. */
-export function redactEmail(email: string): string {
-  const at = email.indexOf("@");
-  if (at <= 0) return "…";
-  return `${email[0]}***@${email.slice(at + 1)}`;
+/**
+ * `alice.smith@example.com` → `al***@example.com`. The local part is the
+ * identifying half, so it goes; the domain stays whole because that's what you
+ * group by when delivery breaks. Anything that isn't an address becomes `***`.
+ */
+export function redactEmail(addr: string): string {
+  const at = addr.lastIndexOf("@");
+  if (at <= 0 || at === addr.length - 1) return "***";
+  return `${addr.slice(0, Math.min(2, at))}***@${addr.slice(at + 1)}`;
 }

--- a/src/soul/git.ts
+++ b/src/soul/git.ts
@@ -13,6 +13,7 @@ import { AsyncLocalStorage } from "node:async_hooks";
 import path from "node:path";
 import { pathExists } from "../fs-utils.js";
 import { isCloud } from "../edition.js";
+import { logWarn } from "../log.js";
 import { withFileLock } from "./lock.js";
 import { soulDir } from "./paths.js";
 
@@ -137,7 +138,7 @@ async function runGit(args: string[]): Promise<GitResult> {
  */
 export async function initSoulRepo(): Promise<void> {
   if (!(await checkGitAvailable())) {
-    console.warn("[soul-git] git not available; soul history disabled");
+    logWarn("[soul-git] git not available; soul history disabled");
     return;
   }
   if (!(await pathExists(soulDir()))) return;

--- a/src/web/mailer.ts
+++ b/src/web/mailer.ts
@@ -38,6 +38,7 @@
  *
  * Env: RESEND_API_KEY, LISA_MAIL_FROM (default "LISA <no-reply@mail.meetlisa.ai>").
  */
+import { logInfo, logWarn, logError, redactEmail } from "../log.js";
 
 export interface MailResult {
   sent: boolean;
@@ -66,16 +67,10 @@ export function mailerConfig(env: Record<string, string | undefined> = process.e
 
 // ── log hygiene ─────────────────────────────────────────────────────────────
 
-/**
- * `alice.smith@example.com` → `al***@example.com`. The local part is the
- * identifying half, so it goes; the domain stays whole because that's what you
- * group by when delivery breaks.
- */
-export function redactEmail(addr: string): string {
-  const at = addr.lastIndexOf("@");
-  if (at <= 0 || at === addr.length - 1) return "***";
-  return `${addr.slice(0, Math.min(2, at))}***@${addr.slice(at + 1)}`;
-}
+// The canonical implementation lives in ../log.js beside the other log-line
+// redactors; re-exported here because callers of this module reach for it as
+// part of the mail surface.
+export { redactEmail };
 
 // ── HTML templating (hand-rolled: no MJML, no react-email, no deps) ─────────
 // Email HTML is 1998 HTML — tables, inline styles, no flexbox, no <style> that
@@ -255,7 +250,7 @@ async function deliver(
   if (!cfg.apiKey) {
     // The one place a live credential is logged: no key means no delivery, so
     // the alternative is a sign-in nobody can complete.
-    console.error(`[mail] outcome=skipped_no_key kind=${kind} to=${who} — ${fallback}`);
+    logWarn(`[mail] outcome=skipped_no_key kind=${kind} to=${who} — ${fallback}`);
     return { sent: false, detail: "no_api_key" };
   }
   try {
@@ -278,17 +273,17 @@ async function deliver(
       // limit) that returns a perfectly well-formed response — it must be
       // logged as loudly as a thrown network error, or it vanishes.
       const body = await res.text().catch(() => "");
-      console.error(
+      logError(
         `[mail] outcome=send_failed kind=${kind} to=${who} status=${res.status} — ${body.slice(0, 200)}`,
       );
       return { sent: false, detail: `http_${res.status}` };
     }
     const parsed = (await res.json().catch(() => ({}))) as { id?: string };
     const id = parsed.id ?? "sent";
-    console.error(`[mail] outcome=success kind=${kind} to=${who} id=${id}`);
+    logInfo(`[mail] outcome=success kind=${kind} to=${who} id=${id}`);
     return { sent: true, detail: id };
   } catch (e) {
-    console.error(`[mail] outcome=send_failed kind=${kind} to=${who} — ${(e as Error).message}`);
+    logError(`[mail] outcome=send_failed kind=${kind} to=${who} — ${(e as Error).message}`);
     return { sent: false, detail: "network_error" };
   }
 }


### PR DESCRIPTION
#363 的三个收尾项——都是在生产验收那个 PR 时查出来的（见下方「怎么发现的」）。纯日志卫生，无行为变更。

## 1. `redactEmail` 有两份实现，且行为不一致

| | 位置 | `alice.smith@example.com` | `trailing@` |
|---|---|---|---|
| 旧 A | `src/log.ts`（#363 新加） | `a***@example.com` | `a***@`（**泄漏原文**） |
| 旧 B | `src/web/mailer.ts:74`（早已存在） | `al***@example.com` | `***` |

是我在 #363 里没查重引入的重复。保留更严谨的 B（`lastIndexOf` + 处理 `@` 结尾），把它移进 `log.ts` 与其它脱敏函数放一起——依赖方向因此是 `web/mailer → log` 而不是反过来；`mailer.ts` 重新导出，其既有调用方和 `mailer.test.ts` 的 5 个 case 不受影响。

## 2. `mailer.ts` 四处 console.error 未分级

发信成功和发信失败此前记在同一级别。现在：`outcome=success` → INFO，`skipped_no_key` → WARNING，两条 `send_failed` → ERROR。收件人**本来就**是脱敏的（`redactEmail(to)`），这点没动。

## 3. 启动路径完全没有 severity

`cli.ts` 两行 serve 日志、`soul/git.ts` 的 git-missing 警告、`entrypoint.sh` 三处 echo。前两者走 logger；shell 那三处加了个 `log_line` helper，逻辑与 `src/log.ts` 一致——`K_SERVICE` 下输出单行 JSON，否则纯文本（消息是固定串、无引号无反斜杠，不需要 JSON 转义）。

## 怎么发现的

在生产核实 #363 时按 revision 分组读日志，发现新旧代码的分界线是 `00020`（`reviewer@meetlisa.ai` → `r***@meetlisa.ai (em-2…b215)`）。当前 `00021` 承 100% 流量、`[sweep]`/`[orchestrator]` 已是 INFO——但同一批日志里仍有 4 条 severity 为空，顺藤摸到上面这些。

## 验证

- `npm test` 1637 pass / 0 fail；`typecheck`、`check:api-contract` 均干净。
- `log.test.ts` 的 redactEmail 用例已按更严格的契约更新（含 `trailing@` 这个原先会泄漏的 case）。
- `sh -n deploy/entrypoint.sh` 通过；`log_line` 两种模式实测：`K_SERVICE` 下输出 `{"severity":"INFO","message":"[cloud] soul already present — skipping birth"}`，无 `K_SERVICE` 时输出原纯文本。
- 本地模式下 logger 仍 fallback 到 `console.error`，所以 `mailer.test.ts` 里捕获日志的既有测试无需改动。

## 不在本 PR 范围

- `src/billing/meter.ts:114` 仍是裸 console.error（anomaly 告警因此要匹配 textPayload，云端已用双写法兜住）。
- meter.ts 的 anomaly 去重仍是进程内存态（`MAX_INSTANCES>1` 会重复告警，需共享态）。
- `src/cli/*` 的 console 调用是终端给用户看的输出，**不应**改成结构化日志。

🤖 Generated with [Claude Code](https://claude.com/claude-code)