### PR TITLE
feat(web): 右侧面板默认收起

### DIFF
--- a/src/web/lisa-client.ts
+++ b/src/web/lisa-client.ts
@@ -1120,10 +1120,12 @@ if (fnSearchBtn && fnFind) {
 
 // Right panel manual collapse (F4) — wide-screen only concern: the ≤1180px
 // media query hides the panel regardless. Persisted; the fnbar button shows
-// an active tint while collapsed.
+// an active tint while collapsed. Collapsed is the DEFAULT: the panel only
+// stays open once the user has explicitly opened it ("open" in localStorage),
+// so a fresh profile boots into the two-column chat-first layout.
 {
-  let collapsed = false;
-  try { collapsed = localStorage.getItem('lisaRightbar') === 'collapsed'; } catch (e) {}
+  let collapsed = true;
+  try { collapsed = localStorage.getItem('lisaRightbar') !== 'open'; } catch (e) {}
   const applyRb = () => {
     document.body.classList.toggle('rb-collapsed', collapsed);
     const btn = document.getElementById('fnPanel');

--- a/src/web/lisa-css.ts
+++ b/src/web/lisa-css.ts
@@ -2416,7 +2416,9 @@ export const MAIN_CSS = `  :root {
   /* Hide the legacy pixel send icon; the text label is enough in the new theme. */
   #sendBtn img { display: none; }
 
-  /* ── Manual right-panel collapse (F4, persisted client-side) ──── */
+  /* ── Manual right-panel collapse (F4, persisted client-side) ────
+     Collapsed is the DEFAULT state; the class is only absent once the user
+     has explicitly opened the panel (lisaRightbar === "open"). */
   body.rb-collapsed .frame {
     grid-template-columns: 300px 1fr;
     grid-template-areas:

--- a/src/web/lisa-html-snapshot.test.ts
+++ b/src/web/lisa-html-snapshot.test.ts
@@ -197,10 +197,16 @@ import { MAIN_HTML } from "./lisa-html.js";
  * #tabStrip); nodes now carry data-* attributes only
  * (runDelegatedAction dispatches approve/deny/send/output/cancel/adopt/
  * stream/open-lisa/close-stream).
+ * Then: the right panel now defaults to COLLAPSED — the lisaRightbar check
+ * inverted (open only when the value is literally "open", so an unset key
+ * reads as collapsed), and a tiny boot <script> right after <body> stamps
+ * body.rb-collapsed before .frame is parsed so a fresh profile never flashes
+ * the 3-column layout while the big inline bundle at the end of <body> is
+ * still loading. #fnPanel still toggles and persists it.
  */
-const EXPECTED_LENGTH = 307402;
+const EXPECTED_LENGTH = 308201;
 const EXPECTED_SHA256 =
-  "8c08d262b17ca6251b05e0430c06fd54482d2803482e317cad59a29bdc9590af";
+  "08a2d262d3ccbc01c761bb4562bfc47c673650725f050105dbc8a36741b700ba";
 
 test("MAIN_HTML length is byte-identical to the pre-split snapshot", () => {
   assert.equal(MAIN_HTML.length, EXPECTED_LENGTH);

--- a/src/web/lisa-html.ts
+++ b/src/web/lisa-html.ts
@@ -64,6 +64,15 @@ ${MAIN_CSS}
 </style>
 </head><body>
 
+<!-- Right-panel default = COLLAPSED. Applied here, before .frame is parsed,
+     so a fresh profile never flashes the 3-column layout during the long tail
+     of inline JS at the end of <body>. MAIN_CLIENT_JS re-applies the same
+     class idempotently and owns the toggle from then on. -->
+<script>
+try { if (localStorage.getItem('lisaRightbar') !== 'open') document.body.classList.add('rb-collapsed'); }
+catch (e) { document.body.classList.add('rb-collapsed'); }
+</script>
+
 <div class="frame">
 
   <!-- ╔════════════════ Title bar (drag zone) ════════════════╗ -->


### PR DESCRIPTION
全新 profile 打开 Lisa 时右侧面板不再展开，默认进入两栏（侧边栏 + 聊天区占满）的布局；只有用户手动打开过一次之后才会保持展开。

## 改动

**`src/web/lisa-client.ts`** — 反转 `lisaRightbar` 的判定。原来是"存了 `collapsed` 才收起"，现在是"存了 `open` 才展开"，于是 key 未设置（全新用户）即读作收起：

```js
let collapsed = true;
try { collapsed = localStorage.getItem('lisaRightbar') !== 'open'; } catch (e) {}
```

`#fnPanel` 的切换与持久化行为不变。

**`src/web/lisa-html.ts`** — 紧跟 `<body>` 增加一段启动脚本，在 `.frame` 被解析前就打上 `body.rb-collapsed`。`MAIN_CLIENT_JS` 挂在 `</body>` 前且体积很大，浏览器很可能先绘制已解析的 DOM 再执行它；收起既然成了多数人的默认路径，不加这段会让**每次**冷加载都闪一下三栏再跳成两栏。主脚本随后幂等地重新应用同一个 class。

**`src/web/lisa-css.ts`** — 更新注释说明默认态。

**`src/web/lisa-html-snapshot.test.ts`** — `MAIN_HTML` 是逐字节校验（长度 + sha256），改 GUI 必须重算，已更新为 `308201` / `08a2d26…`，并在文件顶部的变更流水注释里补了这一条。

## 范围

≤1180px 与 ≤720px 两个断点的自动隐藏逻辑未动，本次只影响宽屏下的默认值。

## 验证

`npm run typecheck` 通过；`npm test` 全绿（1639 项，0 失败，1 跳过）。

真机跑起来在 1440px 宽度逐项验证了三种状态：

| localStorage | body class | 栅格 | `.rightbar` |
|---|---|---|---|
| 未设置（全新） | `rb-collapsed` | `300px 1140px` | `none` |
| `open` | 空 | `300px 820px 320px` | `flex` |
| `collapsed` | `rb-collapsed` | `300px 1140px` | `none` |

`#fnPanel` 按钮的切换与持久化正常，收起时按钮保留高亮态；`open` 与 `collapsed` 都能跨刷新保持。

🤖 Generated with [Claude Code](https://claude.com/claude-code)