### PR TITLE
native: Swift 警告清零并转为错误；Mac 后端安装向导；iOS 可访问性与推送通道

### DIFF
--- a/packaging/ios-companion/README.md
+++ b/packaging/ios-companion/README.md
@@ -53,6 +53,31 @@ not exercised against Apple.
 > applied to unsigned Simulator builds, so without signing the Widget shows its "Open
 > Lisa Pocket" placeholder rather than live counts.
 
+## Accessibility
+
+Every status in the app is carried by **text as well as colour** — a pip's colour
+is never the only signal. `GlanceColors.phrase(_:)` is the single source of that
+wording, shared with the widget extension so a "waiting on you" agent reads the
+same in the roster, the Live Activity, the Dynamic Island and the home Widget.
+
+- `StatusDot` takes an optional `label`. Passing one makes it speak; omitting it
+  hides the pip from VoiceOver, which is right when the text beside it already
+  says the state — so a roster row is one sentence, not "circle, project, circle".
+- Roster rows, needs-you cards, dispatch entries, stat cells and onboarding
+  choice cards are each **one VoiceOver element** with a full label.
+- Icon-only controls (Send, Stop, Copy, Open, Unlock, load-earlier, delegate)
+  have labels and hints; Send/Stop/Copy and every secondary button clear the
+  **44 pt** minimum target using `minHeight`, so labels still grow with Dynamic
+  Type instead of clipping.
+- The pairing viewfinder announces "Camera is live" with a value that tracks the
+  scan note, and points you at the QR code.
+- Onboarding dots announce **"Step N of M"**; mail importance shows the word
+  ("‼ Urgent" / "! Important") next to the colour; the allowance bar and the mood
+  bars expose a value, not just a fill.
+
+Run `./build.sh test` for the logic tests that pin the wording (state → phrase,
+and the pip's colour agreeing with the phrase on a pending permission).
+
 ## Build / verify
 
 ```sh

--- a/packaging/ios-companion/README.md
+++ b/packaging/ios-companion/README.md
@@ -18,8 +18,11 @@ iOS 17+ target). It covers:
   with backoff + a full resync on foreground); rows keyed off `controllable` /
   `resumable`; per-session control: managed **approve/deny** · send · cancel, PTY send ·
   **output** · cancel, and **adopt (resume)** for idle claude sessions (handles the
-  409/403 the server returns). The toolbar opens the **dispatch ledger** (Lisa's own
-  fire-and-forget runs, with a per-entry log tail).
+  409/403 the server returns). A running PTY session shows **live output** — the
+  server's `/api/agents/pty/<id>/stream` SSE attach (snapshot + chunks) with
+  backed-off reconnect, a status line, and horizontal scrolling for long build
+  lines; a finished one keeps the one-shot `/output` pull. The toolbar opens the
+  **dispatch ledger** (Lisa's own fire-and-forget runs, with a per-entry log tail).
 - **Chat** — streams `POST /chat`, with Lisa's live **mood portrait** (the server's own
   art at `/assets/lisa/<slug>.png`, driven by the mood SSE).
 - **Reve** — "while you were away" note + current desire, an agent-activity **recap**

--- a/packaging/ios-companion/README.md
+++ b/packaging/ios-companion/README.md
@@ -27,9 +27,9 @@ iOS 17+ target). It covers:
 - **Sense** — ambient-signal **consent** (revoke-only from the phone; granting stays a
   Mac action) + recent sense events.
 - **Settings** — pairing (**scan** the Mac's QR code, or paste a `lisa-pair://…` /
-  `?token=` string → Keychain), **ntfy + APNs** push registration, read-only
-  remote-control policy, **paired devices**, an optional **Face ID / passcode** lock, and
-  read-only **Inspect Lisa** (Soul / Memory / Skills / Tools).
+  `?token=` string → Keychain), a **notification transport picker** (see below),
+  read-only remote-control policy, **paired devices**, an optional **Face ID /
+  passcode** lock, and read-only **Inspect Lisa** (Soul / Memory / Skills / Tools).
 - **Glance** — a **Live Activity / Dynamic Island** for a pinned agent and a
   **home-screen / lock-screen Widget** (systemSmall/Medium + accessory families) showing
   active / stuck counts, in a WidgetKit extension. The Widget renders a counts-only
@@ -52,6 +52,38 @@ not exercised against Apple.
 > Simulator**. Its data only flows on a **signed** build: App Group capabilities aren't
 > applied to unsigned Simulator builds, so without signing the Widget shows its "Open
 > Lisa Pocket" placeholder rather than live counts.
+
+## Notifications — pick a transport
+
+The server has always supported two delivery paths (`src/web/push.ts`), but the
+app only really offered Apple's, and answered "Push registered" whether or not
+anything could ever be delivered. **Settings → Notifications** now picks one:
+
+| | **ntfy topic** | **This iPhone (APNs)** |
+|---|---|---|
+| Needs | the free ntfy app + a topic you choose | an Apple push key on the Mac (`LISA_APNS_*`) |
+| Works today | yes, with no Apple infrastructure | only once that key is set |
+| Server field | optional — blank means `ntfy.sh`, or point it at your own | — |
+
+The line under the picker is built from **`GET /api/push/list`** — what your Mac
+says it will actually publish to — not from "we sent a register request". So it
+can tell you your Mac is sending to a *different* topic than the one on screen,
+and the APNs line says plainly that the app cannot see whether the Mac has an
+Apple key, so if nothing arrives that is the first thing to check.
+
+**Send a test notification** (ntfy only) posts straight from the phone to the
+topic. That is a real end-to-end check of the topic and your ntfy subscription
+and works even while the Mac is asleep. There is no APNs equivalent: the server
+exposes no test endpoint and a device cannot make Apple push to itself.
+
+The event toggles ("Notify me about") start from what the Mac stored and say
+**Unsaved** until you tap *Save preferences*, which calls `/api/push/prefs` on
+the existing subscription instead of re-registering. `Daily feeds brief` is now
+shown too — the server has always had it.
+
+> The topic is the shared secret: anyone who knows it can read your alerts.
+> Pick something hard to guess. Payloads stay low-sensitivity either way (agent /
+> project / state), never prompts or terminal output.
 
 ## Accessibility
 

--- a/packaging/ios-companion/Shared/GlanceColors.swift
+++ b/packaging/ios-companion/Shared/GlanceColors.swift
@@ -12,6 +12,19 @@ enum GlanceColors {
     static let done    = rgb(0x3DDC97)
     static let idle    = rgb(0x6B7299)
 
+    /// State → a word, so a status pip is never colour-only (review D1). Lives
+    /// beside the palette because the widget and Live Activity targets can't see
+    /// the app's copy and must read the same phrase VoiceOver hears in the roster.
+    static func phrase(_ state: String) -> String {
+        switch state {
+        case "working": return "working"
+        case "waiting": return "waiting on you"
+        case "error":   return "errored"
+        case "done":    return "done"
+        default:        return "idle"
+        }
+    }
+
     /// State → color, using the same buckets as the roster.
     static func forState(_ state: String) -> Color {
         switch state {

--- a/packaging/ios-companion/Sources/AccountViews.swift
+++ b/packaging/ios-companion/Sources/AccountViews.swift
@@ -389,6 +389,9 @@ struct AccountCard: View {
                         .font(.subheadline)
                         ProgressView(value: Double(min(spent, window)), total: Double(window))
                             .tint(remaining > 0 ? Theme.green : Theme.danger)
+                            // Green vs red is the only "you're out" cue here (D1).
+                            .accessibilityLabel("Session allowance")
+                            .accessibilityValue("\(Self.dollars(remaining)) of \(Self.dollars(window)) left")
                         if let reset = q.resetAt, remaining <= 0 {
                             Text("Refreshes \(Date(timeIntervalSince1970: reset / 1000), style: .relative)")
                                 .font(.caption).foregroundStyle(.secondary)

--- a/packaging/ios-companion/Sources/AppState.swift
+++ b/packaging/ios-companion/Sources/AppState.swift
@@ -43,6 +43,13 @@ final class AppState: ObservableObject {
     @Published var appearance: String
     /// Last APNs registration outcome, shown in Settings.
     @Published var pushStatus = ""
+    /// The device token iOS handed us, once it has. nil means Apple never issued
+    /// one here (the Simulator, or notifications denied) — Settings says so
+    /// instead of implying push is live.
+    @Published var apnsToken: String?
+    /// The event toggles the user last chose, so an APNs registration carries the
+    /// same preferences the ntfy path would (they used to be hardcoded defaults).
+    var pushPrefs = PushPrefs()
     /// Drives the first-run onboarding cover (docs/PLAN_IOS_ONBOARDING_v1.0.md).
     @Published var showOnboarding = false
     /// Transient toast for action feedback (so a failed control/mutation — now
@@ -114,13 +121,16 @@ final class AppState: ObservableObject {
     }
 
     // ── APNs registration (client half; delivery needs the Mac's APNs key) ──
-    func enablePush() async {
+    /// Ask iOS for permission + a device token, then hand it to the Mac. Carries
+    /// the user's current toggles rather than silently registering the defaults.
+    func enablePush(prefs: PushPrefs? = nil) async {
+        if let prefs { pushPrefs = prefs }
         do {
             let granted = try await UNUserNotificationCenter.current()
                 .requestAuthorization(options: [.alert, .sound, .badge])
-            guard granted else { pushStatus = "Notifications not allowed in iOS Settings."; return }
+            guard granted else { pushStatus = "Notifications are off for Lisa Pocket in iOS Settings."; return }
             UIApplication.shared.registerForRemoteNotifications()
-            pushStatus = "Registering for push…"
+            pushStatus = "Asking Apple for a device token…"
         } catch {
             pushStatus = error.localizedDescription
         }
@@ -128,12 +138,17 @@ final class AppState: ObservableObject {
 
     private func onApnsToken(_ hex: String?) async {
         guard let hex, !hex.isEmpty else {
-            pushStatus = "APNs unavailable here (no token — e.g. the Simulator)."
+            apnsToken = nil
+            pushStatus = "Apple didn't issue a token here — the Simulator never does. Use an ntfy topic instead."
             return
         }
+        apnsToken = hex
         do {
-            try await client.pushRegister(kind: "apns", target: hex, prefs: PushPrefs())
-            pushStatus = "Push registered (APNs)."
+            try await client.pushRegister(kind: "apns", target: hex, prefs: pushPrefs)
+            // Deliberately NOT "push registered": the Mac stored the token, but
+            // whether Apple ever delivers depends on LISA_APNS_* over there, which
+            // /api/push/* doesn't report. Settings' state line says the rest.
+            pushStatus = "Token sent to your Mac."
         } catch {
             pushStatus = (error as? LocalizedError)?.errorDescription ?? "\(error)"
         }

--- a/packaging/ios-companion/Sources/ChatView.swift
+++ b/packaging/ios-companion/Sources/ChatView.swift
@@ -231,6 +231,7 @@ struct ChatView: View {
         }
         .frame(width: size, height: size)
         .clipShape(RoundedRectangle(cornerRadius: 8))
+        .accessibilityHidden(true)   // chatHeader's combined label already says the mood
     }
 
     private let quickCommands = ["What are the agents doing?", "Summarize today", "Any blockers?"]
@@ -248,6 +249,7 @@ struct ChatView: View {
                                 .foregroundStyle(Theme.accent)
                         }
                         .buttonStyle(.plain)
+                        .accessibilityHint("Sends this as a message")
                     }
                 }
                 .padding(.horizontal).padding(.vertical, Theme.Space.s)
@@ -335,12 +337,14 @@ struct ChatView: View {
                 .frame(width: 44, height: 44)
                 .foregroundStyle(Theme.danger)
                 .accessibilityLabel("Stop")
+                .accessibilityHint("Stops Lisa's reply")
             } else {
                 Button(action: sendCurrent) {
                     Image(systemName: "arrow.up.circle.fill").font(.title2)
                 }
                 .frame(width: 44, height: 44)
                 .accessibilityLabel("Send message")
+                .accessibilityHint("Sends what you typed to Lisa")
                 .disabled(input.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
         }

--- a/packaging/ios-companion/Sources/DispatchLedgerView.swift
+++ b/packaging/ios-companion/Sources/DispatchLedgerView.swift
@@ -23,17 +23,18 @@ struct DispatchLedgerView: View {
                 List(items) { d in
                     NavigationLink { DispatchDetailView(entry: d) } label: {
                         HStack(spacing: 10) {
-                            StatusDot(color: d.alive ? Theme.working : Theme.idle, size: 8)
+                            StatusDot(color: Self.dotColour(d.kind), size: 8)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(d.task).font(.subheadline).lineLimit(1)
-                                // Say "exited" as well as "alive": the pip was the
-                                // only thing distinguishing them before (D1).
-                                Text("\(d.agent) · pid \(d.pid) · \(d.alive ? "alive" : "exited")")
+                                // Not just alive/exited: a crash and a clean
+                                // finish both leave a dead pid, and the roster
+                                // rendered them identically.
+                                Text("\(d.agent) · pid \(d.pid) · \(d.kind.label)")
                                     .font(.caption2).foregroundStyle(.secondary)
                             }
                         }
                         .accessibilityElement(children: .ignore)
-                        .accessibilityLabel("\(d.task), \(d.agent), \(d.alive ? "alive" : "exited")")
+                        .accessibilityLabel("\(d.task), \(d.agent), \(d.kind.accessibleLabel)")
                     }
                 }
             }
@@ -41,6 +42,17 @@ struct DispatchLedgerView: View {
         .navigationTitle("Dispatches")
         .refreshable { await load() }
         .task { await load() }
+    }
+
+    /// Colour is decoration, never the only carrier — every row also spells the
+    /// state out in text and in its accessibility label.
+    static func dotColour(_ kind: DispatchKind) -> Color {
+        switch kind {
+        case .running: return Theme.working
+        case .ok: return Theme.done
+        case .failed: return Theme.danger
+        case .unknown: return Theme.idle
+        }
     }
 
     private func load() async {
@@ -56,13 +68,31 @@ struct DispatchDetailView: View {
     @State private var tail = ""
     @State private var status: DispatchStatus?
 
+    /// Prefer the freshly fetched status; fall back to the roster entry. Names
+    /// the exit code / signal, because "failed" alone does not tell you whether
+    /// the agent errored out or was killed.
+    static func detailStatus(_ status: DispatchStatus?, entry: DispatchView) -> String {
+        let kind = status?.status != nil ? status!.kind : entry.kind
+        let code = status?.exitCode ?? entry.exitCode
+        let signal = status?.exitSignal ?? entry.exitSignal
+        switch kind {
+        case .running: return "running"
+        case .ok: return "finished (exit 0)"
+        case .failed:
+            if let signal { return "killed by \(signal)" }
+            if let code { return "failed (exit \(code))" }
+            return "failed"
+        case .unknown: return "exited — status not captured"
+        }
+    }
+
     var body: some View {
         List {
             Section("Dispatch") {
                 LabeledContent("Agent", value: entry.agent)
                 LabeledContent("Task", value: entry.task)
                 LabeledContent("pid", value: String(entry.pid))
-                LabeledContent("Alive", value: (status?.alive ?? entry.alive) ? "yes" : "no")
+                LabeledContent("Status", value: Self.detailStatus(status, entry: entry))
                 LabeledContent("cwd", value: entry.cwd)
             }
             Section("Log tail") {

--- a/packaging/ios-companion/Sources/DispatchLedgerView.swift
+++ b/packaging/ios-companion/Sources/DispatchLedgerView.swift
@@ -23,13 +23,17 @@ struct DispatchLedgerView: View {
                 List(items) { d in
                     NavigationLink { DispatchDetailView(entry: d) } label: {
                         HStack(spacing: 10) {
-                            Circle().fill(d.alive ? .blue : .gray).frame(width: 8, height: 8)
+                            StatusDot(color: d.alive ? Theme.working : Theme.idle, size: 8)
                             VStack(alignment: .leading, spacing: 2) {
                                 Text(d.task).font(.subheadline).lineLimit(1)
-                                Text("\(d.agent) · pid \(d.pid)\(d.alive ? " · alive" : "")")
+                                // Say "exited" as well as "alive": the pip was the
+                                // only thing distinguishing them before (D1).
+                                Text("\(d.agent) · pid \(d.pid) · \(d.alive ? "alive" : "exited")")
                                     .font(.caption2).foregroundStyle(.secondary)
                             }
                         }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("\(d.task), \(d.agent), \(d.alive ? "alive" : "exited")")
                     }
                 }
             }

--- a/packaging/ios-companion/Sources/HomeView.swift
+++ b/packaging/ios-companion/Sources/HomeView.swift
@@ -98,6 +98,7 @@ struct HomeView: View {
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Agents: \(counts.working) active, \(counts.stuck) need you")
+        .accessibilityHint("Opens the Agents tab")
     }
 
     private func mailCard(_ m: MailDigest) -> some View {
@@ -106,11 +107,15 @@ struct HomeView: View {
                 Text(m.summary).font(.callout)
                 ForEach(m.needsYou.prefix(3)) { i in
                     HStack(alignment: .top, spacing: 6) {
-                        Text(i.importance >= 3 ? "‼" : "!")
-                            .font(.caption.bold()).foregroundStyle(i.importance >= 3 ? Theme.danger : Theme.waiting)
-                            .accessibilityLabel(i.importance >= 3 ? "urgent" : "important")
+                        // Word + glyph, not colour alone (D1) — "‼" red vs "!"
+                        // amber is invisible to a colour-blind reader.
+                        Text(i.importance >= 3 ? "‼ Urgent" : "! Important")
+                            .font(.caption2.bold())
+                            .foregroundStyle(i.importance >= 3 ? Theme.danger : Theme.waiting)
+                            .fixedSize(horizontal: true, vertical: false)
                         Text(i.subject.isEmpty ? "(no subject)" : i.subject).font(.caption).lineLimit(1)
                     }
+                    .accessibilityElement(children: .combine)
                 }
             }
         }
@@ -199,6 +204,9 @@ struct HomeView: View {
         }
         .frame(width: size, height: size)
         .clipShape(RoundedRectangle(cornerRadius: 14))
+        // The portrait IS the mood readout — an unlabeled AsyncImage would drop
+        // it entirely from the combined hero element (D6).
+        .accessibilityLabel("Lisa's portrait, \(ping?.mood.isEmpty == false ? ping!.mood.replacingOccurrences(of: "-", with: " ") : "neutral")")
     }
 
     private var moodLine: String {

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -36,6 +36,13 @@ enum LisaError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .notConfigured: return "Not paired yet — add your Mac in Settings."
+        case .http(403):
+            // Hosted Lisa denies the machine-level routes (push, dispatch,
+            // mail, consent, devices — CLOUD_DENIED_ROUTE_PREFIXES in
+            // src/web/capabilities.ts). "HTTP 403" told the user nothing about
+            // why registering a push destination silently never worked.
+            return "This Lisa won't do that (403). Hosted Lisa keeps machine-level "
+                 + "features — push, dispatch, mail — on your own Mac; pair with it instead."
         case .http(let code): return "Server returned HTTP \(code)."
         case .decode: return "Couldn't read the server response."
         case .unsupportedAPIVersion(let version):

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -428,6 +428,13 @@ final class LisaClient {
         struct R: Codable { var ok: Bool; var output: String? }
         return (try await decode("/api/agents/pty/\(id)/output", as: R.self)).output ?? ""
     }
+    /// Live attach: a `snapshot` frame with the current tail, then a `chunk` per
+    /// burst, then `end` when the agent finishes. Same control gate as send/cancel,
+    /// so a Mac with remote control off answers 403.
+    func ptyStream(_ id: String) -> AsyncThrowingStream<SSEMessage, Error> {
+        let enc = id.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? id
+        return sse("/api/agents/pty/\(enc)/stream")
+    }
     /// Adopt an idle claude session by id (resume-adopt). Returns the HTTP code
     /// (409 ⇒ the session is still live; 403 ⇒ remote adoption disabled).
     func adopt(sessionId: String) async throws -> Int {

--- a/packaging/ios-companion/Sources/LisaClient.swift
+++ b/packaging/ios-companion/Sources/LisaClient.swift
@@ -439,9 +439,32 @@ final class LisaClient {
     func registerLiveActivity(sessionId: String, token: String) async throws {
         try await fire("/api/push/live-activity", json: ["sessionId": sessionId, "token": token])
     }
-    func pushRegister(kind: String, target: String, prefs: PushPrefs) async throws {
-        let p: [String: Any] = ["done": prefs.done, "error": prefs.error, "permission": prefs.permission, "idle": prefs.idle, "advisor": prefs.advisor, "mail": prefs.mail]
-        try await fire("/api/push/register", json: ["kind": kind, "target": target, "prefs": p])
+    /// Register a delivery destination and return what the server stored — the
+    /// caller needs the subscription id to update prefs later without
+    /// re-registering.
+    @discardableResult
+    func pushRegister(kind: String, target: String, server: String? = nil,
+                      prefs: PushPrefs) async throws -> PushSubscriptionDTO? {
+        struct R: Codable { var ok: Bool?; var subscription: PushSubscriptionDTO? }
+        var body: [String: Any] = ["kind": kind, "target": target, "prefs": prefs.json]
+        if let server, !server.isEmpty { body["server"] = server }
+        return (try await decode("/api/push/register", method: "POST", json: body, as: R.self)).subscription
+    }
+
+    /// Every destination the Mac will publish to — the honest basis for the
+    /// "is push actually wired up" line in Settings.
+    func pushList() async throws -> [PushSubscriptionDTO] {
+        try await decode("/api/push/list", as: PushListResponse.self).subscriptions
+    }
+
+    /// Change the event toggles on an existing subscription (no re-register, so a
+    /// registered APNs token isn't churned just to turn off advisor tips).
+    func pushSetPrefs(id: String, prefs: PushPrefs) async throws {
+        try await fire("/api/push/prefs", json: ["id": id, "prefs": prefs.json])
+    }
+
+    func pushUnregister(id: String) async throws {
+        try await fire("/api/push/unregister", json: ["id": id])
     }
 
     // ── chat ──

--- a/packaging/ios-companion/Sources/LockView.swift
+++ b/packaging/ios-companion/Sources/LockView.swift
@@ -11,11 +11,16 @@ struct LockView: View {
             Color(.systemBackground).ignoresSafeArea()
             VStack(spacing: 16) {
                 Image(systemName: "lock.fill").font(.largeTitle).foregroundStyle(.secondary)
+                    .accessibilityHidden(true)
                 Text("Lisa Pocket is locked").font(.headline)
+                    .accessibilityAddTraits(.isHeader)
                 Button { Task { await app.unlock() } } label: {
                     Label("Unlock", systemImage: "faceid")
+                        .frame(minHeight: 44)
                 }
                 .buttonStyle(.borderedProminent)
+                .accessibilityLabel("Unlock")
+                .accessibilityHint("Asks for Face ID or your passcode")
             }
         }
         .task { await app.unlock() }

--- a/packaging/ios-companion/Sources/Models.swift
+++ b/packaging/ios-companion/Sources/Models.swift
@@ -92,6 +92,52 @@ struct DispatchView: Codable, Identifiable, Hashable {
     var startedAt: String
     var alive: Bool
     var hasLog: Bool
+    /// running | ok | failed | unknown. Optional so an older server (which
+    /// sent only `alive`) still decodes; `kind` falls back to alive then.
+    var status: String?
+    var exitCode: Int?
+    var exitSignal: String?
+    var exitedAt: String?
+
+    var kind: DispatchKind { DispatchKind(status, alive: alive) }
+}
+
+/// What actually happened to a dispatch.
+///
+/// `alive: false` on its own says nothing about success — the agent is spawned
+/// detached, so a crash, an OOM kill and a clean finish are indistinguishable
+/// from the pid. The roster used to render all three as one grey "exited".
+enum DispatchKind {
+    case running, ok, failed, unknown
+
+    init(_ raw: String?, alive: Bool) {
+        switch raw {
+        case "running": self = .running
+        case "ok": self = .ok
+        case "failed": self = .failed
+        case "unknown": self = .unknown
+        default: self = alive ? .running : .unknown   // pre-status server
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .running: return "running"
+        case .ok: return "finished"
+        case .failed: return "failed"
+        case .unknown: return "status unknown"
+        }
+    }
+
+    /// Spoken by VoiceOver — the dot's colour is not available to it.
+    var accessibleLabel: String {
+        switch self {
+        case .running: return "running"
+        case .ok: return "finished successfully"
+        case .failed: return "failed"
+        case .unknown: return "exited, status not captured"
+        }
+    }
 }
 
 struct DispatchListResponse: Codable {
@@ -107,6 +153,12 @@ struct DispatchStatus: Codable {
     var startedAt: String?
     var alive: Bool?
     var tail: String?
+    var status: String?
+    var exitCode: Int?
+    var exitSignal: String?
+    var exitedAt: String?
+
+    var kind: DispatchKind { DispatchKind(status, alive: alive ?? false) }
 }
 
 struct IslandPing: Codable {

--- a/packaging/ios-companion/Sources/Models.swift
+++ b/packaging/ios-companion/Sources/Models.swift
@@ -139,6 +139,38 @@ struct PushPrefs: Codable, Equatable {
     var idle: Bool = true
     var advisor: Bool = false
     var mail: Bool = true
+    /// Daily knowledge-base feeds brief — the server has always had it; the app
+    /// silently left it at the server default and never showed the switch.
+    var brief: Bool = true
+
+    /// Tolerant: a Mac that predates a preference just doesn't send that key, and
+    /// the missing switch should fall back to its default rather than throwing
+    /// away the whole subscription.
+    init(done: Bool = true, error: Bool = true, permission: Bool = true, idle: Bool = true,
+         advisor: Bool = false, mail: Bool = true, brief: Bool = true) {
+        self.done = done; self.error = error; self.permission = permission
+        self.idle = idle; self.advisor = advisor; self.mail = mail; self.brief = brief
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        func flag(_ k: CodingKeys, _ fallback: Bool) -> Bool {
+            (try? c.decodeIfPresent(Bool.self, forKey: k)) .flatMap { $0 } ?? fallback
+        }
+        done = flag(.done, true)
+        error = flag(.error, true)
+        permission = flag(.permission, true)
+        idle = flag(.idle, true)
+        advisor = flag(.advisor, false)
+        mail = flag(.mail, true)
+        brief = flag(.brief, true)
+    }
+
+    /// The wire shape `/api/push/register` and `/api/push/prefs` expect.
+    var json: [String: Any] {
+        ["done": done, "error": error, "permission": permission,
+         "idle": idle, "advisor": advisor, "mail": mail, "brief": brief]
+    }
 }
 
 // ── Mail (read-only digest + accounts) ──

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingFlow.swift
@@ -226,6 +226,13 @@ struct OnboardingFlow: View {
                 rescanToken: rescanToken
             )
             .ignoresSafeArea()
+            // A camera preview is an empty rectangle to VoiceOver; announce that
+            // it's live and where to aim, and let the note below update it (D7).
+            .accessibilityElement()
+            .accessibilityLabel("Camera is live")
+            .accessibilityValue(scanNote ?? "Point at the QR code Lisa shows on your Mac.")
+            .accessibilityHint("Scanning happens automatically. Use Paste link to type the code instead.")
+            .accessibilityAddTraits(.updatesFrequently)
             VStack {
                 OnboardingTopBar(step: .scan, onSkip: skip)
                     .background(
@@ -246,7 +253,9 @@ struct OnboardingFlow: View {
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(.white)
                         .padding(.horizontal, 16).padding(.vertical, 10)
+                        .frame(minHeight: 44)
                         .background(.ultraThinMaterial, in: Capsule())
+                        .accessibilityHint("Opens a form to paste the pairing link")
                 }
                 .padding(.bottom, 32)
             }

--- a/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
+++ b/packaging/ios-companion/Sources/Onboarding/OnboardingScaffold.swift
@@ -41,6 +41,7 @@ struct OnboardingDots: View {
         .animation(.easeInOut(duration: 0.2), value: step)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(stepLabel)
+        .accessibilityAddTraits(.updatesFrequently)
     }
     private func isCurrent(_ s: OnboardingStep) -> Bool { s == step }
     private func isActive(_ s: OnboardingStep) -> Bool {
@@ -65,6 +66,8 @@ struct OnboardingTopBar: View {
                 Button("Not now", action: onSkip)
                     .font(.subheadline)
                     .foregroundStyle(Theme.tertiary)
+                    .frame(minHeight: 44)
+                    .accessibilityHint("Skips setup; you can finish it later from the banner")
             }
         }
         .frame(height: 28)
@@ -117,6 +120,7 @@ struct CopyCommandRow: View {
             }
             .buttonStyle(.plain)
             .accessibilityLabel(copied ? "Copied" : "Copy command")
+            .accessibilityHint("Copies the command so you can paste it in Terminal")
         }
         .padding(.vertical, 12).padding(.horizontal, 14)
         .background(Theme.card, in: RoundedRectangle(cornerRadius: Theme.cardRadius))
@@ -173,6 +177,11 @@ struct OnboardingChoiceCard: View {
         .buttonStyle(.plain)
         .disabled(disabled)
         .padding(.horizontal, 24)
+        // One element per card; the checkmark becomes the "selected" trait
+        // rather than a stray "checkmark.circle.fill" (D5).
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel([title, badge, subtitle].compactMap { $0 }.joined(separator: ", "))
+        .accessibilityAddTraits(selected ? [.isButton, .isSelected] : .isButton)
     }
 }
 
@@ -204,9 +213,12 @@ struct OnboardingSecondaryButton: View {
     var body: some View {
         Button(action: action) {
             Text(title).font(.subheadline.weight(.medium)).foregroundStyle(Theme.accent)
+                // minHeight, not a fixed height: the label still grows with
+                // Dynamic Type instead of clipping (D4).
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.top, 4)
     }
 }
 
@@ -225,8 +237,12 @@ struct SetupBanner: View {
             }
             .foregroundStyle(Theme.bgDeep)
             .padding(.horizontal, 16).padding(.vertical, 10)
+            .frame(minHeight: 44)
             .background(Theme.accent)
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Finish setting up — connect to your Mac")
+        .accessibilityHint("Reopens the setup flow")
     }
 }

--- a/packaging/ios-companion/Sources/PTYStreamView.swift
+++ b/packaging/ios-companion/Sources/PTYStreamView.swift
@@ -1,0 +1,201 @@
+import SwiftUI
+
+/// Live output for a PTY agent, over `GET /api/agents/pty/<id>/stream`.
+///
+/// The detail screen used to have a "Load output" button that fetched
+/// `/output` once: to watch a build you tapped it again, and again. The server
+/// has had an SSE attach stream all along — a `snapshot` frame with the current
+/// tail, then a `chunk` per new burst, and an `end` frame when the agent
+/// finishes — so this view follows it instead.
+///
+/// A snapshot always *replaces* the buffer, which is what makes reconnection
+/// safe: after a dropped connection the server re-sends the whole tail rather
+/// than the part we missed, so re-appending would duplicate everything.
+
+/// Where the attach stream stands, for a status line that doesn't lie.
+enum PTYStreamState: Equatable {
+    case connecting
+    case live
+    /// Dropped; a reconnect is scheduled this many seconds out.
+    case retrying(seconds: Int)
+    /// The agent finished — the server sent `end` and closed. No more output.
+    case ended
+    /// A terminal failure we won't retry (403 from the Mac's control policy).
+    case blocked(String)
+
+    var phrase: String {
+        switch self {
+        case .connecting: return "connecting…"
+        case .live: return "live"
+        case .retrying(let s): return "disconnected — retrying in \(s)s"
+        case .ended: return "finished"
+        case .blocked(let why): return why
+        }
+    }
+}
+
+/// Pure buffer rules, so the trimming is pinned by tests rather than eyeballed.
+enum PTYBuffer {
+    /// Keep the tail bounded: a chatty agent can emit megabytes, and the phone
+    /// only ever shows the end of it. Trim on a newline when there is one nearby
+    /// so the top of the view isn't a half line.
+    static let limit = 60_000
+
+    static func appending(_ chunk: String, to text: String, limit: Int = limit) -> String {
+        trimmed(text + chunk, limit: limit)
+    }
+
+    static func trimmed(_ text: String, limit: Int = limit) -> String {
+        guard text.count > limit else { return text }
+        let tail = String(text.suffix(limit))
+        // Drop the leading partial line, but only if that costs little.
+        if let nl = tail.firstIndex(of: "\n"), tail.distance(from: tail.startIndex, to: nl) < 512 {
+            return String(tail[tail.index(after: nl)...])
+        }
+        return tail
+    }
+}
+
+@MainActor
+final class PTYStreamModel: ObservableObject {
+    @Published private(set) var text = ""
+    @Published private(set) var state: PTYStreamState = .connecting
+    /// Bumped on every append so the view can scroll to the bottom.
+    @Published private(set) var revision = 0
+
+    private var task: Task<Void, Never>?
+
+    func start(client: LisaClient, sessionId: String) {
+        task?.cancel()
+        state = .connecting
+        task = Task { @MainActor [weak self] in
+            var backoff = 1
+            while !Task.isCancelled {
+                var sawFrame = false
+                do {
+                    for try await msg in client.ptyStream(sessionId) {
+                        guard let self else { return }
+                        sawFrame = true
+                        backoff = 1                 // healthy traffic resets the backoff
+                        switch msg.type {
+                        case "snapshot":
+                            // Replaces, never appends — see the note at the top.
+                            self.text = PTYBuffer.trimmed(msg.text ?? "")
+                            self.state = .live
+                            self.revision += 1
+                        case "chunk":
+                            self.text = PTYBuffer.appending(msg.text ?? "", to: self.text)
+                            self.state = .live
+                            self.revision += 1
+                        case "end":
+                            self.state = .ended
+                            return              // the agent is done; stop reconnecting
+                        default:
+                            break
+                        }
+                    }
+                } catch {
+                    if case LisaError.http(403) = error {
+                        // The Mac's control policy refuses remote attach — retrying
+                        // would just hammer it (A8).
+                        self?.state = .blocked("Remote control is disabled on this Mac — no live output.")
+                        return
+                    }
+                    if case LisaError.http(404) = error {
+                        self?.state = .blocked("This session is no longer attached on the Mac.")
+                        return
+                    }
+                }
+                if Task.isCancelled { return }
+                // A clean close with no frames at all usually means the session
+                // ended between the roster and here; don't spin forever on it.
+                if !sawFrame && backoff >= 8 {
+                    self?.state = .ended
+                    return
+                }
+                self?.state = .retrying(seconds: backoff)
+                try? await Task.sleep(nanoseconds: UInt64(backoff) * 1_000_000_000)
+                backoff = min(backoff * 2, 30)
+            }
+        }
+    }
+
+    func stop() {
+        task?.cancel()
+        task = nil
+    }
+
+    deinit { task?.cancel() }
+}
+
+/// The live log itself: a status line plus a two-axis scroller, so a 200-column
+/// build line scrolls sideways instead of wrapping into mush (or clipping).
+struct PTYLiveOutput: View {
+    let sessionId: String
+    @EnvironmentObject var app: AppState
+    @Environment(\.scenePhase) private var scenePhase
+    @StateObject private var model = PTYStreamModel()
+
+    private static let bottomID = "pty-bottom"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                StatusDot(color: dotColor, size: 7)
+                Text(model.state.phrase).font(.caption2).foregroundStyle(Theme.tertiary)
+                Spacer()
+                if case .retrying = model.state {
+                    Button("Reconnect now") { model.start(client: app.client, sessionId: sessionId) }
+                        .font(.caption2)
+                }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("Live output, \(model.state.phrase)")
+
+            ScrollViewReader { proxy in
+                ScrollView([.horizontal, .vertical]) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        Text(model.text.isEmpty ? "(no output yet)" : model.text)
+                            .font(.system(.caption, design: .monospaced))
+                            .foregroundStyle(model.text.isEmpty ? Theme.tertiary : Theme.text)
+                            .textSelection(.enabled)
+                            // No wrapping: long lines scroll horizontally instead
+                            // of being folded into unreadable stripes.
+                            .fixedSize(horizontal: true, vertical: true)
+                        Color.clear.frame(height: 1).id(Self.bottomID)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(10)
+                }
+                .frame(height: 220)
+                .background(Theme.sunken, in: RoundedRectangle(cornerRadius: 8))
+                .overlay(RoundedRectangle(cornerRadius: 8).strokeBorder(Theme.border, lineWidth: Theme.hairline))
+                // Follow the tail as output arrives, the way a terminal does.
+                .onChange(of: model.revision) { _, _ in
+                    withAnimation(.easeOut(duration: 0.12)) { proxy.scrollTo(Self.bottomID, anchor: .bottom) }
+                }
+            }
+            .accessibilityLabel("Agent output")
+            .accessibilityValue(model.text.isEmpty ? "No output yet" : String(model.text.suffix(600)))
+        }
+        .task(id: sessionId) { model.start(client: app.client, sessionId: sessionId) }
+        // iOS suspends SSE in the background; reattach on return so the log isn't
+        // silently frozen (the same rule the roster stream follows).
+        .onChange(of: scenePhase) { _, phase in
+            guard phase == .active, !app.locked else { return }
+            if case .ended = model.state { return }
+            model.start(client: app.client, sessionId: sessionId)
+        }
+        .onDisappear { model.stop() }
+    }
+
+    private var dotColor: Color {
+        switch model.state {
+        case .live: return Theme.green
+        case .connecting: return Theme.waiting
+        case .retrying: return Theme.waiting
+        case .ended: return Theme.idle
+        case .blocked: return Theme.danger
+        }
+    }
+}

--- a/packaging/ios-companion/Sources/PushSettings.swift
+++ b/packaging/ios-companion/Sources/PushSettings.swift
@@ -1,0 +1,187 @@
+import Foundation
+
+/// Push transport choice + the pure logic behind the Notifications section.
+///
+/// The server has supported two delivery paths since day one (src/web/push.ts):
+/// `ntfy` is a plain HTTPS POST to a topic and needs no Apple infrastructure,
+/// while `apns` is inert until `LISA_APNS_*` is set on the Mac. The app only ever
+/// offered a topic field buried under a separate "Enable push notifications"
+/// button that answered "Push registered (APNs)" whether or not anything could
+/// ever be delivered — the review's UX-12 dead end.
+///
+/// Everything here is deterministic and unit-tested; the view does the I/O.
+
+/// How this iPhone wants alerts delivered.
+enum PushTransport: String, CaseIterable, Identifiable, Codable {
+    /// Apple Push. Needs an APNs key on the Mac; nothing arrives without one.
+    case apns
+    /// An ntfy topic — works today with no Apple key, read by the ntfy app.
+    case ntfy
+
+    var id: String { rawValue }
+    var label: String { self == .apns ? "This iPhone (APNs)" : "ntfy topic" }
+}
+
+/// One delivery destination exactly as `GET /api/push/list` reports it. Tolerant
+/// decoding: an older Mac may not send `server`, `prefs` or `createdAt`, and a
+/// future one may add fields — neither should make the section fail to load.
+struct PushSubscriptionDTO: Codable, Identifiable, Equatable {
+    var id: String
+    /// "ntfy" | "apns" — anything unknown is treated as ntfy, as the server does.
+    var kind: String
+    /// ntfy topic, or the APNs device token.
+    var target: String
+    var server: String?
+    var prefs: PushPrefs?
+
+    private enum CodingKeys: String, CodingKey { case id, kind, target, server, prefs }
+
+    init(id: String, kind: String, target: String, server: String? = nil, prefs: PushPrefs? = nil) {
+        self.id = id
+        self.kind = kind
+        self.target = target
+        self.server = server
+        self.prefs = prefs
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = (try? c.decode(String.self, forKey: .id)) ?? ""
+        kind = (try? c.decode(String.self, forKey: .kind)) ?? "ntfy"
+        target = (try? c.decode(String.self, forKey: .target)) ?? ""
+        server = try? c.decodeIfPresent(String.self, forKey: .server)
+        prefs = try? c.decodeIfPresent(PushPrefs.self, forKey: .prefs)
+    }
+
+    var transport: PushTransport { kind == "apns" ? .apns : .ntfy }
+}
+
+struct PushListResponse: Codable { var subscriptions: [PushSubscriptionDTO] }
+
+enum PushSettings {
+    /// ntfy's public server — the server-side default when a subscription carries
+    /// no `server`, so the app has to agree or the two disagree about where a
+    /// topic lives.
+    static let defaultNtfyServer = "https://ntfy.sh"
+
+    /// Where a topic publishes. Accepts a bare host ("ntfy.example.com"), a full
+    /// base URL, or nothing at all (→ ntfy.sh). Returns nil for an empty or
+    /// unusable topic so the caller can keep the button disabled.
+    static func ntfyPublishURL(server: String?, topic: String) -> URL? {
+        let t = topic.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty, let encoded = t.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) else { return nil }
+        var base = (server ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        if base.isEmpty { base = defaultNtfyServer }
+        if !base.lowercased().hasPrefix("http://") && !base.lowercased().hasPrefix("https://") {
+            base = "https://" + base
+        }
+        while base.hasSuffix("/") { base.removeLast() }
+        return URL(string: "\(base)/\(encoded)")
+    }
+
+    /// The destination the Mac holds for this transport + target, if any. Matching
+    /// on target (not just kind) is what lets the UI say "your Mac is sending to a
+    /// *different* topic" instead of a falsely reassuring "registered".
+    static func current(_ subs: [PushSubscriptionDTO],
+                        transport: PushTransport,
+                        target: String) -> PushSubscriptionDTO? {
+        let t = target.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !t.isEmpty else { return nil }
+        return subs.first { $0.transport == transport && $0.target == t }
+    }
+
+    /// Any destination on this transport, whatever its target — used to explain a
+    /// mismatch rather than silently ignoring it.
+    static func other(_ subs: [PushSubscriptionDTO],
+                      transport: PushTransport,
+                      target: String) -> PushSubscriptionDTO? {
+        let t = target.trimmingCharacters(in: .whitespacesAndNewlines)
+        return subs.first { $0.transport == transport && $0.target != t }
+    }
+
+    /// The one-line truth under the picker, built ONLY from what the Mac reported
+    /// plus what iOS gave us — never from "we sent a register request, so it must
+    /// work". The APNs line stays explicit that the app cannot see whether the Mac
+    /// has an Apple key: /api/push/* doesn't report it, so claiming delivery works
+    /// would be the same lie the review flagged.
+    static func stateLine(transport: PushTransport,
+                          subs: [PushSubscriptionDTO],
+                          loaded: Bool,
+                          apnsToken: String?,
+                          ntfyTopic: String) -> String {
+        guard loaded else { return "Checking what your Mac has registered…" }
+        switch transport {
+        case .ntfy:
+            let topic = ntfyTopic.trimmingCharacters(in: .whitespacesAndNewlines)
+            if topic.isEmpty {
+                return "Pick any hard-to-guess topic, subscribe to it in the ntfy app, then Register. No Apple key needed."
+            }
+            if let sub = current(subs, transport: .ntfy, target: topic) {
+                let where_ = sub.server ?? defaultNtfyServer
+                return "Your Mac is sending to “\(topic)” on \(displayHost(where_)). Subscribe to that topic in the ntfy app to receive them."
+            }
+            if let mismatch = other(subs, transport: .ntfy, target: topic) {
+                return "Your Mac is sending to a different topic (“\(mismatch.target)”). Register to switch it to “\(topic)”."
+            }
+            return "Not registered yet — tap Register so your Mac starts publishing to “\(topic)”."
+        case .apns:
+            guard let token = apnsToken, !token.isEmpty else {
+                return "This iPhone hasn't been given an Apple push token yet — tap Enable. (The Simulator never gets one.)"
+            }
+            if current(subs, transport: .apns, target: token) != nil {
+                return "This iPhone's token is registered on your Mac. Apple still only delivers if the Mac has an APNs key (LISA_APNS_*) — the app can't check that from here, so if nothing arrives, that's why. The ntfy topic works without one."
+            }
+            return "iOS gave this iPhone a token but your Mac doesn't have it yet — tap Enable to send it."
+        }
+    }
+
+    /// "https://ntfy.sh" → "ntfy.sh" for prose.
+    static func displayHost(_ base: String) -> String {
+        URL(string: base)?.host ?? base
+            .replacingOccurrences(of: "https://", with: "")
+            .replacingOccurrences(of: "http://", with: "")
+    }
+
+    /// True when the toggles on screen differ from what the Mac stored, so the
+    /// section can say "unsaved" instead of pretending a flipped switch took
+    /// effect. Nothing registered ⇒ nothing to be out of sync with.
+    static func hasUnsavedPrefs(local: PushPrefs, registered: PushPrefs?) -> Bool {
+        guard let registered else { return false }
+        return local != registered
+    }
+}
+
+extension String {
+    /// Trimmed of surrounding whitespace — topics and server URLs get pasted with
+    /// stray spaces more often than not.
+    var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+}
+
+/// Publishes a one-off test message straight to the ntfy topic. This deliberately
+/// does NOT go through the Mac: ntfy publishing is an unauthenticated POST, so the
+/// phone can prove "the topic works and my ntfy app is subscribed" even while the
+/// Mac is asleep — and the server offers no test endpoint to call instead.
+enum NtfyTester {
+    enum Outcome: Equatable {
+        case sent
+        case badTopic
+        case rejected(Int)
+        case unreachable(String)
+    }
+
+    static func send(server: String?, topic: String) async -> Outcome {
+        guard let url = PushSettings.ntfyPublishURL(server: server, topic: topic) else { return .badTopic }
+        var req = URLRequest(url: url, timeoutInterval: 10)
+        req.httpMethod = "POST"
+        req.setValue("Lisa Pocket", forHTTPHeaderField: "Title")
+        req.setValue("bell", forHTTPHeaderField: "Tags")
+        req.httpBody = Data("Test notification — your ntfy topic works.".utf8)
+        do {
+            let (_, resp) = try await URLSession.shared.data(for: req)
+            let code = (resp as? HTTPURLResponse)?.statusCode ?? -1
+            return (200..<300).contains(code) ? .sent : .rejected(code)
+        } catch {
+            return .unreachable((error as? LocalizedError)?.errorDescription ?? error.localizedDescription)
+        }
+    }
+}

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -645,9 +645,16 @@ struct SessionDetailView: View {
                     Button("Cancel", role: .destructive) { act { try await app.client.ptyCancel(session.sessionId) } }
                     if !canControl { remoteBlockedNote }
                 }
-                Button("Load output") { act { output = try await app.client.ptyOutput(session.sessionId) } }
-                if !output.isEmpty {
-                    CodeBlock(text: output, maxHeight: 200)
+                // Live attach for a running session (SSE snapshot + chunks, with
+                // reconnect); the one-shot pull stays for a finished one, where
+                // there is nothing left to stream.
+                if isTerminal {
+                    Button("Load output") { act { output = try await app.client.ptyOutput(session.sessionId) } }
+                    if !output.isEmpty {
+                        CodeBlock(text: output, maxHeight: 200)
+                    }
+                } else {
+                    PTYLiveOutput(sessionId: session.sessionId)
                 }
             }
             .disabled(!isTerminal && !canControl)

--- a/packaging/ios-companion/Sources/RosterView.swift
+++ b/packaging/ios-companion/Sources/RosterView.swift
@@ -101,6 +101,13 @@ func sortRows(_ rows: [AgentSession]) -> [AgentSession] {
     }
 }
 
+/// The spoken twin of `stateColor` — a pending permission outranks the raw
+/// state in both, so the pip's colour and its VoiceOver label never disagree.
+func statusPhrase(_ s: AgentSession) -> String {
+    if let p = s.activity?.pendingPermission { return "needs you: \(p)" }
+    return GlanceColors.phrase(s.state)
+}
+
 func stateColor(_ s: AgentSession) -> Color {
     if s.activity?.pendingPermission != nil { return Theme.waiting }
     switch s.state {
@@ -252,6 +259,9 @@ struct RosterView: View {
                             }
                         }
                         .listRowBackground(Theme.card)
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityLabel("\(s.displayName), \(s.messageCount) messages")
+                        .accessibilityHint("Makes this Lisa's active session")
                     }
                 } header: { Text("LISA · \(lisaSessions.count)") }
             }
@@ -343,15 +353,19 @@ struct NeedsYouCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Theme.Space.s) {
             HStack(spacing: 8) {
-                StatusDot(color: stateColor(session))
+                StatusDot(color: stateColor(session), label: statusPhrase(session))
                 Text(session.project).font(.subheadline.weight(.medium)).foregroundStyle(Theme.text).lineLimit(1)
                 Text(session.agent).font(.caption2).foregroundStyle(Theme.secondary)
                 Spacer()
                 Button(action: onOpen) {
                     HStack(spacing: 2) { Text("Open"); Image(systemName: "chevron.right") }
                         .font(.caption).foregroundStyle(Theme.accent)
+                        .frame(minWidth: 44, minHeight: 44, alignment: .trailing)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Open \(session.project)")
+                .accessibilityHint("Shows this agent's full session")
             }
             if let pend = session.activity?.pendingPermission {
                 Text("Paused on: \(pend)").font(.caption).foregroundStyle(Theme.secondary)
@@ -422,7 +436,7 @@ struct RosterRow: View {
     }
 
     private var rowLabel: String {
-        var s = "\(session.project), \(session.agent), \(session.state)"
+        var s = "\(session.project), \(session.agent), \(GlanceColors.phrase(session.state))"
         if let p = session.activity?.pendingPermission { s += ", needs you: \(p)" }
         else if session.resumable == true { s += ", resumable" }
         return s
@@ -455,6 +469,8 @@ struct ProactiveBanner: View {
                 .labelsHidden()
                 .tint(Theme.green)
                 .disabled(app.proactiveBusy || !app.proactiveAvailable)
+                .accessibilityLabel("Proactive mode")
+                .accessibilityValue(app.proactiveEnabled ? "Lisa acts on her own when idle" : "Lisa waits for you")
         }
         .padding(14)
         .background(Theme.green.opacity(0.10), in: RoundedRectangle(cornerRadius: Theme.cardRadius))

--- a/packaging/ios-companion/Sources/SettingsView.swift
+++ b/packaging/ios-companion/Sources/SettingsView.swift
@@ -9,7 +9,14 @@ struct SettingsView: View {
     @State private var pairText = ""
     @State private var policy: ControlPolicy?
     @State private var ntfyTopic = ""
+    @State private var ntfyServer = ""
+    @State private var transport: PushTransport = .ntfy
     @State private var prefs = PushPrefs()
+    /// What the Mac says it will actually publish to (GET /api/push/list).
+    @State private var pushSubs: [PushSubscriptionDTO] = []
+    @State private var pushLoaded = false
+    @State private var testBusy = false
+    @State private var testStatus = ""
     @State private var status = ""
     @State private var showScanner = false
     @State private var showUnpairConfirm = false
@@ -97,36 +104,104 @@ struct SettingsView: View {
                     }
                 }
 
-                Section("Push (ntfy)") {
-                    TextField("ntfy topic", text: $ntfyTopic)
-                        .autocorrectionDisabled()
-                        .textInputAutocapitalization(.never)
+                Section("Notifications") {
+                    Picker("Deliver via", selection: $transport) {
+                        ForEach(PushTransport.allCases) { t in Text(t.label).tag(t) }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityLabel("Notification transport")
+
+                    if transport == .ntfy {
+                        TextField("ntfy topic", text: $ntfyTopic)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .accessibilityHint("Anyone who knows this topic can read your alerts — make it hard to guess")
+                        TextField("ntfy server (optional)", text: $ntfyServer)
+                            .autocorrectionDisabled()
+                            .textInputAutocapitalization(.never)
+                            .keyboardType(.URL)
+                    }
+
+                    // The honest line: built from GET /api/push/list, never from
+                    // "we sent a register request" (the UX-12 dead end).
+                    Text(PushSettings.stateLine(transport: transport, subs: pushSubs, loaded: pushLoaded,
+                                                apnsToken: app.apnsToken, ntfyTopic: ntfyTopic))
+                        .font(.caption).foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if transport == .apns {
+                        Button("Enable push notifications") {
+                            Task { await app.enablePush(prefs: prefs); await loadPush() }
+                        }
+                        if !app.pushStatus.isEmpty {
+                            Text(app.pushStatus).font(.caption).foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    } else {
+                        Button("Register") {
+                            Task { @MainActor in
+                                do {
+                                    _ = try await app.client.pushRegister(
+                                        kind: "ntfy", target: ntfyTopic.trimmed,
+                                        server: ntfyServer.trimmed.isEmpty ? nil : ntfyServer.trimmed,
+                                        prefs: prefs)
+                                    saveNtfyDefaults()
+                                    app.notify("Your Mac will publish to “\(ntfyTopic.trimmed)”.")
+                                    await loadPush()
+                                } catch {
+                                    app.notify((error as? LocalizedError)?.errorDescription ?? "Couldn't register push.", ok: false)
+                                }
+                            }
+                        }
+                        .disabled(ntfyTopic.trimmed.isEmpty)
+
+                        // A real end-to-end check: publishing to an ntfy topic is
+                        // an unauthenticated POST, so the phone can prove the topic
+                        // + the ntfy app work without involving the Mac at all.
+                        // There is no equivalent for APNs — the server exposes no
+                        // test endpoint and Apple delivery can't be triggered from
+                        // the device — so the button is honestly ntfy-only.
+                        Button("Send a test notification") { Task { await sendTestNotification() } }
+                            .disabled(ntfyTopic.trimmed.isEmpty || testBusy)
+                        if !testStatus.isEmpty {
+                            Text(testStatus).font(.caption).foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                }
+
+                Section("Notify me about") {
                     Toggle("Agent done", isOn: $prefs.done)
                     Toggle("Agent error", isOn: $prefs.error)
                     Toggle("Needs permission", isOn: $prefs.permission)
                     Toggle("While-away notes", isOn: $prefs.idle)   // was mislabeled "Reve notes" (B11)
                     Toggle("Advisor tips", isOn: $prefs.advisor)    // was hardcoded, never exposed (B11)
                     Toggle("Mail digest + alerts", isOn: $prefs.mail)
-                    Button("Register push") {
-                        Task { @MainActor in
-                            do {
-                                try await app.client.pushRegister(kind: "ntfy", target: ntfyTopic, prefs: prefs)
-                                app.notify("Push registered.")
-                            } catch {
-                                app.notify((error as? LocalizedError)?.errorDescription ?? "Couldn't register push.", ok: false)
+                    Toggle("Daily feeds brief", isOn: $prefs.brief)  // server had it; the app never showed it
+                    if let sub = registeredSub {
+                        // Flipping a switch used to do nothing until you happened
+                        // to re-register. Say so, and give it a button.
+                        if PushSettings.hasUnsavedPrefs(local: prefs, registered: sub.prefs) {
+                            Button("Save preferences") {
+                                Task { @MainActor in
+                                    do {
+                                        try await app.client.pushSetPrefs(id: sub.id, prefs: prefs)
+                                        app.notify("Preferences saved.")
+                                        await loadPush()
+                                    } catch {
+                                        app.notify((error as? LocalizedError)?.errorDescription ?? "Couldn't save preferences.", ok: false)
+                                    }
+                                }
                             }
+                            Text("Unsaved — these apply once you tap Save preferences.")
+                                .font(.caption).foregroundStyle(Theme.waiting)
+                        } else {
+                            Text("In sync with your Mac.").font(.caption).foregroundStyle(.secondary)
                         }
+                    } else {
+                        Text("These apply when you register a destination above.")
+                            .font(.caption).foregroundStyle(.secondary)
                     }
-                    .disabled(ntfyTopic.isEmpty)
-                }
-
-                Section("Push (APNs)") {
-                    Button("Enable push notifications") { Task { await app.enablePush() } }
-                    if !app.pushStatus.isEmpty {
-                        Text(app.pushStatus).font(.caption).foregroundStyle(.secondary)
-                    }
-                    Text("Native Apple Push. Delivery needs an APNs key set on the Mac; ntfy works without one.")
-                        .font(.caption).foregroundStyle(.secondary)
                 }
 
                 Section("Remote-control policy (set on the Mac)") {
@@ -196,6 +271,8 @@ struct SettingsView: View {
             .navigationTitle("Settings")
             .onAppear(perform: syncFromConfig)
             .task { policy = try? await app.client.controlPolicy(); await app.loadProactive(); await app.refreshAccount() }
+            .task(id: app.config) { await loadPush() }
+            .onChange(of: transport) { _, _ in adoptRegisteredPrefs() }
             .sheet(isPresented: $showScanner) {
                 QRScanSheet(onScanned: handleScan, onError: { status = $0 })
             }
@@ -216,6 +293,65 @@ struct SettingsView: View {
         host = app.config.host
         portText = String(app.config.port)
         token = app.config.token ?? ""
+        let d = UserDefaults.standard
+        // The topic used to live only in @State — leave Settings and it was gone,
+        // so the section couldn't tell you what your Mac was publishing to.
+        if ntfyTopic.isEmpty { ntfyTopic = d.string(forKey: "lisa.ntfy.topic") ?? "" }
+        if ntfyServer.isEmpty { ntfyServer = d.string(forKey: "lisa.ntfy.server") ?? "" }
+        if let saved = d.string(forKey: "lisa.push.transport"), let t = PushTransport(rawValue: saved) {
+            transport = t
+        }
+    }
+
+    private func saveNtfyDefaults() {
+        let d = UserDefaults.standard
+        d.set(ntfyTopic.trimmed, forKey: "lisa.ntfy.topic")
+        d.set(ntfyServer.trimmed, forKey: "lisa.ntfy.server")
+        d.set(transport.rawValue, forKey: "lisa.push.transport")
+    }
+
+    /// The destination this screen is currently talking about, as the Mac has it.
+    private var registeredSub: PushSubscriptionDTO? {
+        PushSettings.current(pushSubs, transport: transport,
+                             target: transport == .apns ? (app.apnsToken ?? "") : ntfyTopic.trimmed)
+    }
+
+    private func loadPush() async {
+        guard app.config.isConfigured else { pushLoaded = true; return }
+        pushSubs = (try? await app.client.pushList()) ?? []
+        pushLoaded = true
+        // Adopt a topic we've never seen locally, so a phone that was set up on
+        // another device (or reinstalled) shows the truth instead of a blank field.
+        if ntfyTopic.trimmed.isEmpty, let n = pushSubs.first(where: { $0.transport == .ntfy }) {
+            ntfyTopic = n.target
+            ntfyServer = n.server ?? ""
+        }
+        adoptRegisteredPrefs()
+    }
+
+    /// Start the toggles from what the Mac stored, so "unsaved" means a real edit.
+    private func adoptRegisteredPrefs() {
+        if let p = registeredSub?.prefs { prefs = p }
+        app.pushPrefs = prefs
+        saveNtfyDefaults()
+    }
+
+    private func sendTestNotification() async {
+        testBusy = true
+        defer { testBusy = false }
+        testStatus = "Sending…"
+        saveNtfyDefaults()
+        switch await NtfyTester.send(server: ntfyServer.trimmed.isEmpty ? nil : ntfyServer.trimmed,
+                                     topic: ntfyTopic.trimmed) {
+        case .sent:
+            testStatus = "Sent. It should appear in the ntfy app within a few seconds — if it doesn't, you're not subscribed to that topic there."
+        case .badTopic:
+            testStatus = "That topic isn't usable as a URL — try letters, digits, - and _."
+        case .rejected(let code):
+            testStatus = "The ntfy server refused it (HTTP \(code)). A self-hosted server may need auth, which Lisa Pocket doesn't send."
+        case .unreachable(let why):
+            testStatus = "Couldn't reach the ntfy server: \(why)"
+        }
     }
 
     /// Probe the just-applied Mac pairing and report the real outcome into the

--- a/packaging/ios-companion/Sources/Theme.swift
+++ b/packaging/ios-companion/Sources/Theme.swift
@@ -119,11 +119,19 @@ extension View {
 }
 
 /// Status pip — replaces the hand-rolled `Circle().fill(stateColor(...))` dots.
+///
+/// Colour alone carries no meaning for VoiceOver or a colour-blind reader
+/// (review D1), so a dot that is the *only* carrier of a status must be given a
+/// `label`. A dot sitting next to text that already says the same thing passes
+/// none and is hidden from the accessibility tree instead of read as "circle".
 struct StatusDot: View {
     let color: Color
     var size: CGFloat = 10
+    var label: String? = nil
     var body: some View {
         Circle().fill(color).frame(width: size, height: size)
+            .accessibilityHidden(label == nil)
+            .accessibilityLabel(label ?? "")
     }
 }
 
@@ -153,5 +161,8 @@ struct StatCell: View {
         }
         .frame(maxWidth: .infinity)
         .consoleCard(padding: 10)
+        // "Needs you: 2", not "2" then "needs you" as two stray elements (D5).
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(label): \(value)")
     }
 }

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -242,6 +242,29 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertFalse(InstallMethod.app.isCLI)
     }
 
+    // ── a11y: every status pip has a word, and it matches the colour bucket ──
+
+    func testGlanceColorsPhraseCoversEveryStateBucket() {
+        XCTAssertEqual(GlanceColors.phrase("working"), "working")
+        XCTAssertEqual(GlanceColors.phrase("waiting"), "waiting on you")
+        XCTAssertEqual(GlanceColors.phrase("error"), "errored")
+        XCTAssertEqual(GlanceColors.phrase("done"), "done")
+        XCTAssertEqual(GlanceColors.phrase("something-new"), "idle")
+        XCTAssertEqual(GlanceColors.phrase(""), "idle")
+    }
+
+    func testStatusPhraseAgreesWithStateColorOnPendingPermission() {
+        // stateColor paints a pending permission amber regardless of raw state;
+        // the spoken label has to make the same call or they contradict.
+        let pending = session("working", pending: "Bash(rm -rf)")
+        XCTAssertEqual(statusPhrase(pending), "needs you: Bash(rm -rf)")
+        XCTAssertEqual(stateColor(pending), Theme.waiting)
+
+        XCTAssertEqual(statusPhrase(session("working")), "working")
+        XCTAssertEqual(statusPhrase(session("error")), "errored")
+        XCTAssertEqual(statusPhrase(session("mystery")), "idle")
+    }
+
     func testOnboardingDottedSequence() {
         XCTAssertEqual(OnboardingStep.dotted, [.install, .start, .pair, .scan, .connect])
         XCTAssertEqual(OnboardingStep.welcome.rawValue, 0)        // welcome/mode are pre-flow

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -418,4 +418,54 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertNil(GoogleSignIn.redirectScheme(clientId: "123-abc.example.com"))
         XCTAssertNil(GoogleSignIn.redirectScheme(clientId: ""))
     }
+
+    // ── DispatchKind — a dead pid is not the same as a clean finish ──────────
+    private func dispatch(status: String?, alive: Bool, exitCode: Int? = nil,
+                          exitSignal: String? = nil) -> DispatchView {
+        DispatchView(id: "d1", agent: "claude", pid: 42, cwd: "/p", task: "t",
+                     startedAt: "1970-01-01T00:00:00.000Z", alive: alive, hasLog: false,
+                     status: status, exitCode: exitCode, exitSignal: exitSignal, exitedAt: nil)
+    }
+
+    func testDispatchKindFromServerStatus() {
+        XCTAssertEqual(dispatch(status: "running", alive: true).kind, .running)
+        XCTAssertEqual(dispatch(status: "ok", alive: false).kind, .ok)
+        XCTAssertEqual(dispatch(status: "failed", alive: false).kind, .failed)
+        XCTAssertEqual(dispatch(status: "unknown", alive: false).kind, .unknown)
+    }
+
+    func testDispatchKindFallsBackForAPreStatusServer() {
+        // An older backend sends only `alive`. Never infer success from it: the
+        // agent is detached, so a crash and a clean finish look identical.
+        XCTAssertEqual(dispatch(status: nil, alive: true).kind, .running)
+        XCTAssertEqual(dispatch(status: nil, alive: false).kind, .unknown)
+        XCTAssertNotEqual(dispatch(status: nil, alive: false).kind, .ok)
+    }
+
+    func testDispatchKindIgnoresAnUnrecognisedStatus() {
+        XCTAssertEqual(dispatch(status: "banana", alive: false).kind, .unknown)
+    }
+
+    func testDispatchDetailNamesTheExitCodeOrSignal() {
+        let failed = dispatch(status: "failed", alive: false, exitCode: 127)
+        XCTAssertEqual(DispatchDetailView.detailStatus(nil, entry: failed), "failed (exit 127)")
+
+        let killed = dispatch(status: "failed", alive: false, exitSignal: "SIGKILL")
+        XCTAssertEqual(DispatchDetailView.detailStatus(nil, entry: killed), "killed by SIGKILL")
+
+        let ok = dispatch(status: "ok", alive: false, exitCode: 0)
+        XCTAssertEqual(DispatchDetailView.detailStatus(nil, entry: ok), "finished (exit 0)")
+
+        let unknown = dispatch(status: nil, alive: false)
+        XCTAssertEqual(DispatchDetailView.detailStatus(nil, entry: unknown),
+                       "exited — status not captured")
+    }
+
+    func testEveryDispatchKindSpeaksItsStateForVoiceOver() {
+        // The dot's colour carries no information for VoiceOver, so each state
+        // must be distinguishable in words alone.
+        let spoken = [DispatchKind.running, .ok, .failed, .unknown].map(\.accessibleLabel)
+        XCTAssertEqual(Set(spoken).count, 4, "each state needs its own spoken label")
+        XCTAssertFalse(spoken.contains { $0.isEmpty })
+    }
 }

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -242,6 +242,42 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertFalse(InstallMethod.app.isCLI)
     }
 
+    // ── PTY live stream: bounded buffer + an honest connection phrase ──
+
+    func testPTYBufferKeepsShortOutputIntact() {
+        XCTAssertEqual(PTYBuffer.appending("world", to: "hello "), "hello world")
+        XCTAssertEqual(PTYBuffer.trimmed("short"), "short")
+    }
+
+    func testPTYBufferTrimsToTheTailOnALineBoundary() {
+        // 20 chars of head, then a newline, then the tail we care about.
+        let text = String(repeating: "x", count: 20) + "\n" + String(repeating: "y", count: 40)
+        let out = PTYBuffer.trimmed(text, limit: 45)
+        XCTAssertEqual(out, String(repeating: "y", count: 40),
+                       "the leading partial line is dropped when it's cheap to do so")
+        XCTAssertLessThanOrEqual(out.count, 45)
+    }
+
+    func testPTYBufferFallsBackToARawTailWhenNoNearbyNewline() {
+        let text = String(repeating: "z", count: 5000)   // one enormous line
+        let out = PTYBuffer.trimmed(text, limit: 100)
+        XCTAssertEqual(out.count, 100)
+    }
+
+    func testPTYBufferAppendStaysBounded() {
+        var text = ""
+        for _ in 0..<50 { text = PTYBuffer.appending(String(repeating: "a", count: 100) + "\n", to: text, limit: 500) }
+        XCTAssertLessThanOrEqual(text.count, 500)
+    }
+
+    func testPTYStreamStatePhrasesAreDistinctAndNameTheReason() {
+        XCTAssertEqual(PTYStreamState.live.phrase, "live")
+        XCTAssertEqual(PTYStreamState.ended.phrase, "finished")
+        XCTAssertTrue(PTYStreamState.retrying(seconds: 4).phrase.contains("4s"))
+        XCTAssertEqual(PTYStreamState.blocked("Remote control is disabled on this Mac — no live output.").phrase,
+                       "Remote control is disabled on this Mac — no live output.")
+    }
+
     // ── push transport: the topic URL, and an honest state line ──
 
     func testNtfyPublishURLDefaultsToNtfySh() {

--- a/packaging/ios-companion/Tests/LisaPocketTests.swift
+++ b/packaging/ios-companion/Tests/LisaPocketTests.swift
@@ -242,6 +242,93 @@ final class LisaPocketTests: XCTestCase {
         XCTAssertFalse(InstallMethod.app.isCLI)
     }
 
+    // ── push transport: the topic URL, and an honest state line ──
+
+    func testNtfyPublishURLDefaultsToNtfySh() {
+        XCTAssertEqual(PushSettings.ntfyPublishURL(server: nil, topic: "lisa-abc")?.absoluteString,
+                       "https://ntfy.sh/lisa-abc")
+        XCTAssertEqual(PushSettings.ntfyPublishURL(server: "", topic: " lisa-abc ")?.absoluteString,
+                       "https://ntfy.sh/lisa-abc")
+    }
+
+    func testNtfyPublishURLAcceptsBareHostAndTrimsSlashes() {
+        XCTAssertEqual(PushSettings.ntfyPublishURL(server: "ntfy.example.com", topic: "t")?.absoluteString,
+                       "https://ntfy.example.com/t")
+        XCTAssertEqual(PushSettings.ntfyPublishURL(server: "http://10.0.0.9:8080/", topic: "t")?.absoluteString,
+                       "http://10.0.0.9:8080/t")
+    }
+
+    func testNtfyPublishURLRejectsEmptyTopic() {
+        XCTAssertNil(PushSettings.ntfyPublishURL(server: nil, topic: "   "))
+    }
+
+    func testStateLineNeverClaimsApnsDeliveryWorks() {
+        let token = "abc123"
+        let registered = [PushSubscriptionDTO(id: "1", kind: "apns", target: token)]
+        let line = PushSettings.stateLine(transport: .apns, subs: registered, loaded: true,
+                                          apnsToken: token, ntfyTopic: "")
+        // The old copy said "Push registered (APNs)" with no Apple key anywhere —
+        // the exact dead end UX-12 flagged. The line must name the dependency.
+        XCTAssertTrue(line.contains("LISA_APNS_"))
+        XCTAssertFalse(line.lowercased().contains("push registered"))
+
+        let noToken = PushSettings.stateLine(transport: .apns, subs: [], loaded: true,
+                                             apnsToken: nil, ntfyTopic: "")
+        XCTAssertTrue(noToken.contains("Simulator"))
+
+        let notSent = PushSettings.stateLine(transport: .apns, subs: [], loaded: true,
+                                             apnsToken: token, ntfyTopic: "")
+        XCTAssertTrue(notSent.contains("doesn't have it yet"))
+    }
+
+    func testStateLineDistinguishesRegisteredFromADifferentTopic() {
+        let subs = [PushSubscriptionDTO(id: "1", kind: "ntfy", target: "old-topic", server: "https://ntfy.example.com")]
+        let mismatch = PushSettings.stateLine(transport: .ntfy, subs: subs, loaded: true,
+                                              apnsToken: nil, ntfyTopic: "new-topic")
+        XCTAssertTrue(mismatch.contains("old-topic"))
+        XCTAssertTrue(mismatch.contains("different topic"))
+
+        let matched = PushSettings.stateLine(transport: .ntfy, subs: subs, loaded: true,
+                                             apnsToken: nil, ntfyTopic: "old-topic")
+        XCTAssertTrue(matched.contains("ntfy.example.com"))
+
+        let none = PushSettings.stateLine(transport: .ntfy, subs: [], loaded: true,
+                                          apnsToken: nil, ntfyTopic: "t")
+        XCTAssertTrue(none.contains("Not registered yet"))
+
+        XCTAssertTrue(PushSettings.stateLine(transport: .ntfy, subs: [], loaded: false,
+                                             apnsToken: nil, ntfyTopic: "t").contains("Checking"))
+    }
+
+    func testUnsavedPrefsOnlyWhenSomethingIsRegistered() {
+        var local = PushPrefs()
+        XCTAssertFalse(PushSettings.hasUnsavedPrefs(local: local, registered: nil))
+        XCTAssertFalse(PushSettings.hasUnsavedPrefs(local: local, registered: PushPrefs()))
+        local.advisor = true
+        XCTAssertTrue(PushSettings.hasUnsavedPrefs(local: local, registered: PushPrefs()))
+    }
+
+    func testPushSubscriptionDecodesTolerantlyAndPrefsFallBack() throws {
+        // A Mac that predates `brief` / `server` must still produce a usable row.
+        let json = Data("""
+        {"subscriptions":[{"id":"a1","kind":"ntfy","target":"topic","prefs":{"done":false,"error":true,"permission":true,"idle":true,"advisor":false,"mail":true}},
+                          {"id":"a2","kind":"apns","target":"deadbeef","server":null,"prefs":null,"createdAt":1}]}
+        """.utf8)
+        let list = try JSONDecoder().decode(PushListResponse.self, from: json).subscriptions
+        XCTAssertEqual(list.count, 2)
+        XCTAssertEqual(list[0].transport, .ntfy)
+        XCTAssertEqual(list[0].prefs?.done, false)
+        XCTAssertEqual(list[0].prefs?.brief, true, "a missing preference falls back to its default")
+        XCTAssertNil(list[0].server)
+        XCTAssertEqual(list[1].transport, .apns)
+        XCTAssertNil(list[1].prefs)
+    }
+
+    func testPushPrefsJSONCarriesEveryServerKey() {
+        let keys = Set(PushPrefs().json.keys)
+        XCTAssertEqual(keys, ["done", "error", "permission", "idle", "advisor", "mail", "brief"])
+    }
+
     // ── a11y: every status pip has a word, and it matches the colour bucket ──
 
     func testGlanceColorsPhraseCoversEveryStateBucket() {

--- a/packaging/ios-companion/Widgets/AgentCountWidget.swift
+++ b/packaging/ios-companion/Widgets/AgentCountWidget.swift
@@ -56,8 +56,11 @@ struct AgentCountWidgetView: View {
                     Text("\(s.stuck > 0 ? s.stuck : s.working)").font(.headline.bold())
                 }
             }
+            // A bare number in a circle is meaningless out loud — say which count.
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(s.stuck > 0 ? "\(s.stuck) agents need you" : "\(s.working) agents active")
         } else {
-            Image(systemName: "cpu")
+            Image(systemName: "cpu").accessibilityLabel("Lisa — open to pair")
         }
     }
 
@@ -108,6 +111,8 @@ struct AgentCountWidgetView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .opacity(isStale(snap) ? 0.55 : 1)                           // B25 — dim a stale snapshot
+        // Dimming is the only cue that a snapshot is old; say it too (D1).
+        .accessibilityHint(isStale(snap) ? "Snapshot may be out of date" : "")
     }
 
     private func stat(_ value: Int, _ label: String, _ color: Color) -> some View {
@@ -115,6 +120,8 @@ struct AgentCountWidgetView: View {
             Text("\(value)").font(.system(.title, design: .rounded).weight(.bold)).foregroundStyle(color)
             Text(label).font(.caption2).foregroundStyle(.secondary)
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(value) \(label)")
     }
 
     private func summary(_ snap: AgentSnapshot) -> String {

--- a/packaging/ios-companion/Widgets/AgentLiveActivity.swift
+++ b/packaging/ios-companion/Widgets/AgentLiveActivity.swift
@@ -10,6 +10,7 @@ struct AgentLiveActivity: Widget {
             // Lock Screen / banner
             HStack(spacing: 10) {
                 Circle().fill(activityColor(context.state.state)).frame(width: 10, height: 10)
+                    .accessibilityHidden(true)   // the combined label below says the state
                 VStack(alignment: .leading, spacing: 2) {
                     Text("\(context.attributes.agent) · \(context.attributes.project)")
                         .font(.headline).lineLimit(1)
@@ -19,6 +20,11 @@ struct AgentLiveActivity: Widget {
                 Text("\(context.state.turns)t").font(.caption.monospacedDigit()).foregroundStyle(.secondary)
             }
             .padding()
+            // One spoken sentence, with the state as a word — the dot's colour was
+            // the only thing carrying it on the Lock Screen (D1).
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel("\(context.attributes.agent), \(context.attributes.project), \(GlanceColors.phrase(context.state.state))")
+            .accessibilityValue("\(context.state.detail), \(context.state.turns) turns")
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
@@ -32,6 +38,8 @@ struct AgentLiveActivity: Widget {
                         Text("\(context.state.turns) turns")     // B22 — was dropped in expanded
                             .font(.caption2.monospacedDigit()).foregroundStyle(.secondary)
                     }
+                    .accessibilityElement(children: .ignore)
+                    .accessibilityLabel("\(GlanceColors.phrase(context.state.state)), \(context.state.turns) turns")
                 }
                 DynamicIslandExpandedRegion(.bottom) {
                     Text("\(context.attributes.project) — \(context.state.detail)")
@@ -39,10 +47,13 @@ struct AgentLiveActivity: Widget {
                 }
             } compactLeading: {
                 Circle().fill(activityColor(context.state.state)).frame(width: 8, height: 8)
+                    .accessibilityLabel("Agent \(GlanceColors.phrase(context.state.state))")
             } compactTrailing: {
                 Text("\(context.state.turns)").font(.caption2.monospacedDigit())
+                    .accessibilityLabel("\(context.state.turns) turns")
             } minimal: {
                 Circle().fill(activityColor(context.state.state)).frame(width: 8, height: 8)
+                    .accessibilityLabel("Agent \(GlanceColors.phrase(context.state.state))")
             }
         }
     }

--- a/packaging/mac-client/Package.swift
+++ b/packaging/mac-client/Package.swift
@@ -1,13 +1,22 @@
 // swift-tools-version:5.9
 import PackageDescription
 
+// Warnings are errors (review T-11): the Mac shell shipped several releases with
+// the same handful of warnings, and Swift 6 strict concurrency turns that class
+// of warning into hard errors anyway — so keep the count pinned at zero here.
+// `unsafeFlags` is acceptable because this package is only ever built as the
+// root package (`swift build`, build.sh, scripts/build-mac-apps.sh), never
+// consumed as a dependency.
+let strict: [SwiftSetting] = [.unsafeFlags(["-warnings-as-errors"])]
+
 let package = Package(
     name: "Lisa",
     platforms: [.macOS(.v13)],
     targets: [
         .executableTarget(
             name: "Lisa",
-            path: "Sources/Lisa"
+            path: "Sources/Lisa",
+            swiftSettings: strict
         )
     ]
 )

--- a/packaging/mac-client/Package.swift
+++ b/packaging/mac-client/Package.swift
@@ -13,10 +13,25 @@ let package = Package(
     name: "Lisa",
     platforms: [.macOS(.v13)],
     targets: [
+        // Pure, AppKit-free logic (the backend install wizard's decisions,
+        // probe/install scripts, failure classification) — unit-tested with
+        // `swift test` without booting the app.
+        .target(
+            name: "LisaSetup",
+            path: "Sources/LisaSetup",
+            swiftSettings: strict
+        ),
         .executableTarget(
             name: "Lisa",
+            dependencies: ["LisaSetup"],
             path: "Sources/Lisa",
             swiftSettings: strict
-        )
+        ),
+        .testTarget(
+            name: "LisaSetupTests",
+            dependencies: ["LisaSetup"],
+            path: "Tests/LisaSetupTests",
+            swiftSettings: strict
+        ),
     ]
 )

--- a/packaging/mac-client/README.md
+++ b/packaging/mac-client/README.md
@@ -20,6 +20,44 @@ Talks only to `localhost:5757`.
 - Swift 5.9+ (bundled with Xcode 15 / current Command Line Tools)
 - LISA running at `localhost:5757` (`lisa serve --web`)
 
+The app doesn't require you to install the backend by hand: if the `lisa` CLI
+isn't there, **Lisa ▸ Set Up Backend…** walks through it (see below).
+
+## Backend setup wizard
+
+The download is one click, but the backend is a separate npm package — so the
+app ships a guided sheet instead of assuming a terminal. Open it from
+**Lisa ▸ Set Up Backend…**, from **Set Up…** in the menu-bar popover, or from
+**Set up backend…** on the offline splash; it also opens on its own when a
+start attempt finds no `lisa` on your PATH.
+
+It checks Node.js and the backend on your *login* shell (`zsh -lc`, plus
+explicit nvm / fnm / Volta / Homebrew / `~/.npm-global` paths — a GUI app
+doesn't read `~/.zshrc`, so a Node that "works in Terminal" would otherwise be
+invisible), then shows exactly one next step:
+
+| It found | You get |
+|---|---|
+| No Node.js (or older than 20) | `brew install node` with a Copy button, a nodejs.org link, and **Re-check** |
+| Node.js but no backend | **Install backend** — runs `npm install -g @oratis/lisa` with live output and a spinner, then starts `lisa serve --web` |
+| Everything | **Start backend**, plus **Update backend** to pull the latest release |
+
+If the global install fails, the failure is classified rather than dumped: an
+`EACCES` gets the standard no-sudo fix (move npm's prefix to `~/.npm-global`,
+add it to `~/.zprofile`) shown verbatim with **Apply fix and retry**; a network
+failure gets a retry; an `EBADENGINE` sends you back to the Node.js step.
+
+`~/.lisa/serve-command.txt` still overrides everything — with it in place the
+wizard reports ready and never checks for the CLI, because you own that command
+line.
+
+Terminal remains a first-class path; the wizard's own footer spells it out:
+
+```sh
+npm install -g @oratis/lisa   # one-time
+lisa serve --web              # start the backend
+```
+
 ## Build
 
 ```sh
@@ -72,11 +110,23 @@ To launch at login: System Settings → General → Login Items → drag in
 ## Architecture
 
 ```
+Sources/LisaSetup/
+└── BackendSetup.swift  # pure setup logic: probe/install scripts, decide(), failure classes
+
 Sources/Lisa/
-├── main.swift          # NSApplication boot (.regular policy)
-├── AppDelegate.swift   # window lifecycle + standard menu bar
-├── MainWindow.swift    # NSWindow + frame autosave + WebContent VC
-└── WebContent.swift    # WKWebView + auto-retry + external link handler
+├── main.swift                    # NSApplication boot (.regular policy)
+├── AppDelegate.swift             # window lifecycle + standard menu bar
+├── MainWindow.swift              # NSWindow + frame autosave + WebContent VC
+├── WebContent.swift              # WKWebView + auto-retry + external link handler
+├── BackendController.swift       # spawn/probe/restart `lisa serve --web`
+├── BackendSetupController.swift  # the install wizard's AppKit sheet
+└── ShellRunner.swift             # `zsh -lc` + streamed, ANSI-stripped output
+```
+
+`LisaSetup` is AppKit-free on purpose so the wizard's decisions are unit-tested:
+
+```sh
+swift test    # Tests/LisaSetupTests
 ```
 
 Communication with LISA is identical to LisaIsland.app — all goes

--- a/packaging/mac-client/Sources/Lisa/AppDelegate.swift
+++ b/packaging/mac-client/Sources/Lisa/AppDelegate.swift
@@ -181,6 +181,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         PreferencesController.shared.show()
     }
 
+    /// Main-actor isolated because the wizard is (it drives AppKit and spawns
+    /// processes); menu actions always arrive on the main thread anyway.
+    @MainActor
+    @objc func openBackendSetup(_ sender: Any?) {
+        BackendSetupController.shared.presentFromMenu()
+    }
+
     @objc func newWindowAction(_ sender: Any?) {
         // Single-window for now; reuse existing.
         showMainWindow()
@@ -216,6 +223,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         )
         settingsItem.target = self
         appMenu.addItem(settingsItem)
+        // Backend install / update wizard (UX-7) — also opens on its own when the
+        // app can't find the `lisa` CLI at start.
+        let setupItem = NSMenuItem(
+            title: "Set Up Backend…",
+            action: #selector(openBackendSetup(_:)),
+            keyEquivalent: ""
+        )
+        setupItem.target = self
+        appMenu.addItem(setupItem)
         // Managed inference (B8d): sign in once, run key-free via LISA Cloud.
         let accountItem = NSMenuItem(
             title: "Sign in to LISA Cloud…",

--- a/packaging/mac-client/Sources/Lisa/BackendController.swift
+++ b/packaging/mac-client/Sources/Lisa/BackendController.swift
@@ -12,7 +12,11 @@
 //    1. ~/.lisa/serve-command.txt — a full command line, if present (escape
 //       hatch for running from source, e.g. "node /path/dist/cli.js serve --web").
 //    2. otherwise `lisa serve --web --host 0.0.0.0` — resolved on the login
-//       shell's PATH (covers `npm i -g @oratis/lisa` / Homebrew installs).
+//       shell's PATH (covers `npm i -g @oratis/lisa` / Homebrew installs), with
+//       LisaSetup.shellPrelude so nvm / fnm / Homebrew-managed tools resolve too.
+//       If `lisa` doesn't resolve, the start script says so immediately and the
+//       install wizard (BackendSetupController, UX-7) takes over instead of a
+//       20 s poll timing out into a hint.
 //
 //  LAN-reachable by default (decision ②): a paired phone can reach the Mac over
 //  Wi-Fi without the user remembering `--host 0.0.0.0`. This is safe only because
@@ -29,6 +33,7 @@
 
 import AppKit
 import Foundation
+import LisaSetup
 
 @MainActor
 final class BackendController {
@@ -39,8 +44,19 @@ final class BackendController {
     /// resolves, so the offline UIs can update.
     static let statusChanged = Notification.Name("ai.meetlisa.backendStatusChanged")
 
+    /// Default: bind all interfaces so a phone on the same Wi-Fi can reach it.
+    /// Token-gated for non-loopback callers (see start() / the header note).
+    static let defaultCommand = "lisa serve --web --host 0.0.0.0"
+
     private let probeURL = URL(string: "http://localhost:5757/")!
     private(set) var isStarting = false
+
+    /// Where the detached backend's stdout/stderr go (the wizard offers to open it).
+    var backendLogPath: String { lisaPath("backend.log") }
+
+    /// True when ~/.lisa/serve-command.txt overrides the start command — the
+    /// user runs the backend their own way, so the `lisa` CLI check doesn't apply.
+    var hasServeOverride: Bool { overrideCommand() != nil }
 
     // MARK: - Launch auto-start
 
@@ -84,10 +100,11 @@ final class BackendController {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
     }
 
-    /// Callers waiting on the outcome of the next start attempt (restart()).
-    /// Drained — on the main actor — by post(), right after the status
-    /// notification goes out, so a waiter sees exactly one resolution.
-    private var startWaiters: [(Bool) -> Void] = []
+    /// Callers waiting on the outcome of the next start attempt (restart(),
+    /// start(completion:)). Drained — on the main actor — by post(), right
+    /// after the status notification goes out, so a waiter sees exactly one
+    /// resolution: (up, note).
+    private var startWaiters: [(Bool, String?) -> Void] = []
 
     /// Stop the (detached) backend and start a fresh one so config.env changes
     /// apply. The backend was launched with nohup, so we match its command line;
@@ -102,7 +119,7 @@ final class BackendController {
             Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: 800_000_000)
                 guard let self else { return }
-                self.startWaiters.append(completion)
+                self.startWaiters.append { up, _ in completion(up) }
                 self.start()
             }
         }
@@ -111,52 +128,58 @@ final class BackendController {
 
     // MARK: - Probe
 
-    func probe(_ completion: @escaping (Bool) -> Void) {
+    func probe(_ completion: @escaping @MainActor (Bool) -> Void) {
         var req = URLRequest(url: probeURL, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 2)
         req.httpMethod = "HEAD"
         URLSession.shared.dataTask(with: req) { _, resp, _ in
             let up = (resp as? HTTPURLResponse) != nil
-            DispatchQueue.main.async { completion(up) }
+            DispatchQueue.main.async { MainActor.assumeIsolated { completion(up) } }
         }.resume()
     }
 
     // MARK: - Start
 
     /// Spawn the backend (detached) and poll until it answers. No-op while a
-    /// start is already in flight.
-    func start() {
+    /// start is already in flight — an optional `completion` still gets that
+    /// in-flight attempt's outcome. When the `lisa` CLI can't be found on the
+    /// login shell, the install wizard opens instead (UX-7).
+    func start(completion: ((Bool, String?) -> Void)? = nil) {
+        if let completion { startWaiters.append(completion) }
         guard !isStarting else { return }
         isStarting = true
 
-        let command = resolveCommand()
+        let override = overrideCommand()
+        let command = override ?? Self.defaultCommand
         // The default command binds 0.0.0.0; arm the token gate so the server will
         // accept it (and reject unauthenticated LAN callers). Harmless for a
         // loopback override — loopback is trusted regardless.
         let webToken = ensureWebToken()
-        let logPath = lisaPath("backend.log")
+        let logPath = backendLogPath
         try? FileManager.default.createDirectory(
             atPath: (logPath as NSString).deletingLastPathComponent,
             withIntermediateDirectories: true)
 
-        let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        // Inherit the app's environment (HOME etc.) and inject the web token; the
-        // login shell rebuilds PATH. Setting `environment` replaces it wholesale,
-        // so start from the current environment rather than a bare dictionary.
-        var env = ProcessInfo.processInfo.environment
-        env["LISA_WEB_TOKEN"] = webToken
-        proc.environment = env
-        // -l: login shell (PATH has npm-global / Homebrew). nohup + & + disown:
-        // fully detach so the backend survives this shell, the launcher, and the app.
-        proc.arguments = ["-lc", "nohup \(command) >> '\(logPath)' 2>&1 & disown"]
-        do {
-            try proc.run()
-        } catch {
-            isStarting = false
-            post(up: false, note: "spawn failed: \(error.localizedDescription)")
-            return
+        // Login shell + PATH prelude (nvm / fnm / Homebrew / npm-global), then
+        // nohup + & + disown so the backend survives this shell, the launcher, and
+        // the app. Without an override the script first checks that `lisa`
+        // resolves and reports LISA_MISSING instead of spawning a shell error.
+        let script = BackendSetup.startScript(command: command, logPath: logPath, requireCLI: override == nil)
+        ShellRunner.run(script, environment: ["LISA_WEB_TOKEN": webToken]) { [weak self] result in
+            guard let self else { return }
+            if result.output.contains(BackendSetup.missingMarker) {
+                self.isStarting = false
+                self.post(up: false, note: "lisa CLI not installed")
+                BackendSetupController.shared.presentForMissingCLI()
+                return
+            }
+            guard result.output.contains(BackendSetup.spawnedMarker) else {
+                self.isStarting = false
+                let why = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+                self.post(up: false, note: "spawn failed: \(why.isEmpty ? "exit \(result.status)" : why)")
+                return
+            }
+            self.pollUntilUp(attempts: 25)
         }
-        pollUntilUp(attempts: 25)
     }
 
     private func pollUntilUp(attempts: Int) {
@@ -176,17 +199,14 @@ final class BackendController {
 
     // MARK: - Helpers
 
-    private func resolveCommand() -> String {
-        // serve-command.txt is a full-control escape hatch (run from source, or
-        // force a different host) — we don't touch its host.
+    /// ~/.lisa/serve-command.txt, if present and non-empty: a full-control
+    /// escape hatch (run from source, or force a different host) — we don't
+    /// touch its host, and we don't check for the `lisa` CLI.
+    private func overrideCommand() -> String? {
         let override = lisaPath("serve-command.txt")
-        if let txt = try? String(contentsOfFile: override, encoding: .utf8) {
-            let t = txt.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !t.isEmpty { return t }
-        }
-        // Default: bind all interfaces so a phone on the same Wi-Fi can reach it.
-        // Token-gated for non-loopback callers (see start() / the header note).
-        return "lisa serve --web --host 0.0.0.0"
+        guard let txt = try? String(contentsOfFile: override, encoding: .utf8) else { return nil }
+        let t = txt.trimmingCharacters(in: .whitespacesAndNewlines)
+        return t.isEmpty ? nil : t
     }
 
     // MARK: - Web token (arms the LAN auth gate)
@@ -252,10 +272,10 @@ final class BackendController {
         var info: [String: Any] = ["up": up]
         if let note { info["note"] = note }
         NotificationCenter.default.post(name: BackendController.statusChanged, object: nil, userInfo: info)
-        // Resolve restart() callers after the broadcast, so the UIs they update
-        // have already seen the new state.
+        // Resolve restart() / start(completion:) callers after the broadcast, so
+        // the UIs they update have already seen the new state.
         let waiters = startWaiters
         startWaiters.removeAll()
-        for waiter in waiters { waiter(up) }
+        for waiter in waiters { waiter(up, note) }
     }
 }

--- a/packaging/mac-client/Sources/Lisa/BackendController.swift
+++ b/packaging/mac-client/Sources/Lisa/BackendController.swift
@@ -84,6 +84,11 @@ final class BackendController {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
     }
 
+    /// Callers waiting on the outcome of the next start attempt (restart()).
+    /// Drained — on the main actor — by post(), right after the status
+    /// notification goes out, so a waiter sees exactly one resolution.
+    private var startWaiters: [(Bool) -> Void] = []
+
     /// Stop the (detached) backend and start a fresh one so config.env changes
     /// apply. The backend was launched with nohup, so we match its command line;
     /// killing only `lisa serve --web` variants keeps unrelated processes safe.
@@ -92,18 +97,13 @@ final class BackendController {
         kill.executableURL = URL(fileURLWithPath: "/usr/bin/pkill")
         kill.arguments = ["-f", "serve --web"]
         kill.terminationHandler = { _ in
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+            // Give the old process a beat to release the port, then hop back to
+            // the main actor: the waiter list and start() are both isolated there.
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: 800_000_000)
                 guard let self else { return }
+                self.startWaiters.append(completion)
                 self.start()
-                // Report through the existing status notification once, then hand
-                // the outcome to the caller.
-                var observer: NSObjectProtocol?
-                observer = NotificationCenter.default.addObserver(
-                    forName: BackendController.statusChanged, object: nil, queue: .main
-                ) { note in
-                    if let observer { NotificationCenter.default.removeObserver(observer) }
-                    completion((note.userInfo?["up"] as? Bool) ?? false)
-                }
             }
         }
         try? kill.run()
@@ -252,5 +252,10 @@ final class BackendController {
         var info: [String: Any] = ["up": up]
         if let note { info["note"] = note }
         NotificationCenter.default.post(name: BackendController.statusChanged, object: nil, userInfo: info)
+        // Resolve restart() callers after the broadcast, so the UIs they update
+        // have already seen the new state.
+        let waiters = startWaiters
+        startWaiters.removeAll()
+        for waiter in waiters { waiter(up) }
     }
 }

--- a/packaging/mac-client/Sources/Lisa/BackendSetupController.swift
+++ b/packaging/mac-client/Sources/Lisa/BackendSetupController.swift
@@ -1,0 +1,569 @@
+//
+//  BackendSetupController.swift
+//  Lisa
+//
+//  The guided backend-install sheet (review UX-7). Until now "one-click
+//  download" meant: drag Lisa.app to Applications, then open Terminal and run
+//  `npm install -g @oratis/lisa` — and if `lisa` wasn't there, the app sat on a
+//  20 s "Starting…" and timed out with a hint. This window closes that gap:
+//
+//    checking ─▶ nodeMissing / nodeTooOld  (Homebrew command + Copy, nodejs.org, Re-check)
+//             ─▶ cliMissing               (Install backend: live npm output + spinner)
+//                   ├─ installFailed      (permissions → the exact no-sudo fix, one click)
+//                   └─ ready ─▶ starting  (lisa serve --web, as before) ─▶ closes itself
+//
+//  Decisions are pure (LisaSetup.BackendSetup, unit-tested); this file is the
+//  AppKit + process plumbing. Opened automatically by BackendController.start()
+//  when `lisa` doesn't resolve, and on demand from Lisa ▸ Set Up Backend….
+//
+
+import AppKit
+import LisaSetup
+
+@MainActor
+final class BackendSetupController: NSObject, NSWindowDelegate {
+    static let shared = BackendSetupController()
+    private override init() { super.init() }
+
+    /// Screen the wizard is on. `SetupState` is the pure decision; the other
+    /// cases are the transient phases around it.
+    private enum Phase {
+        case checking
+        case decided(SetupState, backendUp: Bool)
+        case installing(update: Bool)
+        case installFailed(InstallFailure)
+        case starting
+        case startFailed(note: String)
+    }
+
+    private var phase: Phase = .checking { didSet { render() } }
+    private var lastReport = ToolchainReport()
+    private var installProcess: Process?
+    private var cancelRequested = false
+    /// Auto-start once `.ready` is reached — armed by an explicit user intent
+    /// (menu, a finished install) and disarmed after one attempt, so a start
+    /// that keeps failing can't loop the wizard.
+    private var autoStartArmed = true
+
+    private var window: NSWindow?
+    private weak var hostWindow: NSWindow?
+
+    // ── controls (built once) ──
+    private let spinner = NSProgressIndicator()
+    private let statusLabel = NSTextField(wrappingLabelWithString: "")
+    private let nodeRow = ChecklistRow(title: "Node.js \(BackendSetup.minimumNodeMajor) or newer")
+    private let cliRow = ChecklistRow(title: "Lisa backend (\(BackendSetup.npmPackage))")
+    private let detail = NSStackView()
+    private let logScroll = NSScrollView()
+    private let logView = NSTextView()
+    private lazy var recheckButton = NSButton(title: "Re-check", target: self, action: #selector(recheck))
+    private lazy var closeButton = NSButton(title: "Close", target: self, action: #selector(closeWindow))
+
+    private let contentWidth: CGFloat = 540
+    private let pad: CGFloat = 24
+    private var inner: CGFloat { contentWidth - pad * 2 }
+
+    // MARK: - Entry points
+
+    /// Lisa ▸ Set Up Backend…: open (or refocus) and probe. Arms auto-start so a
+    /// ready-but-stopped backend just starts.
+    func presentFromMenu() {
+        autoStartArmed = true
+        present()
+    }
+
+    /// BackendController.start() found no `lisa` on the login shell. Open the
+    /// wizard without re-arming auto-start (a finished install re-arms it).
+    func presentForMissingCLI() {
+        present()
+    }
+
+    private func present() {
+        if window == nil { build() }
+        guard let window else { return }
+        if window.isVisible {
+            if window.sheetParent == nil {
+                NSApp.activate(ignoringOtherApps: true)
+                window.makeKeyAndOrderFront(nil)
+            }
+            recheck()
+            return
+        }
+        // Sheet on the chat window when it's up (the usual case); a standalone
+        // window when only the menu-bar item is around.
+        if let host = NSApp.windows.first(where: { $0 is MainWindow && $0.isVisible }) {
+            hostWindow = host
+            host.beginSheet(window) { _ in }
+        } else {
+            hostWindow = nil
+            window.center()
+            NSApp.activate(ignoringOtherApps: true)
+            window.makeKeyAndOrderFront(nil)
+        }
+        recheck()
+    }
+
+    @objc private func closeWindow() {
+        guard let window else { return }
+        if let host = hostWindow, window.sheetParent === host {
+            host.endSheet(window)
+        } else {
+            window.orderOut(nil)
+        }
+    }
+
+    private var isInstalling: Bool {
+        if case .installing = phase { return true }
+        return false
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        // Don't let a half-finished npm install get orphaned behind a closed window.
+        !isInstalling
+    }
+
+    // MARK: - Probe → decide
+
+    @objc private func recheck() {
+        guard !isInstalling else { return }
+        phase = .checking
+        let override = BackendController.shared.hasServeOverride
+        ShellRunner.run(BackendSetup.probeScript) { [weak self] result in
+            guard let self else { return }
+            let report = ToolchainReport.parse(result.output, hasServeOverride: override)
+            self.lastReport = report
+            let state = BackendSetup.decide(report)
+            BackendController.shared.probe { [weak self] up in
+                guard let self else { return }
+                self.phase = .decided(state, backendUp: up)
+                if case .ready = state, !up, self.autoStartArmed {
+                    self.autoStartArmed = false
+                    self.startBackend()
+                }
+            }
+        }
+    }
+
+    // MARK: - Install / fix / update
+
+    @objc private func installBackend() { runInstall(BackendSetup.installScript, update: false) }
+    @objc private func updateBackend() { runInstall(BackendSetup.installScript, update: true) }
+    @objc private func applyPermissionsFix() { runInstall(BackendSetup.permissionsFixRunScript, update: false) }
+
+    private func runInstall(_ script: String, update: Bool) {
+        guard !isInstalling else { return }
+        cancelRequested = false
+        clearLog()
+        appendLog("$ \(script.split(separator: "\n").last.map(String.init) ?? BackendSetup.installCommand)\n")
+        phase = .installing(update: update)
+        // Plain, quiet npm: no colours / progress bars in the log, no funding /
+        // audit banners that read like errors.
+        let env = [
+            "NO_COLOR": "1", "npm_config_color": "false", "npm_config_progress": "false",
+            "npm_config_fund": "false", "npm_config_audit": "false",
+        ]
+        installProcess = ShellRunner.run(script, environment: env, onOutput: { [weak self] chunk in
+            self?.appendLog(chunk)
+        }, completion: { [weak self] result in
+            guard let self else { return }
+            self.installProcess = nil
+            if self.cancelRequested {
+                self.cancelRequested = false
+                self.appendLog("\n(cancelled)\n")
+                self.recheck()
+                return
+            }
+            if result.status == 0 {
+                self.appendLog("\n✓ done\n")
+                self.autoStartArmed = true
+                if update { self.restartBackend() } else { self.recheck() }
+            } else {
+                self.phase = .installFailed(
+                    BackendSetup.classifyInstallFailure(output: result.output, exitCode: result.status))
+            }
+        })
+    }
+
+    @objc private func cancelInstall() {
+        cancelRequested = true
+        installProcess?.terminate()
+    }
+
+    // MARK: - Start / restart
+
+    @objc private func startBackend() {
+        phase = .starting
+        BackendController.shared.start { [weak self] up, note in
+            guard let self else { return }
+            if up { self.closeWindow() } else { self.phase = .startFailed(note: note ?? "timeout") }
+        }
+    }
+
+    private func restartBackend() {
+        phase = .starting
+        BackendController.shared.restart { [weak self] up in
+            guard let self else { return }
+            if up { self.closeWindow() } else { self.phase = .startFailed(note: "didn't come back after the update") }
+        }
+    }
+
+    // MARK: - Misc actions
+
+    @objc private func copyBrewNode() { copyToPasteboard(BackendSetup.brewNodeCommand) }
+    @objc private func copyPermissionsFix() { copyToPasteboard(BackendSetup.permissionsFixScript) }
+    @objc private func copyInstallCommand() { copyToPasteboard(BackendSetup.installCommand) }
+    @objc private func openNodeDownload() { NSWorkspace.shared.open(BackendSetup.nodeDownloadURL) }
+    @objc private func openHomebrew() { NSWorkspace.shared.open(BackendSetup.homebrewURL) }
+    @objc private func openBackendLog() {
+        NSWorkspace.shared.open(URL(fileURLWithPath: BackendController.shared.backendLogPath))
+    }
+
+    private func copyToPasteboard(_ s: String) {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(s, forType: .string)
+    }
+
+    // MARK: - Build
+
+    private func build() {
+        let win = NSWindow(contentRect: NSRect(x: 0, y: 0, width: contentWidth, height: 420),
+                           styleMask: [.titled, .closable], backing: .buffered, defer: false)
+        win.title = "Set up the Lisa backend"
+        win.isReleasedWhenClosed = false
+        win.delegate = self
+
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 12
+        stack.edgeInsets = NSEdgeInsets(top: pad, left: pad, bottom: pad, right: pad)
+        stack.translatesAutoresizingMaskIntoConstraints = false
+
+        let title = NSTextField(labelWithString: "Set up the Lisa backend")
+        title.font = .systemFont(ofSize: 17, weight: .bold)
+        stack.addArrangedSubview(title)
+        stack.addArrangedSubview(wrapped(
+            "Lisa.app is the window; the backend (`lisa serve --web`) does the thinking. It runs on Node.js and installs with one command — this walks you through it.",
+            size: 12, color: .secondaryLabelColor))
+
+        spinner.style = .spinning
+        spinner.controlSize = .small
+        spinner.isDisplayedWhenStopped = false
+        statusLabel.font = .systemFont(ofSize: 12, weight: .medium)
+        statusLabel.preferredMaxLayoutWidth = inner - 26
+        let statusRow = NSStackView(views: [spinner, statusLabel])
+        statusRow.orientation = .horizontal
+        statusRow.alignment = .centerY
+        statusRow.spacing = 8
+        statusRow.widthAnchor.constraint(equalToConstant: inner).isActive = true
+        stack.addArrangedSubview(statusRow)
+
+        let list = NSStackView(views: [nodeRow.view, cliRow.view])
+        list.orientation = .vertical
+        list.alignment = .leading
+        list.spacing = 6
+        stack.addArrangedSubview(list)
+
+        detail.orientation = .vertical
+        detail.alignment = .leading
+        detail.spacing = 8
+        detail.translatesAutoresizingMaskIntoConstraints = false
+        detail.widthAnchor.constraint(equalToConstant: inner).isActive = true
+        stack.addArrangedSubview(detail)
+
+        // Live install log — hidden until an install runs.
+        logView.isEditable = false
+        logView.isRichText = false
+        logView.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        logView.textColor = .labelColor
+        logView.isVerticallyResizable = true
+        logView.isHorizontallyResizable = false
+        logView.autoresizingMask = [.width]
+        logView.textContainer?.widthTracksTextView = true
+        logView.textContainer?.containerSize = NSSize(width: inner, height: .greatestFiniteMagnitude)
+        logView.minSize = NSSize(width: 0, height: 0)
+        logView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        logScroll.documentView = logView
+        logScroll.hasVerticalScroller = true
+        logScroll.borderType = .bezelBorder
+        logScroll.translatesAutoresizingMaskIntoConstraints = false
+        logScroll.heightAnchor.constraint(equalToConstant: 150).isActive = true
+        logScroll.widthAnchor.constraint(equalToConstant: inner).isActive = true
+        logScroll.isHidden = true
+        stack.addArrangedSubview(logScroll)
+
+        // The manual path stays visible as the fallback — same words as before.
+        stack.addArrangedSubview(wrapped(
+            "Prefer the terminal? Run `\(BackendSetup.installCommand)` once, then `\(BackendSetup.manualServeCommand)` — this window only does that for you.",
+            size: 11, color: .tertiaryLabelColor))
+
+        recheckButton.bezelStyle = .rounded
+        closeButton.bezelStyle = .rounded
+        let buttons = NSStackView()
+        buttons.orientation = .horizontal
+        buttons.translatesAutoresizingMaskIntoConstraints = false
+        buttons.addView(recheckButton, in: .leading)
+        buttons.addView(closeButton, in: .trailing)
+        buttons.widthAnchor.constraint(equalToConstant: inner).isActive = true
+        stack.addArrangedSubview(buttons)
+
+        let container = NSView()
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: container.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            container.widthAnchor.constraint(equalToConstant: contentWidth),
+        ])
+        win.contentView = container
+        window = win
+    }
+
+    // MARK: - Render
+
+    private func render() {
+        guard window != nil else { return }
+        for v in detail.arrangedSubviews {
+            detail.removeArrangedSubview(v)
+            v.removeFromSuperview()
+        }
+        var busy = false
+        switch phase {
+        case .checking:
+            busy = true
+            statusLabel.stringValue = "Checking this Mac for Node.js and the Lisa backend…"
+            nodeRow.set(.pending, detail: "")
+            cliRow.set(.pending, detail: "")
+
+        case .decided(let state, let up):
+            statusLabel.stringValue = state.summary + (up ? " The backend is running." : "")
+            renderChecklist(state)
+            renderDecided(state, backendUp: up)
+
+        case .installing(let update):
+            busy = true
+            statusLabel.stringValue = update
+                ? "Updating the Lisa backend… (output below)"
+                : "Installing the Lisa backend — a minute or two; npm's output shows below."
+            cliRow.set(.pending, detail: update ? "updating" : "installing")
+            logScroll.isHidden = false
+            detail.addArrangedSubview(button("Cancel", #selector(cancelInstall)))
+
+        case .installFailed(let failure):
+            statusLabel.stringValue = failure.title
+            cliRow.set(.fail, detail: "install failed")
+            logScroll.isHidden = false
+            renderFailure(failure)
+
+        case .starting:
+            busy = true
+            statusLabel.stringValue = "Starting the backend (\(BackendSetup.manualServeCommand))…"
+            cliRow.set(.ok, detail: lastReport.lisaVersion.map { "v\($0)" } ?? "installed")
+
+        case .startFailed(let note):
+            statusLabel.stringValue = "The backend didn't come up (\(note))."
+            detail.addArrangedSubview(wrapped(
+                "~/.lisa/backend.log has the reason — usually a missing API key or a port already in use. Fix that, then try again.",
+                size: 12, color: .secondaryLabelColor))
+            detail.addArrangedSubview(row(button("Open backend.log", #selector(openBackendLog)),
+                                          button("Try again", #selector(startBackend), primary: true)))
+        }
+        if busy { spinner.startAnimation(nil) } else { spinner.stopAnimation(nil) }
+        recheckButton.isEnabled = !busy
+        closeButton.isEnabled = !isInstalling
+        resizeToFit()
+    }
+
+    private func renderChecklist(_ state: SetupState) {
+        switch state {
+        case .ready(let v):
+            nodeRow.set(.ok, detail: lastReport.nodeVersion ?? (lastReport.hasServeOverride ? "custom serve command" : "found"))
+            cliRow.set(.ok, detail: v.map { "v\($0)" } ?? (lastReport.hasServeOverride ? "custom serve command" : "installed"))
+        case .nodeMissing:
+            nodeRow.set(.fail, detail: "not found on your login shell's PATH")
+            cliRow.set(.pending, detail: "needs Node.js first")
+        case .nodeTooOld(let found, _):
+            nodeRow.set(.fail, detail: "\(found) — \(BackendSetup.minimumNodeMajor)+ required")
+            cliRow.set(.pending, detail: "needs a newer Node.js first")
+        case .cliMissing(let node):
+            nodeRow.set(.ok, detail: node)
+            cliRow.set(.fail, detail: "not installed")
+        }
+    }
+
+    private func renderDecided(_ state: SetupState, backendUp: Bool) {
+        switch state {
+        case .ready:
+            if backendUp {
+                detail.addArrangedSubview(wrapped("Nothing to do. You can pull the latest backend release from here any time.",
+                                                  size: 12, color: .secondaryLabelColor))
+                detail.addArrangedSubview(button("Update backend", #selector(updateBackend)))
+            } else {
+                detail.addArrangedSubview(row(button("Start backend", #selector(startBackend), primary: true),
+                                              button("Update backend", #selector(updateBackend))))
+            }
+        case .nodeMissing(let brew), .nodeTooOld(_, let brew):
+            renderNodeOptions(brewAvailable: brew)
+        case .cliMissing:
+            detail.addArrangedSubview(wrapped("One command installs it globally with npm; the output shows here as it runs. Lisa starts on its own when it's done.",
+                                              size: 12, color: .secondaryLabelColor))
+            detail.addArrangedSubview(row(button("Install backend", #selector(installBackend), primary: true),
+                                          button("Copy command", #selector(copyInstallCommand))))
+        }
+    }
+
+    /// Two ways to get Node.js, then Re-check. Homebrew first when it's present.
+    private func renderNodeOptions(brewAvailable: Bool) {
+        detail.addArrangedSubview(wrapped("Install Node.js first — either way works — then click Re-check:",
+                                          size: 12, color: .secondaryLabelColor))
+        detail.addArrangedSubview(sectionLabel(brewAvailable ? "1 · With Homebrew (in Terminal)" : "1 · With Homebrew"))
+        detail.addArrangedSubview(row(codeBox(BackendSetup.brewNodeCommand), button("Copy", #selector(copyBrewNode))))
+        if !brewAvailable {
+            detail.addArrangedSubview(row(
+                wrapped("Homebrew isn't installed on this Mac — get it from brew.sh, or use the download below.",
+                        size: 11, color: .tertiaryLabelColor, width: inner - 110),
+                button("Open brew.sh", #selector(openHomebrew))))
+        }
+        detail.addArrangedSubview(sectionLabel("2 · Download the installer"))
+        detail.addArrangedSubview(button("Download Node.js from nodejs.org", #selector(openNodeDownload)))
+    }
+
+    private func renderFailure(_ failure: InstallFailure) {
+        detail.addArrangedSubview(wrapped(failure.advice, size: 12, color: .secondaryLabelColor))
+        switch failure {
+        case .permissions:
+            detail.addArrangedSubview(codeBox(BackendSetup.permissionsFixScript))
+            detail.addArrangedSubview(row(button("Apply fix and retry", #selector(applyPermissionsFix), primary: true),
+                                          button("Copy fix", #selector(copyPermissionsFix))))
+        case .network, .unknown:
+            detail.addArrangedSubview(button("Retry install", #selector(installBackend), primary: true))
+        case .nodeTooOld:
+            renderNodeOptions(brewAvailable: lastReport.brewPath != nil)
+        }
+    }
+
+    // MARK: - Log
+
+    private func clearLog() {
+        logView.textStorage?.setAttributedString(NSAttributedString(string: ""))
+    }
+
+    private func appendLog(_ text: String) {
+        guard let storage = logView.textStorage else { return }
+        storage.append(NSAttributedString(string: text, attributes: [
+            .font: NSFont.monospacedSystemFont(ofSize: 11, weight: .regular),
+            .foregroundColor: NSColor.labelColor,
+        ]))
+        logView.scrollToEndOfDocument(nil)
+    }
+
+    // MARK: - View helpers
+
+    private func resizeToFit() {
+        guard let window, let content = window.contentView else { return }
+        content.layoutSubtreeIfNeeded()
+        let height = content.fittingSize.height
+        window.setContentSize(NSSize(width: contentWidth, height: height))
+    }
+
+    private func wrapped(_ s: String, size: CGFloat, color: NSColor, width: CGFloat? = nil) -> NSTextField {
+        let l = NSTextField(wrappingLabelWithString: s)
+        l.font = .systemFont(ofSize: size)
+        l.textColor = color
+        l.isSelectable = false
+        let w = width ?? inner
+        l.preferredMaxLayoutWidth = w
+        l.translatesAutoresizingMaskIntoConstraints = false
+        l.widthAnchor.constraint(equalToConstant: w).isActive = true
+        return l
+    }
+
+    private func sectionLabel(_ s: String) -> NSTextField {
+        let l = NSTextField(labelWithString: s)
+        l.font = .systemFont(ofSize: 11, weight: .semibold)
+        l.textColor = .secondaryLabelColor
+        return l
+    }
+
+    private func button(_ title: String, _ action: Selector, primary: Bool = false) -> NSButton {
+        let b = NSButton(title: title, target: self, action: action)
+        b.bezelStyle = .rounded
+        if primary { b.keyEquivalent = "\r" }
+        return b
+    }
+
+    private func row(_ views: NSView...) -> NSStackView {
+        let r = NSStackView(views: views)
+        r.orientation = .horizontal
+        r.alignment = .centerY
+        r.spacing = 8
+        return r
+    }
+
+    /// A selectable, monospaced command box the user can read and copy from.
+    private func codeBox(_ text: String) -> NSView {
+        let label = NSTextField(wrappingLabelWithString: text)
+        label.font = .monospacedSystemFont(ofSize: 11, weight: .regular)
+        label.textColor = .labelColor
+        label.isSelectable = true
+        label.translatesAutoresizingMaskIntoConstraints = false
+        let box = NSView()
+        box.wantsLayer = true
+        box.layer?.backgroundColor = NSColor.labelColor.withAlphaComponent(0.06).cgColor
+        box.layer?.cornerRadius = 6
+        box.translatesAutoresizingMaskIntoConstraints = false
+        box.addSubview(label)
+        // Leave room for a trailing Copy button when it sits in a row.
+        let w = inner - 80
+        label.preferredMaxLayoutWidth = w - 20
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: 10),
+            label.trailingAnchor.constraint(equalTo: box.trailingAnchor, constant: -10),
+            label.topAnchor.constraint(equalTo: box.topAnchor, constant: 7),
+            label.bottomAnchor.constraint(equalTo: box.bottomAnchor, constant: -7),
+            box.widthAnchor.constraint(equalToConstant: w),
+        ])
+        return box
+    }
+}
+
+/// One line of the checklist: ● icon · title — detail.
+@MainActor
+private final class ChecklistRow {
+    enum Mark { case pending, ok, fail }
+
+    let view = NSStackView()
+    private let icon = NSImageView()
+    private let detailLabel = NSTextField(labelWithString: "")
+
+    init(title: String) {
+        let t = NSTextField(labelWithString: title)
+        t.font = .systemFont(ofSize: 12, weight: .medium)
+        detailLabel.font = .systemFont(ofSize: 12)
+        detailLabel.textColor = .secondaryLabelColor
+        detailLabel.lineBreakMode = .byTruncatingMiddle
+        icon.translatesAutoresizingMaskIntoConstraints = false
+        icon.widthAnchor.constraint(equalToConstant: 16).isActive = true
+        icon.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        view.orientation = .horizontal
+        view.alignment = .centerY
+        view.spacing = 8
+        view.addArrangedSubview(icon)
+        view.addArrangedSubview(t)
+        view.addArrangedSubview(detailLabel)
+        set(.pending, detail: "")
+    }
+
+    func set(_ mark: Mark, detail: String) {
+        let (symbol, tint, description): (String, NSColor, String)
+        switch mark {
+        case .pending: (symbol, tint, description) = ("circle.dashed", .tertiaryLabelColor, "not checked yet")
+        case .ok:      (symbol, tint, description) = ("checkmark.circle.fill", .systemGreen, "ok")
+        case .fail:    (symbol, tint, description) = ("xmark.circle.fill", .systemRed, "missing")
+        }
+        icon.image = NSImage(systemSymbolName: symbol, accessibilityDescription: description)
+        icon.contentTintColor = tint
+        detailLabel.stringValue = detail.isEmpty ? "" : "— \(detail)"
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/HotkeyManager.swift
+++ b/packaging/mac-client/Sources/Lisa/HotkeyManager.swift
@@ -64,7 +64,7 @@ final class HotkeyManager {
         )
 
         // Register ⌃⌥S. keyCode 1 = 's' on the ANSI layout.
-        var hotKeyID = EventHotKeyID(signature: Self.signature, id: Self.hotKeyIDValue)
+        let hotKeyID = EventHotKeyID(signature: Self.signature, id: Self.hotKeyIDValue)
         let modifiers = UInt32(controlKey | optionKey)
         RegisterEventHotKey(
             UInt32(kVK_ANSI_S),
@@ -75,7 +75,6 @@ final class HotkeyManager {
             &hotKeyRef,
         )
         FileHandle.standardError.write(Data("[lisa] global hotkey ⌃⌥S registered\n".utf8))
-        _ = hotKeyID // silence unused-mutation warning
     }
 
     func unregister() {

--- a/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
+++ b/packaging/mac-client/Sources/Lisa/Island/IslandContent.swift
@@ -36,7 +36,10 @@ final class IslandContent: NSViewController, WKNavigationDelegate, WKScriptMessa
         let config = WKWebViewConfiguration()
         // Receive postMessage from window.webkit.messageHandlers.island.
         config.userContentController.add(self, name: "island")
-        config.processPool = WKProcessPool()
+        // Same persistent data store as the chat window's WKWebView (WebContent),
+        // so /island sees the same cookies + localStorage as /. (Replaces the
+        // deprecated, no-op-since-macOS-12 `processPool = WKProcessPool()`.)
+        config.websiteDataStore = .default()
 
         let preferences = WKWebpagePreferences()
         preferences.allowsContentJavaScript = true

--- a/packaging/mac-client/Sources/Lisa/MenuBarController.swift
+++ b/packaging/mac-client/Sources/Lisa/MenuBarController.swift
@@ -288,7 +288,16 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
             start.bezelStyle = .rounded
             start.keyEquivalent = "\r"
             start.isEnabled = !starting
-            v.addArrangedSubview(start)
+            // Second door (UX-7): "isn't running" and "was never installed" look
+            // identical from here, so offer the wizard next to the start button.
+            let setup = NSButton(title: "Set Up…", target: self, action: #selector(openBackendSetup))
+            setup.bezelStyle = .rounded
+            setup.isEnabled = !starting
+            let startRow = NSStackView(views: [start, setup])
+            startRow.orientation = .horizontal
+            startRow.alignment = .centerY
+            startRow.spacing = 8
+            v.addArrangedSubview(startRow)
             v.widthAnchor.constraint(equalToConstant: inner).isActive = true
             stack.addArrangedSubview(v)
         } else {
@@ -596,6 +605,11 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
     @objc private func pairPhone() {
         popover?.close()
         PairController.shared.showPairing()
+    }
+
+    @objc private func openBackendSetup() {
+        popover?.performClose(nil)
+        BackendSetupController.shared.presentFromMenu()
     }
 
     @objc private func startBackend() {

--- a/packaging/mac-client/Sources/Lisa/ShellRunner.swift
+++ b/packaging/mac-client/Sources/Lisa/ShellRunner.swift
@@ -1,0 +1,128 @@
+//
+//  ShellRunner.swift
+//  Lisa
+//
+//  Runs a script in a zsh LOGIN shell (`/bin/zsh -lc`) — the only way a GUI
+//  app, launched from Finder with a bare PATH, sees the user's Homebrew / npm /
+//  nvm tools — and streams its combined stdout+stderr back to the main thread.
+//  Used by BackendController (detect + spawn the backend) and the install
+//  wizard (live `npm install -g` output).
+//
+
+import Foundation
+
+enum ShellRunner {
+    /// Outcome of a finished script. `status` is -1 when the shell itself
+    /// couldn't be launched (then `output` is the reason).
+    struct Result {
+        let output: String
+        let status: Int32
+    }
+
+    /// Start `script` under `/bin/zsh -lc`. `onOutput` receives each chunk as it
+    /// arrives (ANSI-stripped, main thread); `completion` runs once, on the main
+    /// actor, after the process exits and the pipe has drained. Returns the
+    /// Process so a caller can terminate it (Cancel in the wizard).
+    @discardableResult
+    static func run(
+        _ script: String,
+        environment: [String: String]? = nil,
+        onOutput: ((String) -> Void)? = nil,
+        completion: @escaping @MainActor (Result) -> Void
+    ) -> Process? {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        proc.arguments = ["-lc", script]
+        // Inherit the app's environment (HOME, LANG, …); the login shell rebuilds
+        // PATH. Setting `environment` replaces it wholesale, so start from the
+        // current one rather than a bare dictionary.
+        var env = ProcessInfo.processInfo.environment
+        for (k, v) in environment ?? [:] { env[k] = v }
+        proc.environment = env
+
+        let pipe = Pipe()
+        proc.standardOutput = pipe
+        proc.standardError = pipe
+        proc.standardInput = FileHandle.nullDevice
+
+        let buffer = OutputBuffer()
+        let reader = pipe.fileHandleForReading
+        reader.readabilityHandler = { fh in
+            let data = fh.availableData
+            if data.isEmpty {           // EOF
+                fh.readabilityHandler = nil
+                return
+            }
+            let text = buffer.append(data)
+            if let onOutput, !text.isEmpty {
+                DispatchQueue.main.async { onOutput(text) }
+            }
+        }
+
+        proc.terminationHandler = { p in
+            // The handler can fire before the last chunk was read; drain the
+            // rest synchronously (the write end is closed once the shell and any
+            // child holding it have exited).
+            reader.readabilityHandler = nil
+            let rest = reader.readDataToEndOfFile()
+            let tail = buffer.append(rest)
+            if let onOutput, !tail.isEmpty {
+                DispatchQueue.main.async { onOutput(tail) }
+            }
+            let result = Result(output: buffer.text, status: p.terminationStatus)
+            Task { @MainActor in completion(result) }
+        }
+
+        do {
+            try proc.run()
+        } catch {
+            reader.readabilityHandler = nil
+            let result = Result(output: "couldn't launch /bin/zsh: \(error.localizedDescription)", status: -1)
+            Task { @MainActor in completion(result) }
+            return nil
+        }
+        return proc
+    }
+
+    /// Accumulates pipe output across threads and decodes it incrementally
+    /// (a chunk can split a UTF-8 sequence; keep the undecodable tail for the
+    /// next chunk). Strips ANSI escapes so npm's colours don't land in the log.
+    private final class OutputBuffer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var pending = Data()
+        private var all = ""
+
+        /// Append raw bytes; returns the newly decoded, cleaned text.
+        func append(_ data: Data) -> String {
+            lock.lock(); defer { lock.unlock() }
+            pending.append(data)
+            // Decode the longest valid prefix; hold back a partial trailing sequence.
+            var cut = pending.count
+            while cut > 0, String(data: pending.prefix(cut), encoding: .utf8) == nil, pending.count - cut < 4 {
+                cut -= 1
+            }
+            guard cut > 0, let s = String(data: pending.prefix(cut), encoding: .utf8) else {
+                if pending.count >= 4 {          // hopelessly invalid — decode lossily, move on
+                    let s = ShellRunner.stripANSI(String(decoding: pending, as: UTF8.self))
+                    pending.removeAll()
+                    all += s
+                    return s
+                }
+                return ""
+            }
+            pending.removeFirst(cut)
+            let clean = ShellRunner.stripANSI(s)
+            all += clean
+            return clean
+        }
+
+        var text: String { lock.lock(); defer { lock.unlock() }; return all }
+    }
+
+    /// Remove CSI / OSC escape sequences and carriage-return progress rewrites.
+    static func stripANSI(_ s: String) -> String {
+        var out = s.replacingOccurrences(of: #"\u{1B}\[[0-?]*[ -/]*[@-~]"#, with: "", options: .regularExpression)
+        out = out.replacingOccurrences(of: #"\u{1B}\][^\u{07}]*\u{07}"#, with: "", options: .regularExpression)
+        return out.replacingOccurrences(of: "\r", with: "")
+    }
+}

--- a/packaging/mac-client/Sources/Lisa/WebContent.swift
+++ b/packaging/mac-client/Sources/Lisa/WebContent.swift
@@ -51,7 +51,12 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WK
 
     override func loadView() {
         let config = WKWebViewConfiguration()
-        config.processPool = WKProcessPool()
+        // Share one persistent website data store with the island pill's web
+        // view, so cookies / localStorage (the web session, theme choice) are the
+        // same in both. This is the real seam for that sharing — the former
+        // `config.processPool = WKProcessPool()` never was: since macOS 12 extra
+        // process pools have no effect, and the API is deprecated.
+        config.websiteDataStore = .default()
 
         let preferences = WKWebpagePreferences()
         preferences.allowsContentJavaScript = true

--- a/packaging/mac-client/Sources/Lisa/WebContent.swift
+++ b/packaging/mac-client/Sources/Lisa/WebContent.swift
@@ -191,6 +191,10 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WK
               let type = body["type"] as? String else { return }
         if type == "start_backend" {
             BackendController.shared.start()
+        } else if type == "setup_backend" {
+            // UX-7: the splash's second door — the guided install wizard, for
+            // when the backend isn't just stopped but was never installed.
+            BackendSetupController.shared.presentFromMenu()
         }
     }
 
@@ -282,11 +286,17 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WK
             <button id=\"startBtn\" onclick=\"startBackend()\">▶&nbsp;&nbsp;Start Lisa backend</button>
             <button class=\"ghost\" onclick=\"location.assign('http://localhost:5757/')\">Retry</button>
           </div>
+          <div class=\"row\">
+            <button class=\"ghost\" onclick=\"setupBackend()\">Set&nbsp;up&nbsp;backend…</button>
+          </div>
           <script>
             function startBackend() {
               var b = document.getElementById('startBtn');
               if (b) { b.textContent = 'Starting…'; b.disabled = true; }
               try { window.webkit.messageHandlers.lisa.postMessage({ type: 'start_backend' }); } catch (e) {}
+            }
+            function setupBackend() {
+              try { window.webkit.messageHandlers.lisa.postMessage({ type: 'setup_backend' }); } catch (e) {}
             }
           </script>
 

--- a/packaging/mac-client/Sources/LisaSetup/BackendSetup.swift
+++ b/packaging/mac-client/Sources/LisaSetup/BackendSetup.swift
@@ -1,0 +1,258 @@
+//
+//  BackendSetup.swift
+//  LisaSetup
+//
+//  Pure, AppKit-free logic behind the Mac app's backend install wizard
+//  (review UX-7: "one-click download" was really a two-step install — the DMG,
+//  then `npm install -g @oratis/lisa` in a terminal). Everything in this module
+//  is deterministic and unit-tested (Tests/LisaSetupTests); the app target does
+//  the actual I/O (BackendSetupController runs the scripts, shows the sheet).
+//
+//  Shape:
+//    probeScript ──(zsh -lc)──▶ ToolchainReport.parse ──▶ BackendSetup.decide
+//                                                              │
+//        ready ◀── lisa found ────────────────────────────────┤
+//        nodeMissing / nodeTooOld ◀── no usable node ─────────┤
+//        cliMissing ◀── node ok, no lisa ──▶ installScript ───┘ (loop)
+//
+
+import Foundation
+
+/// What the login-shell probe reported about this Mac.
+public struct ToolchainReport: Equatable {
+    public var nodePath: String?
+    /// As printed by `node --version`, e.g. "v22.4.0".
+    public var nodeVersion: String?
+    public var npmPath: String?
+    public var lisaPath: String?
+    /// First line of `lisa --version`, e.g. "0.24.0".
+    public var lisaVersion: String?
+    public var brewPath: String?
+    /// ~/.lisa/serve-command.txt is present: the user starts the backend their
+    /// own way (from source, a custom host) and the CLI check doesn't apply.
+    public var hasServeOverride: Bool
+
+    public init(nodePath: String? = nil, nodeVersion: String? = nil, npmPath: String? = nil,
+                lisaPath: String? = nil, lisaVersion: String? = nil, brewPath: String? = nil,
+                hasServeOverride: Bool = false) {
+        self.nodePath = nodePath
+        self.nodeVersion = nodeVersion
+        self.npmPath = npmPath
+        self.lisaPath = lisaPath
+        self.lisaVersion = lisaVersion
+        self.brewPath = brewPath
+        self.hasServeOverride = hasServeOverride
+    }
+
+    /// Parse the `KEY=value` lines printed by `BackendSetup.probeScript`. Empty
+    /// values become nil; unknown lines (shell noise from a chatty ~/.zprofile)
+    /// are ignored, so a decorated login shell can't break detection.
+    public static func parse(_ output: String, hasServeOverride: Bool = false) -> ToolchainReport {
+        var r = ToolchainReport(hasServeOverride: hasServeOverride)
+        for rawLine in output.split(separator: "\n", omittingEmptySubsequences: true) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard let eq = line.firstIndex(of: "=") else { continue }
+            let key = String(line[..<eq])
+            let value = String(line[line.index(after: eq)...]).trimmingCharacters(in: .whitespaces)
+            let v: String? = value.isEmpty ? nil : value
+            switch key {
+            case "NODE":  r.nodePath = v
+            case "NODEV": r.nodeVersion = v
+            case "NPM":   r.npmPath = v
+            case "LISA":  r.lisaPath = v
+            case "LISAV": r.lisaVersion = v
+            case "BREW":  r.brewPath = v
+            default: break
+            }
+        }
+        return r
+    }
+}
+
+/// Where the wizard lands after a probe. Exactly one of these is true at a time;
+/// the app maps each to a screen (checklist + the one action that unblocks it).
+public enum SetupState: Equatable {
+    /// The `lisa` CLI resolves on the login shell (or a serve override is in
+    /// place) — nothing to install, just start it.
+    case ready(lisaVersion: String?)
+    /// No `node` on the login shell's PATH: offer Homebrew + nodejs.org, Re-check.
+    case nodeMissing(brewAvailable: Bool)
+    /// `node` exists but is older than `BackendSetup.minimumNodeMajor`.
+    case nodeTooOld(found: String, brewAvailable: Bool)
+    /// Node is fine and `@oratis/lisa` isn't installed globally: one-click install.
+    case cliMissing(nodeVersion: String)
+
+    /// One-line status for the wizard's header.
+    public var summary: String {
+        switch self {
+        case .ready(let v):
+            return "Lisa backend \(v.map { "v\($0) " } ?? "")is installed."
+        case .nodeMissing:
+            return "Node.js isn't installed on this Mac — the backend runs on it."
+        case .nodeTooOld(let found, _):
+            return "Node.js \(found) is too old — the backend needs \(BackendSetup.minimumNodeMajor) or newer."
+        case .cliMissing(let node):
+            return "Node.js \(node) found — the Lisa backend isn't installed yet."
+        }
+    }
+}
+
+/// Why `npm install -g @oratis/lisa` failed, from its output. Drives the exact
+/// fix the wizard shows (a permissions failure gets a copy-able, one-click fix
+/// rather than "see the log").
+public enum InstallFailure: Equatable {
+    /// EACCES / EPERM on npm's global prefix (a root-owned /usr/local/lib).
+    case permissions
+    /// Couldn't reach the registry.
+    case network
+    /// npm refused the package's `engines` requirement.
+    case nodeTooOld
+    case unknown(exitCode: Int32)
+
+    public var title: String {
+        switch self {
+        case .permissions: return "npm can't write to its global folder."
+        case .network: return "Couldn't reach the npm registry."
+        case .nodeTooOld: return "npm refused: this Node.js is too old for the backend."
+        case .unknown(let code): return "The install failed (exit \(code))."
+        }
+    }
+
+    public var advice: String {
+        switch self {
+        case .permissions:
+            return "That folder is owned by root. The standard fix moves global packages into your home folder — no sudo — then retries the install:"
+        case .network:
+            return "Check your connection (and any proxy or VPN), then retry."
+        case .nodeTooOld:
+            return "Install Node.js \(BackendSetup.minimumNodeMajor) or newer (Homebrew or nodejs.org), then Re-check."
+        case .unknown:
+            return "The log below has npm's own message. You can also run the command in Terminal."
+        }
+    }
+}
+
+public enum BackendSetup {
+    /// package.json `engines.node` — keep in sync.
+    public static let minimumNodeMajor = 20
+    public static let npmPackage = "@oratis/lisa"
+    public static let installCommand = "npm install -g @oratis/lisa"
+    public static let manualServeCommand = "lisa serve --web"
+    public static let brewNodeCommand = "brew install node"
+    public static let nodeDownloadURL = URL(string: "https://nodejs.org/en/download")!
+    public static let homebrewURL = URL(string: "https://brew.sh")!
+
+    /// PATH prelude for every shell the app spawns. A GUI app's login shell
+    /// (`zsh -lc`) runs ~/.zprofile but not ~/.zshrc, which is where nvm / fnm /
+    /// Homebrew shims usually live — so a Node that "works in Terminal" can be
+    /// invisible here. Cover the common homes explicitly, and source nvm / fnm
+    /// when present, so detection, install and `lisa serve` all see the same
+    /// tools.
+    public static let shellPrelude = """
+    export PATH="$HOME/.npm-global/bin:$HOME/.volta/bin:/opt/homebrew/bin:/usr/local/bin:$PATH"
+    if [ -z "${NVM_DIR:-}" ] && [ -d "$HOME/.nvm" ]; then export NVM_DIR="$HOME/.nvm"; fi
+    if [ -s "${NVM_DIR:-/nonexistent}/nvm.sh" ]; then . "$NVM_DIR/nvm.sh" >/dev/null 2>&1; fi
+    if command -v fnm >/dev/null 2>&1; then eval "$(fnm env 2>/dev/null)"; fi
+    """
+
+    /// Reports node / npm / lisa / brew as `KEY=value` lines (ToolchainReport.parse).
+    public static var probeScript: String {
+        shellPrelude + "\n" + """
+        echo "NODE=$(command -v node 2>/dev/null)"
+        echo "NODEV=$(node --version 2>/dev/null)"
+        echo "NPM=$(command -v npm 2>/dev/null)"
+        echo "LISA=$(command -v lisa 2>/dev/null)"
+        echo "LISAV=$(lisa --version 2>/dev/null | head -n 1)"
+        echo "BREW=$(command -v brew 2>/dev/null)"
+        """
+    }
+
+    /// Markers the start script prints so the app can tell "spawned" from
+    /// "there is no CLI to spawn" without waiting for a 20 s poll to time out.
+    public static let spawnedMarker = "LISA_SPAWNED"
+    public static let missingMarker = "LISA_MISSING"
+
+    /// The script BackendController.start() runs: spawn `command` fully detached
+    /// (nohup + & + disown, output appended to `logPath`), or — when
+    /// `requireCLI` and `lisa` doesn't resolve — print the missing marker and
+    /// exit so the wizard can take over. A serve-command override passes
+    /// `requireCLI: false`: the user owns that command line.
+    public static func startScript(command: String, logPath: String, requireCLI: Bool) -> String {
+        var lines = [shellPrelude]
+        if requireCLI {
+            lines.append("if ! command -v lisa >/dev/null 2>&1; then echo \(missingMarker); exit 0; fi")
+        }
+        lines.append("nohup \(command) >> \(shellQuote(logPath)) 2>&1 & disown")
+        lines.append("echo \(spawnedMarker)")
+        return lines.joined(separator: "\n")
+    }
+
+    /// One-click install: the same command the README gives, on the same PATH
+    /// the app will later start the backend from.
+    public static var installScript: String {
+        shellPrelude + "\n" + installCommand
+    }
+
+    /// The standard npm fix for an EACCES global install (no sudo): point the
+    /// global prefix at ~/.npm-global, put its bin on PATH for login shells
+    /// (~/.zprofile — what both Terminal and this app's `zsh -lc` read), then
+    /// install. Shown verbatim with a Copy button and runnable as-is.
+    public static let permissionsFixScript = """
+    mkdir -p "$HOME/.npm-global"
+    npm config set prefix "$HOME/.npm-global"
+    grep -qs 'npm-global/bin' "$HOME/.zprofile" || echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.zprofile"
+    export PATH="$HOME/.npm-global/bin:$PATH"
+    npm install -g @oratis/lisa
+    """
+
+    public static var permissionsFixRunScript: String {
+        shellPrelude + "\n" + permissionsFixScript
+    }
+
+    /// The wizard's decision. Order matters: an installed CLI (or an override)
+    /// wins even when Node looks wrong, because `lisa` resolving on this PATH
+    /// is the thing that actually has to be true.
+    public static func decide(_ r: ToolchainReport) -> SetupState {
+        let brew = r.brewPath != nil
+        if r.hasServeOverride || r.lisaPath != nil {
+            return .ready(lisaVersion: r.lisaVersion)
+        }
+        guard let nodeVersion = r.nodeVersion, let major = nodeMajor(nodeVersion) else {
+            return .nodeMissing(brewAvailable: brew)
+        }
+        if major < minimumNodeMajor {
+            return .nodeTooOld(found: nodeVersion, brewAvailable: brew)
+        }
+        return .cliMissing(nodeVersion: nodeVersion)
+    }
+
+    /// "v22.4.0" / "22.4.0" → 22. nil when there's no leading number.
+    public static func nodeMajor(_ version: String) -> Int? {
+        var s = Substring(version.trimmingCharacters(in: .whitespacesAndNewlines))
+        if s.hasPrefix("v") || s.hasPrefix("V") { s = s.dropFirst() }
+        let digits = s.prefix { $0.isNumber }
+        return digits.isEmpty ? nil : Int(digits)
+    }
+
+    /// Classify a failed install from npm's combined output. Only meaningful
+    /// for a non-zero exit.
+    public static func classifyInstallFailure(output: String, exitCode: Int32) -> InstallFailure {
+        let o = output.lowercased()
+        if o.contains("eacces") || o.contains("eperm") || o.contains("permission denied") {
+            return .permissions
+        }
+        if o.contains("ebadengine") || o.contains("unsupported engine") {
+            return .nodeTooOld
+        }
+        for needle in ["enotfound", "etimedout", "econnreset", "econnrefused", "eai_again", "network"]
+        where o.contains(needle) {
+            return .network
+        }
+        return .unknown(exitCode: exitCode)
+    }
+
+    /// Single-quote a string for sh/zsh.
+    public static func shellQuote(_ s: String) -> String {
+        "'" + s.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}

--- a/packaging/mac-client/Tests/LisaSetupTests/BackendSetupTests.swift
+++ b/packaging/mac-client/Tests/LisaSetupTests/BackendSetupTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import LisaSetup
+
+/// The wizard's decision logic is pure — no shell, no AppKit — so it's pinned here.
+final class BackendSetupTests: XCTestCase {
+
+    // ── ToolchainReport.parse: the probe's KEY=value lines, tolerant of noise ──
+
+    func testParseFullReport() {
+        let out = """
+        Welcome banner from a chatty .zprofile
+        NODE=/opt/homebrew/bin/node
+        NODEV=v22.4.0
+        NPM=/opt/homebrew/bin/npm
+        LISA=/opt/homebrew/bin/lisa
+        LISAV=0.24.0
+        BREW=/opt/homebrew/bin/brew
+        """
+        let r = ToolchainReport.parse(out)
+        XCTAssertEqual(r.nodePath, "/opt/homebrew/bin/node")
+        XCTAssertEqual(r.nodeVersion, "v22.4.0")
+        XCTAssertEqual(r.npmPath, "/opt/homebrew/bin/npm")
+        XCTAssertEqual(r.lisaPath, "/opt/homebrew/bin/lisa")
+        XCTAssertEqual(r.lisaVersion, "0.24.0")
+        XCTAssertEqual(r.brewPath, "/opt/homebrew/bin/brew")
+        XCTAssertFalse(r.hasServeOverride)
+    }
+
+    func testParseEmptyValuesBecomeNil() {
+        let r = ToolchainReport.parse("NODE=\nNODEV=\nNPM=\nLISA=\nLISAV=\nBREW=\n")
+        XCTAssertNil(r.nodePath)
+        XCTAssertNil(r.nodeVersion)
+        XCTAssertNil(r.lisaPath)
+        XCTAssertNil(r.brewPath)
+    }
+
+    // ── decide: the four screens ──
+
+    func testDecideNodeMissing() {
+        XCTAssertEqual(BackendSetup.decide(ToolchainReport()), .nodeMissing(brewAvailable: false))
+        XCTAssertEqual(BackendSetup.decide(ToolchainReport(brewPath: "/opt/homebrew/bin/brew")),
+                       .nodeMissing(brewAvailable: true))
+    }
+
+    func testDecideNodeTooOld() {
+        let r = ToolchainReport(nodePath: "/usr/local/bin/node", nodeVersion: "v18.20.4")
+        XCTAssertEqual(BackendSetup.decide(r), .nodeTooOld(found: "v18.20.4", brewAvailable: false))
+    }
+
+    func testDecideNodeAtFloorIsFine() {
+        let r = ToolchainReport(nodePath: "/usr/local/bin/node", nodeVersion: "v20.0.0")
+        XCTAssertEqual(BackendSetup.decide(r), .cliMissing(nodeVersion: "v20.0.0"))
+    }
+
+    func testDecideCliMissing() {
+        let r = ToolchainReport(nodePath: "/opt/homebrew/bin/node", nodeVersion: "v22.4.0",
+                                npmPath: "/opt/homebrew/bin/npm")
+        XCTAssertEqual(BackendSetup.decide(r), .cliMissing(nodeVersion: "v22.4.0"))
+    }
+
+    func testDecideReadyWhenCliPresent() {
+        let r = ToolchainReport(nodePath: "/opt/homebrew/bin/node", nodeVersion: "v22.4.0",
+                                lisaPath: "/opt/homebrew/bin/lisa", lisaVersion: "0.24.0")
+        XCTAssertEqual(BackendSetup.decide(r), .ready(lisaVersion: "0.24.0"))
+    }
+
+    func testDecideCliWinsOverOddNode() {
+        // A Homebrew-tap lisa carries its own node dependency; if `lisa` resolves,
+        // that's what matters — don't send the user to install Node.
+        let r = ToolchainReport(lisaPath: "/opt/homebrew/bin/lisa")
+        XCTAssertEqual(BackendSetup.decide(r), .ready(lisaVersion: nil))
+    }
+
+    func testDecideServeOverrideIsReadyRegardless() {
+        // serve-command.txt = "I run it from source"; nothing to detect or install.
+        XCTAssertEqual(BackendSetup.decide(ToolchainReport(hasServeOverride: true)), .ready(lisaVersion: nil))
+    }
+
+    // ── nodeMajor ──
+
+    func testNodeMajor() {
+        XCTAssertEqual(BackendSetup.nodeMajor("v22.4.0"), 22)
+        XCTAssertEqual(BackendSetup.nodeMajor("20.1.0"), 20)
+        XCTAssertEqual(BackendSetup.nodeMajor(" v18.0.0\n"), 18)
+        XCTAssertNil(BackendSetup.nodeMajor(""))
+        XCTAssertNil(BackendSetup.nodeMajor("node: command not found"))
+    }
+
+    // ── install failure classification → the exact fix ──
+
+    func testClassifyPermissions() {
+        let out = "npm ERR! code EACCES\nnpm ERR! syscall mkdir\nnpm ERR! path /usr/local/lib/node_modules/@oratis"
+        XCTAssertEqual(BackendSetup.classifyInstallFailure(output: out, exitCode: 243), .permissions)
+        XCTAssertEqual(BackendSetup.classifyInstallFailure(output: "Error: permission denied", exitCode: 1), .permissions)
+    }
+
+    func testClassifyNetwork() {
+        XCTAssertEqual(BackendSetup.classifyInstallFailure(output: "npm ERR! code ENOTFOUND registry.npmjs.org", exitCode: 1), .network)
+        XCTAssertEqual(BackendSetup.classifyInstallFailure(output: "npm ERR! network request to https://… failed", exitCode: 1), .network)
+    }
+
+    func testClassifyEngine() {
+        XCTAssertEqual(BackendSetup.classifyInstallFailure(output: "npm WARN EBADENGINE Unsupported engine", exitCode: 1), .nodeTooOld)
+    }
+
+    func testClassifyUnknownCarriesExitCode() {
+        XCTAssertEqual(BackendSetup.classifyInstallFailure(output: "something else", exitCode: 7), .unknown(exitCode: 7))
+    }
+
+    func testPermissionsFixIsTheNpmGlobalPrefixMove() {
+        let fix = BackendSetup.permissionsFixScript
+        XCTAssertTrue(fix.contains("npm config set prefix \"$HOME/.npm-global\""))
+        XCTAssertTrue(fix.contains(".zprofile"), "login shells (Terminal + this app's zsh -lc) read ~/.zprofile")
+        XCTAssertTrue(fix.hasSuffix(BackendSetup.installCommand))
+        XCTAssertFalse(fix.contains("sudo"))
+    }
+
+    // ── scripts: one PATH story for detect / install / start ──
+
+    func testProbeScriptCoversVersionManagersAndReportsAllKeys() {
+        let s = BackendSetup.probeScript
+        XCTAssertTrue(s.hasPrefix(BackendSetup.shellPrelude))
+        for key in ["NODE=", "NODEV=", "NPM=", "LISA=", "LISAV=", "BREW="] {
+            XCTAssertTrue(s.contains("echo \"\(key)"), "probe must print \(key)")
+        }
+        XCTAssertTrue(s.contains("lisa --version"))
+        XCTAssertTrue(BackendSetup.shellPrelude.contains("nvm.sh"))
+        XCTAssertTrue(BackendSetup.shellPrelude.contains("/opt/homebrew/bin"))
+        XCTAssertTrue(BackendSetup.shellPrelude.contains(".npm-global/bin"))
+    }
+
+    func testStartScriptGatesOnTheCLIUnlessOverridden() {
+        let gated = BackendSetup.startScript(command: "lisa serve --web --host 0.0.0.0",
+                                             logPath: "/Users/x/.lisa/backend.log", requireCLI: true)
+        XCTAssertTrue(gated.contains("command -v lisa"))
+        XCTAssertTrue(gated.contains("echo \(BackendSetup.missingMarker); exit 0"))
+        XCTAssertTrue(gated.contains("nohup lisa serve --web --host 0.0.0.0 >> '/Users/x/.lisa/backend.log' 2>&1 & disown"))
+        XCTAssertTrue(gated.hasSuffix("echo \(BackendSetup.spawnedMarker)"))
+
+        let override = BackendSetup.startScript(command: "node /src/dist/cli.js serve --web",
+                                                logPath: "/tmp/l.log", requireCLI: false)
+        XCTAssertFalse(override.contains("command -v lisa"))
+        XCTAssertTrue(override.contains("nohup node /src/dist/cli.js serve --web >> '/tmp/l.log'"))
+    }
+
+    func testShellQuoteEscapesSingleQuotes() {
+        XCTAssertEqual(BackendSetup.shellQuote("/Users/o'brien/.lisa/backend.log"),
+                       "'/Users/o'\\''brien/.lisa/backend.log'")
+    }
+
+    func testInstallScriptRunsTheReadmeCommandOnTheSamePath() {
+        XCTAssertTrue(BackendSetup.installScript.hasPrefix(BackendSetup.shellPrelude))
+        XCTAssertTrue(BackendSetup.installScript.hasSuffix(BackendSetup.installCommand))
+        XCTAssertEqual(BackendSetup.installCommand, "npm install -g @oratis/lisa")
+    }
+
+    func testSummariesNameTheBlocker() {
+        XCTAssertTrue(SetupState.nodeMissing(brewAvailable: false).summary.contains("Node.js isn't installed"))
+        XCTAssertTrue(SetupState.nodeTooOld(found: "v18.1.0", brewAvailable: true).summary.contains("v18.1.0"))
+        XCTAssertTrue(SetupState.cliMissing(nodeVersion: "v22.4.0").summary.contains("isn't installed yet"))
+        XCTAssertEqual(SetupState.ready(lisaVersion: "0.24.0").summary, "Lisa backend v0.24.0 is installed.")
+        XCTAssertEqual(SetupState.ready(lisaVersion: nil).summary, "Lisa backend is installed.")
+    }
+}


### PR DESCRIPTION
第 3 / 8 条，实现 T-11 与 UX-7、UX-12。基于 #370。

## macOS

**14 个警告 → 0，并开启 warnings-as-errors。** 修掉 `BackendController` 里被 Sendable 闭包捕获后又改写的 observer、`IslandContent`/`WebContent` 两处已弃用的 `WKProcessPool`（改用共享 `WKWebsiteDataStore` 达到同样的会话共享效果）、以及一个从未重新赋值的 var。Swift 6 的严格并发检查下这些会变成错误，现在提前挡住回归。debug 与 release 两种配置均验证通过。

**后端安装向导（UX-7）。** 官网承诺一键下载，实际上下载 DMG 之后还要用户自己跑 `npm install -g @oratis/lisa`。现在检测 Node（经 `/bin/zsh -lc` 以便解析 nvm/brew 的 PATH）与 lisa CLI，提供一键安装并在面板内实时显示输出；Node 缺失时给出 Homebrew 命令（带复制按钮）和官网链接以及重新检测按钮；权限失败时直接给出修复命令。决策逻辑抽成纯函数并有测试。

## iOS

**可访问性（UX-12）。** 之前全应用几乎没有 accessibility 标注：状态点只用颜色区分、roster 行被读成互不相关的碎片、图标按钮无标签、扫码区域没有说明。现在状态一律配文字、每行合并为单个可访问元素、图标按钮全部有标签、进度点读作"第 N 步 / 共 M 步"，Send/Copy 等控件补足 44pt 触控区。

**推送通道。** 服务端一直支持 ntfy，客户端却只接 APNs——没有 Apple 推送密钥时界面显示"已注册"但永远收不到通知。现在 Settings 里可选传输方式，并按服务端实际返回如实说明投递状态。

**PTY 实时输出。** 会话详情改为订阅 `/api/agents/pty/<id>/stream` 的 SSE，替代原来的一次性拉取按钮，断线自动重连。

## 验证

`swift build -c debug` 与 `-c release` 均 0 警告 0 错误；iOS 模拟器测试 **44 通过 / 0 失败**（此前 29）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)