### PR TITLE
feat(cli): REPL 打磨、doctor --probe、lisa upgrade

### DIFF
--- a/completions/README.md
+++ b/completions/README.md
@@ -45,7 +45,7 @@ No reload needed — fish auto-loads completions.
 
 | Position | Suggestions |
 |---|---|
-| First arg | The 13 subcommands |
+| First arg | Every subcommand (chat, inspection, lifecycle, cloud) |
 | `--model` value | 17 common model names across providers |
 | `--provider` value | `anthropic` / `openai` / `gemini` |
 | `--approval` value | `auto` / `ask` / `ask-mutating` |
@@ -53,6 +53,8 @@ No reload needed — fish auto-loads completions.
 | 2nd arg after `lisa skills` | `list` / `approve` / `disable` / `enable` / `audit` |
 | 3rd arg after `lisa skills <action>` | Slugs scanned from `~/.lisa/skills/` |
 | 2nd arg after `lisa heartbeat` | `run` / `install` / `uninstall` |
+| After `lisa doctor` | `--probe` (health of a running backend) |
+| After `lisa upgrade` | `--check` / `--dry-run` |
 | Generic flag completion | All global flags |
 
 ## Future via Homebrew

--- a/completions/_lisa
+++ b/completions/_lisa
@@ -32,6 +32,9 @@ _lisa() {
         '--imessage[start iMessage channel (with serve)]' \
         '--channels[start IM channels]:list:_lisa_channels' \
         '--port[port for serve --web]:port:' \
+        '--verbose[startup banners + full tool results]' \
+        '--no-color[plain output even on a terminal]' \
+        '--host[bind address for serve --web]:addr:' \
         '1: :_lisa_first' \
         '*::arg:->args' \
         && return 0
@@ -43,6 +46,8 @@ _lisa() {
                 heartbeat) _lisa_heartbeat ;;
                 autostart) _lisa_autostart ;;
                 model)    _lisa_model ;;
+                doctor)   _lisa_doctor ;;
+                upgrade)  _lisa_upgrade ;;
                 consent)  _lisa_consent ;;
                 sense)    _lisa_sense ;;
             esac
@@ -58,6 +63,7 @@ _lisa_first() {
         'serve:start web UI / IM channels'
         'heartbeat:run / install / uninstall scheduled tasks'
         'autostart:run the backend from login (install/uninstall/status)'
+        'upgrade:upgrade this install and restart the daemon'
         'search:TF-IDF search across past sessions'
         'birth:run the birth ritual'
         'soul:print current soul summary'
@@ -72,6 +78,12 @@ _lisa_first() {
         'consent:consent for sensitive ambient signals'
         'sense:recent ambient sense events'
         'agents:snapshot of agent sessions across observers'
+        'pair:show a QR to pair a phone (Lisa Pocket)'
+        'mail:mail account setup and inbox commands'
+        'kb:knowledge base (add/list/search/brief)'
+        'login:sign in to Lisa Cloud'
+        'logout:sign out of Lisa Cloud'
+        'billing:allowance, credits and recent usage'
     )
     _describe 'subcommand' subcommands
 }
@@ -119,6 +131,19 @@ _lisa_autostart() {
         )
         _describe 'autostart action' actions
     fi
+}
+
+_lisa_doctor() {
+    _arguments '--probe[probe a running backend'\''s /health]:url:_urls'
+}
+
+_lisa_upgrade() {
+    local -a flags
+    flags=(
+        '--check:only compare installed vs published version'
+        '--dry-run:print the commands without running them'
+    )
+    _describe 'upgrade flag' flags
 }
 
 _lisa_model() {

--- a/completions/lisa.bash
+++ b/completions/lisa.bash
@@ -12,12 +12,14 @@ _lisa_completion() {
     local cur prev words cword
     _init_completion -n : 2>/dev/null || _get_comp_words_by_ref -n : cur prev words cword
 
-    local subcommands="resume sessions serve heartbeat autostart search birth soul channels skills wishlist status doctor monitor autonomy model consent sense agents"
-    local global_flags="--model --provider --think --no-reflect --compact --approval --no-mcp --no-plugins --voice --idle --no-idle --help -h --version -v"
+    local subcommands="resume sessions serve heartbeat autostart upgrade search birth soul channels skills wishlist status doctor monitor autonomy model consent sense agents pair mail kb login logout billing"
+    local global_flags="--model --provider --think --no-reflect --compact --approval --no-mcp --no-plugins --voice --idle --no-idle --verbose --no-color --host --help -h --version -v"
     local serve_flags="--web --imessage --channels --port"
     local skills_actions="list approve disable enable audit"
     local heartbeat_actions="run install uninstall"
     local autostart_actions="install uninstall status"
+    local doctor_flags="--probe"
+    local upgrade_flags="--check --dry-run"
     local model_actions="list install use health"
     local consent_actions="list grant revoke revoke-all"
     local consent_signals="screen voice clipboard selection"
@@ -112,6 +114,14 @@ _lisa_completion() {
                 COMPREPLY=( $(compgen -W "${sense_actions}" -- "${cur}") )
                 return 0
             fi
+            ;;
+        doctor)
+            COMPREPLY=( $(compgen -W "${doctor_flags}" -- "${cur}") )
+            return 0
+            ;;
+        upgrade)
+            COMPREPLY=( $(compgen -W "${upgrade_flags}" -- "${cur}") )
+            return 0
             ;;
         serve)
             COMPREPLY=( $(compgen -W "${serve_flags} ${global_flags}" -- "${cur}") )

--- a/completions/lisa.fish
+++ b/completions/lisa.fish
@@ -17,7 +17,7 @@ end
 # ── helper: did the user already type a subcommand? ─────────────────
 function __lisa_no_subcommand
     set cmd (commandline -opc)
-    set sub resume sessions serve heartbeat autostart search birth soul channels skills wishlist status doctor monitor autonomy model consent sense agents
+    set sub resume sessions serve heartbeat autostart upgrade search birth soul channels skills wishlist status doctor monitor autonomy model consent sense agents pair mail kb login logout billing
     for word in $cmd[2..-1]
         if contains -- $word $sub
             return 1
@@ -56,6 +56,13 @@ complete -c lisa -n __lisa_no_subcommand -f -a model      -d "local model lifecy
 complete -c lisa -n __lisa_no_subcommand -f -a consent    -d "consent for ambient signals"
 complete -c lisa -n __lisa_no_subcommand -f -a sense      -d "recent ambient sense events"
 complete -c lisa -n __lisa_no_subcommand -f -a agents     -d "agent sessions snapshot"
+complete -c lisa -n __lisa_no_subcommand -f -a upgrade    -d "upgrade this install + restart the daemon"
+complete -c lisa -n __lisa_no_subcommand -f -a pair       -d "show a QR to pair a phone"
+complete -c lisa -n __lisa_no_subcommand -f -a mail       -d "mail setup and inbox"
+complete -c lisa -n __lisa_no_subcommand -f -a kb         -d "knowledge base"
+complete -c lisa -n __lisa_no_subcommand -f -a login      -d "sign in to Lisa Cloud"
+complete -c lisa -n __lisa_no_subcommand -f -a logout     -d "sign out of Lisa Cloud"
+complete -c lisa -n __lisa_no_subcommand -f -a billing    -d "allowance, credits, usage"
 
 # ── model / consent / sense sub-actions ─────────────────────────────
 complete -c lisa -n "__lisa_using_subcommand model" -f -a "list install use health" -d "model action"
@@ -70,6 +77,11 @@ complete -c lisa -n "__lisa_using_subcommand skills" -f -a disable  -d "block a 
 complete -c lisa -n "__lisa_using_subcommand skills" -f -a enable   -d "remove disable"
 complete -c lisa -n "__lisa_using_subcommand skills" -f -a audit    -d "show audit trail"
 complete -c lisa -n "__lisa_using_subcommand skills" -f -a "(__lisa_skill_slugs)" -d "skill slug"
+
+# ── doctor / upgrade flags ──────────────────────────────────────────
+complete -c lisa -n "__lisa_using_subcommand doctor" -f -l probe -d "probe a running backend's /health"
+complete -c lisa -n "__lisa_using_subcommand upgrade" -f -l check -d "only compare installed vs published"
+complete -c lisa -n "__lisa_using_subcommand upgrade" -f -l dry-run -d "print the commands, run nothing"
 
 # ── heartbeat sub-actions ───────────────────────────────────────────
 complete -c lisa -n "__lisa_using_subcommand heartbeat" -f -a run       -d "run once"
@@ -91,6 +103,8 @@ complete -c lisa -l no-mcp             -d "skip MCP loading"
 complete -c lisa -l no-plugins         -d "skip plugin loading"
 complete -c lisa -l voice              -d "enable speak/transcribe"
 complete -c lisa -l no-idle            -d "disable idle mode"
+complete -c lisa -l verbose            -d "startup banners + full tool results"
+complete -c lisa -l no-color           -d "plain output even on a terminal"
 complete -c lisa -l web                -d "start web UI (with serve)"
 complete -c lisa -l imessage           -d "start iMessage (with serve)"
 

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -1,6 +1,6 @@
 import { test, describe } from "node:test";
 import assert from "node:assert/strict";
-import { parseArgs } from "./cli-args.js";
+import { isVerboseArgv, parseArgs } from "./cli-args.js";
 
 describe("parseArgs — raw / passthrough subcommand routing", () => {
   test("mail: every trailing flag reaches the handler verbatim, even would-be global ones", () => {
@@ -74,5 +74,39 @@ describe("parseArgs — raw / passthrough subcommand routing", () => {
     assert.equal(a.model, "mail");
     assert.equal(a.subcommand, undefined);
     assert.equal(a.prompt, "hello world");
+  });
+});
+
+describe("parseArgs — verbosity", () => {
+  test("--verbose sets verbose and is not treated as a prompt word", () => {
+    const a = parseArgs(["--verbose", "hello"]);
+    assert.equal(a.verbose, true);
+    assert.equal(a.prompt, "hello");
+  });
+
+  test("verbose defaults to false without LISA_DEBUG", () => {
+    const prev = process.env.LISA_DEBUG;
+    delete process.env.LISA_DEBUG;
+    try {
+      assert.equal(parseArgs(["status"]).verbose, false);
+    } finally {
+      if (prev !== undefined) process.env.LISA_DEBUG = prev;
+    }
+  });
+});
+
+describe("isVerboseArgv", () => {
+  test("--verbose anywhere in argv", () => {
+    assert.equal(isVerboseArgv(["serve", "--web", "--verbose"], {}), true);
+    assert.equal(isVerboseArgv(["serve", "--web"], {}), false);
+  });
+
+  test("LISA_DEBUG=1 (and any other truthy spelling) turns it on; 0/false/empty do not", () => {
+    assert.equal(isVerboseArgv([], { LISA_DEBUG: "1" }), true);
+    assert.equal(isVerboseArgv([], { LISA_DEBUG: "true" }), true);
+    assert.equal(isVerboseArgv([], { LISA_DEBUG: "0" }), false);
+    assert.equal(isVerboseArgv([], { LISA_DEBUG: "false" }), false);
+    assert.equal(isVerboseArgv([], { LISA_DEBUG: "" }), false);
+    assert.equal(isVerboseArgv([], {}), false);
   });
 });

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -48,7 +48,8 @@ export interface ParsedArgs {
     | "kb"
     | "login"
     | "logout"
-    | "billing";
+    | "billing"
+    | "upgrade";
   subargs: string[];
   serveWeb: boolean;
   serveImessage: boolean;
@@ -218,7 +219,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
       first === "kb" ||
       first === "login" ||
       first === "logout" ||
-      first === "billing"
+      first === "billing" ||
+      first === "upgrade"
     ) {
       out.subcommand = first;
       out.subargs = positional.slice(1);

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -19,6 +19,8 @@ export interface ParsedArgs {
   idleMinutes: number;
   /** True when --model was passed, so a LISA_MODEL default from config.env won't override it. */
   modelExplicit: boolean;
+  /** `--verbose` or LISA_DEBUG=1: startup banners, full tool results, hot-reload details. */
+  verbose: boolean;
   subcommand?:
     | "resume"
     | "sessions"
@@ -70,6 +72,18 @@ const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart"]);
  */
 const PASSTHROUGH_SUBCOMMANDS = new Set(["mail", "kb"]);
 
+/**
+ * Is this a debug run? Decided from the raw argv + env rather than ParsedArgs
+ * because the proxy bridge runs at module load, before parseArgs — it must be
+ * in place before any module touches fetch. LISA_DEBUG=1 is the env form for
+ * launchd / scripts that can't edit the command line.
+ */
+export function isVerboseArgv(argv: readonly string[], env: NodeJS.ProcessEnv = process.env): boolean {
+  const debug = env.LISA_DEBUG;
+  if (debug && debug !== "0" && debug.toLowerCase() !== "false") return true;
+  return argv.includes("--verbose");
+}
+
 export function parseArgs(argv: string[]): ParsedArgs {
   const out: ParsedArgs = {
     showHelp: false,
@@ -78,6 +92,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     compaction: false,
     model: DEFAULT_MODEL,
     modelExplicit: false,
+    verbose: isVerboseArgv([], process.env),
     approval: "auto",
     loadMcp: true,
     loadPlugins: true,
@@ -112,6 +127,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     else if (arg === "--compact") out.compaction = true;
     else if (arg === "--no-mcp") out.loadMcp = false;
     else if (arg === "--no-plugins") out.loadPlugins = false;
+    else if (arg === "--verbose") out.verbose = true;
     else if (arg === "--voice") out.voice = true;
     else if (arg === "--no-idle") out.idleMinutes = 0;
     else if (arg === "--idle") {

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -21,6 +21,8 @@ export interface ParsedArgs {
   modelExplicit: boolean;
   /** `--verbose` or LISA_DEBUG=1: startup banners, full tool results, hot-reload details. */
   verbose: boolean;
+  /** `--no-color`: force plain output even on a TTY (NO_COLOR is handled in cli/ansi.ts). */
+  noColor: boolean;
   subcommand?:
     | "resume"
     | "sessions"
@@ -93,6 +95,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     model: DEFAULT_MODEL,
     modelExplicit: false,
     verbose: isVerboseArgv([], process.env),
+    noColor: false,
     approval: "auto",
     loadMcp: true,
     loadPlugins: true,
@@ -128,6 +131,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     else if (arg === "--no-mcp") out.loadMcp = false;
     else if (arg === "--no-plugins") out.loadPlugins = false;
     else if (arg === "--verbose") out.verbose = true;
+    else if (arg === "--no-color" || arg === "--no-colour") out.noColor = true;
     else if (arg === "--voice") out.voice = true;
     else if (arg === "--no-idle") out.idleMinutes = 0;
     else if (arg === "--idle") {

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -64,7 +64,7 @@ export interface ParsedArgs {
  * --model`), so those must still reach the global parser — only *unrecognized*
  * trailing flags are collected verbatim for the handler.
  */
-const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart"]);
+const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart", "doctor", "upgrade"]);
 
 /**
  * Subcommands whose handler re-parses *all* of its trailing args itself, so

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,13 +34,15 @@ import { buildSystemPromptSnapshot, getPromptFingerprint } from "./prompt.js";
 import { providerForModel, resolveDefaultModel, hasCredentialsForModel } from "./providers/registry.js";
 import { reflectOnSession } from "./reflect.js";
 import { runRepl } from "./cli/repl.js";
+import { colorEnabled, setColorOverride } from "./cli/ansi.js";
+import { createEventRenderer, type EventRenderer } from "./cli/render.js";
 import { listSessionsOnDisk, loadSessionMessages } from "./sessions/list.js";
 import { SessionStore } from "./sessions/store.js";
 import { birth } from "./soul/birth.js";
 import { isBorn, readSoulSummary } from "./soul/store.js";
 import { createTaskTool } from "./tools/task.js";
 import { buildToolRegistry, cloudSafeSubset, readOnlySubset } from "./tools/registry.js";
-import type { AgentEvent, StoredMessage, ToolDefinition } from "./types.js";
+import type { StoredMessage, ToolDefinition } from "./types.js";
 
 const HELP = `Lisa — your self-evolving local AI assistant.
 
@@ -150,6 +152,8 @@ FLAGS
   --no-idle             Disable idle mode entirely.
   --host <addr>         Bind address for serve --web (default: 127.0.0.1).
                         Non-loopback binds require LISA_WEB_TOKEN to be set.
+  --verbose             Startup banners, full tool results, hot-reload detail.
+  --no-color            Plain output even on a terminal (so is NO_COLOR=1).
 
 REPL slash commands:
   /help, /exit, /quit
@@ -161,6 +165,14 @@ REPL slash commands:
   /think                Toggle adaptive thinking.
   /clear                Forget current in-memory history (session log preserved).
   /save <text>          Append to MEMORY.md immediately.
+
+REPL editing:
+  ↑ / ↓                 Browse previous prompts — kept across sessions in
+                        ${displayPath(lisaHome())}/history (last 1000, mode 0600).
+  """                   Open a multi-line prompt; """ again to send it.
+  Tool calls show as one line each (⚙ running → ✓ / ✗ with a duration);
+  --verbose adds the full result. Only Lisa's words go to stdout, so
+  \`lisa "…" > answer.md\` captures the answer and nothing else.
 
 Data: ${displayPath(lisaHome())}
 Plugins: ${displayPath(PLUGINS_ROOT)}/<name>/{commands,agents,skills,hooks,.lisa-plugin/plugin.json}
@@ -200,6 +212,10 @@ async function main(): Promise<void> {
     console.log(HELP);
     return;
   }
+
+  // `--no-color` is a process-wide decision (doctor/status/monitor read it via
+  // cli/colors.ts, the REPL renderer via cli/ansi.ts), so record it once here.
+  if (args.noColor) setColorOverride(false);
 
   await ensureDir(lisaHome());
   loadConfigEnv();
@@ -720,8 +736,17 @@ async function main(): Promise<void> {
 
   const rebuildPrompt = makeHotReloadRebuilder(initialFingerprint, snapshot.text);
 
+  const renderer: EventRenderer = createEventRenderer({
+    stdout: process.stdout,
+    stderr: process.stderr,
+    color: colorEnabled({ isTTY: process.stderr.isTTY === true, noColorFlag: args.noColor }),
+    verbose: args.verbose,
+    tty: process.stderr.isTTY === true,
+    columns: process.stderr.columns,
+  });
+
   const turn = async (prompt: string): Promise<void> => {
-    process.stdout.write("\nLisa> ");
+    renderer.beginTurn();
     // Per-turn freshness: pick up any cross-session writes to soul / skills /
     // memory (e.g. she patched her own soul during the previous turn). The
     // closure caches by fingerprint so this is cheap when nothing changed.
@@ -765,15 +790,18 @@ async function main(): Promise<void> {
         );
         if (r.rewriteResult != null) return { rewriteResult: r.rewriteResult };
       },
-      onEvent: renderEvent,
+      onEvent: (e) => renderer.onEvent(e),
       onMessagePersist: (msg) => session.appendMessage(msg),
       onPromptPersist: (text, reason) => session.appendPrompt(text, reason),
       hotReload: {
         initialFingerprint: fresh.fingerprint,
         rebuild: rebuildPrompt,
       },
+    }).finally(() => {
+      // Also on failure: an abandoned spinner would keep redrawing over the
+      // error message.
+      renderer.endTurn();
     });
-    process.stdout.write("\n");
     history.length = 0;
     history.push(...result.history);
     if (result.cacheReadTokens || result.cacheWriteTokens || result.inputTokens) {
@@ -946,34 +974,6 @@ async function main(): Promise<void> {
       await finish();
     },
   });
-}
-
-function renderEvent(event: AgentEvent): void {
-  switch (event.type) {
-    case "text_delta":
-      if (event.text) process.stdout.write(event.text);
-      break;
-    case "thinking_delta":
-      break;
-    case "tool_call_start": {
-      const inputPreview = JSON.stringify(event.toolInput).slice(0, 120);
-      process.stderr.write(`\n[tool ${event.toolName} ${inputPreview}]\n`);
-      break;
-    }
-    case "tool_call_end":
-      if (event.isError) {
-        process.stderr.write(`[tool ${event.toolName} ✗ ${event.toolResult}]\n`);
-      }
-      break;
-    case "system_prompt_rebuilt":
-      process.stderr.write(`[soul] ${event.message}\n`);
-      break;
-    case "error":
-      process.stderr.write(`\n[error] ${event.message}\n`);
-      break;
-    default:
-      break;
-  }
 }
 
 /**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,13 @@ import { dirname, resolve as resolvePath } from "node:path";
 // re-call this after config.env loads (inside main()) to handle proxies set
 // in ~/.lisa/config.env.
 import { configureProxyFromEnv } from "./proxy-bootstrap.js";
-configureProxyFromEnv({ log: (m) => console.error(m) });
+import { isVerboseArgv, parseArgs, type ParsedArgs } from "./cli-args.js";
+// The "[proxy] outbound HTTP routed through …" banner is debug detail on a
+// one-shot command, but at `serve` startup it is the one line in serve.log
+// that says which proxy the daemon actually picked up — keep it there.
+const proxyBanner =
+  isVerboseArgv(process.argv.slice(2)) || process.argv.slice(2).includes("serve");
+configureProxyFromEnv({ log: (m) => console.error(m), verbose: proxyBanner });
 import { logInfo } from "./log.js";
 import { runAgent } from "./agent.js";
 import { buildApprovalCallback, DEFAULT_MUTATING_TOOLS, DEFAULT_MUTATING_ACTIONS } from "./approval.js";
@@ -17,7 +23,7 @@ import { ensureDir } from "./fs-utils.js";
 import { runHeartbeatOnce } from "./heartbeat/runner.js";
 import { fireHooks } from "./hooks/runner.js";
 import { DEFAULT_MODEL } from "./llm.js";
-import { parseArgs, type ParsedArgs } from "./cli-args.js";
+import { displayPath } from "./cli/display-path.js";
 import { connectMcpServers } from "./mcp/client.js";
 import { loadMcpConfig } from "./mcp/config.js";
 import { lisaHome } from "./paths.js";
@@ -156,11 +162,11 @@ REPL slash commands:
   /clear                Forget current in-memory history (session log preserved).
   /save <text>          Append to MEMORY.md immediately.
 
-Data: ${lisaHome()}
-Plugins: ${PLUGINS_ROOT}/<name>/{commands,agents,skills,hooks,.lisa-plugin/plugin.json}
-MCP:     ${lisaHome()}/mcp.json   (Claude-Code-style {"mcpServers": {...}})
-Heartbeat: ${lisaHome()}/heartbeat.json   ({"tasks": [{name, prompt, ...}]})
-Config:  ${CONFIG_ENV_PATH}   (KEY=VALUE)`;
+Data: ${displayPath(lisaHome())}
+Plugins: ${displayPath(PLUGINS_ROOT)}/<name>/{commands,agents,skills,hooks,.lisa-plugin/plugin.json}
+MCP:     ${displayPath(lisaHome())}/mcp.json   (Claude-Code-style {"mcpServers": {...}})
+Heartbeat: ${displayPath(lisaHome())}/heartbeat.json   ({"tasks": [{name, prompt, ...}]})
+Config:  ${displayPath(CONFIG_ENV_PATH)}   (KEY=VALUE)`;
 
 function readPackageVersion(): string {
   try {
@@ -205,8 +211,11 @@ async function main(): Promise<void> {
     args.model = resolveDefaultModel();
   }
   // Re-bridge proxy in case HTTPS_PROXY was set in config.env rather than
-  // the shell. configureProxyFromEnv is idempotent.
-  configureProxyFromEnv({ log: (m) => console.error(m) });
+  // the shell. configureProxyFromEnv is idempotent, so this logs at most once.
+  configureProxyFromEnv({
+    log: (m) => console.error(m),
+    verbose: args.verbose || args.subcommand === "serve",
+  });
 
   // ── soul-only subcommands (don't need agent loop) ─────────────────────
   if (args.subcommand === "birth") {
@@ -269,7 +278,7 @@ async function main(): Promise<void> {
           : "configured ✓";
       console.log(`  ${name.padEnd(12)} ${status}`);
     }
-    console.log(`\nConfig: ${CHANNELS_CONFIG_PATH}`);
+    console.log(`\nConfig: ${displayPath(CHANNELS_CONFIG_PATH)}`);
     console.log(`Start: lisa serve --channels <comma-list>  (or --channels all)`);
     return;
   }
@@ -413,8 +422,13 @@ async function main(): Promise<void> {
   const isWebServe = args.subcommand === "serve" && args.serveWeb;
   if (!isWebServe && !hasCredentialsForModel(args.model)) {
     console.error(
-      `Lisa needs an API key for ${args.model}. Set the provider key in your shell or in ${CONFIG_ENV_PATH} ` +
-        `— e.g. ANTHROPIC_API_KEY (https://console.anthropic.com/), OPENAI_API_KEY, or a preset key like ZHIPU_API_KEY for glm-*.`,
+      [
+        `Lisa needs an API key for ${args.model}.`,
+        `Set the provider key in your shell or in ${displayPath(CONFIG_ENV_PATH)}, e.g.`,
+        `  ANTHROPIC_API_KEY=sk-ant-…   (https://console.anthropic.com/)`,
+        `  OPENAI_API_KEY=…             or a preset key like ZHIPU_API_KEY for glm-*`,
+        `Run \`lisa doctor\` to see which providers are configured.`,
+      ].join("\n"),
     );
     process.exit(1);
   }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -348,6 +348,18 @@ async function main(): Promise<void> {
   }
 
   if (args.subcommand === "doctor") {
+    const probe = args.subargs.find((a) => a === "--probe" || a.startsWith("--probe="));
+    if (probe) {
+      const { runProbe } = await import("./cli/probe.js");
+      const inline = probe.startsWith("--probe=") ? probe.slice("--probe=".length) : undefined;
+      // `--probe` on its own means the local daemon; a bare word after it (not
+      // another flag) is the instance to ask instead.
+      const target =
+        inline ?? args.subargs.slice(args.subargs.indexOf(probe) + 1).find((a) => !a.startsWith("-"));
+      const code = await runProbe(target);
+      if (code !== 0) process.exit(code);
+      return;
+    }
     const { runDoctor } = await import("./cli/doctor.js");
     await runDoctor();
     return;

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -365,6 +365,16 @@ async function main(): Promise<void> {
     return;
   }
 
+  if (args.subcommand === "upgrade") {
+    const { runUpgrade } = await import("./cli/upgrade.js");
+    const code = await runUpgrade({
+      check: args.subargs.includes("--check"),
+      dryRun: args.subargs.includes("--dry-run"),
+    });
+    if (code !== 0) process.exit(code);
+    return;
+  }
+
   if (args.subcommand === "monitor") {
     const { runMonitor } = await import("./cli/monitor.js");
     await runMonitor();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,6 +58,11 @@ INSPECTION
                                desires, sessions, providers, heartbeat last-run.
   lisa doctor                  Health check (config, network, git, providers).
                                Exits non-zero on critical issues.
+  lisa doctor --probe [url]    Ask a running backend how it feels: version,
+                               uptime, event-loop lag (p50/p99/max), heap and
+                               tenants. Defaults to http://127.0.0.1:5757; a
+                               bare port or a full URL both work. Warns above
+                               1s of p99 lag, exits non-zero if unreachable.
   lisa monitor                 TUI live dashboard (mood + soul commits + events
                                + heartbeat). Polls every 2s. Ctrl-C to quit.
   lisa soul                    Print full soul summary.
@@ -82,6 +87,12 @@ INSPECTION
                                per-device token via a running serve (localhost).
 
 LIFECYCLE
+  lisa upgrade [--check|--dry-run]
+                               Upgrade this install (Homebrew formula or npm
+                               global), then restart the login agent so the
+                               running daemon picks up the new code. --check
+                               only compares installed vs published; --dry-run
+                               prints the commands without running them.
   lisa birth                   Run the birth ritual (auto-runs on first launch).
   lisa heartbeat run [name]    Run heartbeat tasks once (incl. self-driven desires).
   lisa heartbeat install [--load] [--every <30m|1h|...>]

--- a/src/cli/ansi.test.ts
+++ b/src/cli/ansi.test.ts
@@ -1,0 +1,66 @@
+import { test, describe, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { colorEnabled, makePalette, PLAIN, setColorOverride, visibleLength } from "./ansi.js";
+
+afterEach(() => setColorOverride(null));
+
+describe("colorEnabled", () => {
+  test("a TTY with a normal env gets colour", () => {
+    assert.equal(colorEnabled({ isTTY: true, env: { TERM: "xterm-256color" } }), true);
+  });
+
+  test("a pipe never gets colour", () => {
+    assert.equal(colorEnabled({ isTTY: false, env: {} }), false);
+    assert.equal(colorEnabled({ env: {} }), false);
+  });
+
+  test("NO_COLOR (any non-empty value) wins over a TTY", () => {
+    assert.equal(colorEnabled({ isTTY: true, env: { NO_COLOR: "1" } }), false);
+    assert.equal(colorEnabled({ isTTY: true, env: { NO_COLOR: "0" } }), false);
+    assert.equal(colorEnabled({ isTTY: true, env: { NO_COLOR: "" } }), true);
+  });
+
+  test("TERM=dumb disables colour", () => {
+    assert.equal(colorEnabled({ isTTY: true, env: { TERM: "dumb" } }), false);
+  });
+
+  test("--no-color beats everything, including the override", () => {
+    setColorOverride(true);
+    assert.equal(colorEnabled({ isTTY: false, env: {}, noColorFlag: true }), false);
+  });
+
+  test("the process-wide override decides when set", () => {
+    setColorOverride(false);
+    assert.equal(colorEnabled({ isTTY: true, env: {} }), false);
+    setColorOverride(true);
+    assert.equal(colorEnabled({ isTTY: false, env: { NO_COLOR: "1" } }), true);
+    setColorOverride(null);
+    assert.equal(colorEnabled({ isTTY: true, env: {} }), true);
+  });
+});
+
+describe("makePalette", () => {
+  test("enabled wraps in SGR pairs", () => {
+    const p = makePalette(true);
+    assert.equal(p.red("x"), "\x1b[31mx\x1b[39m");
+    assert.equal(p.dim("x"), "\x1b[2mx\x1b[22m");
+    assert.equal(p.enabled, true);
+  });
+
+  test("disabled is the identity, and PLAIN is that palette", () => {
+    const p = makePalette(false);
+    for (const f of [p.red, p.dim, p.bold, p.green, p.yellow, p.cyan, p.grey]) {
+      assert.equal(f("x"), "x");
+    }
+    assert.equal(PLAIN.enabled, false);
+    assert.equal(PLAIN.green("x"), "x");
+  });
+});
+
+describe("visibleLength", () => {
+  test("ignores escape sequences", () => {
+    const p = makePalette(true);
+    assert.equal(visibleLength(p.green("done")), 4);
+    assert.equal(visibleLength("plain"), 5);
+  });
+});

--- a/src/cli/ansi.ts
+++ b/src/cli/ansi.ts
@@ -1,0 +1,69 @@
+/**
+ * ANSI colour for CLI output — hand-rolled, because the project policy is "no
+ * chalk-class dependencies" for a handful of escape codes.
+ *
+ * One decision function, `colorEnabled()`, is the single source of truth for
+ * "may this stream carry colour?": `--no-color` beats everything, then the
+ * NO_COLOR convention (https://no-color.org: any non-empty value disables),
+ * then TERM=dumb, and finally the stream has to be an interactive terminal —
+ * piped or redirected output is always plain so `lisa … | grep` and log files
+ * never see escape codes. stdout and stderr are decided separately: a user
+ * running `lisa "…" > answer.md` still gets a coloured tool trace on the
+ * terminal while the file stays clean.
+ */
+
+export interface Palette {
+  readonly enabled: boolean;
+  dim(s: string): string;
+  bold(s: string): string;
+  red(s: string): string;
+  green(s: string): string;
+  yellow(s: string): string;
+  cyan(s: string): string;
+  grey(s: string): string;
+}
+
+/** Process-wide override set by `--no-color`; null means "decide per stream". */
+let override: boolean | null = null;
+
+export function setColorOverride(value: boolean | null): void {
+  override = value;
+}
+
+export function colorEnabled(
+  opts: { isTTY?: boolean; env?: NodeJS.ProcessEnv; noColorFlag?: boolean } = {},
+): boolean {
+  if (opts.noColorFlag) return false;
+  if (override !== null) return override;
+  const env = opts.env ?? process.env;
+  if (env.NO_COLOR != null && env.NO_COLOR !== "") return false;
+  if (env.TERM === "dumb") return false;
+  return opts.isTTY === true;
+}
+
+function wrap(enabled: boolean, open: number, close: number): (s: string) => string {
+  if (!enabled) return (s) => s;
+  return (s) => `\x1b[${open}m${s}\x1b[${close}m`;
+}
+
+export function makePalette(enabled: boolean): Palette {
+  return {
+    enabled,
+    dim: wrap(enabled, 2, 22),
+    bold: wrap(enabled, 1, 22),
+    red: wrap(enabled, 31, 39),
+    green: wrap(enabled, 32, 39),
+    yellow: wrap(enabled, 33, 39),
+    cyan: wrap(enabled, 36, 39),
+    grey: wrap(enabled, 90, 39),
+  };
+}
+
+/** The identity palette — handy for tests and for streams decided as plain. */
+export const PLAIN: Palette = makePalette(false);
+
+/** Length of a string as the terminal shows it (escape sequences excluded). */
+export function visibleLength(s: string): number {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;]*[A-Za-z]/g, "").length;
+}

--- a/src/cli/colors.ts
+++ b/src/cli/colors.ts
@@ -1,17 +1,15 @@
 /**
- * Tiny zero-dep ANSI color helpers.
+ * Tiny zero-dep ANSI color helpers for stdout-bound reports (doctor, status,
+ * monitor).
  *
- * Project policy is "no chalk-class CLI deps" so this module rolls its own.
- * Every function checks if stdout is a TTY and respects NO_COLOR env;
- * non-TTY / piped / NO_COLOR=1 output is plain text.
+ * The decision of whether colour is allowed lives in ./ansi.ts (one place for
+ * --no-color / NO_COLOR / TERM=dumb / TTY); this module is the convenience
+ * layer that binds it to process.stdout and adds the ✓ ✗ ⚠ badges and rules.
  */
-
-const NO_COLOR =
-  process.env.NO_COLOR != null && process.env.NO_COLOR !== "" && process.env.NO_COLOR !== "0";
+import { colorEnabled } from "./ansi.js";
 
 function supportsColor(): boolean {
-  if (NO_COLOR) return false;
-  return process.stdout.isTTY === true;
+  return colorEnabled({ isTTY: process.stdout.isTTY === true });
 }
 
 function wrap(open: number, close: number) {

--- a/src/cli/display-path.test.ts
+++ b/src/cli/display-path.test.ts
@@ -1,0 +1,33 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import { displayPath } from "./display-path.js";
+
+describe("displayPath", () => {
+  const home = "/Users/alice";
+
+  test("collapses a child of $HOME to ~/…", () => {
+    assert.equal(displayPath("/Users/alice/.lisa/config.env", home), "~/.lisa/config.env");
+  });
+
+  test("$HOME itself becomes ~", () => {
+    assert.equal(displayPath("/Users/alice", home), "~");
+  });
+
+  test("a sibling that merely shares the prefix is left alone", () => {
+    assert.equal(displayPath("/Users/alicefoo/.lisa", home), "/Users/alicefoo/.lisa");
+  });
+
+  test("paths outside $HOME are unchanged", () => {
+    assert.equal(displayPath("/opt/homebrew/bin/lisa", home), "/opt/homebrew/bin/lisa");
+  });
+
+  test("tolerates a trailing separator on $HOME", () => {
+    assert.equal(displayPath("/Users/alice/.lisa", "/Users/alice/"), "~/.lisa");
+  });
+
+  test("empty input and empty home are passthrough", () => {
+    assert.equal(displayPath("", home), "");
+    assert.equal(displayPath("/x/y", ""), "/x/y");
+    assert.equal(displayPath("/x/y", "/"), "/x/y");
+  });
+});

--- a/src/cli/display-path.ts
+++ b/src/cli/display-path.ts
@@ -1,0 +1,25 @@
+/**
+ * Render a filesystem path the way a person reads it: `$HOME` collapsed to `~`.
+ *
+ * CLI messages used to print absolute paths in full — a missing-key error was
+ * one 200-character line dominated by `/Users/<name>/.lisa/config.env`. The
+ * abbreviation is display-only; anything that opens, writes or execs a path
+ * keeps using the absolute form.
+ */
+import os from "node:os";
+
+export function displayPath(p: string, home: string = os.homedir()): string {
+  if (!p || !home) return p;
+  // Tolerate a trailing separator on the home dir (`HOME=/Users/x/`) so the
+  // prefix test below never produces `~//.lisa`.
+  const root = home.replace(/[\\/]+$/, "");
+  if (!root) return p;
+  if (p === root) return "~";
+  // Only a real child path collapses — `/Users/oratisfoo` must not become
+  // `~foo`, so the character after the home prefix has to be a separator.
+  if (p.startsWith(root)) {
+    const next = p.charAt(root.length);
+    if (next === "/" || next === "\\") return "~" + p.slice(root.length);
+  }
+  return p;
+}

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -26,6 +26,7 @@ import {
 } from "./colors.js";
 import { lisaHome } from "../paths.js";
 import { CONFIG_ENV_PATH } from "../env.js";
+import { displayPath } from "./display-path.js";
 import { soulDir } from "../soul/paths.js";
 import { listConfiguredProviders, OPENAI_COMPAT_PRESETS } from "../providers/registry.js";
 import { isBorn } from "../soul/store.js";
@@ -61,20 +62,20 @@ const checks: Check[] = [
     },
   },
   {
-    label: "~/.lisa/ exists",
+    label: `${displayPath(lisaHome())}/ exists`,
     critical: false,
     run: async () => {
       return (await pathExists(lisaHome()))
-        ? { ok: true, detail: lisaHome() }
-        : { ok: false, detail: `${lisaHome()} not yet created (will be on first run)` };
+        ? { ok: true, detail: displayPath(lisaHome()) }
+        : { ok: false, detail: `${displayPath(lisaHome())} not yet created (will be on first run)` };
     },
   },
   {
-    label: "~/.lisa/config.env exists",
+    label: `${displayPath(CONFIG_ENV_PATH)} exists`,
     critical: false,
     run: async () => {
       return (await pathExists(CONFIG_ENV_PATH))
-        ? { ok: true, detail: CONFIG_ENV_PATH }
+        ? { ok: true, detail: displayPath(CONFIG_ENV_PATH) }
         : { ok: false, detail: `not found — keys must be in shell env` };
     },
   },
@@ -93,7 +94,7 @@ const checks: Check[] = [
     run: async () => {
       const dotGit = path.join(soulDir(), ".git");
       return (await pathExists(dotGit))
-        ? { ok: true, detail: dotGit }
+        ? { ok: true, detail: displayPath(dotGit) }
         : { ok: false, detail: "init pending; will run automatically on next start" };
     },
   },
@@ -143,7 +144,7 @@ export async function runDoctor(): Promise<void> {
   console.log(heading("Environment"));
   console.log(`  ${dim("platform:")}  ${process.platform} ${os.release()}`);
   console.log(`  ${dim("node:")}      ${process.versions.node}`);
-  console.log(`  ${dim("lisaHome():")} ${lisaHome()}`);
+  console.log(`  ${dim("lisaHome():")} ${displayPath(lisaHome())}`);
   if (process.env.HTTPS_PROXY || process.env.HTTP_PROXY) {
     console.log(`  ${dim("proxy:")}     ${process.env.HTTPS_PROXY ?? process.env.HTTP_PROXY}`);
   } else {

--- a/src/cli/history.test.ts
+++ b/src/cli/history.test.ts
@@ -1,0 +1,76 @@
+import { test, describe, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { HISTORY_LIMIT, loadHistory, normalizeHistory, saveHistory } from "./history.js";
+
+const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-history-"));
+after(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+describe("normalizeHistory", () => {
+  test("drops blanks and consecutive duplicates, keeps distant repeats", () => {
+    assert.deepEqual(normalizeHistory(["a", "", "  ", "a", "b", "a"]), ["a", "b", "a"]);
+  });
+
+  test("keeps the newest entries when over the cap", () => {
+    const many = Array.from({ length: 10 }, (_, i) => `q${i}`);
+    assert.deepEqual(normalizeHistory(many, 3), ["q7", "q8", "q9"]);
+  });
+
+  test("strips a trailing CR so a file written on Windows round-trips", () => {
+    assert.deepEqual(normalizeHistory(["a\r", "a"]), ["a"]);
+  });
+
+  test("the default cap is 1000", () => {
+    assert.equal(HISTORY_LIMIT, 1000);
+    const many = Array.from({ length: 1200 }, (_, i) => `q${i}`);
+    const out = normalizeHistory(many);
+    assert.equal(out.length, 1000);
+    assert.equal(out[0], "q200");
+  });
+});
+
+describe("loadHistory / saveHistory", () => {
+  test("round-trips oldest-first and creates the file 0600", async () => {
+    const file = path.join(tmp, "nested", "history");
+    await saveHistory(["one", "two", "two", "", "three"], file);
+    assert.deepEqual(await loadHistory(file), ["one", "two", "three"]);
+    // Prompts routinely contain pasted secrets: owner-only, always.
+    const mode = (await fs.stat(file)).mode & 0o777;
+    assert.equal(mode, 0o600, `expected 0600, got ${mode.toString(8)}`);
+  });
+
+  test("a missing file is an empty history, not an error", async () => {
+    assert.deepEqual(await loadHistory(path.join(tmp, "nope", "history")), []);
+  });
+
+  test("saving replaces the file rather than appending", async () => {
+    const file = path.join(tmp, "replace");
+    await saveHistory(["a", "b"], file);
+    await saveHistory(["c"], file);
+    assert.deepEqual(await loadHistory(file), ["c"]);
+    // …and leaves no temp file behind.
+    const left = (await fs.readdir(tmp)).filter((n) => n.startsWith("replace."));
+    assert.deepEqual(left, []);
+  });
+
+  test("an empty history writes an empty file", async () => {
+    const file = path.join(tmp, "empty");
+    await saveHistory(["", "   "], file);
+    assert.equal(await fs.readFile(file, "utf8"), "");
+    assert.deepEqual(await loadHistory(file), []);
+  });
+
+  test("the cap is enforced on write", async () => {
+    const file = path.join(tmp, "capped");
+    await saveHistory(
+      Array.from({ length: 50 }, (_, i) => `q${i}`),
+      file,
+      5,
+    );
+    assert.deepEqual(await loadHistory(file), ["q45", "q46", "q47", "q48", "q49"]);
+  });
+});

--- a/src/cli/history.ts
+++ b/src/cli/history.ts
@@ -1,0 +1,59 @@
+/**
+ * Persistent REPL history — `~/.lisa/history`.
+ *
+ * readline keeps history in memory only, so every new `lisa` session started
+ * from a blank slate. The file is stored oldest-first (append-friendly, easy to
+ * read), one entry per line; readline wants newest-first, so the caller
+ * reverses at the boundary. Prompts routinely contain pasted secrets and
+ * personal context, hence 0600 and a per-file cap rather than unbounded growth.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { lisaHome } from "../paths.js";
+
+export const HISTORY_LIMIT = 1000;
+
+export function historyPath(): string {
+  return path.join(lisaHome(), "history");
+}
+
+/**
+ * Blank lines dropped, consecutive duplicates collapsed (hitting ↑ and Enter
+ * twice must not fill the file with copies), capped to the newest `limit`
+ * entries. Input and output are oldest-first.
+ */
+export function normalizeHistory(lines: readonly string[], limit = HISTORY_LIMIT): string[] {
+  const out: string[] = [];
+  for (const raw of lines) {
+    const line = raw.replace(/\r$/, "");
+    if (!line.trim()) continue;
+    if (out.length > 0 && out[out.length - 1] === line) continue;
+    out.push(line);
+  }
+  return out.length > limit ? out.slice(out.length - limit) : out;
+}
+
+/** Oldest-first. A missing or unreadable file is an empty history, never an error. */
+export async function loadHistory(file = historyPath(), limit = HISTORY_LIMIT): Promise<string[]> {
+  try {
+    const raw = await fs.readFile(file, "utf8");
+    return normalizeHistory(raw.split("\n"), limit);
+  } catch {
+    return [];
+  }
+}
+
+/** Takes oldest-first lines. Atomic rename so a crash mid-write never truncates the file. */
+export async function saveHistory(
+  lines: readonly string[],
+  file = historyPath(),
+  limit = HISTORY_LIMIT,
+): Promise<void> {
+  const body = normalizeHistory(lines, limit);
+  await fs.mkdir(path.dirname(file), { recursive: true });
+  const tmp = `${file}.${process.pid}.tmp`;
+  // mode applies at creation, and the temp file is always new — so there is no
+  // window in which the history is world-readable.
+  await fs.writeFile(tmp, body.length > 0 ? body.join("\n") + "\n" : "", { mode: 0o600 });
+  await fs.rename(tmp, file);
+}

--- a/src/cli/probe.test.ts
+++ b/src/cli/probe.test.ts
@@ -1,0 +1,222 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import {
+  collectWarnings,
+  DEFAULT_PROBE_URL,
+  formatProbe,
+  formatUptime,
+  normalizeProbeUrl,
+  probeHealth,
+  runProbe,
+  type HealthPayload,
+} from "./probe.js";
+
+/**
+ * A throwaway server on port 0. `routes` maps a path to the response; anything
+ * else 404s, which is how the /health → /healthz fallback gets exercised.
+ */
+async function withServer(
+  routes: Record<string, { status?: number; body: string }>,
+  fn: (base: string) => Promise<void>,
+): Promise<void> {
+  const server = http.createServer((req, res) => {
+    const hit = routes[req.url ?? ""];
+    if (!hit) {
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end('{"error":"not found"}');
+      return;
+    }
+    res.writeHead(hit.status ?? 200, { "content-type": "application/json" });
+    res.end(hit.body);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as AddressInfo).port;
+  try {
+    await fn(`http://127.0.0.1:${port}`);
+  } finally {
+    // Close every socket too, or node:test sees a live handle after the test.
+    server.closeAllConnections();
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+const RICH: HealthPayload = {
+  ok: true,
+  version: "0.25.0",
+  uptime_s: 511_200,
+  event_loop_lag_ms: { p50: 1.2, p99: 38, max: 240 },
+  heap_used_mb: 184,
+  rss_mb: 402,
+  tenants: 3,
+  pending_turns: 0,
+  sessions: 12,
+  edition: "local",
+};
+
+describe("normalizeProbeUrl", () => {
+  test("defaults to the local daemon", () => {
+    assert.equal(normalizeProbeUrl(), DEFAULT_PROBE_URL);
+    assert.equal(normalizeProbeUrl(""), DEFAULT_PROBE_URL);
+    assert.equal(normalizeProbeUrl("   "), DEFAULT_PROBE_URL);
+  });
+
+  test("accepts a bare port, a bare host, and a full origin", () => {
+    assert.equal(normalizeProbeUrl("8080"), "http://127.0.0.1:8080");
+    assert.equal(normalizeProbeUrl("localhost:5757"), "http://localhost:5757");
+    assert.equal(normalizeProbeUrl("https://lisa.example.com/"), "https://lisa.example.com");
+  });
+
+  test("a pasted health URL means the instance, not a sub-path", () => {
+    assert.equal(normalizeProbeUrl("http://127.0.0.1:5757/health"), "http://127.0.0.1:5757");
+    assert.equal(normalizeProbeUrl("http://127.0.0.1:5757/healthz"), "http://127.0.0.1:5757");
+  });
+});
+
+describe("probeHealth", () => {
+  test("reads the extended payload from /health", async () => {
+    await withServer({ "/health": { body: JSON.stringify(RICH) } }, async (base) => {
+      const r = await probeHealth(base);
+      assert.equal(r.reachable, true);
+      assert.equal(r.endpoint, "/health");
+      assert.equal(r.status, 200);
+      assert.equal(r.payload?.version, "0.25.0");
+      assert.ok(r.latencyMs >= 0);
+      assert.deepEqual(r.warnings, []);
+    });
+  });
+
+  test("an old server answering {ok:true} is healthy, just quiet", async () => {
+    await withServer({ "/health": { body: '{"ok":true}' } }, async (base) => {
+      const r = await probeHealth(base);
+      assert.equal(r.reachable, true);
+      assert.equal(r.payload?.version, undefined);
+      const text = formatProbe(r).join("\n");
+      assert.match(text, /no telemetry/);
+    });
+  });
+
+  test("falls back to /healthz when /health is not routed", async () => {
+    await withServer({ "/healthz": { body: '{"ok":true}' } }, async (base) => {
+      const r = await probeHealth(base);
+      assert.equal(r.reachable, true);
+      assert.equal(r.endpoint, "/healthz");
+    });
+  });
+
+  test("a 503 is reachable-but-unhealthy, and fails", async () => {
+    await withServer(
+      { "/health": { status: 503, body: '{"ok":false}' }, "/healthz": { status: 503, body: '{"ok":false}' } },
+      async (base) => {
+        const r = await probeHealth(base);
+        assert.equal(r.reachable, false);
+        assert.equal(r.error, "HTTP 503");
+      },
+    );
+  });
+
+  test("a 200 with a non-JSON body still counts as alive", async () => {
+    await withServer({ "/health": { body: "OK" } }, async (base) => {
+      const r = await probeHealth(base);
+      assert.equal(r.reachable, true);
+      assert.equal(r.payload, undefined);
+    });
+  });
+
+  test("nothing listening is unreachable, with the reason", async () => {
+    // Bind then immediately release the port so the connection is refused.
+    const server = http.createServer();
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+    const r = await probeHealth(`http://127.0.0.1:${port}`, { timeoutMs: 1000 });
+    assert.equal(r.reachable, false);
+    assert.ok((r.error ?? "").length > 0);
+    assert.match(formatProbe(r).join("\n"), /unreachable/);
+  });
+});
+
+describe("warnings", () => {
+  test("p99 lag over a second is flagged", () => {
+    const w = collectWarnings({ event_loop_lag_ms: { p50: 2, p99: 1400 } }, 5);
+    assert.equal(w.length, 1);
+    assert.match(w[0]!, /p99 1400ms > 1000ms/);
+  });
+
+  test("a p99 under the threshold, or absent telemetry, is silent", () => {
+    assert.deepEqual(collectWarnings({ event_loop_lag_ms: { p99: 999 } }, 5), []);
+    assert.deepEqual(collectWarnings({ ok: true }, 5), []);
+    assert.deepEqual(collectWarnings(null, 5), []);
+  });
+
+  test("a slow /health is itself a warning", () => {
+    const w = collectWarnings({ ok: true }, 4200);
+    assert.equal(w.length, 1);
+    assert.match(w[0]!, /took 4200ms/);
+  });
+
+  test("a lagging server prints the warning glyph and still exits 0", async () => {
+    const laggy = { ...RICH, event_loop_lag_ms: { p50: 4, p99: 2300, max: 9000 } };
+    await withServer({ "/health": { body: JSON.stringify(laggy) } }, async (base) => {
+      const lines: string[] = [];
+      const code = await runProbe(base, { log: (l) => lines.push(l) });
+      assert.equal(code, 0);
+      const text = lines.join("\n");
+      assert.match(text, /⚠/);
+      assert.match(text, /p99 2300ms/);
+    });
+  });
+});
+
+describe("formatProbe", () => {
+  test("prints every field the server reported", () => {
+    const text = formatProbe({
+      url: "http://127.0.0.1:5757",
+      endpoint: "/health",
+      reachable: true,
+      status: 200,
+      latencyMs: 3,
+      payload: RICH,
+      warnings: [],
+    }).join("\n");
+    assert.match(text, /version:\s+0\.25\.0/);
+    assert.match(text, /uptime:\s+5d 22h/);
+    assert.match(text, /p50 1\.2ms {2}p99 38ms {2}max 240ms/);
+    assert.match(text, /heap used:\s+184 MB {2}\(rss 402 MB\)/);
+    assert.match(text, /tenants:\s+3/);
+    assert.match(text, /sessions:\s+12/);
+    assert.match(text, /pending turns:\s+0/);
+    assert.match(text, /edition:\s+local/);
+  });
+});
+
+describe("runProbe exit codes", () => {
+  test("healthy is 0", async () => {
+    await withServer({ "/health": { body: JSON.stringify(RICH) } }, async (base) => {
+      const lines: string[] = [];
+      assert.equal(await runProbe(base, { log: (l) => lines.push(l) }), 0);
+      assert.match(lines.join("\n"), /backend healthy/);
+    });
+  });
+
+  test("unreachable is 1 — so `lisa doctor --probe || …` can restart it", async () => {
+    const lines: string[] = [];
+    const code = await runProbe("http://127.0.0.1:1", {
+      timeoutMs: 1000,
+      log: (l) => lines.push(l),
+    });
+    assert.equal(code, 1);
+    assert.match(lines.join("\n"), /not answering/);
+  });
+});
+
+describe("formatUptime", () => {
+  test("picks the two units that matter", () => {
+    assert.equal(formatUptime(45), "45s");
+    assert.equal(formatUptime(605), "10m 05s");
+    assert.equal(formatUptime(11_220), "3h 07m");
+    assert.equal(formatUptime(511_200), "5d 22h");
+    assert.equal(formatUptime(-1), "0s");
+  });
+});

--- a/src/cli/probe.test.ts
+++ b/src/cli/probe.test.ts
@@ -124,6 +124,22 @@ describe("probeHealth", () => {
     });
   });
 
+  test("a server that never answers times out instead of hanging", async () => {
+    // Accept the connection and say nothing — the "wedged event loop" case the
+    // probe exists for.
+    const server = http.createServer(() => {});
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const port = (server.address() as AddressInfo).port;
+    try {
+      const r = await probeHealth(`http://127.0.0.1:${port}`, { timeoutMs: 150 });
+      assert.equal(r.reachable, false);
+      assert.match(r.error ?? "", /timed out after 150ms/);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
   test("nothing listening is unreachable, with the reason", async () => {
     // Bind then immediately release the port so the connection is refused.
     const server = http.createServer();

--- a/src/cli/probe.ts
+++ b/src/cli/probe.ts
@@ -1,0 +1,251 @@
+/**
+ * `lisa doctor --probe [url]` — ask a running backend how it feels.
+ *
+ * The review found the daily-driver instance stalling for 5+ seconds at a time
+ * with nothing to show for it: launchd's KeepAlive only restarts a process that
+ * *exited*, and `/health` answered `{ok:true}`, which a wedged event loop will
+ * happily keep saying. So the server side now reports version, uptime, event
+ * loop lag percentiles, heap and tenant counts, and this is the client that
+ * reads them.
+ *
+ * Two compatibility rules, because a probe that only works against the newest
+ * build is useless for diagnosing an old one:
+ *   - every telemetry field is optional and printed only when present;
+ *   - `/health` is tried first, `/healthz` second, since which of the two a
+ *     deployment exposes has changed over time.
+ */
+import { dim, fail, grey, heading, ok, rule, warn } from "./colors.js";
+
+/** The extended `/health` body. Everything but `ok` may be missing on an older server. */
+export interface HealthPayload {
+  ok?: boolean;
+  version?: string;
+  uptime_s?: number;
+  event_loop_lag_ms?: { p50?: number; p99?: number; max?: number };
+  heap_used_mb?: number;
+  rss_mb?: number;
+  tenants?: number;
+  pending_turns?: number;
+  sessions?: number;
+  edition?: string;
+}
+
+export interface ProbeResult {
+  /** The base that was probed, after normalization. */
+  url: string;
+  /** The path that answered (`/health` or `/healthz`), when one did. */
+  endpoint?: string;
+  reachable: boolean;
+  status?: number;
+  latencyMs: number;
+  payload?: HealthPayload;
+  error?: string;
+  /** Human-readable concerns that do not by themselves mean "down". */
+  warnings: string[];
+}
+
+export const DEFAULT_PROBE_URL = "http://127.0.0.1:5757";
+/** Lag above this is the "5 seconds of nothing" symptom in the making. */
+export const LAG_P99_WARN_MS = 1000;
+const ENDPOINTS = ["/health", "/healthz"] as const;
+
+/**
+ * Accepts what people actually type: nothing, a bare port, `localhost:5757`,
+ * a full origin, or the health URL itself pasted back in.
+ */
+export function normalizeProbeUrl(input?: string | null): string {
+  const raw = (input ?? "").trim();
+  if (!raw) return DEFAULT_PROBE_URL;
+  if (/^\d{2,5}$/.test(raw)) return `http://127.0.0.1:${raw}`;
+  const withScheme = /^[a-z][a-z0-9+.-]*:\/\//i.test(raw) ? raw : `http://${raw}`;
+  let u: URL;
+  try {
+    u = new URL(withScheme);
+  } catch {
+    return withScheme.replace(/\/+$/, "");
+  }
+  // A pasted `…/health` is the same instance, not a sub-path to probe under.
+  if (u.pathname === "/health" || u.pathname === "/healthz") u.pathname = "/";
+  const path = u.pathname.replace(/\/+$/, "");
+  return `${u.origin}${path}`;
+}
+
+export interface ProbeOptions {
+  timeoutMs?: number;
+  /** Injectable for tests that need a failure without a socket. */
+  fetchImpl?: typeof fetch;
+  now?: () => number;
+}
+
+export async function probeHealth(
+  baseUrl: string,
+  opts: ProbeOptions = {},
+): Promise<ProbeResult> {
+  const url = normalizeProbeUrl(baseUrl);
+  const doFetch = opts.fetchImpl ?? fetch;
+  const now = opts.now ?? (() => Date.now());
+  const timeoutMs = opts.timeoutMs ?? 5000;
+  const started = now();
+  let lastError = "";
+  let lastStatus: number | undefined;
+
+  for (const endpoint of ENDPOINTS) {
+    try {
+      const res = await doFetch(`${url}${endpoint}`, {
+        method: "GET",
+        headers: { accept: "application/json" },
+        signal: AbortSignal.timeout(timeoutMs),
+      });
+      lastStatus = res.status;
+      // 404 on /health is the signal to try /healthz; any other status is the
+      // instance's real answer and we report it as such.
+      if (res.status === 404 && endpoint !== ENDPOINTS[ENDPOINTS.length - 1]) continue;
+      const payload = await readJson(res);
+      const latencyMs = now() - started;
+      const reachable = res.ok && payload?.ok !== false;
+      return {
+        url,
+        endpoint,
+        reachable,
+        status: res.status,
+        latencyMs,
+        payload: payload ?? undefined,
+        error: reachable ? undefined : `HTTP ${res.status}`,
+        warnings: reachable ? collectWarnings(payload, latencyMs) : [],
+      };
+    } catch (err) {
+      lastError = (err as Error).message || String(err);
+    }
+  }
+
+  return {
+    url,
+    reachable: false,
+    status: lastStatus,
+    latencyMs: now() - started,
+    error: lastError || (lastStatus ? `HTTP ${lastStatus}` : "unreachable"),
+    warnings: [],
+  };
+}
+
+async function readJson(res: Response): Promise<HealthPayload | null> {
+  try {
+    const text = await res.text();
+    const parsed: unknown = JSON.parse(text);
+    return parsed && typeof parsed === "object" ? (parsed as HealthPayload) : null;
+  } catch {
+    // A 200 with a non-JSON body still proves the socket is alive; treat the
+    // telemetry as simply absent.
+    return null;
+  }
+}
+
+export function collectWarnings(
+  payload: HealthPayload | null | undefined,
+  latencyMs: number,
+): string[] {
+  const out: string[] = [];
+  const p99 = payload?.event_loop_lag_ms?.p99;
+  if (typeof p99 === "number" && p99 > LAG_P99_WARN_MS) {
+    out.push(
+      `event loop lag p99 ${fmtMs(p99)} > ${LAG_P99_WARN_MS}ms — requests will stall`,
+    );
+  }
+  if (latencyMs > LAG_P99_WARN_MS) {
+    out.push(`/health itself took ${fmtMs(latencyMs)} to answer`);
+  }
+  return out;
+}
+
+/** `5d 22h`, `3h 07m`, `48s` — uptime the way `lisa status` would say it. */
+export function formatUptime(seconds: number): string {
+  const s = Math.max(0, Math.floor(seconds));
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${String(h).padStart(2, "0")}h`;
+  if (h > 0) return `${h}h ${String(m).padStart(2, "0")}m`;
+  if (m > 0) return `${m}m ${String(s % 60).padStart(2, "0")}s`;
+  return `${s}s`;
+}
+
+function fmtMs(ms: number): string {
+  return ms >= 100 ? `${Math.round(ms)}ms` : `${Number(ms.toFixed(1))}ms`;
+}
+
+/** The probe report, as lines. Split out from printing so tests can read it. */
+export function formatProbe(r: ProbeResult): string[] {
+  const lines: string[] = [];
+  lines.push(heading(`Probe ${r.url}`));
+  if (!r.reachable) {
+    lines.push(`  ${fail("unreachable")}${grey(`  ${r.error ?? "no response"}`)}`);
+    lines.push(
+      `  ${dim("is the backend running? try `lisa serve --web` or `lisa autostart status`")}`,
+    );
+    return lines;
+  }
+
+  const p = r.payload ?? {};
+  lines.push(
+    `  ${ok(`${r.endpoint} ${r.status}`)}${grey(`  ${fmtMs(r.latencyMs)} round-trip`)}`,
+  );
+  const rows: [string, string][] = [];
+  if (p.version) rows.push(["version", p.version]);
+  if (p.edition) rows.push(["edition", p.edition]);
+  if (typeof p.uptime_s === "number") rows.push(["uptime", formatUptime(p.uptime_s)]);
+  const lag = p.event_loop_lag_ms;
+  if (lag && (lag.p50 != null || lag.p99 != null || lag.max != null)) {
+    const parts: string[] = [];
+    if (lag.p50 != null) parts.push(`p50 ${fmtMs(lag.p50)}`);
+    if (lag.p99 != null) parts.push(`p99 ${fmtMs(lag.p99)}`);
+    if (lag.max != null) parts.push(`max ${fmtMs(lag.max)}`);
+    rows.push(["event loop lag", parts.join("  ")]);
+  }
+  if (typeof p.heap_used_mb === "number") {
+    const rss = typeof p.rss_mb === "number" ? `  (rss ${p.rss_mb} MB)` : "";
+    rows.push(["heap used", `${p.heap_used_mb} MB${rss}`]);
+  } else if (typeof p.rss_mb === "number") {
+    rows.push(["rss", `${p.rss_mb} MB`]);
+  }
+  if (typeof p.tenants === "number") rows.push(["tenants", String(p.tenants)]);
+  if (typeof p.sessions === "number") rows.push(["sessions", String(p.sessions)]);
+  if (typeof p.pending_turns === "number") rows.push(["pending turns", String(p.pending_turns)]);
+
+  if (rows.length === 0) {
+    lines.push(
+      `  ${dim("no telemetry — this server answers {ok:true} only (pre-0.25 /health)")}`,
+    );
+  } else {
+    const width = Math.max(...rows.map(([k]) => k.length));
+    for (const [k, v] of rows) lines.push(`  ${dim((k + ":").padEnd(width + 2))} ${v}`);
+  }
+  for (const w of r.warnings) lines.push(`  ${warn(w)}`);
+  return lines;
+}
+
+/**
+ * Run the probe and report. Returns the process exit code: 0 when the instance
+ * answered, 1 when it did not — so `lisa doctor --probe || restart` works as a
+ * watchdog line in a script or a launchd wrapper.
+ */
+export async function runProbe(
+  target?: string,
+  opts: ProbeOptions & { log?: (line: string) => void } = {},
+): Promise<number> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+  log(rule("LISA PROBE"));
+  const result = await probeHealth(normalizeProbeUrl(target), opts);
+  for (const line of formatProbe(result)) log(line);
+  log("");
+  log(rule());
+  if (!result.reachable) {
+    log(fail(`${result.url} is not answering — Lisa's backend is down or wedged`));
+    return 1;
+  }
+  if (result.warnings.length > 0) {
+    log(warn(`${result.warnings.length} warning(s) — the instance is up but degraded`));
+    return 0;
+  }
+  log(ok("backend healthy"));
+  return 0;
+}

--- a/src/cli/probe.ts
+++ b/src/cli/probe.ts
@@ -90,11 +90,20 @@ export async function probeHealth(
   let lastStatus: number | undefined;
 
   for (const endpoint of ENDPOINTS) {
+    // An own controller rather than AbortSignal.timeout(), so the timer is
+    // cleared the moment the request settles instead of lingering for the full
+    // timeout — Node 22's test runner counts anything still pending as a leak.
+    const ac = new AbortController();
+    const timer = setTimeout(
+      () => ac.abort(new Error(`timed out after ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+    timer.unref?.();
     try {
       const res = await doFetch(`${url}${endpoint}`, {
         method: "GET",
         headers: { accept: "application/json" },
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: ac.signal,
       });
       lastStatus = res.status;
       // 404 on /health is the signal to try /healthz; any other status is the
@@ -115,6 +124,8 @@ export async function probeHealth(
       };
     } catch (err) {
       lastError = (err as Error).message || String(err);
+    } finally {
+      clearTimeout(timer);
     }
   }
 

--- a/src/cli/render.test.ts
+++ b/src/cli/render.test.ts
@@ -1,0 +1,208 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createEventRenderer,
+  formatDuration,
+  summarizeToolInput,
+  type RendererOptions,
+} from "./render.js";
+import type { AgentEvent } from "../types.js";
+
+/** A writer that just accumulates — the "non-TTY" case the tests care about. */
+function sink(): { text: () => string; write(chunk: string): void } {
+  const chunks: string[] = [];
+  return { write: (c: string) => void chunks.push(c), text: () => chunks.join("") };
+}
+
+function harness(opts: Partial<RendererOptions> = {}) {
+  const stdout = sink();
+  const stderr = sink();
+  // A clock the test advances by hand, and timers that never touch the event
+  // loop, so a leaked interval can't outlive the test on CI.
+  let clock = 0;
+  const intervals: (() => void)[] = [];
+  const r = createEventRenderer({
+    stdout,
+    stderr,
+    now: () => clock,
+    timers: {
+      setInterval: (fn) => {
+        intervals.push(fn);
+        return intervals.length - 1;
+      },
+      clearInterval: () => {},
+    },
+    ...opts,
+  });
+  return {
+    r,
+    stdout,
+    stderr,
+    intervals,
+    advance: (ms: number) => {
+      clock += ms;
+    },
+    send: (e: AgentEvent) => r.onEvent(e),
+  };
+}
+
+describe("createEventRenderer — piped (non-TTY) output", () => {
+  test("stdout carries Lisa's text and nothing else", () => {
+    const h = harness();
+    h.r.beginTurn();
+    h.send({ type: "text_delta", text: "hello " });
+    h.send({ type: "tool_call_start", toolName: "bash", toolInput: { command: "npm test" } });
+    h.send({ type: "tool_call_end", toolName: "bash", toolResult: "ok" });
+    h.send({ type: "text_delta", text: "world" });
+    h.r.endTurn();
+    assert.equal(h.stdout.text(), "hello world\n");
+  });
+
+  test("a tool call is one line running + one line done", () => {
+    const h = harness();
+    h.r.beginTurn();
+    h.send({ type: "tool_call_start", toolName: "bash", toolInput: { command: "npm test" } });
+    h.advance(1200);
+    h.send({ type: "tool_call_end", toolName: "bash", toolResult: "42 passing" });
+    h.r.endTurn();
+    const lines = h.stderr.text().split("\n").filter((l) => l.length > 0);
+    assert.deepEqual(lines, ["⚙ bash  npm test", "✓ bash (1.2s)"]);
+  });
+
+  test("a failed tool shows only the first line of the error", () => {
+    const h = harness();
+    h.r.beginTurn();
+    h.send({ type: "tool_call_start", toolName: "bash", toolInput: { command: "false" } });
+    h.advance(300);
+    h.send({
+      type: "tool_call_end",
+      toolName: "bash",
+      toolResult: "Error: exit 1\n  at foo\n  at bar",
+      isError: true,
+    });
+    h.r.endTurn();
+    const out = h.stderr.text();
+    assert.match(out, /✗ bash \(0\.3s\): Error: exit 1\n/);
+    assert.doesNotMatch(out, /at foo/);
+  });
+
+  test("results stay hidden unless --verbose", () => {
+    const quiet = harness();
+    quiet.r.beginTurn();
+    quiet.send({ type: "tool_call_start", toolName: "read", toolInput: { path: "/tmp/x" } });
+    quiet.send({ type: "tool_call_end", toolName: "read", toolResult: "secret payload" });
+    assert.doesNotMatch(quiet.stderr.text(), /secret payload/);
+
+    const loud = harness({ verbose: true });
+    loud.r.beginTurn();
+    loud.send({ type: "tool_call_start", toolName: "read", toolInput: { path: "/tmp/x" } });
+    loud.send({ type: "tool_call_end", toolName: "read", toolResult: "secret payload" });
+    assert.match(loud.stderr.text(), /secret payload/);
+  });
+
+  test("thinking is announced once per turn and never quoted", () => {
+    const h = harness();
+    h.r.beginTurn();
+    h.send({ type: "thinking_delta", text: "the user's password is hunter2" });
+    h.send({ type: "thinking_delta", text: "more private reasoning" });
+    h.r.endTurn();
+    const out = h.stderr.text();
+    assert.equal(out.split("thinking…").length - 1, 1);
+    assert.doesNotMatch(out, /hunter2|private reasoning/);
+  });
+
+  test("system_prompt_rebuilt reads as [soul updated]", () => {
+    const h = harness();
+    h.send({ type: "system_prompt_rebuilt", message: "3 files changed" });
+    assert.equal(h.stderr.text(), "[soul updated]\n");
+    const loud = harness({ verbose: true });
+    loud.send({ type: "system_prompt_rebuilt", message: "3 files changed" });
+    assert.equal(loud.stderr.text(), "[soul updated] 3 files changed\n");
+  });
+
+  test("no spinner and no escape codes without a TTY", () => {
+    const h = harness();
+    h.r.beginTurn();
+    h.send({ type: "turn_start" });
+    h.r.endTurn();
+    assert.equal(h.intervals.length, 0);
+    assert.doesNotMatch(h.stderr.text(), /\x1b/);
+  });
+
+  test("colour is opt-in and only ever decorates stderr", () => {
+    const h = harness({ color: true });
+    h.r.beginTurn();
+    h.send({ type: "text_delta", text: "plain" });
+    h.send({ type: "error", message: "boom" });
+    h.r.endTurn();
+    assert.equal(h.stdout.text(), "plain\n");
+    assert.match(h.stderr.text(), /\x1b\[31m\[error\] boom\x1b\[39m/);
+  });
+});
+
+describe("createEventRenderer — TTY output", () => {
+  test("the spinner starts on beginTurn and stops at the first text", () => {
+    const h = harness({ tty: true, columns: 80 });
+    h.r.beginTurn();
+    assert.equal(h.intervals.length, 1, "one interval, unref'd in production");
+    h.send({ type: "text_delta", text: "hi" });
+    // Spinner cleared, then the label, then the text on stdout.
+    assert.match(h.stderr.text(), /\r\x1b\[K.*Lisa> $/s);
+    assert.equal(h.stdout.text(), "hi");
+    h.r.endTurn();
+  });
+
+  test("the in-flight tool line is overwritten in place by its result", () => {
+    const h = harness({ tty: true, columns: 80 });
+    h.r.beginTurn();
+    h.send({ type: "tool_call_start", toolName: "bash", toolInput: { command: "sleep 1" } });
+    h.advance(1000);
+    h.send({ type: "tool_call_end", toolName: "bash", toolResult: "" });
+    h.r.endTurn();
+    const out = h.stderr.text();
+    assert.match(out, /⚙ bash {2}sleep 1\r\x1b\[K✓ bash \(1\.0s\)\n/);
+  });
+
+  test("a long tool summary is truncated to the terminal width", () => {
+    const h = harness({ tty: true, columns: 40 });
+    h.r.beginTurn();
+    h.send({ type: "tool_call_start", toolName: "bash", toolInput: { command: "x".repeat(200) } });
+    const running = h.stderr.text().split("\r\x1b[K").pop() ?? "";
+    assert.ok(running.length < 40, `expected a fitted line, got ${running.length} chars`);
+    assert.ok(running.endsWith("…"));
+    h.r.endTurn();
+  });
+});
+
+describe("summarizeToolInput", () => {
+  test("prefers the key that says what the call is about", () => {
+    assert.equal(summarizeToolInput({ command: "npm test", timeout: 5 }), "npm test");
+    assert.equal(summarizeToolInput({ file_path: "/a/b.ts", content: "…" }), "/a/b.ts");
+    assert.equal(summarizeToolInput({ action: "list", path: "/a" }), "list /a");
+    assert.equal(summarizeToolInput({ action: "health" }), "health");
+  });
+
+  test("collapses newlines so a line stays a line", () => {
+    assert.equal(summarizeToolInput({ command: "a\n  b\tc" }), "a b c");
+  });
+
+  test("falls back to compact JSON, and truncates", () => {
+    assert.equal(summarizeToolInput({ n: 1 }), '{"n":1}');
+    assert.equal(summarizeToolInput({}), "");
+    assert.equal(summarizeToolInput(null), "");
+    assert.equal(summarizeToolInput({ command: "y".repeat(200) }, 10).length, 10);
+  });
+});
+
+describe("formatDuration", () => {
+  test("sub-minute is one decimal of seconds", () => {
+    assert.equal(formatDuration(1234), "1.2s");
+    assert.equal(formatDuration(300), "0.3s");
+    assert.equal(formatDuration(-5), "0.0s");
+  });
+
+  test("a minute or more reads as m + padded s", () => {
+    assert.equal(formatDuration(65_000), "1m 05s");
+    assert.equal(formatDuration(600_000), "10m 00s");
+  });
+});

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -1,0 +1,348 @@
+/**
+ * Terminal rendering of AgentEvents for the CLI (REPL and one-shot prompts).
+ *
+ * Two streams with two jobs:
+ *   - stdout carries Lisa's words and nothing else, so `lisa "…" | pbcopy`
+ *     and `> answer.md` get exactly the answer.
+ *   - stderr carries everything about *how* the answer is being produced: the
+ *     `Lisa> ` label, a spinner while waiting for the model, a `thinking…`
+ *     marker, one compact line per tool call, `[soul updated]`, errors.
+ *
+ * On a terminal, transient state (spinner, thinking marker, a tool call in
+ * flight) occupies the current line and is redrawn in place with `\r\x1b[K`;
+ * when stderr is not a TTY every state change is a plain line instead. The
+ * in-place rewrite only ever touches the line the cursor is on, so if a tool
+ * or hook writes to the terminal in between, the worst case is an orphaned
+ * "⚙ running" line — never corrupted output.
+ *
+ * Thinking content is never printed: only the fact that it is happening.
+ */
+import type { AgentEvent } from "../types.js";
+import { makePalette, type Palette } from "./ansi.js";
+
+export interface Writer {
+  write(chunk: string): unknown;
+}
+
+export interface RendererOptions {
+  stdout: Writer;
+  stderr: Writer;
+  /** Colour the stderr decorations. Lisa's text on stdout is never coloured. */
+  color?: boolean;
+  /** Print full tool results and hot-reload details. */
+  verbose?: boolean;
+  /** stderr is an interactive terminal: spinner + in-place line updates. */
+  tty?: boolean;
+  /** Terminal width; the in-flight tool line is truncated to it so the rewrite never wraps. */
+  columns?: number;
+  now?: () => number;
+  /** Injectable for tests so no real interval is ever left running. */
+  timers?: {
+    setInterval: (fn: () => void, ms: number) => unknown;
+    clearInterval: (handle: unknown) => void;
+  };
+}
+
+export interface EventRenderer {
+  onEvent(event: AgentEvent): void;
+  /** Right before a prompt is sent: separator line + spinner until the model responds. */
+  beginTurn(): void;
+  /** After the agent returns or throws: stop the spinner, finish the output line, reset. */
+  endTurn(): void;
+}
+
+const LABEL = "Lisa> ";
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const SPINNER_MS = 80;
+const CLEAR_LINE = "\r\x1b[K";
+const RESULT_MAX_LINES = 20;
+
+export function createEventRenderer(opts: RendererOptions): EventRenderer {
+  const { stdout, stderr } = opts;
+  const p: Palette = makePalette(opts.color === true);
+  const verbose = opts.verbose === true;
+  const tty = opts.tty === true;
+  const now = opts.now ?? Date.now;
+  const timers = opts.timers ?? {
+    setInterval: (fn, ms) => {
+      const h = setInterval(fn, ms);
+      // Never let the animation keep the process alive after the work is done.
+      h.unref();
+      return h;
+    },
+    clearInterval: (h) => clearInterval(h as NodeJS.Timeout),
+  };
+  const columns = Math.max(20, opts.columns ?? 100);
+
+  // `Lisa> ` is emitted lazily, right before the first text of the turn, so
+  // tool lines that precede any words stand on their own and the label sits
+  // next to what it labels.
+  let labelPending = false;
+  // Two different "unfinished line" questions, and they are not the same one:
+  //   stdoutMidLine — the *terminal cursor* sits mid-line because of Lisa's
+  //     text, so a stderr decoration must break the line first.
+  //   stdoutOpen    — the *stdout stream* is not newline-terminated. Only a
+  //     newline written to stdout clears it, because `lisa … > answer.md` must
+  //     end with one and must NOT contain the line breaks we emit for the
+  //     terminal's benefit.
+  let stdoutMidLine = false;
+  let stdoutOpen = false;
+  let thinkingShown = false;
+  // What currently occupies the stderr line on a TTY. Only one thing can.
+  let status: "none" | "spinner" | "tool" = "none";
+  let spinnerLabel = "";
+  let spinnerHandle: unknown = null;
+  let frame = 0;
+  const toolStarts: { name: string; at: number }[] = [];
+
+  function drawSpinner(): void {
+    const glyph = SPINNER_FRAMES[frame % SPINNER_FRAMES.length]!;
+    frame++;
+    stderr.write(CLEAR_LINE + p.dim(spinnerLabel ? `${glyph} ${spinnerLabel}` : glyph));
+  }
+
+  /** Start (or relabel) the wait indicator. TTY only; a pipe gets nothing. */
+  function showSpinner(label: string): void {
+    if (!tty) return;
+    if (status === "tool") return; // a tool line is in flight; it owns the line
+    breakStdoutLine();
+    spinnerLabel = label;
+    if (status === "spinner") {
+      drawSpinner();
+      return;
+    }
+    status = "spinner";
+    frame = 0;
+    drawSpinner();
+    spinnerHandle = timers.setInterval(drawSpinner, SPINNER_MS);
+  }
+
+  /** Remove whatever transient thing is on the stderr line. */
+  function clearStatus(): void {
+    if (status === "spinner") {
+      timers.clearInterval(spinnerHandle);
+      spinnerHandle = null;
+      stderr.write(CLEAR_LINE);
+    } else if (status === "tool") {
+      // A tool line is being abandoned (error mid-call, turn aborted): keep it
+      // as a finished line rather than overwriting it.
+      stderr.write("\n");
+    }
+    status = "none";
+  }
+
+  /** If Lisa's text stopped mid-line, move stderr decorations to a fresh line. */
+  function breakStdoutLine(): void {
+    if (stdoutMidLine) {
+      stderr.write("\n");
+      stdoutMidLine = false;
+    }
+  }
+
+  function writeLine(line: string): void {
+    clearStatus();
+    breakStdoutLine();
+    stderr.write(line + "\n");
+  }
+
+  function onText(text: string): void {
+    if (!text) return;
+    clearStatus();
+    if (labelPending) {
+      stderr.write(LABEL);
+      labelPending = false;
+    }
+    stdout.write(text);
+    stdoutMidLine = !text.endsWith("\n");
+    stdoutOpen = stdoutMidLine;
+  }
+
+  function onToolStart(name: string, input: unknown): void {
+    clearStatus();
+    breakStdoutLine();
+    toolStarts.push({ name, at: now() });
+    const head = `${p.yellow("⚙")} ${p.bold(name)}`;
+    const summary = summarizeToolInput(input);
+    if (tty) {
+      // Budget: "⚙ " + name + "  " + summary must fit on one row, or the
+      // \r\x1b[K rewrite on tool_call_end would only clear the last row.
+      const room = columns - 1 - (2 + name.length + 2);
+      const fitted = room > 3 && summary.length > room ? summary.slice(0, room - 1) + "…" : summary;
+      stderr.write(CLEAR_LINE + head + (fitted ? `  ${p.dim(fitted)}` : ""));
+      status = "tool";
+    } else {
+      stderr.write(head + (summary ? `  ${summary}` : "") + "\n");
+    }
+  }
+
+  function onToolEnd(name: string, result: unknown, isError: boolean): void {
+    let started: number | undefined;
+    for (let i = toolStarts.length - 1; i >= 0; i--) {
+      if (toolStarts[i]!.name === name) {
+        started = toolStarts.splice(i, 1)[0]!.at;
+        break;
+      }
+    }
+    const took = p.dim(`(${formatDuration(started === undefined ? 0 : now() - started)})`);
+    const text = resultText(result);
+    const line = isError
+      ? `${p.red("✗")} ${name} ${took}${text ? `: ${firstLine(text)}` : ""}`
+      : `${p.green("✓")} ${name} ${took}`;
+    if (tty && status === "tool") {
+      stderr.write(CLEAR_LINE + line + "\n");
+      status = "none";
+    } else {
+      writeLine(line);
+    }
+    if (verbose && text) {
+      const lines = text.split("\n");
+      const shown = lines.slice(0, RESULT_MAX_LINES);
+      for (const l of shown) stderr.write(`    ${p.dim(l)}\n`);
+      if (lines.length > shown.length) {
+        stderr.write(`    ${p.dim(`… ${lines.length - shown.length} more line(s)`)}\n`);
+      }
+    }
+  }
+
+  function onThinking(): void {
+    if (thinkingShown) return;
+    thinkingShown = true;
+    if (tty) showSpinner("thinking…");
+    else writeLine(p.dim("thinking…"));
+  }
+
+  return {
+    beginTurn(): void {
+      // Blank separator after the user's line; the label itself waits for text.
+      stderr.write("\n");
+      labelPending = true;
+      stdoutMidLine = false;
+      stdoutOpen = false;
+      thinkingShown = false;
+      toolStarts.length = 0;
+      showSpinner("");
+    },
+
+    endTurn(): void {
+      clearStatus();
+      if (stdoutOpen) {
+        // Finish the line on stdout so piped output is newline-terminated and
+        // the next prompt starts at column 0.
+        stdout.write("\n");
+        stdoutOpen = false;
+        stdoutMidLine = false;
+      }
+      labelPending = false;
+      thinkingShown = false;
+      toolStarts.length = 0;
+    },
+
+    onEvent(event: AgentEvent): void {
+      switch (event.type) {
+        case "turn_start":
+          // Each provider call is a fresh wait — and a fresh chance to think.
+          thinkingShown = false;
+          showSpinner("");
+          break;
+        case "text_delta":
+          onText(event.text ?? "");
+          break;
+        case "thinking_delta":
+          onThinking();
+          break;
+        case "tool_call_start":
+          onToolStart(event.toolName ?? "tool", event.toolInput);
+          break;
+        case "tool_call_end":
+          onToolEnd(event.toolName ?? "tool", event.toolResult, event.isError === true);
+          break;
+        case "turn_end":
+          clearStatus();
+          break;
+        case "system_prompt_rebuilt":
+          writeLine(p.dim(verbose && event.message ? `[soul updated] ${event.message}` : "[soul updated]"));
+          break;
+        case "error":
+          writeLine(p.red(`[error] ${event.message ?? "unknown error"}`));
+          break;
+        case "info":
+          // Rare and load-bearing ("stopped after N iterations", "budget
+          // reached"): they explain why Lisa went quiet, so always shown.
+          if (event.message) writeLine(p.dim(event.message));
+          break;
+        default:
+          break;
+      }
+    },
+  };
+}
+
+/** `1.2s`, `0.3s`, `1m 05s` — the shape a person scans, not a millisecond count. */
+export function formatDuration(ms: number): string {
+  const s = Math.max(0, ms) / 1000;
+  if (s < 60) return `${s.toFixed(1)}s`;
+  const m = Math.floor(s / 60);
+  const rest = Math.round(s - m * 60);
+  return `${m}m ${String(rest).padStart(2, "0")}s`;
+}
+
+/** Keys that, when present, say what a tool call is *about* better than the whole JSON. */
+const PREFERRED_KEYS = [
+  "command",
+  "cmd",
+  "path",
+  "file_path",
+  "filePath",
+  "file",
+  "url",
+  "query",
+  "pattern",
+  "prompt",
+  "name",
+  "slug",
+  "text",
+  "content",
+  "message",
+  "title",
+];
+
+/**
+ * One short line describing a tool input: the shell command for bash, the
+ * path for file tools, the URL for fetches — falling back to compact JSON.
+ * Newlines and runs of whitespace collapse so the line stays a line.
+ */
+export function summarizeToolInput(input: unknown, max = 80): string {
+  let s: string;
+  if (input == null) s = "";
+  else if (typeof input === "string") s = input;
+  else if (typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    const action = typeof obj.action === "string" ? obj.action : "";
+    const key = PREFERRED_KEYS.find((k) => typeof obj[k] === "string" && (obj[k] as string).length > 0);
+    if (key) s = action ? `${action} ${obj[key] as string}` : (obj[key] as string);
+    else if (action) s = action;
+    else s = safeJson(input);
+  } else s = String(input);
+  s = s.replace(/\s+/g, " ").trim();
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+function safeJson(v: unknown): string {
+  try {
+    const j = JSON.stringify(v);
+    return j === "{}" ? "" : j;
+  } catch {
+    return String(v);
+  }
+}
+
+function resultText(result: unknown): string {
+  if (result == null) return "";
+  return typeof result === "string" ? result : safeJson(result);
+}
+
+function firstLine(text: string, max = 120): string {
+  const line = text.split("\n").find((l) => l.trim().length > 0) ?? "";
+  const t = line.trim();
+  return t.length > max ? t.slice(0, max - 1) + "…" : t;
+}

--- a/src/cli/repl.test.ts
+++ b/src/cli/repl.test.ts
@@ -1,0 +1,104 @@
+import { test, describe, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { PassThrough } from "node:stream";
+import { runRepl, type ReplHandlers } from "./repl.js";
+import { loadHistory, saveHistory } from "./history.js";
+
+const tmp = await fs.mkdtemp(path.join(os.tmpdir(), "lisa-repl-"));
+after(async () => {
+  await fs.rm(tmp, { recursive: true, force: true });
+});
+
+/**
+ * Drive the REPL with a pair of in-memory streams. `lines` are fed as if typed;
+ * the input then ends, which closes readline the way Ctrl-D does.
+ */
+async function drive(
+  lines: string[],
+  opts: { historyFile?: string | null } = {},
+): Promise<{ prompts: string[]; slashes: [string, string][]; out: string; closed: boolean }> {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const chunks: string[] = [];
+  output.on("data", (c: Buffer) => chunks.push(c.toString("utf8")));
+  const prompts: string[] = [];
+  const slashes: [string, string][] = [];
+  let closed = false;
+  const handlers: ReplHandlers = {
+    onLine: async (line) => void prompts.push(line),
+    onSlash: async (cmd, args) => {
+      slashes.push([cmd, args]);
+      return cmd !== "bogus";
+    },
+    onClose: async () => {
+      closed = true;
+    },
+  };
+  const done = runRepl(handlers, {
+    input,
+    output,
+    terminal: true,
+    historyFile: opts.historyFile ?? null,
+  });
+  for (const l of lines) input.write(l + "\n");
+  input.end();
+  await done;
+  // Leave no open handles behind — node:test on CI fails the run otherwise.
+  output.end();
+  input.destroy();
+  output.destroy();
+  return { prompts, slashes, out: chunks.join(""), closed };
+}
+
+describe("runRepl — streams are injectable", () => {
+  test("plain lines reach onLine; onClose runs at EOF", async () => {
+    const r = await drive(["hello", "  ", "world  "]);
+    assert.deepEqual(r.prompts, ["hello", "world"]);
+    assert.equal(r.closed, true);
+  });
+
+  test("slash commands are split into command and args", async () => {
+    const r = await drive(["/think", "/save a note here"]);
+    assert.deepEqual(r.slashes, [
+      ["think", ""],
+      ["save", "a note here"],
+    ]);
+    assert.deepEqual(r.prompts, []);
+  });
+
+  test("an unhandled slash command reports on the injected output, not stderr", async () => {
+    const r = await drive(["/bogus"]);
+    assert.match(r.out, /unknown command: \/bogus/);
+  });
+
+  test('""" collects a multi-line prompt', async () => {
+    const r = await drive(['"""', "line one", "line two", '"""']);
+    assert.deepEqual(r.prompts, ["line one\nline two"]);
+    assert.match(r.out, /multi-line mode/);
+  });
+});
+
+describe("runRepl — persistent history", () => {
+  test("earlier prompts are loaded and this session's are appended", async () => {
+    const file = path.join(tmp, "history");
+    await saveHistory(["older prompt"], file);
+    await drive(["first", "second", "second"], { historyFile: file });
+    // Oldest-first on disk, duplicates collapsed.
+    assert.deepEqual(await loadHistory(file), ["older prompt", "first", "second"]);
+  });
+
+  test("slash commands and blanks are recorded too, but never empty lines", async () => {
+    const file = path.join(tmp, "history-slash");
+    await drive(["/think", "", "  "], { historyFile: file });
+    assert.deepEqual(await loadHistory(file), ["/think"]);
+  });
+
+  test("historyFile: null writes nothing", async () => {
+    const file = path.join(tmp, "history-disabled");
+    await drive(["secret prompt"], { historyFile: null });
+    await assert.rejects(fs.stat(file));
+  });
+});

--- a/src/cli/repl.ts
+++ b/src/cli/repl.ts
@@ -1,4 +1,21 @@
+/**
+ * The interactive `lisa` prompt.
+ *
+ * Two things beyond a bare readline loop:
+ *   - **Persistent history.** readline keeps history in memory only, so every
+ *     session used to start with an empty ↑. History is loaded from
+ *     `~/.lisa/history` at start and written back on close (see ./history.ts
+ *     for the file format and the 0600 reasoning).
+ *   - **Injectable streams.** stdin/stderr are parameters, not globals, so the
+ *     loop can be driven by a test with a pair of PassThroughs instead of a
+ *     terminal.
+ *
+ * Everything the REPL itself says (prompt, errors, mode hints) goes to the
+ * output stream — stderr in production — because stdout is reserved for Lisa's
+ * words so `lisa … | …` keeps working.
+ */
 import readline from "node:readline";
+import { HISTORY_LIMIT, historyPath, loadHistory, saveHistory } from "./history.js";
 
 export interface ReplHandlers {
   onLine: (line: string) => Promise<void>;
@@ -6,26 +23,61 @@ export interface ReplHandlers {
   onClose: () => Promise<void>;
 }
 
+export interface ReplOptions {
+  input?: NodeJS.ReadableStream;
+  /** Where the prompt and REPL-level messages go. Defaults to stderr. */
+  output?: NodeJS.WritableStream;
+  /** Enable readline line editing. Defaults to "input is a TTY". */
+  terminal?: boolean;
+  /** History file; `null` disables persistence (used by tests). */
+  historyFile?: string | null;
+  prompt?: string;
+}
+
 const MULTILINE_DELIM = `"""`;
 
-export async function runRepl(handlers: ReplHandlers): Promise<void> {
+export async function runRepl(
+  handlers: ReplHandlers,
+  options: ReplOptions = {},
+): Promise<void> {
+  const input = options.input ?? process.stdin;
+  const out = options.output ?? process.stderr;
+  const terminal = options.terminal ?? (input as NodeJS.ReadStream).isTTY === true;
+  const historyFile =
+    options.historyFile === undefined ? historyPath() : options.historyFile;
+
+  // Only a terminal session has history: piped stdin has no ↑ to press, and a
+  // scripted `lisa < script.txt` must not pollute the user's history file.
+  const persist = historyFile != null && terminal;
+  // The file is oldest-first (append-shaped); readline wants newest-first.
+  const loaded = persist ? await loadHistory(historyFile) : [];
+
   const rl = readline.createInterface({
-    input: process.stdin,
-    output: process.stderr,
-    terminal: process.stdin.isTTY,
+    input,
+    output: out,
+    terminal,
+    history: loaded.slice().reverse(),
+    historySize: HISTORY_LIMIT,
+    removeHistoryDuplicates: true,
   });
-  rl.setPrompt("you> ");
+  rl.setPrompt(options.prompt ?? "you> ");
   rl.prompt();
 
   let buffer: string[] | null = null;
+  let closed = false;
+  // Handlers are async and `line` events are not: without a queue, a second
+  // line typed (or piped) while a turn is running would run its handler
+  // concurrently and interleave with the first. Chaining also gives close a
+  // single thing to await before it saves history.
+  let pending: Promise<void> = Promise.resolve();
 
-  rl.on("line", async (raw) => {
+  const handleLine = async (raw: string): Promise<void> => {
     if (buffer) {
       if (raw.trim() === MULTILINE_DELIM) {
         const text = buffer.join("\n").trim();
         buffer = null;
-        if (text) await processInput(text, handlers, rl);
-        rl.prompt();
+        if (text) await processInput(text, handlers, rl, out);
+        reprompt();
         return;
       }
       buffer.push(raw);
@@ -33,19 +85,51 @@ export async function runRepl(handlers: ReplHandlers): Promise<void> {
     }
     const line = raw.trim();
     if (!line) {
-      rl.prompt();
+      reprompt();
       return;
     }
     if (line === MULTILINE_DELIM) {
       buffer = [];
-      process.stderr.write(`(multi-line mode — finish with ${MULTILINE_DELIM} on its own line)\n`);
+      out.write(`(multi-line mode — finish with ${MULTILINE_DELIM} on its own line)\n`);
       return;
     }
-    await processInput(line, handlers, rl);
-    rl.prompt();
+    await processInput(line, handlers, rl, out);
+    reprompt();
+  };
+
+  /** Ctrl-D (or an ended stdin) can land mid-turn; readline throws if touched after. */
+  function reprompt(): void {
+    if (!closed) rl.prompt();
+  }
+
+  rl.on("line", (raw) => {
+    pending = pending.then(() => handleLine(raw)).catch((err) => {
+      out.write(`[error] ${(err as Error).message}\n`);
+    });
   });
 
-  await new Promise<void>((resolve) => rl.on("close", resolve));
+  await new Promise<void>((resolve) =>
+    rl.on("close", () => {
+      closed = true;
+      resolve();
+    }),
+  );
+  // The last prompt may still be running when stdin ends — finish it before
+  // reflection and history are written.
+  await pending;
+
+  if (persist) {
+    try {
+      // rl.history is newest-first; the file is oldest-first.
+      const lines = ((rl as unknown as { history?: string[] }).history ?? [])
+        .slice()
+        .reverse();
+      await saveHistory(lines, historyFile);
+    } catch {
+      // A history file we cannot write is never worth failing a session over.
+    }
+  }
+
   await handlers.onClose();
 }
 
@@ -53,6 +137,7 @@ async function processInput(
   line: string,
   handlers: ReplHandlers,
   rl: readline.Interface,
+  out: NodeJS.WritableStream,
 ): Promise<void> {
   if (line.startsWith("/")) {
     const space = line.indexOf(" ");
@@ -62,19 +147,25 @@ async function processInput(
     try {
       const handled = await handlers.onSlash(cmd, args);
       if (!handled) {
-        process.stderr.write(`unknown command: /${cmd}\n`);
+        out.write(`unknown command: /${cmd}\n`);
       }
     } catch (err) {
-      process.stderr.write(`[error] ${(err as Error).message}\n`);
+      out.write(`[error] ${(err as Error).message}\n`);
     }
-    rl.resume();
+    resume(rl);
     return;
   }
   rl.pause();
   try {
     await handlers.onLine(line);
   } catch (err) {
-    process.stderr.write(`[error] ${(err as Error).message}\n`);
+    out.write(`[error] ${(err as Error).message}\n`);
   }
+  resume(rl);
+}
+
+/** readline throws ERR_USE_AFTER_CLOSE if stdin ended while the turn ran. */
+function resume(rl: readline.Interface): void {
+  if ((rl as unknown as { closed?: boolean }).closed) return;
   rl.resume();
 }

--- a/src/cli/upgrade.test.ts
+++ b/src/cli/upgrade.test.ts
@@ -1,0 +1,294 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  AUTOSTART_LABEL,
+  BREW_FORMULA,
+  compareVersions,
+  detectInstall,
+  formatStep,
+  kickstartCommand,
+  manualInstructions,
+  PACKAGE_NAME,
+  runUpgrade,
+  upgradeCommands,
+  type InstallFacts,
+  type Step,
+} from "./upgrade.js";
+
+/**
+ * The default is a real Homebrew install on Apple silicon: `bin/lisa` is a
+ * symlink into the Cellar, and the formula wraps the npm package — so the
+ * resolved path contains both `/Cellar/` and `/node_modules/@oratis/lisa/`,
+ * which is exactly why detection checks Cellar first.
+ */
+const facts = (over: Partial<InstallFacts> = {}): InstallFacts => ({
+  entry: "/opt/homebrew/bin/lisa",
+  realEntry: `/opt/homebrew/Cellar/lisa/0.24.0/libexec/lib/node_modules/${PACKAGE_NAME}/dist/cli.js`,
+  brewPrefix: "/opt/homebrew",
+  npmPrefix: "/opt/homebrew",
+  repoRoot: null,
+  platform: "darwin",
+  ...over,
+});
+
+describe("detectInstall", () => {
+  test("a Cellar path is Homebrew, wherever the prefix is", () => {
+    const d = detectInstall(
+      facts({ realEntry: "/opt/homebrew/Cellar/lisa/0.24.0/libexec/dist/cli.js", brewPrefix: null }),
+    );
+    assert.equal(d.flavor, "homebrew");
+  });
+
+  test("Intel Macs and Linuxbrew prefixes work too", () => {
+    assert.equal(
+      detectInstall(
+        facts({
+          realEntry: "/usr/local/Cellar/lisa/0.24.0/libexec/dist/cli.js",
+          brewPrefix: "/usr/local",
+        }),
+      ).flavor,
+      "homebrew",
+    );
+    assert.equal(
+      detectInstall(facts({ realEntry: "/opt/homebrew/opt/lisa/bin/lisa" })).flavor,
+      "homebrew",
+    );
+  });
+
+  test("a package path is an npm global install", () => {
+    const d = detectInstall(
+      facts({
+        realEntry: `/usr/local/lib/node_modules/${PACKAGE_NAME}/dist/cli.js`,
+        brewPrefix: null,
+        npmPrefix: "/usr/local",
+      }),
+    );
+    assert.equal(d.flavor, "npm-global");
+    assert.match(d.reason, /\/usr\/local\/lib/);
+  });
+
+  test("the npm global prefix alone is enough when the shim isn't a package path", () => {
+    assert.equal(
+      detectInstall(
+        facts({ realEntry: "/Users/x/.nvm/versions/node/v22.0.0/bin/lisa", brewPrefix: null, npmPrefix: "/Users/x/.nvm/versions/node/v22.0.0" }),
+      ).flavor,
+      "npm-global",
+    );
+  });
+
+  test("a checkout wins over nothing, and a Cellar path still wins over a checkout", () => {
+    assert.equal(
+      detectInstall(
+        facts({ realEntry: "/Users/x/Projects/LISA/dist/cli.js", brewPrefix: null, npmPrefix: null, repoRoot: "/Users/x/Projects/LISA" }),
+      ).flavor,
+      "source",
+    );
+    // `brew install` of a checkout-shaped path: Cellar is conclusive.
+    assert.equal(
+      detectInstall(
+        facts({ realEntry: "/opt/homebrew/Cellar/lisa/0.24.0/libexec/dist/cli.js", repoRoot: "/opt/homebrew/Cellar/lisa/0.24.0" }),
+      ).flavor,
+      "homebrew",
+    );
+  });
+
+  test("no evidence at all is 'unknown', not a guess", () => {
+    assert.equal(
+      detectInstall(facts({ realEntry: "/somewhere/odd/lisa", brewPrefix: null, npmPrefix: null })).flavor,
+      "unknown",
+    );
+  });
+});
+
+describe("upgradeCommands", () => {
+  test("Homebrew updates the tap before upgrading the formula", () => {
+    assert.deepEqual(upgradeCommands("homebrew").map(formatStep), [
+      "brew update",
+      `brew upgrade ${BREW_FORMULA}`,
+    ]);
+  });
+
+  test("npm global pins @latest", () => {
+    assert.deepEqual(upgradeCommands("npm-global").map(formatStep), [
+      `npm install -g ${PACKAGE_NAME}@latest`,
+    ]);
+  });
+
+  test("a checkout and an unknown install run nothing automatically", () => {
+    assert.deepEqual(upgradeCommands("source"), []);
+    assert.deepEqual(upgradeCommands("unknown"), []);
+    assert.match(manualInstructions("source", "/Users/x/LISA").join("\n"), /git pull/);
+    assert.match(manualInstructions("unknown").join("\n"), /npm install -g/);
+  });
+});
+
+describe("kickstartCommand", () => {
+  test("targets the user's GUI domain and forces a restart", () => {
+    assert.equal(formatStep(kickstartCommand(501)), `launchctl kickstart -k gui/501/${AUTOSTART_LABEL}`);
+  });
+
+  test("the label still matches src/autostart/install.ts", async () => {
+    // A copied constant is only safe if something notices when it drifts.
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const src = await fs.readFile(path.resolve(here, "..", "autostart", "install.ts"), "utf8");
+    const found = /const PLIST_LABEL = "([^"]+)"/.exec(src)?.[1];
+    assert.equal(found, AUTOSTART_LABEL);
+  });
+});
+
+describe("compareVersions", () => {
+  test("orders releases numerically, not lexically", () => {
+    assert.equal(compareVersions("0.24.0", "0.9.0"), 1);
+    assert.equal(compareVersions("0.24.0", "0.24.0"), 0);
+    assert.equal(compareVersions("1.0.0", "0.99.99"), 1);
+    assert.equal(compareVersions("0.24.1", "0.24.10"), -1);
+  });
+
+  test("tolerates a v prefix and short versions", () => {
+    assert.equal(compareVersions("v1.2", "1.2.0"), 0);
+    assert.equal(compareVersions("2", "1.9.9"), 1);
+  });
+
+  test("a prerelease sorts below its release", () => {
+    assert.equal(compareVersions("1.0.0-rc.1", "1.0.0"), -1);
+    assert.equal(compareVersions("1.0.0", "1.0.0-rc.1"), 1);
+  });
+});
+
+/** Collects the log and every command a run would have executed. */
+function harness(opts: {
+  facts?: Partial<InstallFacts>;
+  local?: string;
+  latest?: string | null;
+  loaded?: boolean;
+  fail?: string;
+}) {
+  const lines: string[] = [];
+  const ran: string[] = [];
+  const run = async (s: Step): Promise<string> => {
+    const printed = formatStep(s);
+    if (opts.fail && printed.startsWith(opts.fail)) throw new Error("boom: command failed");
+    ran.push(printed);
+    return s.args.includes("--version") ? (opts.latest ?? "0.25.0") : "";
+  };
+  return {
+    lines,
+    ran,
+    call: (over: Parameters<typeof runUpgrade>[0] = {}) =>
+      runUpgrade({
+        facts: facts(opts.facts),
+        localVersion: async () => opts.local ?? "0.24.0",
+        fetchLatest: async () => (opts.latest === undefined ? "0.25.0" : opts.latest),
+        autostartLoaded: async () => opts.loaded === true,
+        uid: 501,
+        run,
+        log: (l) => lines.push(l),
+        ...over,
+      }),
+    text: () => lines.join("\n"),
+  };
+}
+
+describe("runUpgrade", () => {
+  test("--check compares and changes nothing", async () => {
+    const h = harness({ loaded: true });
+    assert.equal(await h.call({ check: true }), 0);
+    assert.deepEqual(h.ran, []);
+    assert.match(h.text(), /0\.24\.0 → 0\.25\.0 available/);
+    assert.match(h.text(), /run `lisa upgrade`/);
+  });
+
+  test("--check on the newest version says so and still exits 0", async () => {
+    const h = harness({ local: "0.25.0", latest: "0.25.0" });
+    assert.equal(await h.call({ check: true }), 0);
+    assert.match(h.text(), /already on the newest published version/);
+  });
+
+  test("--check survives an unreachable registry", async () => {
+    const h = harness({ latest: null });
+    assert.equal(await h.call({ check: true }), 0);
+    assert.match(h.text(), /registry unreachable/);
+  });
+
+  test("--dry-run prints the commands, including the daemon restart", async () => {
+    const h = harness({ loaded: true });
+    assert.equal(await h.call({ dryRun: true }), 0);
+    assert.deepEqual(h.ran, []);
+    assert.match(h.text(), /brew update/);
+    assert.match(h.text(), new RegExp(`brew upgrade ${BREW_FORMULA.replace(/\//g, "\\/")}`));
+    assert.match(h.text(), /launchctl kickstart -k gui\/501\/ai\.lisa\.autostart/);
+  });
+
+  test("--dry-run says why there is no restart when the agent isn't loaded", async () => {
+    const h = harness({ loaded: false });
+    await h.call({ dryRun: true });
+    assert.doesNotMatch(h.text(), /kickstart/);
+    assert.match(h.text(), /no loaded LaunchAgent/);
+  });
+
+  test("a real run upgrades then kickstarts the loaded LaunchAgent", async () => {
+    const h = harness({ loaded: true });
+    assert.equal(await h.call(), 0);
+    assert.deepEqual(h.ran, [
+      "brew update",
+      `brew upgrade ${BREW_FORMULA}`,
+      "lisa --version",
+      `launchctl kickstart -k gui/501/${AUTOSTART_LABEL}`,
+    ]);
+    assert.match(h.text(), /0\.24\.0 → 0\.25\.0/);
+    assert.match(h.text(), /restarted the login agent/);
+  });
+
+  test("no LaunchAgent, no kickstart", async () => {
+    const h = harness({ loaded: false });
+    await h.call();
+    assert.ok(!h.ran.some((c) => c.startsWith("launchctl")));
+  });
+
+  test("a non-macOS host never touches launchctl", async () => {
+    const h = harness({ facts: { platform: "linux" }, loaded: true });
+    await h.call();
+    assert.ok(!h.ran.some((c) => c.startsWith("launchctl")));
+  });
+
+  test("an npm-global install runs the npm command", async () => {
+    const h = harness({
+      facts: { realEntry: `/usr/local/lib/node_modules/${PACKAGE_NAME}/dist/cli.js`, brewPrefix: null },
+    });
+    await h.call();
+    assert.equal(h.ran[0], `npm install -g ${PACKAGE_NAME}@latest`);
+  });
+
+  test("a failing command exits 1 and says which one", async () => {
+    const h = harness({ loaded: true, fail: "brew upgrade" });
+    assert.equal(await h.call(), 1);
+    assert.match(h.text(), /`brew upgrade .*` failed — Lisa is still on 0\.24\.0/);
+    assert.ok(!h.ran.some((c) => c.startsWith("launchctl")), "no restart after a failed upgrade");
+  });
+
+  test("a source checkout prints instructions and runs nothing", async () => {
+    const h = harness({
+      facts: {
+        realEntry: "/Users/x/Projects/LISA/dist/cli.js",
+        brewPrefix: null,
+        npmPrefix: null,
+        repoRoot: "/Users/x/Projects/LISA",
+      },
+      loaded: true,
+    });
+    assert.equal(await h.call(), 0);
+    assert.deepEqual(h.ran, []);
+    assert.match(h.text(), /source checkout/);
+    assert.match(h.text(), /git pull && npm install && npm run build/);
+  });
+
+  test("a kickstart failure is a warning, not a failed upgrade", async () => {
+    const h = harness({ loaded: true, fail: "launchctl" });
+    assert.equal(await h.call(), 0);
+    assert.match(h.text(), /couldn't restart the daemon/);
+    assert.match(h.text(), /run it yourself: launchctl kickstart/);
+  });
+});

--- a/src/cli/upgrade.test.ts
+++ b/src/cli/upgrade.test.ts
@@ -16,6 +16,9 @@ import {
   upgradeCommands,
   type InstallFacts,
   type Step,
+  classifyUpgradeFailure,
+  failureAdvice,
+  MIN_NODE_MAJOR,
 } from "./upgrade.js";
 
 /**
@@ -290,5 +293,80 @@ describe("runUpgrade", () => {
     assert.equal(await h.call(), 0);
     assert.match(h.text(), /couldn't restart the daemon/);
     assert.match(h.text(), /run it yourself: launchctl kickstart/);
+  });
+});
+
+describe("a failed upgrade says what to do about it", () => {
+  // `npm install -g` failing on EACCES is the single most common way this
+  // command fails, and #371 already taught the Mac wizard the no-sudo prefix
+  // fix. The CLI printed npm's first line and stopped, so the same user got a
+  // dead end from one surface and a fix from the other.
+  test("EACCES / EPERM / permission denied are the permissions case", () => {
+    for (const out of [
+      "npm ERR! code EACCES\nnpm ERR! syscall mkdir",
+      "npm ERR! code EPERM",
+      "Error: permission denied, mkdir '/usr/local/lib/node_modules'",
+    ]) {
+      assert.equal(classifyUpgradeFailure(out), "permissions", out.slice(0, 30));
+    }
+  });
+
+  test("registry / DNS / connection failures are the network case", () => {
+    for (const out of ["getaddrinfo ENOTFOUND registry.npmjs.org", "npm ERR! code ETIMEDOUT", "ECONNRESET"]) {
+      assert.equal(classifyUpgradeFailure(out), "network", out.slice(0, 30));
+    }
+  });
+
+  test("an engine mismatch is called out as Node, not as a generic failure", () => {
+    assert.equal(classifyUpgradeFailure("npm ERR! code EBADENGINE"), "node-too-old");
+    assert.equal(classifyUpgradeFailure("Unsupported engine for @oratis/lisa"), "node-too-old");
+  });
+
+  test("anything else stays unknown rather than guessing", () => {
+    assert.equal(classifyUpgradeFailure("npm ERR! something new"), "unknown");
+    assert.equal(classifyUpgradeFailure(""), "unknown");
+  });
+
+  test("classification reads the whole message, not just its first line", () => {
+    // runCmd rejects with `npm exited 1: <stderr>`, and the needle is almost
+    // never on line one.
+    const real = "npm exited 1: npm ERR! code EACCES\nnpm ERR! syscall mkdir\nnpm ERR! path /usr/local/lib";
+    assert.equal(classifyUpgradeFailure(real), "permissions");
+  });
+
+  test("the permissions advice is the same no-sudo prefix move the Mac wizard runs", () => {
+    const advice = failureAdvice("permissions", "npm-global").join("\n");
+    for (const needle of [
+      'npm config set prefix "$HOME/.npm-global"',
+      ".zprofile",
+      'export PATH="$HOME/.npm-global/bin:$PATH"',
+      "npm install -g @oratis/lisa@latest",
+    ]) {
+      assert.ok(advice.includes(needle), `advice should carry: ${needle}`);
+    }
+    // "no sudo" in the prose is the point; an actual `sudo npm` command is not.
+    const commands = failureAdvice("permissions", "npm-global").filter((l) => l.startsWith("  "));
+    assert.ok(
+      commands.every((l) => !/\bsudo\b/.test(l)),
+      "never hand someone a sudo npm install — that is what creates the root-owned folder",
+    );
+  });
+
+  test("every failure kind produces non-empty, actionable advice", () => {
+    for (const kind of ["permissions", "network", "node-too-old", "unknown"] as const) {
+      const lines = failureAdvice(kind, "npm-global");
+      assert.ok(lines.length > 0, kind);
+      assert.ok(lines.every((l) => l.trim().length > 0), kind);
+    }
+  });
+
+  test("MIN_NODE_MAJOR tracks package.json engines.node", async () => {
+    const fs = await import("node:fs/promises");
+    const url = await import("node:url");
+    const path = await import("node:path");
+    const root = path.resolve(path.dirname(url.fileURLToPath(import.meta.url)), "../..");
+    const pkg = JSON.parse(await fs.readFile(path.join(root, "package.json"), "utf8"));
+    const declared = Number(/(\d+)/.exec(String(pkg.engines?.node ?? ""))?.[1]);
+    assert.equal(MIN_NODE_MAJOR, declared, "keep upgrade.ts in sync with engines.node");
   });
 });

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -1,0 +1,357 @@
+/**
+ * `lisa upgrade` — update the installed Lisa and restart the daemon.
+ *
+ * The tech review's note was blunt: the author's own machine runs whatever was
+ * installed weeks ago, because upgrading means remembering *how* Lisa got
+ * installed (brew? npm -g? a checkout?) and then remembering that the LaunchAgent
+ * keeps running the old code until something kicks it. Both halves are
+ * mechanical, so they live here.
+ *
+ * Everything that decides *what to do* is a pure function of a few facts about
+ * the process (`detectInstall`, `upgradeCommands`, `compareVersions`), and
+ * everything that *does* it is injectable — so the tests below cover the whole
+ * decision surface without a network call or a real install.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { runCmd } from "../launchd.js";
+import { bold, dim, fail, green, grey, heading, ok, rule, warn } from "./colors.js";
+import { displayPath } from "./display-path.js";
+
+export const PACKAGE_NAME = "@oratis/lisa";
+/** The tap formula from README.md (`brew install oratis/tap/lisa`). */
+export const BREW_FORMULA = "oratis/tap/lisa";
+/**
+ * Must match PLIST_LABEL in src/autostart/install.ts — that file owns the
+ * label, this is a copy because it isn't exported. upgrade.test.ts reads the
+ * installer and fails if the two ever drift.
+ */
+export const AUTOSTART_LABEL = "ai.lisa.autostart";
+
+export type InstallFlavor = "homebrew" | "npm-global" | "source" | "unknown";
+
+/** Everything about the environment that the detection depends on. */
+export interface InstallFacts {
+  /** process.argv[1] — often a symlink shim. */
+  entry: string;
+  /** `entry` with symlinks resolved; the same string when it can't be resolved. */
+  realEntry: string;
+  /** `brew --prefix`, or null when Homebrew isn't installed. */
+  brewPrefix?: string | null;
+  /** `npm prefix -g`, or null when npm isn't installed. */
+  npmPrefix?: string | null;
+  /** Nearest ancestor of `realEntry` containing a `.git`, when there is one. */
+  repoRoot?: string | null;
+  platform?: NodeJS.Platform;
+}
+
+export interface Detection {
+  flavor: InstallFlavor;
+  /** One line the user can check against reality. */
+  reason: string;
+}
+
+export interface Step {
+  cmd: string;
+  args: string[];
+}
+
+export function formatStep(s: Step): string {
+  return [s.cmd, ...s.args].join(" ");
+}
+
+/**
+ * Which install is this? Ordered by how conclusive the evidence is:
+ * a Cellar path can only be Homebrew; a `node_modules/@oratis/lisa` path can
+ * only be a package install; a checkout is what's left when neither holds and
+ * there is a git repo around the entrypoint.
+ */
+export function detectInstall(facts: InstallFacts): Detection {
+  const real = facts.realEntry || facts.entry;
+  const brewPrefix = facts.brewPrefix?.replace(/\/+$/, "") ?? "";
+
+  if (real.includes("/Cellar/")) {
+    return { flavor: "homebrew", reason: `runs from a Homebrew Cellar path (${displayPath(real)})` };
+  }
+  if (brewPrefix && (real.startsWith(`${brewPrefix}/opt/`) || real.startsWith(`${brewPrefix}/Cellar/`))) {
+    return { flavor: "homebrew", reason: `runs from ${displayPath(brewPrefix)}` };
+  }
+  if (real.includes(`/node_modules/${PACKAGE_NAME}/`)) {
+    return {
+      flavor: "npm-global",
+      reason: `installed as a package under ${displayPath(real.slice(0, real.indexOf("/node_modules/")))}`,
+    };
+  }
+  const npmPrefix = facts.npmPrefix?.replace(/\/+$/, "") ?? "";
+  if (npmPrefix && real.startsWith(`${npmPrefix}/`)) {
+    return { flavor: "npm-global", reason: `runs from the npm global prefix ${displayPath(npmPrefix)}` };
+  }
+  if (facts.repoRoot) {
+    return { flavor: "source", reason: `a source checkout at ${displayPath(facts.repoRoot)}` };
+  }
+  return { flavor: "unknown", reason: `can't tell from ${displayPath(real)}` };
+}
+
+/** The commands that perform the upgrade. Empty when there is nothing to run. */
+export function upgradeCommands(flavor: InstallFlavor): Step[] {
+  switch (flavor) {
+    case "homebrew":
+      // `brew update` first: without it the tap never learns the new formula.
+      return [
+        { cmd: "brew", args: ["update"] },
+        { cmd: "brew", args: ["upgrade", BREW_FORMULA] },
+      ];
+    case "npm-global":
+      return [{ cmd: "npm", args: ["install", "-g", `${PACKAGE_NAME}@latest`] }];
+    default:
+      return [];
+  }
+}
+
+/**
+ * What to tell someone whose install we won't touch. A checkout is deliberately
+ * hands-off: it may hold uncommitted work, and `git pull` on someone's working
+ * tree is not an upgrade command, it's a merge.
+ */
+export function manualInstructions(flavor: InstallFlavor, repoRoot?: string | null): string[] {
+  if (flavor === "source") {
+    const where = repoRoot ? `cd ${displayPath(repoRoot)} && ` : "";
+    return [
+      "This is a source checkout — Lisa won't touch a working tree that may hold your changes.",
+      `  ${where}git pull && npm install && npm run build`,
+    ];
+  }
+  return [
+    "Couldn't identify how Lisa was installed. Pick the one that matches:",
+    `  brew upgrade ${BREW_FORMULA}`,
+    `  npm install -g ${PACKAGE_NAME}@latest`,
+  ];
+}
+
+export function kickstartCommand(uid: number, label = AUTOSTART_LABEL): Step {
+  // -k kills the running instance first, so the agent comes back on new code.
+  return { cmd: "launchctl", args: ["kickstart", "-k", `gui/${uid}/${label}`] };
+}
+
+/** semver-lite: numeric compare of the release parts; a prerelease sorts below its release. */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string): { nums: number[]; pre: string } => {
+    const cleaned = v.trim().replace(/^v/, "");
+    const [release = "", ...rest] = cleaned.split("-");
+    return {
+      nums: release.split(".").map((n) => parseInt(n, 10) || 0),
+      pre: rest.join("-"),
+    };
+  };
+  const x = parse(a);
+  const y = parse(b);
+  for (let i = 0; i < Math.max(x.nums.length, y.nums.length); i++) {
+    const d = (x.nums[i] ?? 0) - (y.nums[i] ?? 0);
+    if (d !== 0) return d > 0 ? 1 : -1;
+  }
+  if (x.pre === y.pre) return 0;
+  if (!x.pre) return 1; // 1.0.0 > 1.0.0-rc.1
+  if (!y.pre) return -1;
+  return x.pre > y.pre ? 1 : -1;
+}
+
+// ── I/O side ──────────────────────────────────────────────────────────
+
+/** The version of the code that is running right now, read fresh from disk. */
+export async function readLocalVersion(): Promise<string> {
+  try {
+    // dist/cli/upgrade.js → ../../package.json (and src/cli/upgrade.ts under tsx).
+    const here = path.dirname(fileURLToPath(import.meta.url));
+    const raw = await fs.readFile(path.resolve(here, "..", "..", "package.json"), "utf8");
+    return (JSON.parse(raw) as { version?: string }).version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+/** Walk up from `start` looking for a `.git` — the "am I in a checkout" fact. */
+export async function findRepoRoot(start: string): Promise<string | null> {
+  let dir = path.dirname(start);
+  for (let i = 0; i < 12; i++) {
+    try {
+      await fs.access(path.join(dir, ".git"));
+      return dir;
+    } catch {}
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return null;
+}
+
+export async function gatherFacts(argv1 = process.argv[1] ?? ""): Promise<InstallFacts> {
+  const entry = argv1;
+  let realEntry = entry;
+  try {
+    realEntry = await fs.realpath(entry);
+  } catch {}
+  const brewPrefix = await runCmd("brew", ["--prefix"])
+    .then((s) => s.trim())
+    .catch(() => null);
+  const npmPrefix = await runCmd("npm", ["prefix", "-g"])
+    .then((s) => s.trim())
+    .catch(() => null);
+  return {
+    entry,
+    realEntry,
+    brewPrefix,
+    npmPrefix,
+    repoRoot: await findRepoRoot(realEntry),
+    platform: process.platform,
+  };
+}
+
+/** The newest published version, straight from the registry via the npm CLI. */
+export async function fetchPublishedVersion(): Promise<string | null> {
+  try {
+    const out = await runCmd("npm", ["view", PACKAGE_NAME, "version"]);
+    const v = out.trim().split("\n").pop()?.trim();
+    return v && /^\d/.test(v) ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+export interface UpgradeOptions {
+  /** Only compare versions; change nothing. */
+  check?: boolean;
+  /** Print the commands instead of running them. */
+  dryRun?: boolean;
+  log?: (line: string) => void;
+  facts?: InstallFacts;
+  localVersion?: () => Promise<string>;
+  fetchLatest?: () => Promise<string | null>;
+  run?: (step: Step) => Promise<string>;
+  /** Is the login LaunchAgent loaded (so it holds the old code)? */
+  autostartLoaded?: () => Promise<boolean>;
+  uid?: number;
+}
+
+/** Reads the autostart status text rather than duplicating its plist logic. */
+async function defaultAutostartLoaded(): Promise<boolean> {
+  try {
+    const { autostartStatus } = await import("../autostart/install.js");
+    return /loaded in launchd: yes/.test(await autostartStatus());
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns the process exit code: 0 when there was nothing to do or the upgrade
+ * succeeded, 1 when a command failed. `--check` never fails on "an upgrade is
+ * available" — it is a report, and a cron line that mails its output shouldn't
+ * look like an error.
+ */
+export async function runUpgrade(opts: UpgradeOptions = {}): Promise<number> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+  const facts = opts.facts ?? (await gatherFacts());
+  const readVersion = opts.localVersion ?? readLocalVersion;
+  const fetchLatest = opts.fetchLatest ?? fetchPublishedVersion;
+  const run = opts.run ?? ((s: Step) => runCmd(s.cmd, s.args));
+  const uid = opts.uid ?? (typeof process.getuid === "function" ? process.getuid() : 0);
+
+  log(rule("LISA UPGRADE"));
+  const detection = detectInstall(facts);
+  const before = await readVersion();
+  const latest = await fetchLatest();
+
+  log(heading("Install"));
+  log(`  ${dim("flavour:")}   ${bold(detection.flavor)}${grey("  " + detection.reason)}`);
+  log(`  ${dim("installed:")} ${before}`);
+  log(`  ${dim("published:")} ${latest ?? grey("(registry unreachable)")}`);
+
+  const behind = latest ? compareVersions(latest, before) > 0 : false;
+  if (latest) {
+    if (behind) log(`  ${warn(`${before} → ${latest} available`)}`);
+    else log(`  ${ok("already on the newest published version")}`);
+  }
+
+  if (opts.check) {
+    log("");
+    log(rule());
+    log(behind ? warn(`run \`lisa upgrade\` to move to ${latest}`) : ok("up to date"));
+    return 0;
+  }
+
+  const steps = upgradeCommands(detection.flavor);
+  if (steps.length === 0) {
+    log(heading("Nothing to run"));
+    for (const line of manualInstructions(detection.flavor, facts.repoRoot)) log(`  ${line}`);
+    log("");
+    log(rule());
+    log(warn("nothing upgraded — run one of the commands above yourself"));
+    return 0;
+  }
+
+  const restart = facts.platform === "darwin" && (await (opts.autostartLoaded ?? defaultAutostartLoaded)());
+  const all = restart ? [...steps, kickstartCommand(uid)] : steps;
+
+  if (opts.dryRun) {
+    log(heading("Would run"));
+    for (const s of all) log(`  ${formatStep(s)}`);
+    if (!restart) {
+      log(`  ${dim("(no loaded LaunchAgent — nothing to restart)")}`);
+    }
+    log("");
+    log(rule());
+    log(ok("dry run — nothing changed"));
+    return 0;
+  }
+
+  log(heading("Upgrading"));
+  for (const s of steps) {
+    log(`  ${dim("$")} ${formatStep(s)}`);
+    try {
+      await run(s);
+    } catch (err) {
+      log(`  ${fail((err as Error).message.split("\n")[0] ?? "failed")}`);
+      log("");
+      log(rule());
+      log(fail(`\`${formatStep(s)}\` failed — Lisa is still on ${before}`));
+      return 1;
+    }
+  }
+
+  const after = (await probeVersion(run)) ?? (await readVersion());
+  log(`  ${green("✓")} ${before} → ${after}`);
+
+  if (restart) {
+    // The LaunchAgent is still executing the old code until it is replaced.
+    const kick = kickstartCommand(uid);
+    log(`  ${dim("$")} ${formatStep(kick)}`);
+    try {
+      await run(kick);
+      log(`  ${green("✓")} restarted the login agent (${AUTOSTART_LABEL})`);
+    } catch (err) {
+      log(`  ${warn(`couldn't restart the daemon: ${(err as Error).message.split("\n")[0]}`)}`);
+      log(`  ${dim(`run it yourself: ${formatStep(kick)}`)}`);
+    }
+  }
+
+  log("");
+  log(rule());
+  if (after === before) {
+    log(warn(`still on ${before} — the registry may not have the new version yet`));
+  } else {
+    log(ok(`now on ${after}`));
+  }
+  return 0;
+}
+
+/** Ask the freshly-installed binary its version; the in-process package.json may be stale. */
+async function probeVersion(run: (s: Step) => Promise<string>): Promise<string | null> {
+  try {
+    const out = await run({ cmd: "lisa", args: ["--version"] });
+    const v = out.trim().split("\n").pop()?.trim();
+    return v && /^\d/.test(v) ? v : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/cli/upgrade.ts
+++ b/src/cli/upgrade.ts
@@ -20,6 +20,12 @@ import { bold, dim, fail, green, grey, heading, ok, rule, warn } from "./colors.
 import { displayPath } from "./display-path.js";
 
 export const PACKAGE_NAME = "@oratis/lisa";
+/**
+ * package.json `engines.node`, and BackendSetup.minimumNodeMajor in the Mac
+ * client — keep the three in sync. upgrade.test.ts reads package.json and
+ * fails if this drifts from it.
+ */
+export const MIN_NODE_MAJOR = 20;
 /** The tap formula from README.md (`brew install oratis/tap/lisa`). */
 export const BREW_FORMULA = "oratis/tap/lisa";
 /**
@@ -127,6 +133,59 @@ export function manualInstructions(flavor: InstallFlavor, repoRoot?: string | nu
     `  brew upgrade ${BREW_FORMULA}`,
     `  npm install -g ${PACKAGE_NAME}@latest`,
   ];
+}
+
+/**
+ * Why an upgrade command failed, from the tool's own combined output.
+ *
+ * Mirrors classifyInstallFailure() in
+ * packaging/mac-client/Sources/LisaSetup/BackendSetup.swift — both surfaces run
+ * the same `npm install -g`, so they must hand out the same fix. The Mac wizard
+ * gained one in #371 while `lisa upgrade` still printed npm's first line and
+ * stopped, which left the CLI user at a dead end for the single most common
+ * failure this command has.
+ */
+export type UpgradeFailure = "permissions" | "network" | "node-too-old" | "unknown";
+
+export function classifyUpgradeFailure(output: string): UpgradeFailure {
+  const o = output.toLowerCase();
+  if (o.includes("eacces") || o.includes("eperm") || o.includes("permission denied")) {
+    return "permissions";
+  }
+  if (o.includes("ebadengine") || o.includes("unsupported engine")) return "node-too-old";
+  for (const needle of ["enotfound", "etimedout", "econnreset", "econnrefused", "eai_again", "network"]) {
+    if (o.includes(needle)) return "network";
+  }
+  return "unknown";
+}
+
+/**
+ * What to tell someone after a failed upgrade. The permissions branch is the
+ * standard no-sudo npm prefix move, verbatim the same commands the Mac wizard
+ * offers, so the two surfaces cannot drift into contradicting each other.
+ */
+export function failureAdvice(kind: UpgradeFailure, flavor: InstallFlavor): string[] {
+  switch (kind) {
+    case "permissions":
+      return [
+        "npm can't write to its global folder — it's owned by root.",
+        "The standard fix moves global packages into your home folder (no sudo), then retries:",
+        '  mkdir -p "$HOME/.npm-global"',
+        '  npm config set prefix "$HOME/.npm-global"',
+        `  grep -qs 'npm-global/bin' "$HOME/.zprofile" || echo 'export PATH="$HOME/.npm-global/bin:$PATH"' >> "$HOME/.zprofile"`,
+        '  export PATH="$HOME/.npm-global/bin:$PATH"',
+        `  npm install -g ${PACKAGE_NAME}@latest`,
+      ];
+    case "network":
+      return ["Couldn't reach the registry. Check your connection (and any proxy or VPN), then retry."];
+    case "node-too-old":
+      return [`This Node.js is too old for Lisa — install Node ${MIN_NODE_MAJOR} or newer, then retry.`];
+    case "unknown":
+      return [
+        "The message above is the tool's own. Running the command yourself shows its full output:",
+        ...manualInstructions(flavor),
+      ];
+  }
 }
 
 export function kickstartCommand(uid: number, label = AUTOSTART_LABEL): Step {
@@ -311,7 +370,15 @@ export async function runUpgrade(opts: UpgradeOptions = {}): Promise<number> {
     try {
       await run(s);
     } catch (err) {
-      log(`  ${fail((err as Error).message.split("\n")[0] ?? "failed")}`);
+      const message = (err as Error).message;
+      log(`  ${fail(message.split("\n")[0] ?? "failed")}`);
+      log("");
+      log(heading("What to do"));
+      // Classify on the whole message: runCmd puts the command's stderr in it,
+      // and the needle (EACCES, EBADENGINE, …) is rarely on the first line.
+      for (const line of failureAdvice(classifyUpgradeFailure(message), detection.flavor)) {
+        log(`  ${line}`);
+      }
       log("");
       log(rule());
       log(fail(`\`${formatStep(s)}\` failed — Lisa is still on ${before}`));

--- a/src/proxy-bootstrap.test.ts
+++ b/src/proxy-bootstrap.test.ts
@@ -1,0 +1,60 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+// The module keeps process-wide state (one ProxyAgent per process), so these
+// tests are ordered: the no-proxy case runs before anything installs, and the
+// verbose-announce case loads a fresh module instance via a query-string
+// specifier so it starts from "not installed" again. node --test runs each
+// file in its own process, so the global dispatcher never leaks into other
+// suites.
+const PROXY_VARS = ["HTTPS_PROXY", "https_proxy", "HTTP_PROXY", "http_proxy"] as const;
+function clearProxyEnv(): void {
+  for (const k of PROXY_VARS) delete process.env[k];
+}
+
+describe("configureProxyFromEnv", () => {
+  test("no proxy env → nothing installed, nothing logged, no status line", async () => {
+    clearProxyEnv();
+    const mod = await import("./proxy-bootstrap.js");
+    const logs: string[] = [];
+    mod.configureProxyFromEnv({ log: (m) => logs.push(m), verbose: true });
+    assert.deepEqual(logs, []);
+    assert.equal(mod.isProxyInstalled(), false);
+    assert.equal(mod.proxyStatusLine(), null);
+  });
+
+  test("quiet by default: installs the bridge without printing the banner", async () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = "http://127.0.0.1:7897";
+    const mod = await import("./proxy-bootstrap.js");
+    const logs: string[] = [];
+    mod.configureProxyFromEnv({ log: (m) => logs.push(m) });
+    assert.deepEqual(logs, [], "the success banner is opt-in");
+    assert.equal(mod.isProxyInstalled(), true);
+    // …but the same line stays available for serve startup / doctor.
+    assert.equal(
+      mod.proxyStatusLine(),
+      "[proxy] outbound HTTP routed through http://127.0.0.1:7897 (Accept-Encoding=identity)",
+    );
+  });
+
+  test("idempotent: a later verbose call neither re-installs nor re-announces", async () => {
+    const mod = await import("./proxy-bootstrap.js");
+    const logs: string[] = [];
+    mod.configureProxyFromEnv({ log: (m) => logs.push(m), verbose: true });
+    assert.deepEqual(logs, []);
+  });
+
+  test("verbose: announces exactly once on install (fresh module instance)", async () => {
+    clearProxyEnv();
+    process.env.HTTPS_PROXY = "http://127.0.0.1:7897";
+    const fresh = (await import("./proxy-bootstrap.js?instance=verbose")) as typeof import("./proxy-bootstrap.js");
+    assert.equal(fresh.isProxyInstalled(), false, "query-string import must yield a new module instance");
+    const logs: string[] = [];
+    fresh.configureProxyFromEnv({ log: (m) => logs.push(m), verbose: true });
+    fresh.configureProxyFromEnv({ log: (m) => logs.push(m), verbose: true });
+    assert.deepEqual(logs, [
+      "[proxy] outbound HTTP routed through http://127.0.0.1:7897 (Accept-Encoding=identity)",
+    ]);
+  });
+});

--- a/src/proxy-bootstrap.ts
+++ b/src/proxy-bootstrap.ts
@@ -26,6 +26,7 @@
 import { ProxyAgent, setGlobalDispatcher } from "undici";
 
 let installed = false;
+let installedUrl: string | null = null;
 
 class IdentityEncodingProxyAgent extends ProxyAgent {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -48,7 +49,19 @@ class IdentityEncodingProxyAgent extends ProxyAgent {
   }
 }
 
-export function configureProxyFromEnv(opts: { log?: (msg: string) => void } = {}): void {
+export function configureProxyFromEnv(
+  opts: {
+    log?: (msg: string) => void;
+    /**
+     * Announce a successful install. Off by default: the banner was printed at
+     * the top of every single command (`doctor`, `status`, a one-line prompt),
+     * which made it noise rather than information. Failures are always logged
+     * — they are actionable — and `proxyStatusLine()` lets a long-lived
+     * process (`serve`) or a diagnostic (`doctor`) print the line deliberately.
+     */
+    verbose?: boolean;
+  } = {},
+): void {
   const url =
     process.env.HTTPS_PROXY ??
     process.env.https_proxy ??
@@ -59,7 +72,8 @@ export function configureProxyFromEnv(opts: { log?: (msg: string) => void } = {}
   try {
     setGlobalDispatcher(new IdentityEncodingProxyAgent(url));
     installed = true;
-    opts.log?.(`[proxy] outbound HTTP routed through ${url} (Accept-Encoding=identity)`);
+    installedUrl = url;
+    if (opts.verbose) opts.log?.(proxyStatusLine()!);
   } catch (err) {
     opts.log?.(
       `[proxy] failed to install ProxyAgent for ${url}: ${(err as Error).message}`,
@@ -70,6 +84,16 @@ export function configureProxyFromEnv(opts: { log?: (msg: string) => void } = {}
 /** True iff a proxy was successfully installed. */
 export function isProxyInstalled(): boolean {
   return installed;
+}
+
+/**
+ * The one-line description of the active proxy bridge, or null when outbound
+ * HTTP goes direct. Exactly the text the verbose banner prints, so a startup
+ * log and a debug run describe the same state in the same words.
+ */
+export function proxyStatusLine(): string | null {
+  if (!installed || !installedUrl) return null;
+  return `[proxy] outbound HTTP routed through ${installedUrl} (Accept-Encoding=identity)`;
 }
 
 /**


### PR DESCRIPTION
第 4 / 8 条，实现 UX-9 与 T-3、T-11 的 CLI 部分。基于 #371。

## 做了什么

**日志噪音与路径（UX-9）。** `[proxy] outbound HTTP routed through …` 之前每条命令都打印，现在只在 `--verbose` 或 `LISA_DEBUG=1` 下出现（`serve` 启动时仍保留一行）。所有面向用户的路径统一用 `~` 缩写——缺密钥的报错之前会打出 200 多字符的绝对路径。

**REPL。** 持久化历史（`~/.lisa/history`，0600，上限 1000 行，跳过空行与连续重复）；ANSI 颜色助手，遵守 `NO_COLOR`、`--no-color` 和非 TTY；工具调用压缩成单行——运行中 `⚙ bash  npm test`，结束时 `✓ bash (1.2s)` 或 `✗ bash (0.3s): <首行错误>`，完整结果只在 `--verbose` 下展开；发送提示词到首个响应之间显示 spinner（仅 TTY，走 stderr）；thinking 事件显示为暗色标记但从不打印思考内容。stdout 仍然只承载 Lisa 的正文，管道用法不受影响。

**`lisa doctor --probe [url]`。** 探测运行中后端的 `/health`，打印版本、运行时长、事件循环延迟、堆内存、租户数；p99 超过 1000ms 标警告；不可达时退出码非零。同时兼容只返回 `{ok:true}` 的旧服务端。

**`lisa upgrade`。** 识别安装方式（Homebrew / npm 全局 / 源码检出），执行对应升级，打印升级前后版本；若 LaunchAgent 已加载则顺带 `launchctl kickstart` 让守护进程用上新代码——这正是此前需要手工执行 6 条命令的场景。`--check` 只比对版本，`--dry-run` 只打印将要执行的命令。

## 验证

新增逻辑均有测试（渲染器用假的非 TTY writer，探测用端口 0 的本地服务，升级只测纯检测与命令拼装，不联网不真装）。无新增运行时依赖。

🤖 Generated with [Claude Code](https://claude.com/claude-code)