### PR TITLE
feat(billing): 持久化用量 outbox + 对账，fail-closed（T-8）

### DIFF
--- a/docs/RUNBOOK_CLOUD_PROD.md
+++ b/docs/RUNBOOK_CLOUD_PROD.md
@@ -168,7 +168,96 @@ gcloud billing budgets create --billing-account <BILLING_ACCOUNT_ID> \
 其余日志侧已内建：sweep 报告行 `[sweep] scanned…`（severity INFO，
 jsonPayload.message）；Scheduler 首跳失败直接看 Cloud Scheduler 的执行历史。
 
-## 7. 急停开关（记住这三个）
+## 7. 计费 outbox 与对账（T-8）
+
+### 它是什么
+
+结算一次计费推理是**两次写**：先记下"provider 已经收了钱、花了多少"，再从余额里扣。
+T-8 之前只有第二次写是持久的，所以两次之间崩溃／Firestore 抖动／磁盘写满，
+这笔账就**静默丢失**——用户拿到了推理，运营方付了成本，磁盘上没有任何东西记得为什么对不上。
+
+usage outbox 让第一次写也持久、第二次写可重放：
+
+```
+append(pending) ──► debit(balance, eventId) ──► update(committed)
+     append 失败 ⇒ FAIL CLOSED：不扣费、释放 permit、给调用方一个可重试的错误
+     debit  失败 ⇒ 事件停在 failed，对账器稍后重试
+     mark   失败 ⇒ 不算错误：钱已经对了，记录留着让对账器关闭
+```
+
+**幂等键在账本里，不在 outbox 里**：`debitTurn` 把 event id 记进余额文档的 `settled` 环，
+和扣款在同一个原子更新里。所以重放是被"拿着钱的那一方"拒绝的，而不是靠调用方记得检查。
+这也是"标记 committed"可以单独一次写的原因——`firestore.ts` 只有 CAS，没有 runTransaction。
+
+存储：本地版是租户 billing 目录下的 `outbox.jsonl`（追加写，同 id 以最后一行为准）；
+Cloud 是 `lisa-outbox/{uid}/events/{id}`（`exists:false` 创建 ⇒ 按 id 幂等）
+加一个 `lisa-outbox/{uid}` 的 open 索引（本客户端没有 query API）。
+
+### 怎么读对账报告
+
+```bash
+# 只看不动（推荐先跑这个）
+lisa billing reconcile --dry-run
+# 真跑一轮；--json 给监控用
+lisa billing reconcile --json
+# 只扫一个租户
+lisa billing reconcile --uid <uid>
+```
+
+| 计数 | 含义 | 该有的样子 |
+|---|---|---|
+| `scanned` | 本轮看到的未关闭事件 | 正常几乎为 0 |
+| `committed` | 本轮补上的扣款 | 偶发几个正常（崩溃/重启后） |
+| `failed` | 这次没成，但还在 5 次重试预算内 | 持续 >0 说明账本还病着 |
+| `escalated` | 本轮升级成 `needs_human` | **任何非 0 都要人看** |
+| `skipped` | 故意没动：已 parked，或 pending 还在 5 分钟宽限期内 | 与 `needs_human` 数量对得上 |
+
+serve 起来后台每 15 分钟自动跑一轮（启动后 30 秒先跑一次，把崩溃残留清掉），
+多实例下用 `lisa-leases/billing-reconcile` 抢锁，一轮只有一个实例真跑。
+日志按 `[billing] reconcile:` 找（severity INFO）。
+
+### `needs_human` 怎么处理
+
+事件在两种情况下停下来等人，日志是 severity ERROR、含 event id、脱敏 uid 和金额：
+
+- **重试用尽**（5 次）：`[billing] outbox event <id> → needs_human after 5 attempts`
+- **不能证明重放安全**：`replay_window`（事件比账本幂等窗口还老，重放和重复扣款无法区分）
+  或 `account_missing`（uid 已经没有账号记录了）
+
+处理步骤：
+
+1. `lisa billing reconcile --uid <uid>` 看清单，拿到 event id、金额、`lastError`。
+2. 先修根因（余额文档损坏？Firestore 权限？账号被删了？）。
+3. 根因修好后，`lisa billing reconcile --uid <uid> --retry-human` 让它再自动走一轮。
+4. 只有当**这笔钱不该再扣**（比如账号已注销并退款、或你已手工改过余额）时，才手工关闭：
+
+```bash
+lisa billing reconcile --uid <uid> --resolve <event-id>
+```
+
+`--resolve` **不扣款**，只把记录关掉。钱还欠着的话，先手工改余额再 resolve，顺序别反。
+
+### 手工补偿配方（本地版 / 单实例）
+
+余额和 outbox 都在租户 home 下，对账前后各留一份：
+
+```bash
+UID=<uid>; H=~/.lisa/users/$UID/billing
+cp $H/balance.json /tmp/balance.before.json
+cat $H/outbox.jsonl | jq -c 'select(.status != "committed")'   # 还开着的事件
+# 手工加一笔（micro-USD，整数），改完再 --resolve 对应事件
+jq '.paidMicroUSD -= 4200' $H/balance.json > $H/balance.next && mv $H/balance.next $H/balance.json
+```
+
+改 `balance.json` 时**不要**动 `settled` 数组：那是幂等环，手工删条目会让重放变成重复扣款。
+`usage.jsonl` 是审计源，随时可以拿来重算 outbox 对不上的部分。
+
+### 开关
+
+`LISA_BILLING_OUTBOX=0` 只关掉 outbox 那一次写，T-8 之前就有的 fail-closed 检查一个都不动。
+**它不是急停开关**——关掉它等于回到"崩溃就丢账"的旧行为。要停计费用 `LISA_BILLING_KILL=1`（见下节）。
+
+## 8. 急停开关（记住这三个）
 
 | 开关 | 效果 |
 |---|---|
@@ -176,7 +265,7 @@ jsonPayload.message）；Scheduler 首跳失败直接看 Cloud Scheduler 的执�
 | Cloudflare Turnstile 调成 Managed-challenge 全量 | 注册口收紧到人类 |
 | `gcloud run services update lisa-cloud --max-instances 0` | 整站下线（保数据） |
 
-## 8. 上线冒烟清单
+## 9. 上线冒烟清单
 
 - [ ] 无痕窗口 → cloud.meetlisa.ai → 登录页三种方式齐全（Google/Apple/邮箱+验证码）
 - [ ] 新邮箱注册 → 收到验证码邮件 → birth 仪式打字机完整跑完 → 落进 island
@@ -184,3 +273,4 @@ jsonPayload.message）；Scheduler 首跳失败直接看 Cloud Scheduler 的执�
 - [ ] 免费窗口计量在账号页可见；Stripe 测试卡充值到账
 - [ ] 官网 meetlisa.ai 导航「登录」与 /cloud 页链接可达
 - [ ] sweep 手动 curl 返回报告；Scheduler 首跳成功
+- [ ] `lisa billing reconcile --dry-run` 返回全 0；日志里看得到 `[billing] reconcile:` 心跳

--- a/src/billing/admission.ts
+++ b/src/billing/admission.ts
@@ -5,10 +5,12 @@
  * applies abuse limits, serializes the tenant across instances, checks quota,
  * and returns an idempotently releasable permit for the lifetime of the turn.
  */
+import crypto from "node:crypto";
 import type { AccountRecord } from "../web/accounts.js";
 import { preflightLimits, type LimitVerdict } from "./limits.js";
-import { debitTurn, precheckTurn, type PrecheckResult } from "./quota.js";
+import { precheckTurn, type PrecheckResult } from "./quota.js";
 import { recordUsage, type UsageRecord } from "./meter.js";
+import { settleUsage } from "./outbox.js";
 import type { ProviderUsage } from "../providers/types.js";
 import {
   acquireTurnLease,
@@ -19,6 +21,8 @@ import {
 
 export interface InferencePermit {
   budgetMicroUSD: number;
+  /** Ties this turn's usage outbox event back to the admission that ran it (T-8). */
+  reservationId: string;
   /** Price, audit and debit this permit's aggregated provider usage once. */
   settle(source: string, usage: ProviderUsage): Promise<UsageRecord>;
   release(): Promise<void>;
@@ -39,6 +43,7 @@ export interface AdmissionDependencies {
     source: string,
     model: string,
     usage: ProviderUsage,
+    reservationId: string,
   ): Promise<UsageRecord>;
 }
 
@@ -48,9 +53,19 @@ const DEFAULT_DEPS: AdmissionDependencies = {
   acquire: acquireTurnLease,
   startRenewal: startLeaseRenewal,
   releaseLease: releaseTurnLease,
-  settle: async (acct, source, model, usage) => {
+  // T-8: the debit now goes through the durable usage outbox. recordUsage
+  // stays the AUDIT append (best-effort, never throws); settleUsage owns the
+  // money and fails closed if the event cannot be made durable first.
+  settle: async (acct, source, model, usage, reservationId) => {
     const record = await recordUsage(source, model, usage);
-    await debitTurn(acct, model, record.microUSD);
+    await settleUsage({
+      acct,
+      kind: source,
+      model,
+      usage,
+      costMicros: record.microUSD,
+      reservationId,
+    });
     return record;
   },
 };
@@ -87,6 +102,7 @@ export async function admitInference(
     };
   }
 
+  const reservationId = crypto.randomUUID();
   let released = false;
   let settlement: Promise<UsageRecord> | null = null;
   let stopRenewal: () => void = () => {};
@@ -108,8 +124,9 @@ export async function admitInference(
       ok: true,
       permit: {
         budgetMicroUSD: pre.budgetMicroUSD,
+        reservationId,
         settle: (source, usage) => {
-          settlement ??= deps.settle(acct, source, model, usage);
+          settlement ??= deps.settle(acct, source, model, usage, reservationId);
           return settlement;
         },
         release,

--- a/src/billing/media-admission.ts
+++ b/src/billing/media-admission.ts
@@ -5,18 +5,22 @@ import type { AccountRecord } from "../web/accounts.js";
 import type { MediaUsage } from "./media-prices.js";
 import { recordMediaUsage, type MediaUsageRecord } from "./media-meter.js";
 import { preflightLimits, type LimitVerdict } from "./limits.js";
-import { debitTurn, precheckTurn, type PrecheckResult } from "./quota.js";
+import { precheckTurn, type PrecheckResult } from "./quota.js";
+import { settleUsage } from "./outbox.js";
 import {
   acquireTurnLease,
   releaseTurnLease,
   startLeaseRenewal,
   type TurnLease,
 } from "../cloud/turn-lease.js";
+import crypto from "node:crypto";
 
 /** Unknown models are premium in quota.ts: media never consumes free LLM credit. */
 export const MEDIA_BILLING_MODEL = "media/voice-transcription";
 
 export interface MediaPermit {
+  /** Ties this turn's usage outbox event back to the admission that ran it (T-8). */
+  reservationId: string;
   settle(source: string, usage: MediaUsage): Promise<MediaUsageRecord>;
   release(): Promise<void>;
 }
@@ -31,7 +35,12 @@ export interface MediaAdmissionDependencies {
   acquire(uid: string): Promise<TurnLease | null>;
   startRenewal(lease: TurnLease): () => void;
   releaseLease(lease: TurnLease): Promise<void>;
-  settle(acct: AccountRecord, source: string, usage: MediaUsage): Promise<MediaUsageRecord>;
+  settle(
+    acct: AccountRecord,
+    source: string,
+    usage: MediaUsage,
+    reservationId: string,
+  ): Promise<MediaUsageRecord>;
 }
 
 const DEFAULT_DEPS: MediaAdmissionDependencies = {
@@ -40,9 +49,17 @@ const DEFAULT_DEPS: MediaAdmissionDependencies = {
   acquire: acquireTurnLease,
   startRenewal: startLeaseRenewal,
   releaseLease: releaseTurnLease,
-  settle: async (acct, source, usage) => {
+  // T-8: voice is a metered inference like any other, so it settles through
+  // the durable outbox too. Duration-priced, hence no token counts.
+  settle: async (acct, source, usage, reservationId) => {
     const record = await recordMediaUsage(source, usage);
-    await debitTurn(acct, MEDIA_BILLING_MODEL, record.microUSD);
+    await settleUsage({
+      acct,
+      kind: source,
+      model: MEDIA_BILLING_MODEL,
+      costMicros: record.microUSD,
+      reservationId,
+    });
     return record;
   },
 };
@@ -72,6 +89,7 @@ export async function admitMedia(
     return { ok: false, status: 429, body: { error: "turn_in_progress" } };
   }
 
+  const reservationId = crypto.randomUUID();
   let released = false;
   let settlement: Promise<MediaUsageRecord> | null = null;
   let stopRenewal: () => void = () => {};
@@ -92,8 +110,9 @@ export async function admitMedia(
     return {
       ok: true,
       permit: {
+        reservationId,
         settle: (source, usage) => {
-          settlement ??= deps.settle(acct, source, usage);
+          settlement ??= deps.settle(acct, source, usage, reservationId);
           return settlement;
         },
         release,

--- a/src/billing/outbox.test.ts
+++ b/src/billing/outbox.test.ts
@@ -1,0 +1,497 @@
+/**
+ * Failure-injection suite for the durable usage outbox (T-8).
+ *
+ * Every test here models one way the two-write settlement ("charge the
+ * provider, then debit the balance") can be torn, and asserts the money
+ * invariants (.codex/INVARIANTS.md 计费与交易):
+ *   - no double charge, no lost charge after reconciliation;
+ *   - the outbox append fails CLOSED (no debit, retryable error);
+ *   - the admission permit is still releasable after every failure;
+ *   - nothing secret (raw uid, bearer tokens) reaches the logs.
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-outbox-"));
+process.env.LISA_HOME = TMP;
+delete process.env.LISA_FIRESTORE;
+// log.ts routes through console.error only in text mode; captureLogs() below
+// hooks console, so pin the format instead of inheriting K_SERVICE from CI.
+process.env.LISA_LOG_FORMAT = "text";
+
+import type { AccountRecord } from "../web/accounts.js";
+import type { AdmissionDependencies } from "./admission.js";
+import type { UsageEvent, SettlementDeps, SettlementInput } from "./outbox.js";
+
+const {
+  MemoryOutboxStore,
+  JsonlOutboxStore,
+  settleUsage,
+  commitUsageEvent,
+  newUsageEvent,
+  describeError,
+  outboxEnabled,
+} = await import("./outbox.js");
+const { reconcileOnce } = await import("./reconcile.js");
+const { admitInference } = await import("./admission.js");
+const { debitTurn, readBalance, creditPurchase, BillingStateError, SETTLED_MAX } = await import("./quota.js");
+const { homeScope, homeForUid } = await import("../paths.js");
+const { redactId } = await import("../log.js");
+
+const T0 = Date.parse("2026-09-06T08:00:00Z");
+const UID = "em-topsecretuid0001";
+const ACCT: AccountRecord = {
+  uid: UID,
+  kind: "email",
+  email: "u@example.com",
+  createdAt: T0,
+  lastLoginAt: T0,
+  verified: true,
+  sessionVersion: 0,
+};
+const USAGE = { inputTokens: 1000, outputTokens: 500, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+function input(overrides: Partial<SettlementInput> = {}): SettlementInput {
+  return {
+    acct: ACCT,
+    kind: "chat",
+    model: "glm-4.6",
+    usage: USAGE,
+    costMicros: 4_200,
+    reservationId: "resv-1",
+    ...overrides,
+  };
+}
+
+/**
+ * A balance ledger double with the SAME idempotency contract as quota.ts
+ * debitTurn(eventId): a replayed event id returns false and changes nothing.
+ * `failTimes` injects a store outage on the next N debits.
+ */
+function fakeLedger(opts: { failTimes?: number; error?: () => Error } = {}) {
+  const applied = new Set<string>();
+  let failures = opts.failTimes ?? 0;
+  const state = { calls: 0, balance: 0 };
+  const debit: SettlementDeps["debit"] = async (_acct, event, eventId) => {
+    state.calls += 1;
+    if (failures > 0) {
+      failures -= 1;
+      throw opts.error?.() ?? new Error(`balance store down for ${UID} Bearer sk-secret-token-123456`);
+    }
+    if (eventId && applied.has(eventId)) return false;
+    if (eventId) applied.add(eventId);
+    state.balance -= event.costMicros;
+    return true;
+  };
+  return { debit, state, applied };
+}
+
+function deps(
+  store: InstanceType<typeof MemoryOutboxStore>,
+  ledger: ReturnType<typeof fakeLedger>,
+  overrides: Partial<SettlementDeps> = {},
+): SettlementDeps {
+  return { store, debit: ledger.debit, now: () => T0, enabled: () => true, ...overrides };
+}
+
+function captureLogs(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const orig = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  return { lines, restore: () => { console.error = orig; } };
+}
+
+let logs: ReturnType<typeof captureLogs>;
+beforeEach(() => {
+  logs = captureLogs();
+  fs.rmSync(path.join(TMP, "users"), { recursive: true, force: true });
+});
+afterEach(() => {
+  logs.restore();
+});
+
+describe("usage outbox — settlement failure injection", () => {
+  test("(a) outbox append failure fails CLOSED: nothing debited, retryable BillingStateError", async () => {
+    const store = new MemoryOutboxStore({
+      faults: { append: () => new Error(`ENOSPC writing outbox for ${UID}`) },
+    });
+    const ledger = fakeLedger();
+    await assert.rejects(
+      settleUsage(input(), deps(store, ledger)),
+      (err: unknown) => err instanceof BillingStateError && err.code === "outbox_unavailable",
+    );
+    assert.equal(ledger.state.calls, 0, "the balance must not be touched when the event is not durable");
+    assert.equal(ledger.state.balance, 0);
+    assert.deepEqual(await store.listOpen(UID), []);
+    // Logged loudly, but never with the raw uid.
+    const line = logs.lines.find((l) => l.includes("[billing]") && l.includes("outbox"));
+    assert.ok(line, "an append failure must be logged");
+    assert.ok(!line.includes(UID), `raw uid leaked into logs: ${line}`);
+    assert.ok(line.includes(redactId(UID)));
+  });
+
+  test("(b) balance commit failure after a durable append: event is 'failed', settle throws, reconciler finishes it once", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger({ failTimes: 1 });
+    await assert.rejects(
+      settleUsage(input(), deps(store, ledger)),
+      (err: unknown) => err instanceof BillingStateError && err.code === "balance_unavailable",
+    );
+    const open = await store.listOpen(UID);
+    assert.equal(open.length, 1);
+    const ev = open[0]!;
+    assert.equal(ev.status, "failed");
+    assert.equal(ev.attempts, 1);
+    assert.ok(ev.lastError && !ev.lastError.includes(UID), "lastError must not carry the raw uid");
+    assert.ok(!ev.lastError.includes("sk-secret-token"), "lastError must not carry a token");
+    assert.equal(ledger.state.balance, 0, "a failed commit must not have charged");
+
+    // The store recovers; the reconciler applies the charge exactly once.
+    const report = await reconcileOnce(
+      { now: T0 + 60_000 },
+      { store, debit: ledger.debit, loadAccount: async () => ACCT, now: () => T0 + 60_000 },
+    );
+    assert.equal(report.committed, 1);
+    assert.equal(report.escalated, 0);
+    assert.equal(ledger.state.balance, -4_200);
+    assert.deepEqual(await store.listOpen(UID), []);
+    assert.equal((await store.get(UID, ev.id))?.status, "committed");
+    // A second pass finds nothing and changes nothing.
+    const again = await reconcileOnce(
+      { now: T0 + 120_000 },
+      { store, debit: ledger.debit, loadAccount: async () => ACCT, now: () => T0 + 120_000 },
+    );
+    assert.equal(again.scanned, 0);
+    assert.equal(ledger.state.balance, -4_200);
+  });
+
+  test("(c) mark-committed failure after a successful debit: no throw, no second charge, reconciler closes it", async () => {
+    let failMark = true;
+    const store = new MemoryOutboxStore({
+      faults: {
+        update: (event) => {
+          if (event.status === "committed" && failMark) {
+            failMark = false;
+            return new Error("outbox write failed after debit");
+          }
+          return undefined;
+        },
+      },
+    });
+    const ledger = fakeLedger();
+    const result = await settleUsage(input(), deps(store, ledger));
+    assert.ok(result.eventId);
+    assert.equal(result.applied, true);
+    assert.equal(result.committed, false, "the caller learns the mark did not land, but the turn is paid");
+    assert.equal(ledger.state.balance, -4_200);
+    // The event is still open; the debit already happened.
+    const open = await store.listOpen(UID);
+    assert.equal(open.length, 1);
+    assert.equal(open[0]!.status, "pending");
+    // Reconciliation must NOT debit again: the idempotency key says "already applied".
+    const later = T0 + 10 * 60_000;
+    const report = await reconcileOnce(
+      { now: later },
+      { store, debit: ledger.debit, loadAccount: async () => ACCT, now: () => later },
+    );
+    assert.equal(report.committed, 1);
+    assert.equal(ledger.state.balance, -4_200, "double charge");
+    assert.equal(ledger.state.calls, 2, "the replay consulted the ledger once and was refused");
+    assert.deepEqual(await store.listOpen(UID), []);
+  });
+
+  test("(d) process crash between append and commit: the reconciler applies the charge exactly once", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger();
+    // Simulate the crash: a durable pending event with no commit ever attempted.
+    const ev = newUsageEvent(input(), T0 - 10 * 60_000);
+    await store.append(ev);
+    assert.equal(ev.status, "pending");
+    assert.equal(ev.attempts, 0);
+    const first = await reconcileOnce(
+      { now: T0 },
+      { store, debit: ledger.debit, loadAccount: async () => ACCT, now: () => T0 },
+    );
+    assert.deepEqual(
+      { scanned: first.scanned, committed: first.committed, escalated: first.escalated, skipped: first.skipped, failed: first.failed },
+      { scanned: 1, committed: 1, escalated: 0, skipped: 0, failed: 0 },
+    );
+    assert.equal(ledger.state.balance, -4_200);
+    const second = await reconcileOnce(
+      { now: T0 + 1 },
+      { store, debit: ledger.debit, loadAccount: async () => ACCT, now: () => T0 + 1 },
+    );
+    assert.equal(second.scanned, 0);
+    assert.equal(ledger.state.balance, -4_200);
+  });
+
+  test("(d') a pending event younger than the grace period is left alone (a live settlement may own it)", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger();
+    await store.append(newUsageEvent(input(), T0 - 30_000));
+    const report = await reconcileOnce(
+      { now: T0 },
+      { store, debit: ledger.debit, loadAccount: async () => ACCT, now: () => T0 },
+    );
+    assert.equal(report.skipped, 1);
+    assert.equal(report.committed, 0);
+    assert.equal(ledger.state.calls, 0);
+  });
+
+  test("(e) replaying the same event is a no-op at every layer", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger();
+    const ev = newUsageEvent(input(), T0);
+    await store.append(ev);
+    await store.append({ ...ev }); // idempotent create
+    assert.equal((await store.listOpen(UID)).length, 1);
+    const first = await commitUsageEvent(ev, ACCT, deps(store, ledger));
+    assert.deepEqual(first, { applied: true, committed: true });
+    const second = await commitUsageEvent(ev, ACCT, deps(store, ledger));
+    assert.deepEqual(second, { applied: false, committed: true });
+    assert.equal(ledger.state.balance, -4_200);
+    // A committed record can never be reopened by a stale replay of its pending form.
+    await store.append({ ...ev, status: "pending", attempts: 0 });
+    assert.deepEqual(await store.listOpen(UID), []);
+    assert.equal((await store.get(UID, ev.id))?.status, "committed");
+  });
+
+  test("(f) via admitInference: a settle failure rejects and the permit still releases the lease exactly once", async () => {
+    const calls: string[] = [];
+    const d: AdmissionDependencies = {
+      preflight: () => ({ ok: true }),
+      precheck: async () => ({ ok: true, budgetMicroUSD: 100 }),
+      acquire: async () => "off",
+      startRenewal: () => () => calls.push("stop"),
+      releaseLease: async () => {
+        calls.push("release");
+      },
+      settle: async () => {
+        throw new BillingStateError("outbox_unavailable", "outbox append failed");
+      },
+    };
+    const admission = await admitInference(ACCT, "glm-4.6", d);
+    assert.ok(admission.ok);
+    if (!admission.ok) return;
+    assert.ok(admission.permit.reservationId, "a permit carries a reservation id for the outbox");
+    await assert.rejects(admission.permit.settle("chat", USAGE), BillingStateError);
+    // The caller's finally block:
+    await admission.permit.release();
+    await admission.permit.release();
+    assert.deepEqual(calls, ["stop", "release"]);
+  });
+
+  test("(g) no secrets in logs: a store error carrying the uid and a bearer token is redacted", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger({
+      failTimes: 1,
+      error: () => new Error(`commit lisa-balances/${UID} failed (503) Authorization: Bearer ya29.secret-token-value`),
+    });
+    await assert.rejects(settleUsage(input(), deps(store, ledger)));
+    const all = logs.lines.join("\n");
+    assert.ok(all.includes("[billing]"), "the failure must be logged");
+    assert.ok(!all.includes(UID), `raw uid leaked: ${all}`);
+    assert.ok(!all.includes("ya29.secret-token-value"), `token leaked: ${all}`);
+    const ev = (await store.listOpen(UID))[0]!;
+    assert.ok(all.includes(ev.id), "the event id is the operator's handle and must be logged");
+    assert.ok(!ev.lastError!.includes("ya29.secret-token-value"));
+  });
+
+  test("(h) LISA_BILLING_OUTBOX=0 skips the outbox write but still debits (existing fail-closed checks untouched)", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger();
+    const result = await settleUsage(input(), deps(store, ledger, { enabled: () => false }));
+    assert.equal(result.eventId, null);
+    assert.equal(result.applied, true);
+    assert.equal(ledger.state.balance, -4_200);
+    assert.deepEqual(await store.listOpen(UID), []);
+    assert.deepEqual(
+      store.calls.filter((c) => c.op === "append" || c.op === "update"),
+      [],
+      "the store must not be WRITTEN when the flag is off",
+    );
+    // ...and a balance failure with the flag off still surfaces as the same retryable error.
+    const down = fakeLedger({ failTimes: 1 });
+    await assert.rejects(
+      settleUsage(input(), deps(store, down, { enabled: () => false })),
+      (err: unknown) => err instanceof BillingStateError && err.code === "balance_unavailable",
+    );
+    assert.equal(outboxEnabled({ LISA_BILLING_OUTBOX: "0" }), false);
+    assert.equal(outboxEnabled({ LISA_BILLING_OUTBOX: "false" }), false);
+    assert.equal(outboxEnabled({}), true);
+    assert.equal(outboxEnabled({ LISA_BILLING_OUTBOX: "1" }), true);
+  });
+
+  test("(i) a zero-cost settlement writes no event and debits nothing", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger();
+    const result = await settleUsage(input({ costMicros: 0 }), deps(store, ledger));
+    assert.deepEqual(result, { eventId: null, applied: false, committed: true });
+    assert.equal(ledger.state.calls, 0);
+    assert.equal(store.calls.length, 0);
+  });
+
+  test("the happy path: append → debit → committed, with the full event shape", async () => {
+    const store = new MemoryOutboxStore();
+    const ledger = fakeLedger();
+    const result = await settleUsage(input({ provider: "zhipu" }), deps(store, ledger));
+    assert.ok(result.eventId);
+    assert.equal(result.applied, true);
+    assert.equal(result.committed, true);
+    const ev = await store.get(UID, result.eventId!);
+    assert.ok(ev);
+    assert.equal(ev.uid, UID);
+    assert.equal(ev.kind, "chat");
+    assert.equal(ev.provider, "zhipu");
+    assert.equal(ev.model, "glm-4.6");
+    assert.equal(ev.tokensIn, 1000);
+    assert.equal(ev.tokensOut, 500);
+    assert.equal(ev.costMicros, 4_200);
+    assert.equal(ev.reservationId, "resv-1");
+    assert.equal(ev.status, "committed");
+    assert.equal(ev.attempts, 1);
+    assert.equal(ev.createdAt, T0);
+    assert.deepEqual(
+      store.calls.filter((c) => c.op !== "get" && c.op !== "listOpen").map((c) => c.op),
+      ["append", "update"],
+      "the record is made durable BEFORE the debit and closed after — in that order",
+    );
+    assert.deepEqual(await store.listOpen(UID), []);
+  });
+});
+
+describe("usage outbox — the balance ledger's idempotency key (quota.ts)", () => {
+  test("debitTurn(eventId) applies once; a replay returns false and leaves the balance alone", async () => {
+    await homeScope.run(homeForUid("em-idem"), async () => {
+      await creditPurchase({ at: T0, microUSD: 5_000_000, transactionId: "seed-idem" }, T0);
+      assert.equal(await debitTurn(ACCT, "claude-sonnet-4-6", 1_000_000, T0, { eventId: "evt-1" }), true);
+      assert.equal(await debitTurn(ACCT, "claude-sonnet-4-6", 1_000_000, T0 + 1, { eventId: "evt-1" }), false);
+      const b = await readBalance();
+      assert.equal(b.paidMicroUSD, 4_000_000);
+      assert.deepEqual(b.settled?.map((s) => s.id), ["evt-1"]);
+      // A different event id is a real charge; no id means the legacy (non-idempotent) debit.
+      assert.equal(await debitTurn(ACCT, "claude-sonnet-4-6", 1_000_000, T0 + 2, { eventId: "evt-2" }), true);
+      assert.equal(await debitTurn(ACCT, "claude-sonnet-4-6", 1_000_000, T0 + 3), true);
+      assert.equal((await readBalance()).paidMicroUSD, 2_000_000);
+    });
+  });
+
+  test("the settled ring is bounded and survives a round-trip through the balance file", async () => {
+    await homeScope.run(homeForUid("em-ring"), async () => {
+      await creditPurchase({ at: T0, microUSD: 50_000_000, transactionId: "seed-ring" }, T0);
+      for (let i = 0; i < SETTLED_MAX + 5; i++) {
+        await debitTurn(ACCT, "claude-sonnet-4-6", 1, T0 + i, { eventId: `evt-${i}` });
+      }
+      const b = await readBalance();
+      assert.equal(b.settled?.length, SETTLED_MAX);
+      assert.equal(b.settled?.[0]?.id, "evt-5", "oldest entries are evicted first");
+      assert.equal(b.paidMicroUSD, 50_000_000 - (SETTLED_MAX + 5));
+    });
+  });
+
+  test("a corrupt settled entry makes the balance fail closed (never silently dropped)", async () => {
+    const home = homeForUid("em-corrupt-ring");
+    fs.mkdirSync(path.join(home, "billing"), { recursive: true });
+    fs.writeFileSync(
+      path.join(home, "billing", "balance.json"),
+      JSON.stringify({ paidMicroUSD: 1, purchases: [], settled: [{ id: 42, at: "x" }] }),
+    );
+    await homeScope.run(home, async () => {
+      await assert.rejects(readBalance(), (err: unknown) => err instanceof BillingStateError && err.code === "balance_corrupt");
+      await assert.rejects(debitTurn(ACCT, "claude-sonnet-4-6", 1, T0, { eventId: "e" }), BillingStateError);
+    });
+  });
+});
+
+describe("usage outbox — end to end on the local JSONL store with the real balance ledger", () => {
+  const uid = "em-e2e";
+  const acct: AccountRecord = { ...ACCT, uid };
+  const realDebit: SettlementDeps["debit"] = (a, event, eventId) =>
+    homeScope.run(homeForUid(a.uid), () =>
+      debitTurn(a, event.model, event.costMicros, event.createdAt, eventId ? { eventId } : undefined),
+    );
+
+  test("settle writes the event before the debit and marks it committed after", async () => {
+    const store = new JsonlOutboxStore();
+    const result = await homeScope.run(homeForUid(uid), () =>
+      settleUsage(input({ acct }), { store, debit: realDebit, now: () => T0, enabled: () => true }),
+    );
+    assert.equal(result.committed, true);
+    const file = path.join(homeForUid(uid), "billing", "outbox.jsonl");
+    const lines = fs.readFileSync(file, "utf8").trim().split("\n").map((l) => JSON.parse(l) as UsageEvent);
+    assert.deepEqual(lines.map((l) => l.status), ["pending", "committed"]);
+    const balance = await homeScope.run(homeForUid(uid), readBalance);
+    assert.equal(balance.window?.spentMicroUSD, 4_200);
+    assert.deepEqual(balance.settled?.map((s) => s.id), [result.eventId]);
+  });
+
+  test("an unwritable outbox fails closed: no debit, no ledger change", async () => {
+    const store = new JsonlOutboxStore();
+    const uid2 = "em-e2e-ro";
+    const acct2 = { ...ACCT, uid: uid2 };
+    // billing/outbox.jsonl as a DIRECTORY ⇒ every append fails with EISDIR.
+    fs.mkdirSync(path.join(homeForUid(uid2), "billing", "outbox.jsonl"), { recursive: true });
+    await assert.rejects(
+      homeScope.run(homeForUid(uid2), () =>
+        settleUsage(input({ acct: acct2 }), { store, debit: realDebit, now: () => T0, enabled: () => true }),
+      ),
+      (err: unknown) => err instanceof BillingStateError && err.code === "outbox_unavailable",
+    );
+    const balance = await homeScope.run(homeForUid(uid2), readBalance);
+    assert.equal(balance.window, undefined, "no window was opened, nothing was spent");
+  });
+
+  test("a corrupt balance after a durable append: event parked as failed, then recovered by the reconciler", async () => {
+    const store = new JsonlOutboxStore();
+    const uid3 = "em-e2e-recover";
+    const acct3 = { ...ACCT, uid: uid3 };
+    const billing = path.join(homeForUid(uid3), "billing");
+    fs.mkdirSync(billing, { recursive: true });
+    fs.writeFileSync(path.join(billing, "balance.json"), "{corrupt");
+    await assert.rejects(
+      homeScope.run(homeForUid(uid3), () =>
+        settleUsage(input({ acct: acct3 }), { store, debit: realDebit, now: () => T0, enabled: () => true }),
+      ),
+      (err: unknown) => err instanceof BillingStateError && err.code === "balance_corrupt",
+    );
+    assert.equal(fs.readFileSync(path.join(billing, "balance.json"), "utf8"), "{corrupt", "never overwritten");
+    let open = await store.listOpen(uid3);
+    assert.equal(open.length, 1);
+    assert.equal(open[0]!.status, "failed");
+    // Operator restores the balance file; the reconciler settles the parked charge once.
+    fs.rmSync(path.join(billing, "balance.json"));
+    const report = await reconcileOnce(
+      { now: T0 + 60_000 },
+      { store, debit: realDebit, loadAccount: async () => acct3, now: () => T0 + 60_000 },
+    );
+    assert.equal(report.committed, 1);
+    open = await store.listOpen(uid3);
+    assert.deepEqual(open, []);
+    const balance = await homeScope.run(homeForUid(uid3), readBalance);
+    assert.equal(balance.window?.spentMicroUSD, 4_200);
+    const again = await reconcileOnce(
+      { now: T0 + 120_000 },
+      { store, debit: realDebit, loadAccount: async () => acct3, now: () => T0 + 120_000 },
+    );
+    assert.equal(again.scanned, 0);
+    assert.equal((await homeScope.run(homeForUid(uid3), readBalance)).window?.spentMicroUSD, 4_200);
+  });
+});
+
+describe("describeError", () => {
+  test("keeps the class, code and a short message; strips the uid and bearer tokens", () => {
+    const err = new BillingStateError("balance_unavailable", `commit lisa-balances/${UID} failed Bearer abc.def-ghi`);
+    const text = describeError(err, UID);
+    assert.ok(text.startsWith("BillingStateError(balance_unavailable)"));
+    assert.ok(!text.includes(UID));
+    assert.ok(text.includes(redactId(UID)));
+    assert.ok(!text.includes("abc.def-ghi"));
+    assert.ok(describeError("plain string").includes("plain string"));
+    assert.ok(describeError(new Error("x".repeat(500))).length < 260);
+  });
+});

--- a/src/billing/outbox.ts
+++ b/src/billing/outbox.ts
@@ -1,0 +1,657 @@
+/**
+ * Durable usage outbox (T-8) — the record that survives a torn settlement.
+ *
+ * Settling a metered turn is TWO writes: "the provider has been paid, here is
+ * what it cost" and "take it out of the balance". Before T-8 only the second
+ * one was durable, so a crash, a Firestore blip or a full disk between them
+ * lost the charge silently — the user got the inference, the operator got the
+ * bill, and nothing on disk remembered why the numbers stopped matching.
+ *
+ * The outbox makes the FIRST write durable and the second one replayable:
+ *
+ *   append(pending) ──► debit(balance, eventId) ──► update(committed)
+ *        │                      │                        │
+ *        └ fails ⇒ FAIL CLOSED  └ fails ⇒ event parked    └ fails ⇒ event stays
+ *          (no charge, the         as `failed`, the         `pending`; the debit
+ *          permit is released,     reconciler retries       ALREADY landed and
+ *          caller retries)         it later                 the ledger's own
+ *                                                           idempotency key
+ *                                                           refuses a replay
+ *
+ * The invariant we buy (.codex/INVARIANTS.md 计费与交易 §1): every state the
+ * process can die in is either "no charge and no record" or "a record that the
+ * reconciler can settle exactly once". Never "charged and forgotten", never
+ * "charged twice".
+ *
+ * Idempotency lives in the LEDGER, not here: `debitTurn(…, {eventId})` records
+ * the id in the balance's `settled` ring inside the same atomic update as the
+ * money, so a replay is refused by the thing holding the money rather than by
+ * a caller who remembered to check. Firestore has no multi-document
+ * transaction in this codebase's client (firestore.ts exposes CAS only), so
+ * "mark committed" is a separate write on purpose — the ledger key is what
+ * makes that safe, and is why the reconciler can re-run a half-finished
+ * settlement without a second charge.
+ *
+ * Flag: LISA_BILLING_OUTBOX=0 disables ONLY the outbox write. Every fail-closed
+ * check that existed before T-8 keeps its exact behaviour with the flag off.
+ */
+import path from "node:path";
+import crypto from "node:crypto";
+import type { AccountRecord } from "../web/accounts.js";
+import type { ProviderUsage } from "../providers/types.js";
+import { homeScope, homeForUid, lisaGlobalHome } from "../paths.js";
+import { logError, logInfo, redactId } from "../log.js";
+import { appendLine, atomicWrite, readTextOrEmpty } from "../fs-utils.js";
+import { withFileLock } from "../soul/lock.js";
+import { firestoreEnabled, getDoc, setDoc, casUpdate, FirestoreError } from "../cloud/firestore.js";
+import { BillingStateError, debitTurn, SETTLED_TTL_MS } from "./quota.js";
+
+// ── the event ───────────────────────────────────────────────────────────────
+
+export type UsageEventStatus = "pending" | "committed" | "failed" | "needs_human";
+
+/** One settled inference, durable BEFORE the balance moves. */
+export interface UsageEvent {
+  /** Random id — also the balance ledger's idempotency key. Never derived from the uid. */
+  id: string;
+  uid: string;
+  /** What drove the turn: chat | gw | reflect | birth | voice_* | autonomy… */
+  kind: string;
+  provider: string;
+  model: string;
+  tokensIn: number;
+  tokensOut: number;
+  /** Cache reads + writes, summed: they price differently but reconcile as one number. */
+  tokensCache: number;
+  /** Face cost, micro-USD, already priced by prices.ts. */
+  costMicros: number;
+  /** The admission permit this turn ran under — the audit link back to the lease. */
+  reservationId: string;
+  /** ms since epoch. */
+  createdAt: number;
+  status: UsageEventStatus;
+  /** Balance-commit attempts made so far. */
+  attempts: number;
+  /** Redacted failure detail from the last attempt (never raw ids or tokens). */
+  lastError?: string;
+}
+
+/**
+ * Commit attempts before an event stops being retried and waits for a person.
+ * Five spread over 15-minute reconciler passes is a bit over an hour of
+ * automatic recovery — long enough for a Firestore incident, short enough that
+ * a genuinely broken tenant reaches a human the same day.
+ */
+export const MAX_COMMIT_ATTEMPTS = 5;
+
+/**
+ * How old an event may be and still be safely re-applied.
+ *
+ * The ledger's idempotency ring (quota.ts `settled`) forgets ids after
+ * SETTLED_TTL_MS, and sooner for a very busy tenant (SETTLED_MAX entries). Past
+ * this window a "replay" could be indistinguishable from a fresh charge, so the
+ * reconciler escalates instead of guessing. Half the TTL leaves margin for the
+ * count-based eviction the age bound cannot see.
+ */
+export const SETTLED_REPLAY_WINDOW_MS = SETTLED_TTL_MS / 2;
+
+/** Where a failed attempt parks the event. Shared by settlement and reconciliation. */
+export function parkedStatusAfter(attempts: number): UsageEventStatus {
+  return attempts >= MAX_COMMIT_ATTEMPTS ? "needs_human" : "failed";
+}
+
+/** Coarse provider name for reconciliation against a provider invoice. */
+function providerOfModel(model: string): string {
+  const m = model.trim().toLowerCase();
+  if (m.startsWith("glm-") || m.startsWith("chatglm-")) return "zhipu";
+  if (m.startsWith("claude-")) return "anthropic";
+  if (m.startsWith("gpt-") || m.startsWith("o1") || m.startsWith("o3")) return "openai";
+  if (m.startsWith("media/")) return "media";
+  return "unknown";
+}
+
+export interface SettlementInput {
+  acct: AccountRecord;
+  kind: string;
+  model: string;
+  /** Token counts for the audit trail. Absent for duration-priced media turns. */
+  usage?: ProviderUsage;
+  /** Face cost, micro-USD. Zero or less means there is nothing to settle. */
+  costMicros: number;
+  reservationId: string;
+  provider?: string;
+  /** Force the event id (tests, and a caller that already minted one). */
+  eventId?: string;
+}
+
+export function newUsageEvent(input: SettlementInput, now: number = Date.now()): UsageEvent {
+  const usage = input.usage;
+  return {
+    id: input.eventId ?? crypto.randomUUID(),
+    uid: input.acct.uid,
+    kind: input.kind,
+    provider: input.provider ?? providerOfModel(input.model),
+    model: input.model,
+    tokensIn: usage?.inputTokens ?? 0,
+    tokensOut: usage?.outputTokens ?? 0,
+    tokensCache: (usage?.cacheReadTokens ?? 0) + (usage?.cacheWriteTokens ?? 0),
+    costMicros: input.costMicros,
+    reservationId: input.reservationId,
+    createdAt: now,
+    status: "pending",
+    attempts: 0,
+  };
+}
+
+// ── redaction ───────────────────────────────────────────────────────────────
+
+const BEARER_RE = /\b(bearer|token|key|secret)[=:\s]+[A-Za-z0-9._~+/-]{6,}=*/gi;
+const MAX_ERROR_CHARS = 240;
+
+/**
+ * A store/ledger error rendered for a log line and for `lastError`.
+ *
+ * Both destinations are read by operators and neither is an audit trail, so the
+ * uid is redacted and anything that looks like a credential is stripped:
+ * provider clients love to echo the failing URL (which carries the uid) and the
+ * Authorization header back inside the error message.
+ */
+export function describeError(err: unknown, uid?: string): string {
+  let text: string;
+  if (err instanceof BillingStateError) text = `BillingStateError(${err.code}): ${err.message}`;
+  else if (err instanceof Error) text = `${err.name}: ${err.message}`;
+  else text = String(err);
+  text = text.replace(BEARER_RE, (m) => `${m.split(/[=:\s]/)[0]} ***`);
+  if (uid) text = text.split(uid).join(redactId(uid));
+  return text.length > MAX_ERROR_CHARS ? `${text.slice(0, MAX_ERROR_CHARS)}…` : text;
+}
+
+// ── the store seam ──────────────────────────────────────────────────────────
+
+export interface OutboxStore {
+  /**
+   * Idempotent CREATE. An id that already exists is left exactly as it is — a
+   * replayed append must never reopen an event that has since been committed.
+   */
+  append(event: UsageEvent): Promise<void>;
+  /** Replace an existing event's status/attempts/lastError. */
+  update(event: UsageEvent): Promise<void>;
+  get(uid: string, id: string): Promise<UsageEvent | null>;
+  /** Everything not yet committed for one tenant, oldest first. */
+  listOpen(uid: string): Promise<UsageEvent[]>;
+  /** Tenants that may have open events. May over-report; never under-report. */
+  listTenants(): Promise<string[]>;
+}
+
+/** In-memory adapter: the test double, and the store when nothing is durable. */
+export class MemoryOutboxStore implements OutboxStore {
+  readonly calls: Array<{ op: string; uid?: string; id?: string }> = [];
+  private readonly events = new Map<string, Map<string, UsageEvent>>();
+  constructor(
+    private readonly opts: {
+      faults?: {
+        append?: (event: UsageEvent) => Error | undefined;
+        update?: (event: UsageEvent) => Error | undefined;
+        list?: () => Error | undefined;
+      };
+    } = {},
+  ) {}
+
+  private tenant(uid: string): Map<string, UsageEvent> {
+    let t = this.events.get(uid);
+    if (!t) this.events.set(uid, (t = new Map()));
+    return t;
+  }
+
+  async append(event: UsageEvent): Promise<void> {
+    this.calls.push({ op: "append", uid: event.uid, id: event.id });
+    const fault = this.opts.faults?.append?.(event);
+    if (fault) throw fault;
+    const t = this.tenant(event.uid);
+    if (t.has(event.id)) return;
+    t.set(event.id, { ...event });
+  }
+
+  async update(event: UsageEvent): Promise<void> {
+    this.calls.push({ op: "update", uid: event.uid, id: event.id });
+    const fault = this.opts.faults?.update?.(event);
+    if (fault) throw fault;
+    this.tenant(event.uid).set(event.id, { ...event });
+  }
+
+  async get(uid: string, id: string): Promise<UsageEvent | null> {
+    this.calls.push({ op: "get", uid, id });
+    const found = this.events.get(uid)?.get(id);
+    return found ? { ...found } : null;
+  }
+
+  async listOpen(uid: string): Promise<UsageEvent[]> {
+    this.calls.push({ op: "listOpen", uid });
+    const fault = this.opts.faults?.list?.();
+    if (fault) throw fault;
+    return [...(this.events.get(uid)?.values() ?? [])]
+      .filter((e) => e.status !== "committed")
+      .sort((a, b) => a.createdAt - b.createdAt)
+      .map((e) => ({ ...e }));
+  }
+
+  async listTenants(): Promise<string[]> {
+    this.calls.push({ op: "listTenants" });
+    const fault = this.opts.faults?.list?.();
+    if (fault) throw fault;
+    return [...this.events.entries()]
+      .filter(([, t]) => [...t.values()].some((e) => e.status !== "committed"))
+      .map(([uid]) => uid);
+  }
+}
+
+// ── local edition: append-only JSONL beside usage.jsonl ─────────────────────
+
+/** Compact once the log passes this many lines. */
+const JSONL_MAX_LINES = 4000;
+/** Committed events are kept this long for a human comparing against usage.jsonl. */
+const JSONL_RETENTION_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * The tenant's billing directory.
+ *
+ * Inside a home scope we are servicing that tenant's own request and the active
+ * home already IS its subtree (which is also what the Mac edition's single home
+ * means). The reconciler runs OUTSIDE any scope and addresses tenants by uid,
+ * so it resolves the cloud layout explicitly.
+ */
+function billingDirFor(uid: string): string {
+  const scoped = homeScope.getStore();
+  return path.join(scoped ?? homeForUid(uid), "billing");
+}
+function outboxFile(uid: string): string {
+  return path.join(billingDirFor(uid), "outbox.jsonl");
+}
+function outboxLock(uid: string): string {
+  return path.join(billingDirFor(uid), "outbox.lock");
+}
+
+function parseEvent(line: string): UsageEvent | null {
+  try {
+    const raw = JSON.parse(line) as Partial<UsageEvent>;
+    if (typeof raw.id !== "string" || !raw.id) return null;
+    if (typeof raw.uid !== "string" || typeof raw.costMicros !== "number") return null;
+    if (typeof raw.createdAt !== "number" || typeof raw.attempts !== "number") return null;
+    return raw as UsageEvent;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Local adapter. Append-only: every state change is a new line and the LAST
+ * line for an id wins on replay, so a torn write costs at most the newest
+ * transition — never an earlier one. Appends take the tenant's billing lock so
+ * that "does this id already exist?" and "write it" cannot interleave, and so
+ * compaction can never drop a line that landed while it was rewriting.
+ */
+export class JsonlOutboxStore implements OutboxStore {
+  private async replay(uid: string): Promise<Map<string, UsageEvent>> {
+    const text = await readTextOrEmpty(outboxFile(uid));
+    const byId = new Map<string, UsageEvent>();
+    for (const line of text.split("\n")) {
+      if (!line.trim()) continue;
+      const event = parseEvent(line);
+      if (event) byId.set(event.id, event);
+    }
+    return byId;
+  }
+
+  async append(event: UsageEvent): Promise<void> {
+    await withFileLock(outboxLock(event.uid), async () => {
+      const existing = (await this.replay(event.uid)).get(event.id);
+      if (existing) return;
+      await appendLine(outboxFile(event.uid), JSON.stringify(event));
+    });
+  }
+
+  async update(event: UsageEvent): Promise<void> {
+    await withFileLock(outboxLock(event.uid), async () => {
+      await appendLine(outboxFile(event.uid), JSON.stringify(event));
+      await this.compact(event.uid);
+    });
+  }
+
+  async get(uid: string, id: string): Promise<UsageEvent | null> {
+    return (await this.replay(uid)).get(id) ?? null;
+  }
+
+  async listOpen(uid: string): Promise<UsageEvent[]> {
+    return [...(await this.replay(uid)).values()]
+      .filter((e) => e.status !== "committed")
+      .sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  async listTenants(): Promise<string[]> {
+    const scoped = homeScope.getStore();
+    // Inside a scope there is exactly one tenant to look at; the reconciler
+    // (unscoped) walks the cloud layout.
+    if (scoped) return [];
+    const fs = await import("node:fs/promises");
+    let entries: string[];
+    try {
+      entries = (await fs.readdir(path.join(lisaGlobalHome(), "users"), { withFileTypes: true }))
+        .filter((d) => d.isDirectory())
+        .map((d) => d.name);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+      throw err;
+    }
+    const out: string[] = [];
+    for (const uid of entries) {
+      if ((await this.listOpen(uid)).length) out.push(uid);
+    }
+    return out;
+  }
+
+  /** Best-effort: drop committed events past the retention window. Caller holds the lock. */
+  private async compact(uid: string): Promise<void> {
+    try {
+      const file = outboxFile(uid);
+      const text = await readTextOrEmpty(file);
+      const lines = text.split("\n").filter(Boolean);
+      if (lines.length <= JSONL_MAX_LINES) return;
+      const cutoff = Date.now() - JSONL_RETENTION_MS;
+      const kept = [...(await this.replay(uid)).values()].filter(
+        (e) => e.status !== "committed" || e.createdAt >= cutoff,
+      );
+      await atomicWrite(file, kept.map((e) => JSON.stringify(e)).join("\n") + "\n");
+    } catch (err) {
+      // Losing a compaction only wastes disk; losing an event would lose money,
+      // so this never propagates.
+      logError(`[billing] outbox compaction failed (uid ${redactId(uid)}): ${describeError(err, uid)}`);
+    }
+  }
+}
+
+// ── cloud edition: Firestore ────────────────────────────────────────────────
+
+// lisa-outbox/{uid}                 — the tenant's OPEN index  { uid, open: [ids] }
+// lisa-outbox/{uid}/events/{id}     — the event itself, created id-keyed
+// lisa-outbox-tenants/{shard}       — sticky registry of tenants that ever opened one
+const TENANT_SHARDS = 8;
+
+function tenantShard(uid: string): string {
+  const h = crypto.createHash("sha256").update(uid).digest();
+  return `lisa-outbox-tenants/${h[0]! % TENANT_SHARDS}`;
+}
+
+function isAlreadyExists(err: unknown): boolean {
+  return err instanceof FirestoreError && (err.status === 409 || err.status === 412);
+}
+
+/**
+ * Cloud adapter. The event document is created with an `exists:false`
+ * precondition so creation is idempotent by id, and every listing goes through
+ * a per-tenant index document because the Firestore client here has no query
+ * API — an index write is one extra CAS on a document only this tenant writes,
+ * which is the same cost profile as the balance itself.
+ *
+ * The tenant registry is STICKY on purpose: adding a uid is skipped entirely
+ * once this process has seen it, so the steady-state cost is zero writes on a
+ * shared document. Entries are pruned lazily, by the reconciler, when a
+ * tenant's index turns out to be empty.
+ */
+export class FirestoreOutboxStore implements OutboxStore {
+  private readonly registered = new Set<string>();
+
+  async append(event: UsageEvent): Promise<void> {
+    // Index FIRST: a dangling id is self-healing (listOpen prunes ids with no
+    // document), whereas an event nothing indexes would be invisible forever.
+    await this.registerTenant(event.uid);
+    await casUpdate(`lisa-outbox/${event.uid}`, (current) => {
+      const open = readIds(current);
+      if (open.includes(event.id)) return { next: null, result: undefined };
+      return { next: { uid: event.uid, open: [...open, event.id] }, result: undefined };
+    });
+    try {
+      await setDoc(`lisa-outbox/${event.uid}/events/${event.id}`, toDoc(event), { exists: false });
+    } catch (err) {
+      if (!isAlreadyExists(err)) throw err; // already durable: an idempotent replay
+    }
+  }
+
+  async update(event: UsageEvent): Promise<void> {
+    await setDoc(`lisa-outbox/${event.uid}/events/${event.id}`, toDoc(event));
+    if (event.status !== "committed") return;
+    await casUpdate(`lisa-outbox/${event.uid}`, (current) => {
+      const open = readIds(current).filter((id) => id !== event.id);
+      if (open.length === readIds(current).length) return { next: null, result: undefined };
+      return { next: { uid: event.uid, open }, result: undefined };
+    });
+  }
+
+  async get(uid: string, id: string): Promise<UsageEvent | null> {
+    const doc = await getDoc(`lisa-outbox/${uid}/events/${id}`);
+    return doc ? fromDoc(doc.data) : null;
+  }
+
+  async listOpen(uid: string): Promise<UsageEvent[]> {
+    const index = await getDoc(`lisa-outbox/${uid}`);
+    const ids = readIds(index?.data ?? null);
+    const events: UsageEvent[] = [];
+    const stale: string[] = [];
+    for (const id of ids) {
+      const event = await this.get(uid, id);
+      if (!event || event.status === "committed") stale.push(id);
+      else events.push(event);
+    }
+    if (stale.length) await this.pruneIndex(uid, stale);
+    return events.sort((a, b) => a.createdAt - b.createdAt);
+  }
+
+  async listTenants(): Promise<string[]> {
+    const out = new Set<string>();
+    for (let shard = 0; shard < TENANT_SHARDS; shard++) {
+      const doc = await getDoc(`lisa-outbox-tenants/${shard}`);
+      for (const uid of readIds(doc?.data ?? null, "uids")) out.add(uid);
+    }
+    return [...out];
+  }
+
+  private async registerTenant(uid: string): Promise<void> {
+    if (this.registered.has(uid)) return;
+    await casUpdate(tenantShard(uid), (current) => {
+      const uids = readIds(current, "uids");
+      if (uids.includes(uid)) return { next: null, result: undefined };
+      return { next: { uids: [...uids, uid] }, result: undefined };
+    });
+    this.registered.add(uid);
+  }
+
+  private async pruneIndex(uid: string, stale: string[]): Promise<void> {
+    try {
+      const remaining = await casUpdate(`lisa-outbox/${uid}`, (current) => {
+        const open = readIds(current).filter((id) => !stale.includes(id));
+        return { next: { uid, open }, result: open.length };
+      });
+      if (remaining > 0) return;
+      // Nothing open: let the sticky registry forget this tenant too.
+      await casUpdate(tenantShard(uid), (current) => {
+        const uids = readIds(current, "uids").filter((u) => u !== uid);
+        return { next: { uids }, result: undefined };
+      });
+      this.registered.delete(uid);
+    } catch (err) {
+      logInfo(`[billing] outbox index prune skipped (uid ${redactId(uid)}): ${describeError(err, uid)}`);
+    }
+  }
+}
+
+function readIds(data: Record<string, unknown> | null, field = "open"): string[] {
+  const raw = data?.[field];
+  return Array.isArray(raw) ? raw.filter((v): v is string => typeof v === "string") : [];
+}
+function toDoc(event: UsageEvent): Record<string, unknown> {
+  return { ...event, lastError: event.lastError ?? "" };
+}
+function fromDoc(data: Record<string, unknown>): UsageEvent {
+  const event = { ...data } as unknown as UsageEvent;
+  if (!event.lastError) delete event.lastError;
+  return event;
+}
+
+let defaultStore: OutboxStore | null = null;
+/** The adapter for this edition. Firestore in the cloud, JSONL everywhere else. */
+export function defaultOutboxStore(): OutboxStore {
+  defaultStore ??= firestoreEnabled() ? new FirestoreOutboxStore() : new JsonlOutboxStore();
+  return defaultStore;
+}
+/** Tests only: forget the memoized adapter after changing LISA_FIRESTORE. */
+export function _resetOutboxStoreForTests(): void {
+  defaultStore = null;
+}
+
+// ── settlement ──────────────────────────────────────────────────────────────
+
+export interface SettlementDeps {
+  store: OutboxStore;
+  /**
+   * Move the money. `eventId` is the ledger's idempotency key: a replay of an
+   * id already applied MUST return false without changing the balance.
+   */
+  debit(acct: AccountRecord, event: UsageEvent, eventId?: string): Promise<boolean>;
+  now(): number;
+  enabled(): boolean;
+}
+
+export interface CommitOutcome {
+  /** True when this call actually moved the balance (false for a refused replay). */
+  applied: boolean;
+  /** True when the event's `committed` status is durable. */
+  committed: boolean;
+}
+
+export interface SettlementResult extends CommitOutcome {
+  /** The outbox event id, or null when nothing durable was written. */
+  eventId: string | null;
+}
+
+/** LISA_BILLING_OUTBOX: default ON; "0"/"false"/"off" disables the outbox write only. */
+export function outboxEnabled(env: Record<string, string | undefined> = process.env): boolean {
+  const raw = env.LISA_BILLING_OUTBOX?.trim().toLowerCase();
+  return !(raw === "0" || raw === "false" || raw === "off" || raw === "no");
+}
+
+/** Debit through the real ledger, inside the tenant's home scope. */
+export const defaultDebit: SettlementDeps["debit"] = (acct, event, eventId) =>
+  withTenantHome(acct.uid, () =>
+    debitTurn(acct, event.model, event.costMicros, event.createdAt, eventId ? { eventId } : {}),
+  );
+
+/**
+ * A live settlement already runs inside its tenant's scope, so entering one
+ * again would be wrong (the Mac edition's single home is not `users/<uid>`).
+ * The reconciler has no scope at all and needs one.
+ */
+function withTenantHome<T>(uid: string, fn: () => Promise<T>): Promise<T> {
+  return homeScope.getStore() ? fn() : homeScope.run(homeForUid(uid), fn);
+}
+
+export function defaultSettlementDeps(): SettlementDeps {
+  return {
+    store: defaultOutboxStore(),
+    debit: defaultDebit,
+    now: () => Date.now(),
+    enabled: outboxEnabled,
+  };
+}
+
+function wrapDebitError(err: unknown, uid: string): BillingStateError {
+  if (err instanceof BillingStateError) return err;
+  return new BillingStateError("balance_unavailable", `balance commit failed: ${describeError(err, uid)}`);
+}
+
+/**
+ * Apply one outbox event to the balance and close it out.
+ *
+ * Throws when the DEBIT fails (the caller must not treat the turn as paid) —
+ * having first parked the event so the charge is not forgotten. Does NOT throw
+ * when only the "mark committed" write fails: the money is already correct and
+ * a thrown error there would tell the caller to retry a charge that landed.
+ */
+export async function commitUsageEvent(
+  event: UsageEvent,
+  acct: AccountRecord,
+  deps: SettlementDeps,
+): Promise<CommitOutcome> {
+  const attempts = event.attempts + 1;
+  let applied: boolean;
+  try {
+    applied = await deps.debit(acct, event, event.id);
+  } catch (err) {
+    const detail = describeError(err, acct.uid);
+    const status = parkedStatusAfter(attempts);
+    try {
+      await deps.store.update({ ...event, status, attempts, lastError: detail });
+    } catch (parkErr) {
+      logError(
+        `[billing] outbox park failed (event ${event.id}, uid ${redactId(acct.uid)}): ` +
+          describeError(parkErr, acct.uid),
+      );
+    }
+    logError(
+      status === "needs_human"
+        ? `[billing] outbox event ${event.id} → needs_human after ${attempts} attempts ` +
+            `(uid ${redactId(acct.uid)}, ${event.costMicros} micros, ${event.kind}/${event.model}): ${detail}`
+        : `[billing] outbox commit failed (event ${event.id}, uid ${redactId(acct.uid)}, ` +
+            `attempt ${attempts}/${MAX_COMMIT_ATTEMPTS}, ${event.costMicros} micros): ${detail}`,
+    );
+    throw wrapDebitError(err, acct.uid);
+  }
+  let committed = true;
+  try {
+    await deps.store.update({ ...event, status: "committed", attempts, lastError: undefined });
+  } catch (err) {
+    committed = false;
+    logError(
+      `[billing] outbox mark-committed failed (event ${event.id}, uid ${redactId(acct.uid)}) — ` +
+        `the debit LANDED, the reconciler will close the record: ${describeError(err, acct.uid)}`,
+    );
+  }
+  return { applied, committed };
+}
+
+/**
+ * Settle one metered turn: durable record first, money second.
+ *
+ * Fails closed on an outbox write failure — the caller releases its permit and
+ * gets a retryable error rather than a turn that was paid for but unrecorded.
+ */
+export async function settleUsage(
+  input: SettlementInput,
+  deps: SettlementDeps = defaultSettlementDeps(),
+): Promise<SettlementResult> {
+  if (!(input.costMicros > 0)) return { eventId: null, applied: false, committed: true };
+  const event = newUsageEvent(input, deps.now());
+
+  if (!deps.enabled()) {
+    // Flag off: no durable record, but the pre-T-8 debit path is untouched —
+    // including its fail-closed behaviour on a balance-store failure.
+    try {
+      const applied = await deps.debit(input.acct, event, undefined);
+      return { eventId: null, applied, committed: true };
+    } catch (err) {
+      throw wrapDebitError(err, input.acct.uid);
+    }
+  }
+
+  try {
+    await deps.store.append(event);
+  } catch (err) {
+    const detail = describeError(err, input.acct.uid);
+    logError(
+      `[billing] outbox append failed — settlement refused, nothing charged ` +
+        `(event ${event.id}, uid ${redactId(input.acct.uid)}, ${event.costMicros} micros): ${detail}`,
+    );
+    throw new BillingStateError("outbox_unavailable", `usage outbox is unavailable: ${detail}`);
+  }
+
+  const outcome = await commitUsageEvent(event, input.acct, deps);
+  return { eventId: event.id, ...outcome };
+}

--- a/src/billing/quota.ts
+++ b/src/billing/quota.ts
@@ -18,6 +18,13 @@
  *
  * Storage: `<active home>/billing/balance.json` — the fast path beside the
  * usage.jsonl audit ledger; atomic writes under the billing lock.
+ *
+ * T-8: the balance is also the idempotency boundary for the usage OUTBOX
+ * (outbox.ts). A metered turn is debited under its outbox event id, and the
+ * ids of recently applied events ride along in `settled` — so a replay of the
+ * same event (reconciler after a crash between "balance written" and "event
+ * marked committed") is refused here, by the ledger itself, not by a caller
+ * remembering to check.
  */
 import path from "node:path";
 import fs from "node:fs/promises";
@@ -49,6 +56,14 @@ export interface PurchaseEntry {
   transactionId?: string;
 }
 
+/** One applied outbox event — the ledger-side idempotency key (T-8). */
+export interface SettledEntry {
+  /** Outbox event id. */
+  id: string;
+  /** ms since epoch when the debit was applied. */
+  at: number;
+}
+
 export interface BalanceState {
   /** Paid balance, micro-USD. Never expires; may go negative after a refund. */
   paidMicroUSD: number;
@@ -56,7 +71,18 @@ export interface BalanceState {
   purchases: PurchaseEntry[];
   /** The active free window, if one has been opened. */
   window?: { start: number; spentMicroUSD: number };
+  /**
+   * Recently applied outbox event ids, oldest first. Bounded by SETTLED_MAX
+   * and SETTLED_TTL_MS because this document is read on every turn; the
+   * reconciler refuses to replay anything that could have aged out of it.
+   */
+  settled?: SettledEntry[];
 }
+
+/** How many applied event ids the balance remembers (see SettledEntry). */
+export const SETTLED_MAX = 1000;
+/** How long an applied event id is remembered. Older replays are escalated, never re-applied. */
+export const SETTLED_TTL_MS = 7 * 24 * 60 * 60 * 1000;
 
 function balanceFile(): string {
   return path.join(billingDir(), "balance.json");
@@ -69,7 +95,11 @@ const EMPTY: BalanceState = { paidMicroUSD: 0, purchases: [] };
 
 export class BillingStateError extends Error {
   constructor(
-    public readonly code: "balance_unavailable" | "balance_corrupt" | "purchase_conflict",
+    public readonly code:
+      | "balance_unavailable"
+      | "balance_corrupt"
+      | "purchase_conflict"
+      | "outbox_unavailable",
     message: string,
   ) {
     super(message);
@@ -119,11 +149,42 @@ function parseBalance(parsed: unknown): BalanceState {
     }
     window = { ...raw.window };
   }
+  let settled: SettledEntry[] | undefined;
+  if (raw.settled !== undefined) {
+    // Fail closed on a malformed ring: dropping it silently would let the
+    // reconciler double-charge a replay it can no longer recognise.
+    if (!Array.isArray(raw.settled)) {
+      throw new BillingStateError("balance_corrupt", "balance store has an invalid settlement ring");
+    }
+    settled = [];
+    for (const item of raw.settled) {
+      const entry = item as Partial<SettledEntry> | null;
+      if (!entry || typeof entry !== "object" || typeof entry.id !== "string" || !entry.id || !safeInteger(entry.at)) {
+        throw new BillingStateError("balance_corrupt", "balance store has an invalid settlement entry");
+      }
+      settled.push({ id: entry.id, at: entry.at });
+    }
+  }
   return {
     paidMicroUSD: raw.paidMicroUSD,
     purchases,
     ...(window ? { window } : {}),
+    ...(settled && settled.length ? { settled } : {}),
   };
+}
+
+/** Has this outbox event already been applied to the balance? */
+export function settledContains(state: BalanceState, eventId: string): boolean {
+  return !!state.settled?.some((entry) => entry.id === eventId);
+}
+
+/** Remember an applied event id, keeping the ring within its size/age bounds. */
+function noteSettled(state: BalanceState, eventId: string, now: number): void {
+  const ring = state.settled ?? [];
+  ring.push({ id: eventId, at: now });
+  let kept = ring.filter((entry) => now - entry.at <= SETTLED_TTL_MS);
+  if (kept.length > SETTLED_MAX) kept = kept.slice(kept.length - SETTLED_MAX);
+  state.settled = kept;
 }
 
 // B9: with Firestore enabled AND a per-uid scope active, the balance lives in
@@ -288,27 +349,38 @@ export async function precheckTurn(
  * Debit one metered turn AFTER it ran: free window first (standard models),
  * then paid balance. Premium models bill paid only. A concurrent overshoot may
  * push paid slightly negative — absorbed by the next purchase.
+ *
+ * With `opts.eventId` (the outbox event, T-8) the debit is idempotent: the id
+ * is checked against and recorded in the balance's `settled` ring inside the
+ * same atomic update, so the reconciler can replay a torn settlement without
+ * ever charging twice. Returns true when this call changed the balance, false
+ * for a replay (or nothing to charge).
  */
 export async function debitTurn(
   acct: AccountRecord,
   model: string,
   microUSD: number,
   now: number = Date.now(),
-): Promise<void> {
-  if (microUSD <= 0) return;
-  await updateBalance((state) => {
+  opts: { eventId?: string } = {},
+): Promise<boolean> {
+  if (microUSD <= 0) return false;
+  const eventId = opts.eventId;
+  return updateBalance((state) => {
+    if (eventId && settledContains(state, eventId)) return false;
     if (modelTier(model) === "premium") {
       state.paidMicroUSD -= microUSD;
-      return;
+    } else {
+      const tier = tierFor(acct, state, now);
+      const w = liveWindow(state, now);
+      const allowance = windowAllowance(tier);
+      const freeLeft = Math.max(0, allowance - w.spentMicroUSD);
+      const fromFree = Math.min(freeLeft, microUSD);
+      w.spentMicroUSD += fromFree;
+      const rest = microUSD - fromFree;
+      if (rest > 0) state.paidMicroUSD -= rest;
     }
-    const tier = tierFor(acct, state, now);
-    const w = liveWindow(state, now);
-    const allowance = windowAllowance(tier);
-    const freeLeft = Math.max(0, allowance - w.spentMicroUSD);
-    const fromFree = Math.min(freeLeft, microUSD);
-    w.spentMicroUSD += fromFree;
-    const rest = microUSD - fromFree;
-    if (rest > 0) state.paidMicroUSD -= rest;
+    if (eventId) noteSettled(state, eventId, now);
+    return true;
   });
 }
 

--- a/src/billing/reconcile.test.ts
+++ b/src/billing/reconcile.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Reconciler behaviour for the usage outbox (T-8): retry budget, escalation
+ * to needs_human, dry-run, tenant filtering, staleness, the startup timer and
+ * the operator CLI report.
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const TMP = fs.mkdtempSync(path.join(os.tmpdir(), "lisa-reconcile-"));
+process.env.LISA_HOME = TMP;
+delete process.env.LISA_FIRESTORE;
+// log.ts routes through console.error only in text mode; captureLogs() below
+// hooks console, so pin the format instead of inheriting K_SERVICE from CI.
+process.env.LISA_LOG_FORMAT = "text";
+
+import type { AccountRecord } from "../web/accounts.js";
+import type { ReconcileDeps } from "./reconcile.js";
+import type { SettlementDeps, UsageEvent } from "./outbox.js";
+
+const { MemoryOutboxStore, newUsageEvent, SETTLED_REPLAY_WINDOW_MS } = await import("./outbox.js");
+const {
+  reconcileOnce,
+  startBillingReconciler,
+  cmdBillingReconcile,
+  RECONCILE_MAX_ATTEMPTS,
+  RECONCILE_PENDING_GRACE_MS,
+} = await import("./reconcile.js");
+const { redactId } = await import("../log.js");
+
+const T0 = Date.parse("2026-09-06T08:00:00Z");
+const UID = "em-reconcile-secret-0001";
+const ACCT: AccountRecord = {
+  uid: UID,
+  kind: "email",
+  email: "r@example.com",
+  createdAt: T0,
+  lastLoginAt: T0,
+  verified: true,
+  sessionVersion: 0,
+};
+const USAGE = { inputTokens: 10, outputTokens: 10, cacheReadTokens: 0, cacheWriteTokens: 0 };
+
+function event(overrides: Partial<UsageEvent> = {}, acct: AccountRecord = ACCT): UsageEvent {
+  const ev = newUsageEvent(
+    { acct, kind: "gw", model: "claude-sonnet-4-6", usage: USAGE, costMicros: 777, reservationId: "r" },
+    T0 - 2 * RECONCILE_PENDING_GRACE_MS,
+  );
+  return { ...ev, ...overrides };
+}
+
+function ledger(opts: { fail?: boolean } = {}) {
+  const applied = new Set<string>();
+  const state = { calls: 0, balance: 0, fail: opts.fail ?? false };
+  const debit: SettlementDeps["debit"] = async (_acct, ev, eventId) => {
+    state.calls += 1;
+    if (state.fail) throw new Error(`ledger down for ${UID}`);
+    if (eventId && applied.has(eventId)) return false;
+    if (eventId) applied.add(eventId);
+    state.balance -= ev.costMicros;
+    return true;
+  };
+  return { debit, state };
+}
+
+function deps(
+  store: InstanceType<typeof MemoryOutboxStore>,
+  l: ReturnType<typeof ledger>,
+  overrides: Partial<ReconcileDeps> = {},
+): ReconcileDeps {
+  return { store, debit: l.debit, loadAccount: async () => ACCT, now: () => T0, ...overrides };
+}
+
+function captureLogs(): { lines: string[]; restore: () => void } {
+  const lines: string[] = [];
+  const origErr = console.error;
+  const origLog = console.log;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  console.log = (...args: unknown[]) => {
+    lines.push(args.map(String).join(" "));
+  };
+  return {
+    lines,
+    restore: () => {
+      console.error = origErr;
+      console.log = origLog;
+    },
+  };
+}
+
+/**
+ * Wait for a condition instead of for a fixed number of milliseconds: these
+ * tests exercise real timers, and under a loaded `npm test` a 15ms interval
+ * routinely slips past any fixed sleep. The deadline is the failure mode.
+ */
+async function until(cond: () => boolean, deadlineMs = 3000): Promise<boolean> {
+  const stop = Date.now() + deadlineMs;
+  while (Date.now() < stop) {
+    if (cond()) return true;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  return cond();
+}
+
+let logs: ReturnType<typeof captureLogs>;
+beforeEach(() => {
+  logs = captureLogs();
+});
+afterEach(() => {
+  logs.restore();
+});
+
+describe("reconcileOnce", () => {
+  test("retries a failed event while under the attempt cap, then escalates with a structured ERROR", async () => {
+    const store = new MemoryOutboxStore();
+    const l = ledger({ fail: true });
+    const ev = event({ status: "failed", attempts: 1, lastError: "first failure" });
+    await store.append(ev);
+    // attempts 1 → cap-1: each pass fails and bumps attempts.
+    for (let attempt = ev.attempts; attempt < RECONCILE_MAX_ATTEMPTS - 1; attempt++) {
+      const r = await reconcileOnce({}, deps(store, l));
+      assert.equal(r.failed, 1, `attempt ${attempt}`);
+      assert.equal(r.escalated, 0);
+      const live = (await store.get(UID, ev.id))!;
+      assert.equal(live.status, "failed");
+      assert.equal(live.attempts, attempt + 1);
+      assert.ok(!live.lastError!.includes(UID));
+    }
+    // The last allowed attempt fails ⇒ needs_human.
+    const r = await reconcileOnce({}, deps(store, l));
+    assert.equal(r.escalated, 1);
+    assert.equal(r.failed, 0);
+    const live = (await store.get(UID, ev.id))!;
+    assert.equal(live.status, "needs_human");
+    assert.equal(live.attempts, RECONCILE_MAX_ATTEMPTS);
+    const line = logs.lines.find((x) => x.includes("needs_human"));
+    assert.ok(line, "escalation must be logged");
+    assert.ok(line.includes("[billing]"));
+    assert.ok(line.includes(ev.id));
+    assert.ok(line.includes(redactId(UID)));
+    assert.ok(!line.includes(UID), `raw uid in escalation log: ${line}`);
+    assert.ok(line.includes("777"), "the amount at stake is part of the operator's handle");
+    // needs_human is parked: later passes skip it, even when the ledger is back.
+    l.state.fail = false;
+    const parked = await reconcileOnce({}, deps(store, l));
+    assert.equal(parked.skipped, 1);
+    assert.equal(parked.committed, 0);
+    assert.equal(l.state.balance, 0);
+    // --retry-human gives it one more cycle.
+    const retried = await reconcileOnce({ retryHuman: true }, deps(store, l));
+    assert.equal(retried.committed, 1);
+    assert.equal(l.state.balance, -777);
+    assert.equal((await store.get(UID, ev.id))!.status, "committed");
+  });
+
+  test("dry run reports what it would do and writes nothing", async () => {
+    const store = new MemoryOutboxStore();
+    const l = ledger();
+    const pending = event();
+    const failed = event({ status: "failed", attempts: 2 });
+    const human = event({ status: "needs_human", attempts: RECONCILE_MAX_ATTEMPTS });
+    const fresh = event({ createdAt: T0 - 1000 });
+    for (const ev of [pending, failed, human, fresh]) await store.append(ev);
+    store.calls.length = 0;
+    const r = await reconcileOnce({ dryRun: true }, deps(store, l));
+    assert.equal(r.dryRun, true);
+    assert.equal(r.scanned, 4);
+    assert.equal(r.committed, 2, "pending + failed would be committed");
+    assert.equal(r.skipped, 2, "needs_human + within-grace are skipped");
+    assert.equal(r.escalated, 0);
+    assert.equal(l.state.calls, 0, "dry run never debits");
+    assert.deepEqual(store.calls.filter((c) => c.op !== "listOpen" && c.op !== "listTenants" && c.op !== "get"), []);
+    assert.equal((await store.get(UID, pending.id))!.status, "pending");
+  });
+
+  test("a missing account cannot be charged: escalated, never silently dropped", async () => {
+    const store = new MemoryOutboxStore();
+    const l = ledger();
+    const ev = event();
+    await store.append(ev);
+    const r = await reconcileOnce({}, deps(store, l, { loadAccount: async () => null }));
+    assert.equal(r.escalated, 1);
+    assert.equal(l.state.calls, 0);
+    const live = (await store.get(UID, ev.id))!;
+    assert.equal(live.status, "needs_human");
+    assert.match(live.lastError!, /account_missing/);
+  });
+
+  test("an event older than the ledger's replay window is escalated instead of re-applied", async () => {
+    const store = new MemoryOutboxStore();
+    const l = ledger();
+    const ev = event({ createdAt: T0 - SETTLED_REPLAY_WINDOW_MS - 1 });
+    await store.append(ev);
+    const r = await reconcileOnce({}, deps(store, l));
+    assert.equal(r.escalated, 1);
+    assert.equal(l.state.calls, 0, "the idempotency key may have aged out — a replay could double charge");
+    assert.match((await store.get(UID, ev.id))!.lastError!, /replay_window/);
+  });
+
+  test("scans every tenant, or only --uid; reports the tenant count", async () => {
+    const store = new MemoryOutboxStore();
+    const l = ledger();
+    const other: AccountRecord = { ...ACCT, uid: "em-other" };
+    await store.append(event());
+    await store.append(event({}, other));
+    const only = await reconcileOnce(
+      { uid: "em-other" },
+      deps(store, l, { loadAccount: async (uid) => (uid === "em-other" ? other : ACCT) }),
+    );
+    assert.equal(only.tenants, 1);
+    assert.equal(only.committed, 1);
+    assert.equal((await store.listOpen(UID)).length, 1);
+    const all = await reconcileOnce(
+      {},
+      deps(store, l, { loadAccount: async (uid) => (uid === "em-other" ? other : ACCT) }),
+    );
+    assert.equal(all.tenants, 1, "em-other has nothing open any more");
+    assert.equal(all.committed, 1);
+    assert.equal(l.state.balance, -777 * 2);
+  });
+
+  test("a store that cannot be listed fails the run loudly rather than reporting a clean sweep", async () => {
+    const store = new MemoryOutboxStore({ faults: { list: () => new Error("index unreadable") } });
+    const l = ledger();
+    await store.append(event());
+    await assert.rejects(reconcileOnce({}, deps(store, l)), /index unreadable/);
+    assert.equal(l.state.calls, 0);
+  });
+});
+
+describe("startBillingReconciler", () => {
+  test("runs after the initial delay, then on the interval, and stop() ends it", async () => {
+    let runs = 0;
+    const handle = startBillingReconciler({
+      initialDelayMs: 5,
+      intervalMs: 15,
+      run: async () => {
+        runs += 1;
+        return { scanned: 0, committed: 0, escalated: 0, skipped: 0, failed: 0, tenants: 0, dryRun: false };
+      },
+    });
+    assert.ok(await until(() => runs >= 2), `expected the initial run plus at least one tick, got ${runs}`);
+    handle.stop();
+    const seen = runs;
+    await new Promise((r) => setTimeout(r, 60));
+    assert.equal(runs, seen, "no runs after stop()");
+  });
+
+  test("a run that cannot take the cross-instance lock is skipped, and a throwing run never kills the timer", async () => {
+    let attempts = 0;
+    let locks = 0;
+    const handle = startBillingReconciler({
+      initialDelayMs: 1,
+      intervalMs: 5,
+      acquireRunLock: async () => {
+        locks += 1;
+        return locks === 1 ? null : async () => {};
+      },
+      run: async () => {
+        attempts += 1;
+        throw new Error("boom");
+      },
+    });
+    assert.ok(await until(() => attempts >= 2), `expected at least two attempted runs, got ${attempts}`);
+    handle.stop();
+    assert.ok(locks >= 2);
+    assert.equal(attempts, locks - 1, "the first lock refusal skipped the run; later ticks ran and threw");
+    assert.ok(logs.lines.some((l) => l.includes("[billing]") && l.includes("boom")));
+  });
+
+  test("overlapping ticks do not run concurrently", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    let runs = 0;
+    const handle = startBillingReconciler({
+      initialDelayMs: 1,
+      intervalMs: 2,
+      run: async () => {
+        runs += 1;
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((r) => setTimeout(r, 15));
+        inFlight -= 1;
+        return { scanned: 0, committed: 0, escalated: 0, skipped: 0, failed: 0, tenants: 0, dryRun: false };
+      },
+    });
+    // Several intervals must elapse while one run is still in flight.
+    assert.ok(await until(() => runs >= 2), `expected the run to be re-entered, got ${runs}`);
+    handle.stop();
+    await until(() => inFlight === 0);
+    assert.equal(maxInFlight, 1);
+  });
+});
+
+describe("lisa billing reconcile (operator CLI)", () => {
+  test("--dry-run --json prints the report without touching the store", async () => {
+    const store = new MemoryOutboxStore();
+    const l = ledger();
+    await store.append(event());
+    await cmdBillingReconcile(["--dry-run", "--json"], deps(store, l));
+    const json = logs.lines.find((x) => x.trim().startsWith("{"));
+    assert.ok(json, "a JSON report line");
+    const report = JSON.parse(json!) as { scanned: number; committed: number; dryRun: boolean };
+    assert.equal(report.dryRun, true);
+    assert.equal(report.scanned, 1);
+    assert.equal(report.committed, 1);
+    assert.equal(l.state.calls, 0);
+    assert.equal(process.exitCode ?? 0, 0);
+  });
+
+  test("the default text report names every counter; --uid narrows the scan; --resolve closes a parked event by hand", async () => {
+    const store = new MemoryOutboxStore();
+    const l = ledger();
+    const parked = event({ status: "needs_human", attempts: RECONCILE_MAX_ATTEMPTS, lastError: "x" });
+    await store.append(parked);
+    await cmdBillingReconcile(["--uid", UID], deps(store, l));
+    const text = logs.lines.join("\n");
+    for (const key of ["scanned", "committed", "escalated", "skipped", "failed"]) {
+      assert.ok(text.includes(key), `report mentions ${key}`);
+    }
+    assert.ok(text.includes(parked.id), "parked events are listed with their id for the operator");
+    logs.lines.length = 0;
+    // The operator fixed the balance by hand and closes the event without a debit.
+    await cmdBillingReconcile(["--uid", UID, "--resolve", parked.id], deps(store, l));
+    assert.equal((await store.get(UID, parked.id))!.status, "committed");
+    assert.equal(l.state.calls, 0, "resolve never debits");
+    assert.ok(logs.lines.some((x) => x.includes(parked.id) && x.includes("resolved")));
+    // Resolving something that is not parked is refused.
+    logs.lines.length = 0;
+    await cmdBillingReconcile(["--uid", UID, "--resolve", "nope"], deps(store, l));
+    assert.equal(process.exitCode, 1);
+    process.exitCode = 0;
+  });
+});

--- a/src/billing/reconcile.ts
+++ b/src/billing/reconcile.ts
@@ -1,0 +1,383 @@
+/**
+ * Billing reconciler (T-8) — the compensator for a torn settlement.
+ *
+ * outbox.ts guarantees that a charge is either invisible or recorded. This is
+ * what turns "recorded" back into "settled": it sweeps every open usage event,
+ * re-applies the balance commit idempotently, and escalates what it cannot fix
+ * to a human instead of guessing (.codex/INVARIANTS.md 计费与交易 §1/§5).
+ *
+ * Three ways an event reaches this module:
+ *   pending      the process died between the durable append and the debit;
+ *   failed       the debit was attempted and the balance store said no;
+ *   needs_human  the retry budget ran out, or a replay would not be provably
+ *                safe — parked until an operator looks.
+ *
+ * Everything here is safe to run concurrently with live traffic: the debit
+ * carries the event id, and the ledger refuses an id it already applied.
+ */
+import crypto from "node:crypto";
+import type { AccountRecord } from "../web/accounts.js";
+import { getAccount } from "../web/accounts.js";
+import { logError, logInfo, redactId } from "../log.js";
+import { firestoreEnabled, acquireLease, releaseLease as releaseFsLease } from "../cloud/firestore.js";
+import {
+  commitUsageEvent,
+  defaultDebit,
+  defaultOutboxStore,
+  describeError,
+  parkedStatusAfter,
+  MAX_COMMIT_ATTEMPTS,
+  SETTLED_REPLAY_WINDOW_MS,
+  type OutboxStore,
+  type SettlementDeps,
+  type UsageEvent,
+} from "./outbox.js";
+
+export const RECONCILE_MAX_ATTEMPTS = MAX_COMMIT_ATTEMPTS;
+
+/**
+ * How long a `pending` event is left alone.
+ *
+ * A pending event younger than this may still be owned by a settlement in
+ * flight in another process. Racing it is harmless to the money (the ledger key
+ * refuses the double) but it would burn the retry budget on an event that was
+ * about to close itself, and it would log failures that are not failures.
+ */
+export const RECONCILE_PENDING_GRACE_MS = 5 * 60_000;
+
+/** Reconciler cadence. */
+export const RECONCILE_INTERVAL_MS = 15 * 60_000;
+const RECONCILE_INITIAL_DELAY_MS = 30_000;
+/** Cross-instance lock TTL — comfortably longer than a pass, shorter than the interval. */
+const RECONCILE_LOCK_TTL_MS = 5 * 60_000;
+
+export interface ReconcileOptions {
+  /** Report what would happen; write nothing, debit nothing. */
+  dryRun?: boolean;
+  /** Restrict the sweep to one tenant. */
+  uid?: string;
+  /** Give parked (needs_human) events one more automatic cycle. */
+  retryHuman?: boolean;
+  /** Override the clock (tests, and the CLI's single-shot run). */
+  now?: number;
+}
+
+/** A parked event, named so an operator can act on it. */
+export interface ParkedRef {
+  id: string;
+  uid: string;
+  costMicros: number;
+  attempts: number;
+  lastError?: string;
+}
+
+export interface ReconcileReport {
+  /** Open events examined. */
+  scanned: number;
+  /** Events settled by this pass (or that would be, in a dry run). */
+  committed: number;
+  /** Events moved to needs_human by this pass. */
+  escalated: number;
+  /** Events deliberately left alone (parked, or still inside the grace period). */
+  skipped: number;
+  /** Events that failed this attempt but keep their retry budget. */
+  failed: number;
+  /** Tenants that actually had an open event. */
+  tenants: number;
+  dryRun: boolean;
+  /** Everything currently waiting for a human, for the operator report. */
+  parked?: ParkedRef[];
+}
+
+export interface ReconcileDeps {
+  store: OutboxStore;
+  debit: SettlementDeps["debit"];
+  loadAccount(uid: string): Promise<AccountRecord | null>;
+  now(): number;
+}
+
+export function defaultReconcileDeps(): ReconcileDeps {
+  return {
+    store: defaultOutboxStore(),
+    debit: defaultDebit,
+    loadAccount: getAccount,
+    now: () => Date.now(),
+  };
+}
+
+function refOf(event: UsageEvent): ParkedRef {
+  return {
+    id: event.id,
+    uid: event.uid,
+    costMicros: event.costMicros,
+    attempts: event.attempts,
+    ...(event.lastError ? { lastError: event.lastError } : {}),
+  };
+}
+
+/**
+ * Park an event a machine must not decide about. The reason is written into
+ * `lastError` because that is what `lisa billing reconcile` shows the operator.
+ */
+async function park(
+  deps: ReconcileDeps,
+  event: UsageEvent,
+  reason: string,
+  dryRun: boolean,
+): Promise<void> {
+  logError(
+    `[billing] outbox event ${event.id} → needs_human (uid ${redactId(event.uid)}, ` +
+      `${event.costMicros} micros, ${event.kind}/${event.model}): ${reason}`,
+  );
+  if (dryRun) return;
+  try {
+    await deps.store.update({ ...event, status: "needs_human", lastError: reason });
+  } catch (err) {
+    logError(`[billing] outbox park failed (event ${event.id}): ${describeError(err, event.uid)}`);
+  }
+}
+
+/**
+ * One reconciliation pass.
+ *
+ * Throws only when the STORE cannot be listed: reporting a clean sweep over a
+ * store we could not read would be the most dangerous possible lie here.
+ */
+export async function reconcileOnce(
+  opts: ReconcileOptions = {},
+  deps: ReconcileDeps = defaultReconcileDeps(),
+): Promise<ReconcileReport> {
+  const now = opts.now ?? deps.now();
+  const dryRun = !!opts.dryRun;
+  const report: ReconcileReport = {
+    scanned: 0,
+    committed: 0,
+    escalated: 0,
+    skipped: 0,
+    failed: 0,
+    tenants: 0,
+    dryRun,
+    parked: [],
+  };
+  const uids = opts.uid ? [opts.uid] : await deps.store.listTenants();
+
+  for (const uid of uids) {
+    const open = await deps.store.listOpen(uid);
+    if (!open.length) continue;
+    report.tenants += 1;
+    // One account read per tenant, and only once we know we have work.
+    let acct: AccountRecord | null | undefined;
+
+    for (const event of open) {
+      report.scanned += 1;
+
+      if (event.status === "needs_human" && !opts.retryHuman) {
+        report.skipped += 1;
+        report.parked!.push(refOf(event));
+        continue;
+      }
+      if (event.status === "pending" && now - event.createdAt < RECONCILE_PENDING_GRACE_MS) {
+        report.skipped += 1;
+        continue;
+      }
+      if (now - event.createdAt > SETTLED_REPLAY_WINDOW_MS) {
+        // The ledger may no longer remember this id, so "re-apply" and "charge
+        // a second time" are indistinguishable. A person decides.
+        report.escalated += 1;
+        report.parked!.push(refOf(event));
+        await park(deps, event, "replay_window: older than the balance ledger's idempotency window", dryRun);
+        continue;
+      }
+
+      if (acct === undefined) acct = await deps.loadAccount(uid);
+      if (!acct) {
+        report.escalated += 1;
+        report.parked!.push(refOf(event));
+        await park(deps, event, "account_missing: no account record for this uid", dryRun);
+        continue;
+      }
+      if (dryRun) {
+        report.committed += 1;
+        continue;
+      }
+
+      try {
+        await commitUsageEvent(event, acct, {
+          store: deps.store,
+          debit: deps.debit,
+          now: () => now,
+          enabled: () => true,
+        });
+        report.committed += 1;
+      } catch {
+        // commitUsageEvent has already parked the event and logged the detail;
+        // mirror its own escalation rule to classify the outcome.
+        if (parkedStatusAfter(event.attempts + 1) === "needs_human") {
+          report.escalated += 1;
+          report.parked!.push(refOf(event));
+        } else {
+          report.failed += 1;
+        }
+      }
+    }
+  }
+  return report;
+}
+
+// ── the background timer ────────────────────────────────────────────────────
+
+export interface ReconcilerHandle {
+  stop(): void;
+}
+
+export interface ReconcilerOptions {
+  initialDelayMs?: number;
+  intervalMs?: number;
+  run?: () => Promise<ReconcileReport>;
+  /**
+   * Claim this cycle across instances. Returns a release function, or null when
+   * another instance already owns it. Doing the sweep twice would be safe (the
+   * ledger key refuses the double) but it would double the Firestore reads and
+   * duplicate every escalation alert.
+   */
+  acquireRunLock?: () => Promise<(() => Promise<void>) | null>;
+}
+
+async function defaultRunLock(): Promise<(() => Promise<void>) | null> {
+  if (!firestoreEnabled()) return async () => {}; // single instance: nothing to arbitrate
+  const owner = `${process.pid}-${crypto.randomUUID().slice(0, 8)}`;
+  const handle = await acquireLease("billing-reconcile", owner, RECONCILE_LOCK_TTL_MS);
+  if (!handle) return null;
+  return () => releaseFsLease(handle);
+}
+
+/**
+ * Start the reconciler: once shortly after boot (so a crash's leftovers are
+ * settled without waiting a full interval) and then on the interval.
+ *
+ * The timers are unref'd — reconciliation must never be the reason a process
+ * refuses to exit — and a pass that throws is logged, never fatal.
+ */
+export function startBillingReconciler(opts: ReconcilerOptions = {}): ReconcilerHandle {
+  const initialDelayMs = opts.initialDelayMs ?? RECONCILE_INITIAL_DELAY_MS;
+  const intervalMs = opts.intervalMs ?? RECONCILE_INTERVAL_MS;
+  const run = opts.run ?? (() => reconcileOnce());
+  const acquireRunLock = opts.acquireRunLock ?? defaultRunLock;
+
+  let stopped = false;
+  let running = false;
+  let interval: NodeJS.Timeout | null = null;
+
+  const tick = async (): Promise<void> => {
+    // A slow pass must not stack up behind the interval.
+    if (stopped || running) return;
+    running = true;
+    let release: (() => Promise<void>) | null = null;
+    try {
+      release = await acquireRunLock();
+      if (!release) return;
+      const report = await run();
+      if (report.committed || report.escalated || report.failed) {
+        logInfo(
+          `[billing] reconcile: ${report.committed} committed, ${report.failed} retrying, ` +
+            `${report.escalated} escalated, ${report.skipped} skipped across ${report.tenants} tenants`,
+        );
+      }
+    } catch (err) {
+      logError(`[billing] reconcile pass failed: ${describeError(err)}`);
+    } finally {
+      running = false;
+      if (release) await release().catch(() => {});
+    }
+  };
+
+  const first = setTimeout(() => {
+    if (stopped) return;
+    void tick();
+    interval = setInterval(() => void tick(), intervalMs);
+    interval.unref?.();
+  }, initialDelayMs);
+  first.unref?.();
+
+  return {
+    stop(): void {
+      stopped = true;
+      clearTimeout(first);
+      if (interval) clearInterval(interval);
+    },
+  };
+}
+
+// ── operator CLI: `lisa billing reconcile` ──────────────────────────────────
+
+function flagValue(argv: string[], flag: string): string | undefined {
+  const i = argv.indexOf(flag);
+  return i >= 0 ? argv[i + 1] : undefined;
+}
+
+function usdOf(micros: number): string {
+  return `$${(micros / 1e6).toFixed(4)}`;
+}
+
+/**
+ * `lisa billing reconcile [--dry-run] [--json] [--uid <uid>] [--retry-human]
+ *                         [--resolve <event-id>]`
+ *
+ * Runs against THIS host's ledger, so it is an operator command (a Cloud Run
+ * shell or the Mac host), not something a signed-in user can call.
+ */
+export async function cmdBillingReconcile(
+  argv: string[],
+  deps: ReconcileDeps = defaultReconcileDeps(),
+): Promise<void> {
+  const uid = flagValue(argv, "--uid");
+  const resolveId = flagValue(argv, "--resolve");
+
+  if (resolveId) {
+    if (!uid) {
+      console.error("✗ --resolve needs --uid <uid> (events are addressed per tenant)");
+      process.exitCode = 1;
+      return;
+    }
+    const event = await deps.store.get(uid, resolveId);
+    if (!event || event.status !== "needs_human") {
+      console.error(
+        `✗ ${resolveId}: no parked event with that id — only needs_human events can be closed by hand`,
+      );
+      process.exitCode = 1;
+      return;
+    }
+    await deps.store.update({
+      ...event,
+      status: "committed",
+      lastError: `resolved by operator at ${new Date(deps.now()).toISOString()}`,
+    });
+    console.log(
+      `✓ ${resolveId} resolved — closed WITHOUT a debit (${usdOf(event.costMicros)}). ` +
+        `If the charge is still owed, correct the balance by hand first.`,
+    );
+    return;
+  }
+
+  const report = await reconcileOnce(
+    { dryRun: argv.includes("--dry-run"), retryHuman: argv.includes("--retry-human"), ...(uid ? { uid } : {}) },
+    deps,
+  );
+
+  if (argv.includes("--json")) {
+    console.log(JSON.stringify(report));
+    return;
+  }
+  console.log(`${report.dryRun ? "dry run — nothing was written" : "reconcile"} across ${report.tenants} tenant(s)`);
+  console.log(`  scanned:   ${report.scanned}`);
+  console.log(`  committed: ${report.committed}`);
+  console.log(`  failed:    ${report.failed} (will retry, under the ${RECONCILE_MAX_ATTEMPTS}-attempt cap)`);
+  console.log(`  escalated: ${report.escalated}`);
+  console.log(`  skipped:   ${report.skipped}`);
+  for (const p of report.parked ?? []) {
+    console.log(
+      `  needs_human ${p.id} uid=${redactId(p.uid)} ${usdOf(p.costMicros)} ` +
+        `attempts=${p.attempts} ${p.lastError ?? ""}`,
+    );
+  }
+}

--- a/src/cli-args.test.ts
+++ b/src/cli-args.test.ts
@@ -64,6 +64,13 @@ describe("parseArgs — raw / passthrough subcommand routing", () => {
     assert.deepEqual(a.subargs, ["connect", "--email", "me@x.com"]);
   });
 
+  test("billing keeps its own flags: `billing reconcile --dry-run` reaches the handler", () => {
+    // T-8: the reconciler's flags are money-adjacent — a swallowed --dry-run
+    // would turn "show me what you would do" into "go do it".
+    const args = parseArgs(["billing", "reconcile", "--dry-run", "--uid", "em-1"]);
+    assert.deepEqual(args.subargs, ["reconcile", "--dry-run", "--uid", "em-1"]);
+  });
+
   test("an unknown flag in global position throws", () => {
     assert.throws(() => parseArgs(["--totallybogus"]), /unknown flag: --totallybogus/);
   });

--- a/src/cli-args.ts
+++ b/src/cli-args.ts
@@ -73,7 +73,7 @@ const RAW_SUBCOMMANDS = new Set(["heartbeat", "autostart", "doctor", "upgrade"])
  * global flags (`mail connect --host/--port/--provider …`), which would
  * otherwise be swallowed as global settings and never reach the handler.
  */
-const PASSTHROUGH_SUBCOMMANDS = new Set(["mail", "kb"]);
+const PASSTHROUGH_SUBCOMMANDS = new Set(["mail", "kb", "billing"]);
 
 /**
  * Is this a debug run? Decided from the raw argv + env rather than ParsedArgs

--- a/src/cli/account.ts
+++ b/src/cli/account.ts
@@ -199,7 +199,13 @@ export async function cmdLogout(): Promise<void> {
   console.error("✓ signed out — managed inference disabled (BYO keys unaffected).");
 }
 
-export async function cmdBilling(_subargs: string[]): Promise<void> {
+export async function cmdBilling(subargs: string[]): Promise<void> {
+  // `billing reconcile` is an OPERATOR command against THIS host's ledger
+  // (T-8), not a call to the cloud API — dispatch before the session check.
+  if (subargs[0] === "reconcile") {
+    const { cmdBillingReconcile } = await import("../billing/reconcile.js");
+    return cmdBillingReconcile(subargs.slice(1));
+  }
   const managed = managedConfig();
   if (!managed) {
     console.error("Not signed in. Run `lisa login` first (BYO-key usage isn't metered).");

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -42,6 +42,7 @@ import { recordUsage, summarizeUsage, setAnomalySink } from "../billing/meter.js
 import { PRICES_VERSION, tokensAffordable } from "../billing/prices.js";
 import { quotaStatus, BillingStateError } from "../billing/quota.js";
 import { admitInference, type InferencePermit } from "../billing/admission.js";
+import { startBillingReconciler } from "../billing/reconcile.js";
 import {
   verifyAppleJWS,
   validateTransaction,
@@ -1214,6 +1215,12 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       sessions: sessionCtxs.size,
     };
   };
+
+  // T-8: settle usage events a crashed or throttled turn left behind. Cloud
+  // only — the Mac edition has no accounts, so nothing is ever metered there.
+  // The handle is intentionally unused: the timers are unref'd and the sweep
+  // is safe to abandon at shutdown (every event it did not reach stays open).
+  if (isCloud()) startBillingReconciler();
 
   const server = http.createServer(async (req, res) => {
     const url = req.url ?? "/";


### PR DESCRIPTION
第 6 / 8 条，实现 T-8。基于 #373。

## 问题

计费此前存在一个无法恢复的窗口：provider 已经收费，但余额提交失败或进程在两次写之间崩溃，就既没有账也没有补偿路径。仓库里 `outbox|reconcil` 零命中，v0.21 审查把它列为后续项，一直未做。

## 做法

**先写测试。** 故障注入覆盖五种情形：outbox 追加失败、追加成功后余额提交失败、标记 committed 失败、追加与提交之间崩溃、同一事件重放。断言：不重复扣费、对账后不丢费、(a) 情形 fail closed、每条失败路径都释放 permit、日志不含密钥。

**Outbox。** 每次结算前先追加一条不可变用量事件（本地为 JSONL + 索引，Cloud 为以事件 id 为文档 id 的 Firestore 集合，天然幂等）。**写事件失败即结算失败**：释放 permit、记录不含敏感信息的日志、向调用方返回可重试错误。绝不允许"扣了 provider 的钱但没有记录"。

**提交。** 支持事务的存储里，标记 committed 与余额变更在同一事务内完成；否则紧接余额写入之后，并以事件 id 作为账本幂等键，使重放无法二次扣费。

**对账器。** 扫描超过宽限期的 pending 与未超重试上限的 failed，幂等地重放余额提交；超过上限则升级为 `needs_human` 并打结构化 ERROR。`startBillingReconciler()` 在 serve 启动后 30 秒首跑、之后每 15 分钟一次（unref 定时器，仅在计费启用时）。运维命令 `lisa billing reconcile [--dry-run] [--json] [--uid] [--resolve <id>]`。

**开关** `LISA_BILLING_OUTBOX` 默认开启；设为 0 只关闭 outbox 写入，不影响既有的 fail-closed 检查。

`docs/RUNBOOK_CLOUD_PROD.md` 新增一节：如何读报告、如何处理 needs_human、手工修复流程。

## 验证

全部测试离线运行，使用内存与临时目录 fake，不接触任何真实 Firestore / GCS / Stripe / Apple 端点。

🤖 Generated with [Claude Code](https://claude.com/claude-code)