### PR TITLE
feat(mac): Lisa.app 自带后端 + Node 运行时；离线横幅改成底部 toast

### DIFF
--- a/.github/workflows/release-mac-apps.yml
+++ b/.github/workflows/release-mac-apps.yml
@@ -75,6 +75,17 @@ jobs:
             exit 1
           fi
 
+      # Lisa.app embeds the compiled backend (packaging/mac-client/embed-runtime.sh
+      # stages dist/ + production node_modules + an official Node into the
+      # bundle), so dist/ has to exist before the app is assembled. Without this
+      # the app would ship as a bare window again and every DMG user would be
+      # back to installing the CLI by hand.
+      - name: Build the backend (dist/) for embedding
+        run: |
+          set -euo pipefail
+          npm ci
+          npm run build
+
       - name: Import Apple Developer ID certificate
         # Ephemeral keychain — created here, deleted at job end. Lifted
         # from the Markup workflow with cosmetic renames.

--- a/.github/workflows/release-mac-apps.yml
+++ b/.github/workflows/release-mac-apps.yml
@@ -33,7 +33,7 @@ on:
         required: true
 
 permissions:
-  contents: write   # needed to attach assets to the GitHub Release
+  contents: write # needed to attach assets to the GitHub Release
 
 jobs:
   mac-apps:

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@
 ```sh
 # 1. Install — pick one (Node ≥ 22.19)
 brew install oratis/tap/lisa              # Homebrew (CLI)
-npm install -g @oratis/lisa               # npm (CLI, and the backend Lisa.app talks to)
-#    Mac app: download Lisa-Suite.dmg from https://github.com/oratis/LISA/releases/latest
+npm install -g @oratis/lisa               # npm (CLI)
+#    Mac app: download Lisa-Suite.dmg — self-contained, needs no Node at all
+#    https://github.com/oratis/LISA/releases/latest
 
 # 2. One provider key — Anthropic is the default; any of 20+ providers works
 mkdir -p ~/.lisa

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -17,8 +17,9 @@
 ```sh
 # 1. 安装 —— 三选一（Node ≥ 22.19）
 brew install oratis/tap/lisa              # Homebrew（CLI）
-npm install -g @oratis/lisa               # npm（CLI，也是 Lisa.app 连的 backend）
-#    Mac App：到 https://github.com/oratis/LISA/releases/latest 下载 Lisa-Suite.dmg
+npm install -g @oratis/lisa               # npm（CLI）
+#    Mac App：下载 Lisa-Suite.dmg —— 自带后端，完全不需要 Node
+#    https://github.com/oratis/LISA/releases/latest
 
 # 2. 一个 provider key —— 默认 Anthropic，20+ 个 provider 都能用
 mkdir -p ~/.lisa

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -89,12 +89,14 @@ Download the **signed + notarized** disk image from the latest GitHub Release �
 
 The DMG contains **Lisa.app** — full chat client (sidebar + glass-morphism UI) with the **Island** built in: a pill widget that lives by the menu bar / notch and shows her mood + agent activity at a glance (toggle it from the menu-bar popover or ⌘, preferences; the standalone LisaIsland.app was folded into Lisa.app in v0.7).
 
-It's a universal binary (Intel + Apple Silicon). After dragging it to `/Applications`, install the LISA backend and start it:
+It's a universal binary (Intel + Apple Silicon) and it is **self-contained** — the app
+carries its own backend and its own Node runtime, and starts them the first time you open
+it. Nothing to install first: no Node, no npm, no terminal. Drag it to `/Applications`,
+open it, and set your LLM key in the app's own setup screen.
 
-```sh
-npm install -g @oratis/lisa
-lisa serve --web                # apps load http://localhost:5757
-```
+Already have the CLI? The app uses a backend that's already listening on
+`localhost:5757`, so an existing `npm i -g @oratis/lisa` / Homebrew install keeps working
+unchanged.
 
 #### 📟 Homebrew (CLI only)
 

--- a/docs/GUIDE.zh-CN.md
+++ b/docs/GUIDE.zh-CN.md
@@ -86,12 +86,12 @@ echo 'ANTHROPIC_API_KEY=sk-ant-...' > ~/.lisa/config.env
 
 DMG 里是 **Lisa.app** —— 完整聊天客户端（侧边栏 + 玻璃拟态界面），**灵动岛内置其中**：菜单栏/刘海下的小胶囊，一眼看到 Lisa 心情 + agent 活动（在菜单栏弹窗或 ⌘, 偏好里开关；独立的 LisaIsland.app 已在 v0.7 并入 Lisa.app）。
 
-Universal binary（Intel + Apple Silicon）。拖到 `/Applications` 之后，装 backend 并启动：
+Universal binary（Intel + Apple Silicon），而且是**自带后端**的：app 内置了自己的 backend
+和自己的 Node 运行时，第一次打开就会自动拉起来。不需要先装 Node、不需要 npm、不需要开终端
+—— 拖到 `/Applications`、双击、在 app 自己的设置页填上 LLM key 就能用。
 
-```sh
-npm install -g @oratis/lisa
-lisa serve --web                # app 从 http://localhost:5757 读
-```
+已经装过 CLI？app 发现 `localhost:5757` 上已经有后端在跑时会直接用它，所以原来的
+`npm i -g @oratis/lisa` / Homebrew 安装照常工作。
 
 #### 📟 Homebrew（只装 CLI）
 

--- a/packaging/mac-client/Sources/Lisa/AppDelegate.swift
+++ b/packaging/mac-client/Sources/Lisa/AppDelegate.swift
@@ -120,6 +120,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        // Coming back to the app is the other moment "the client started" means
+        // to a user — and the backend may have died since launch. ensureRunning
+        // probes first and no-ops while a start is already in flight, so this is
+        // free when everything is healthy.
+        BackendController.shared.ensureRunning()
         if !flag {
             showMainWindow()
         }

--- a/packaging/mac-client/Sources/Lisa/BackendController.swift
+++ b/packaging/mac-client/Sources/Lisa/BackendController.swift
@@ -4,19 +4,24 @@
 //
 //  Owns the lifecycle of the local LISA backend (`lisa serve --web`) from the
 //  Mac app's side:
-//    • on launch, if the backend isn't already up, start it (auto-start);
+//    • on launch (and on reopen), if the backend isn't already up, start it;
 //    • a manual start() the offline UIs (menu-bar popover, main window splash,
-//      island pill) call as a fallback.
+//      island pill) call as a fallback;
+//    • when a start attempt dies, `lastFailure` carries the backend's OWN error
+//      line out of ~/.lisa/backend.log so the offline UIs can say why. A
+//      launcher that silently fails is worse than no launcher — the user is
+//      told to run a command that will fail the same way.
 //
 //  Start command resolution:
 //    1. ~/.lisa/serve-command.txt — a full command line, if present (escape
 //       hatch for running from source, e.g. "node /path/dist/cli.js serve --web").
-//    2. otherwise `lisa serve --web --host 0.0.0.0` — resolved on the login
-//       shell's PATH (covers `npm i -g @oratis/lisa` / Homebrew installs), with
-//       LisaSetup.shellPrelude so nvm / fnm / Homebrew-managed tools resolve too.
-//       If `lisa` doesn't resolve, the start script says so immediately and the
-//       install wizard (BackendSetupController, UX-7) takes over instead of a
-//       20 s poll timing out into a hint.
+//    2. the backend embedded in this bundle — Contents/Resources/backend/dist
+//       run by Contents/Resources/node-runtime/bin/node (both staged by
+//       embed-runtime.sh). This is the path for a user who only downloaded the
+//       DMG: nothing installed, no Node, no npm, and the app still comes up.
+//    3. otherwise `lisa serve --web --host 0.0.0.0` — resolved on the login
+//       shell's PATH (covers `npm i -g @oratis/lisa` / Homebrew installs, and
+//       a `swift run` dev build with no embedded backend).
 //
 //  LAN-reachable by default (decision ②): a paired phone can reach the Mac over
 //  Wi-Fi without the user remembering `--host 0.0.0.0`. This is safe only because
@@ -33,7 +38,6 @@
 
 import AppKit
 import Foundation
-import LisaSetup
 
 @MainActor
 final class BackendController {
@@ -44,19 +48,50 @@ final class BackendController {
     /// resolves, so the offline UIs can update.
     static let statusChanged = Notification.Name("ai.meetlisa.backendStatusChanged")
 
-    /// Default: bind all interfaces so a phone on the same Wi-Fi can reach it.
-    /// Token-gated for non-loopback callers (see start() / the header note).
-    static let defaultCommand = "lisa serve --web --host 0.0.0.0"
-
     private let probeURL = URL(string: "http://localhost:5757/")!
     private(set) var isStarting = false
 
-    /// Where the detached backend's stdout/stderr go (the wizard offers to open it).
+    /// Callers waiting on the in-flight start (the install wizard, restart(),
+    /// the menu bar's "Start backend"). Drained exactly once by finishStart(),
+    /// which hands over the SAME classified note it stores in `lastFailure` —
+    /// the wizard shows it verbatim, so "timeout" is a last resort, not the
+    /// usual answer.
+    private var startWaiters: [(Bool, String?) -> Void] = []
+
+    /// Where the detached backend's stdout/stderr go. The install wizard
+    /// (BackendSetupController, UX-7) offers to open it.
     var backendLogPath: String { lisaPath("backend.log") }
 
     /// True when ~/.lisa/serve-command.txt overrides the start command — the
-    /// user runs the backend their own way, so the `lisa` CLI check doesn't apply.
-    var hasServeOverride: Bool { overrideCommand() != nil }
+    /// user runs the backend their own way, so neither the embedded backend nor
+    /// the `lisa` CLI check applies and the wizard must not offer to "fix" it.
+    var hasServeOverride: Bool {
+        guard let txt = try? String(contentsOfFile: lisaPath("serve-command.txt"), encoding: .utf8)
+        else { return false }
+        return !txt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    /// Why the last start attempt failed — the backend's OWN line from
+    /// ~/.lisa/backend.log (a missing dependency, `lisa` not on PATH, the port
+    /// already taken), not a generic "it didn't come up". The offline surfaces
+    /// show this so a backend that dies the instant it launches is a readable
+    /// failure instead of a silent one. Nil once a start succeeds.
+    private(set) var lastFailure: String?
+
+    /// backend.log size at the moment we spawned, so we only ever read what
+    /// THIS attempt wrote (the log is append-only across launches).
+    private var logMark: UInt64 = 0
+
+    /// Which of the three start paths the last attempt used, so a failure can
+    /// name it. "command not found" means something very different depending on
+    /// whether it came from the user's own serve-command.txt override or from a
+    /// build with no embedded backend.
+    private enum CommandSource {
+        case fileOverride   // ~/.lisa/serve-command.txt
+        case embedded       // Contents/Resources/backend, run by the bundled node
+        case path           // `lisa` on the login shell's PATH
+    }
+    private var commandSource: CommandSource = .path
 
     // MARK: - Launch auto-start
 
@@ -100,12 +135,6 @@ final class BackendController {
         try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: path)
     }
 
-    /// Callers waiting on the outcome of the next start attempt (restart(),
-    /// start(completion:)). Drained — on the main actor — by post(), right
-    /// after the status notification goes out, so a waiter sees exactly one
-    /// resolution: (up, note).
-    private var startWaiters: [(Bool, String?) -> Void] = []
-
     /// Stop the (detached) backend and start a fresh one so config.env changes
     /// apply. The backend was launched with nohup, so we match its command line;
     /// killing only `lisa serve --web` variants keeps unrelated processes safe.
@@ -115,7 +144,10 @@ final class BackendController {
         kill.arguments = ["-f", "serve --web"]
         kill.terminationHandler = { _ in
             // Give the old process a beat to release the port, then hop back to
-            // the main actor: the waiter list and start() are both isolated there.
+            // the main actor: the waiter list and start() are both isolated
+            // there. A self-removing NotificationCenter observer would need to
+            // mutate its own token after a sendable closure captured it, which
+            // is a hard error under -warnings-as-errors (T-11).
             Task { @MainActor [weak self] in
                 try? await Task.sleep(nanoseconds: 800_000_000)
                 guard let self else { return }
@@ -128,28 +160,25 @@ final class BackendController {
 
     // MARK: - Probe
 
-    func probe(_ completion: @escaping @MainActor (Bool) -> Void) {
+    func probe(_ completion: @escaping (Bool) -> Void) {
         var req = URLRequest(url: probeURL, cachePolicy: .reloadIgnoringLocalCacheData, timeoutInterval: 2)
         req.httpMethod = "HEAD"
         URLSession.shared.dataTask(with: req) { _, resp, _ in
             let up = (resp as? HTTPURLResponse) != nil
-            DispatchQueue.main.async { MainActor.assumeIsolated { completion(up) } }
+            DispatchQueue.main.async { completion(up) }
         }.resume()
     }
 
     // MARK: - Start
 
     /// Spawn the backend (detached) and poll until it answers. No-op while a
-    /// start is already in flight — an optional `completion` still gets that
-    /// in-flight attempt's outcome. When the `lisa` CLI can't be found on the
-    /// login shell, the install wizard opens instead (UX-7).
+    /// start is already in flight.
     func start(completion: ((Bool, String?) -> Void)? = nil) {
         if let completion { startWaiters.append(completion) }
         guard !isStarting else { return }
         isStarting = true
 
-        let override = overrideCommand()
-        let command = override ?? Self.defaultCommand
+        let command = resolveCommand()
         // The default command binds 0.0.0.0; arm the token gate so the server will
         // accept it (and reject unauthenticated LAN callers). Harmless for a
         // loopback override — loopback is trusted regardless.
@@ -158,55 +187,193 @@ final class BackendController {
         try? FileManager.default.createDirectory(
             atPath: (logPath as NSString).deletingLastPathComponent,
             withIntermediateDirectories: true)
+        logMark = logSize()
+        lastFailure = nil
 
-        // Login shell + PATH prelude (nvm / fnm / Homebrew / npm-global), then
-        // nohup + & + disown so the backend survives this shell, the launcher, and
-        // the app. Without an override the script first checks that `lisa`
-        // resolves and reports LISA_MISSING instead of spawning a shell error.
-        let script = BackendSetup.startScript(command: command, logPath: logPath, requireCLI: override == nil)
-        ShellRunner.run(script, environment: ["LISA_WEB_TOKEN": webToken]) { [weak self] result in
-            guard let self else { return }
-            if result.output.contains(BackendSetup.missingMarker) {
-                self.isStarting = false
-                self.post(up: false, note: "lisa CLI not installed")
-                BackendSetupController.shared.presentForMissingCLI()
-                return
-            }
-            guard result.output.contains(BackendSetup.spawnedMarker) else {
-                self.isStarting = false
-                let why = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
-                self.post(up: false, note: "spawn failed: \(why.isEmpty ? "exit \(result.status)" : why)")
-                return
-            }
-            self.pollUntilUp(attempts: 25)
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        // Inherit the app's environment (HOME etc.) and inject the web token; the
+        // login shell rebuilds PATH. Setting `environment` replaces it wholesale,
+        // so start from the current environment rather than a bare dictionary.
+        var env = ProcessInfo.processInfo.environment
+        env["LISA_WEB_TOKEN"] = webToken
+        proc.environment = env
+        // -l: login shell (PATH has npm-global / Homebrew). nohup + & + disown:
+        // fully detach so the backend survives this shell, the launcher, and the app.
+        proc.arguments = ["-lc", "nohup \(command) >> '\(logPath)' 2>&1 & disown"]
+        do {
+            try proc.run()
+        } catch {
+            finishStart(up: false, note: "spawn failed: \(error.localizedDescription)")
+            return
         }
+        pollUntilUp(attempts: 25)
     }
 
     private func pollUntilUp(attempts: Int) {
         guard attempts > 0 else {
-            isStarting = false
-            post(up: false, note: "timeout")
+            finishStart(up: false, note: crashNote() ?? "no response from localhost:5757 after 20s")
             return
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
             self?.probe { up in
                 guard let self else { return }
-                if up { self.isStarting = false; self.post(up: true) }
-                else { self.pollUntilUp(attempts: attempts - 1) }
+                if up { self.finishStart(up: true); return }
+                // A backend that dies on launch (missing dependency, `lisa` not
+                // installed, port taken) writes why to backend.log and never
+                // binds. Surface that instead of counting 20s of silence down to
+                // "timeout" — but only after ~2.5s, so a slow-but-healthy start
+                // is never cut short by something it logged on the way up.
+                if attempts <= 22, let note = self.crashNote() {
+                    self.finishStart(up: false, note: note)
+                    return
+                }
+                self.pollUntilUp(attempts: attempts - 1)
             }
         }
     }
 
+    /// Single exit point for a start attempt: clears the in-flight flag, records
+    /// the failure reason, and notifies the offline UIs.
+    private func finishStart(up: Bool, note: String? = nil) {
+        isStarting = false
+        let detail = up ? nil : note.map(describeFailure)
+        lastFailure = detail
+        let waiters = startWaiters
+        startWaiters = []
+        post(up: up, note: detail)
+        for waiter in waiters { waiter(up, detail) }
+    }
+
+    /// Prefix a raw error with the start path it came from — the difference
+    /// between "something says command not found" and "the override you wrote
+    /// in ~/.lisa/serve-command.txt is what failed".
+    private func describeFailure(_ note: String) -> String {
+        switch commandSource {
+        case .fileOverride:
+            return "~/.lisa/serve-command.txt failed — " + note
+        case .embedded:
+            return "The bundled backend failed — " + note
+        case .path:
+            return "No backend found — " + note
+        }
+    }
+
+    // MARK: - Crash detection
+
+    /// The backend's own fatal line from what it appended to backend.log since
+    /// this attempt spawned, or nil while it is still booting quietly.
+    ///
+    /// Deliberately narrow: Node refusing to load a module, the port already
+    /// taken, or the login shell refusing to spawn the command at all ("zsh:1:
+    /// command not found: lisa"). A broad "contains error" match would call a
+    /// healthy start dead over a warning it logged on the way up.
+    private func crashNote() -> String? {
+        let fatal = [
+            "ERR_MODULE_NOT_FOUND", "MODULE_NOT_FOUND", "ERR_REQUIRE_ESM",
+            "Cannot find package", "Cannot find module",
+            "command not found", "EADDRINUSE",
+        ]
+        var echo: String?
+        for line in appendedLogLines() {
+            guard line.hasPrefix("zsh:") || fatal.contains(where: { line.contains($0) })
+            else { continue }
+            // Node prints the offending source line ("throw new ERR_MODULE_…")
+            // and a stack before the readable one ("Error [ERR_MODULE_NOT_FOUND]:
+            // Cannot find package 'undici' …"). Show the message; keep the echo
+            // only if no better line turns up.
+            if line.hasPrefix("throw ") || line.hasPrefix("at ") {
+                if echo == nil { echo = line }
+                continue
+            }
+            return String(line.prefix(200))
+        }
+        return echo.map { String($0.prefix(200)) }
+    }
+
+    /// Non-empty, trimmed lines the backend wrote since `logMark`.
+    private func appendedLogLines() -> [String] {
+        guard let handle = FileHandle(forReadingAtPath: lisaPath("backend.log")) else { return [] }
+        defer { try? handle.close() }
+        do {
+            try handle.seek(toOffset: logMark)
+            let data = try handle.readToEnd() ?? Data()
+            guard let text = String(data: data, encoding: .utf8) else { return [] }
+            return text
+                .split(separator: "\n")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+        } catch {
+            return []
+        }
+    }
+
+    private func logSize() -> UInt64 {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: lisaPath("backend.log"))
+        return (attrs?[.size] as? NSNumber)?.uint64Value ?? 0
+    }
+
     // MARK: - Helpers
 
-    /// ~/.lisa/serve-command.txt, if present and non-empty: a full-control
-    /// escape hatch (run from source, or force a different host) — we don't
-    /// touch its host, and we don't check for the `lisa` CLI.
-    private func overrideCommand() -> String? {
+    private func resolveCommand() -> String {
+        // serve-command.txt is a full-control escape hatch (run from source, or
+        // force a different host) — we don't touch its host.
         let override = lisaPath("serve-command.txt")
-        guard let txt = try? String(contentsOfFile: override, encoding: .utf8) else { return nil }
-        let t = txt.trimmingCharacters(in: .whitespacesAndNewlines)
-        return t.isEmpty ? nil : t
+        if let txt = try? String(contentsOfFile: override, encoding: .utf8) {
+            let t = txt.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !t.isEmpty {
+                // Deliberately still wins over the embedded backend: someone who
+                // wrote this file wants their own tree to run, and silently
+                // swapping in the bundled copy would hide their edits.
+                commandSource = .fileOverride
+                return t
+            }
+        }
+        // Everything below binds all interfaces so a phone on the same Wi-Fi can
+        // reach it. Token-gated for non-loopback callers (see start() / header).
+        if let embedded = embeddedCommand() {
+            commandSource = .embedded
+            return embedded
+        }
+        commandSource = .path
+        return "lisa serve --web --host 0.0.0.0"
+    }
+
+    // MARK: - Embedded backend
+
+    /// The backend shipped inside this bundle, as a ready-to-run command line,
+    /// or nil when this build has none (a `swift run` dev build, or one made
+    /// with LISA_SKIP_EMBED=1).
+    ///
+    /// Prefers the embedded Node so the app depends on nothing the user has to
+    /// install; falls back to a system Node if only the JS half is present.
+    private func embeddedCommand() -> String? {
+        guard let resources = Bundle.main.resourceURL else { return nil }
+        let cli = resources.appendingPathComponent("backend/dist/cli.js").path
+        guard FileManager.default.isReadableFile(atPath: cli) else { return nil }
+        guard let node = embeddedNode() ?? systemNode() else { return nil }
+        return "\(shellQuote(node)) \(shellQuote(cli)) serve --web --host 0.0.0.0"
+    }
+
+    /// Contents/Resources/node-runtime/bin/node, if this build embeds one.
+    private func embeddedNode() -> String? {
+        guard let resources = Bundle.main.resourceURL else { return nil }
+        let node = resources.appendingPathComponent("node-runtime/bin/node").path
+        return FileManager.default.isExecutableFile(atPath: node) ? node : nil
+    }
+
+    /// A Node already on the machine. The login shell's PATH is not consulted
+    /// here — this runs before we spawn one — so check where Homebrew and the
+    /// official installer put it.
+    private func systemNode() -> String? {
+        let candidates = ["/opt/homebrew/bin/node", "/usr/local/bin/node", "/usr/bin/node"]
+        return candidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    /// POSIX single-quoting — the command is handed to `zsh -lc`, and a user
+    /// can install Lisa.app under a path with spaces or quotes in it.
+    private func shellQuote(_ path: String) -> String {
+        "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     // MARK: - Web token (arms the LAN auth gate)
@@ -272,10 +439,5 @@ final class BackendController {
         var info: [String: Any] = ["up": up]
         if let note { info["note"] = note }
         NotificationCenter.default.post(name: BackendController.statusChanged, object: nil, userInfo: info)
-        // Resolve restart() / start(completion:) callers after the broadcast, so
-        // the UIs they update have already seen the new state.
-        let waiters = startWaiters
-        startWaiters.removeAll()
-        for waiter in waiters { waiter(up, note) }
     }
 }

--- a/packaging/mac-client/Sources/Lisa/MenuBarController.swift
+++ b/packaging/mac-client/Sources/Lisa/MenuBarController.swift
@@ -283,6 +283,12 @@ final class MenuBarController: NSObject, NSPopoverDelegate {
             v.addArrangedSubview(wrappedLabel(
                 starting ? "Starting the Lisa backend…" : "The Lisa backend isn't running.",
                 size: 12, color: .secondaryLabelColor, width: inner))
+            // Why the last auto-start died, straight from backend.log — otherwise
+            // "Start Lisa backend" just fails again with nothing to go on.
+            if !starting, let why = BackendController.shared.lastFailure {
+                v.addArrangedSubview(wrappedLabel(
+                    why, size: 10.5, color: .tertiaryLabelColor, width: inner))
+            }
             let start = NSButton(title: starting ? "Starting…" : "Start Lisa backend",
                                  target: self, action: #selector(startBackend))
             start.bezelStyle = .rounded

--- a/packaging/mac-client/Sources/Lisa/WebContent.swift
+++ b/packaging/mac-client/Sources/Lisa/WebContent.swift
@@ -213,10 +213,17 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WK
     /// real chat UI's dark theme; replaced atomically when the next
     /// retry succeeds (the actual page load replaces the entire document).
     private func loadOfflineSplash(error: Error) {
-        let html = Self.offlineHTML(errorMessage: error.localizedDescription)
+        // Prefer the backend's OWN reason for not being there — BackendController
+        // reads it out of ~/.lisa/backend.log after a start attempt dies. WebKit's
+        // error only ever says "could not connect", never why.
+        let detail = BackendController.shared.lastFailure
+            ?? "Last error: " + error.localizedDescription
+        let html = Self.offlineHTML(errorMessage: detail)
         webView.loadHTMLString(html, baseURL: nil)
     }
 
+    /// `errorMessage` is already a full sentence (see loadOfflineSplash) — the
+    /// backend's own exit line when we have it, WebKit's connection error if not.
     static func offlineHTML(errorMessage: String) -> String {
         // Bridge from JS → Swift via window.webkit.messageHandlers.island
         // isn't wired here, so the retry button just reloads the WebView's
@@ -278,8 +285,8 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WK
         <div class=\"card\">
           <h1>LISA backend offline</h1>
           <p class=\"sub\">
-            Lisa.app loads its chat from <code>http://localhost:5757</code> — but
-            that server isn't responding right now.
+            Lisa.app starts its own backend on <code>http://localhost:5757</code>
+            — that server isn't answering yet.
           </p>
 
           <div class=\"row\">
@@ -300,11 +307,10 @@ final class WebContent: NSViewController, WKNavigationDelegate, WKUIDelegate, WK
             }
           </script>
 
-          <h2>Or start it manually</h2>
-          <pre>npm install -g @oratis/lisa     # one-time
-        lisa serve --web                # start the backend</pre>
+          <h2>If it keeps failing</h2>
+          <pre>tail -n 40 ~/.lisa/backend.log</pre>
 
-          <div class=\"err\">Last error: \(escaped)</div>
+          <div class=\"err\">\(escaped)</div>
           <p class=\"hint\">
             Lisa.app will also retry automatically every 4 seconds.
             Once the backend is up, this page disappears on its own.

--- a/packaging/mac-client/build.sh
+++ b/packaging/mac-client/build.sh
@@ -23,11 +23,18 @@ if [ "${1:-}" = "--debug" ]; then
     CONFIG="debug"
 fi
 
-cd "$(dirname "$0")"
+# Resolve this script's directory BEFORE the cd, and use it for every sibling
+# path below. `dirname "$0"` is relative to the ORIGINAL cwd, so re-deriving it
+# after the cd resolves against the wrong base: `bash packaging/mac-client/build.sh`
+# from the repo root looked for packaging/mac-client/packaging/mac-client/… .
+# CI happens to invoke this as `cd packaging/mac-client && bash build.sh`, where
+# dirname is "." and the bug is invisible.
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
 REPO_ROOT="$(cd ../.. && pwd)"
 # App icon: the dedicated pixel-girl icon (scripts/generate-app-icon.ts),
 # falling back to the website mascot if it hasn't been generated.
-MASCOT="$(dirname "$0")/Resources/app-icon-1024.png"
+MASCOT="$HERE/Resources/app-icon-1024.png"
 if [ ! -f "$MASCOT" ]; then
     MASCOT="$REPO_ROOT/src/web/assets/lisa-mascot.png"
 fi
@@ -124,7 +131,7 @@ fi
 # all. embed-runtime.sh stages dist/ + production node_modules + an official
 # node into Contents/Resources. LISA_SKIP_EMBED=1 skips it for fast Swift-only
 # iteration (the app falls back to `lisa` on PATH, as it always did).
-bash "$(dirname "$0")/embed-runtime.sh" "$APP"
+bash "$HERE/embed-runtime.sh" "$APP"
 
 # ── 4. ad-hoc sign ──────────────────────────────────────────────────
 # Proper signing (Developer ID + notarization) is Phase 4.

--- a/packaging/mac-client/build.sh
+++ b/packaging/mac-client/build.sh
@@ -6,6 +6,8 @@
 #   1. swift build -c release  (universal binary, falls back to host arch)
 #   2. iconset → .icns from src/web/assets/lisa-mascot.png (1024x1024)
 #   3. assemble Lisa.app bundle (Contents/MacOS, Resources, Info.plist)
+#   3.5 embed the backend + a Node runtime (embed-runtime.sh) so the app is
+#       self-contained — needs dist/ built; LISA_SKIP_EMBED=1 skips it
 #   4. ad-hoc codesign so Gatekeeper at least doesn't reject outright
 #
 # Output: packaging/mac-client/Lisa.app
@@ -116,8 +118,18 @@ if [ -f Resources/MenuBarIcon.png ]; then
     cp Resources/MenuBarIcon.png "$APP/Contents/Resources/MenuBarIcon.png"
 fi
 
+# ── 3.5 embed the backend + Node runtime ────────────────────────────
+# Without this the app is only a window: it spawns `lisa serve --web` off the
+# login shell's PATH, so a user who just downloaded the DMG has no backend at
+# all. embed-runtime.sh stages dist/ + production node_modules + an official
+# node into Contents/Resources. LISA_SKIP_EMBED=1 skips it for fast Swift-only
+# iteration (the app falls back to `lisa` on PATH, as it always did).
+bash "$(dirname "$0")/embed-runtime.sh" "$APP"
+
 # ── 4. ad-hoc sign ──────────────────────────────────────────────────
 # Proper signing (Developer ID + notarization) is Phase 4.
+# NB: the embedded node is signed by embed-runtime.sh — --deep does not reach
+# a bare Mach-O under Resources/, and it must be signed to run on arm64.
 codesign --force --deep --sign - "$APP" >/dev/null 2>&1 || true
 
 # Force Finder/Dock to pick up the new icon (the system caches by bundle path).

--- a/packaging/mac-client/embed-runtime.sh
+++ b/packaging/mac-client/embed-runtime.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#
+# Embed a self-contained LISA backend into Lisa.app.
+#
+# Why this exists: the app spawns `lisa serve --web`, which until now had to
+# come from the login shell's PATH — i.e. the user had to run
+# `npm i -g @oratis/lisa` (and have Node) BEFORE the app was any use. Someone
+# who only downloaded the DMG got the "backend offline" splash and a list of
+# terminal commands. After this step Lisa.app carries its own backend AND its
+# own Node, so a Mac with nothing installed answers on localhost:5757 the
+# first time the app is opened.
+#
+# Layout produced inside the bundle:
+#   Contents/Resources/backend/dist/          compiled JS + web assets
+#   Contents/Resources/backend/node_modules/  runtime deps
+#   Contents/Resources/backend/package.json   required — carries "type":"module"
+#   Contents/Resources/node-runtime/bin/node  official nodejs.org build
+#
+# `--omit=optional` drops node-pty, the only native module in the tree, which
+# keeps the embedded backend pure JS: nothing is compiled against a specific
+# Node ABI and nothing needs `disable-library-validation` under the hardened
+# runtime. The PTY agent surface degrades to the 503 it already returns when
+# node-pty is absent.
+#
+# The embedded `node` is ad-hoc signed here because lipo strips the signature
+# nodejs.org shipped, and an unsigned Mach-O will not execute on Apple
+# Silicon. scripts/build-mac-apps.sh re-signs it with the Developer ID (see
+# sign_one) before the outer bundle, inside-out as codesign requires.
+#
+# Usage:
+#   bash embed-runtime.sh <path-to-Lisa.app>
+#
+# Env:
+#   LISA_SKIP_EMBED=1   skip entirely — Swift-only iteration. The app then
+#                       falls back to `lisa` on PATH exactly as it used to.
+#   LISA_NODE_VERSION   Node to embed (default: the LTS pinned below).
+#   LISA_EMBED_ARCHS    space-separated, default "arm64 x64"; two archs are
+#                       lipo'd into one universal binary.
+set -euo pipefail
+
+APP="${1:-}"
+if [ -z "$APP" ]; then
+    echo "usage: embed-runtime.sh <path-to-Lisa.app>" >&2
+    exit 2
+fi
+if [ ! -d "$APP/Contents" ]; then
+    echo "✗ $APP doesn't look like an .app bundle" >&2
+    exit 1
+fi
+
+if [ "${LISA_SKIP_EMBED:-}" = "1" ]; then
+    echo "▸ LISA_SKIP_EMBED=1 — no embedded backend (app will use \`lisa\` on PATH)"
+    exit 0
+fi
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$HERE/../.." && pwd)"
+CACHE="$HERE/.build/embed"
+RES="$APP/Contents/Resources"
+NODE_VERSION="${LISA_NODE_VERSION:-v22.23.2}"
+ARCHS="${LISA_EMBED_ARCHS:-arm64 x64}"
+
+# ── 1. backend: dist/ + production node_modules ─────────────────────
+if [ ! -f "$REPO_ROOT/dist/cli.js" ]; then
+    echo "✗ $REPO_ROOT/dist/cli.js missing — run 'npm run build' first" >&2
+    exit 1
+fi
+
+# Install the runtime deps in a staging dir rather than in the repo: a dev
+# running build.sh must not have their devDependencies pruned out from under
+# them. Keyed on the lockfile so repeat builds skip the install.
+STAGE="$CACHE/backend"
+LOCK_HASH="$(shasum -a 256 "$REPO_ROOT/package-lock.json" | cut -d' ' -f1)"
+if [ "$(cat "$STAGE/.lockhash" 2>/dev/null || true)" != "$LOCK_HASH" ]; then
+    echo "▸ installing production deps for the embedded backend…"
+    rm -rf "$STAGE"
+    mkdir -p "$STAGE"
+    cp "$REPO_ROOT/package.json" "$REPO_ROOT/package-lock.json" "$STAGE/"
+    ( cd "$STAGE" && npm ci --omit=dev --omit=optional --ignore-scripts \
+                             --no-audit --no-fund >/dev/null )
+    echo "$LOCK_HASH" > "$STAGE/.lockhash"
+else
+    echo "▸ reusing cached production deps"
+fi
+
+echo "▸ staging backend into the bundle…"
+rm -rf "$RES/backend"
+mkdir -p "$RES/backend"
+cp "$REPO_ROOT/package.json" "$RES/backend/package.json"
+# -L dereferences: `npm run copy-assets` leaves dist/web/assets as a symlink
+# into src/, and a symlink pointing outside the bundle is dead on the user's
+# machine (and would break the code signature seal).
+cp -RL "$REPO_ROOT/dist" "$RES/backend/dist"
+cp -R "$STAGE/node_modules" "$RES/backend/node_modules"
+
+# ── 2. Node runtime ─────────────────────────────────────────────────
+mkdir -p "$CACHE/node"
+SUMS="$CACHE/node/SHASUMS256-$NODE_VERSION.txt"
+if [ ! -s "$SUMS" ]; then
+    curl -fsSL "https://nodejs.org/dist/$NODE_VERSION/SHASUMS256.txt" -o "$SUMS"
+fi
+
+NODE_BINS=()
+for arch in $ARCHS; do
+    tarball="node-$NODE_VERSION-darwin-$arch.tar.gz"
+    tgz="$CACHE/node/$tarball"
+    if [ ! -s "$tgz" ]; then
+        echo "▸ downloading $tarball…"
+        curl -fsSL "https://nodejs.org/dist/$NODE_VERSION/$tarball" -o "$tgz"
+    fi
+    # We are about to ship this binary to users — never skip the checksum.
+    expected="$(awk -v f="$tarball" '$2 == f { print $1 }' "$SUMS")"
+    if [ -z "$expected" ]; then
+        echo "✗ $tarball is not listed in SHASUMS256.txt for $NODE_VERSION" >&2
+        exit 1
+    fi
+    actual="$(shasum -a 256 "$tgz" | cut -d' ' -f1)"
+    if [ "$actual" != "$expected" ]; then
+        echo "✗ checksum mismatch for $tarball (expected $expected, got $actual)" >&2
+        rm -f "$tgz"
+        exit 1
+    fi
+    extracted="$CACHE/node/node-$NODE_VERSION-$arch"
+    if [ ! -x "$extracted" ]; then
+        tmp="$(mktemp -d)"
+        tar -xzf "$tgz" -C "$tmp" "node-$NODE_VERSION-darwin-$arch/bin/node"
+        mv "$tmp/node-$NODE_VERSION-darwin-$arch/bin/node" "$extracted"
+        rm -rf "$tmp"
+        # ~19% off (113 MB → 91 MB per arch) by dropping the symbol table we
+        # will never read. Invalidates nodejs.org's signature, which lipo would
+        # drop anyway — we re-sign below.
+        strip -x "$extracted" 2>/dev/null || true
+    fi
+    NODE_BINS+=("$extracted")
+done
+
+mkdir -p "$RES/node-runtime/bin"
+NODE_OUT="$RES/node-runtime/bin/node"
+if [ "${#NODE_BINS[@]}" -gt 1 ]; then
+    echo "▸ lipo → universal node ($ARCHS)"
+    lipo -create -output "$NODE_OUT" "${NODE_BINS[@]}"
+else
+    cp "${NODE_BINS[0]}" "$NODE_OUT"
+fi
+chmod +x "$NODE_OUT"
+# lipo/cp dropped nodejs.org's signature; re-sign so it can execute at all.
+codesign --force --sign - "$NODE_OUT"
+
+# ── 3. smoke test ───────────────────────────────────────────────────
+# Prove the embedded pair actually runs before we ship it — a bundle whose
+# node can't load its own dist is the exact failure this script exists to
+# prevent, and it is invisible until a user double-clicks the app.
+EMBEDDED_VERSION="$("$NODE_OUT" -v)"
+if ! "$NODE_OUT" "$RES/backend/dist/cli.js" --version >/dev/null 2>&1; then
+    echo "✗ embedded backend failed to run:" >&2
+    "$NODE_OUT" "$RES/backend/dist/cli.js" --version >&2 || true
+    exit 1
+fi
+
+echo "✓ embedded backend  $(du -sh "$RES/backend" | cut -f1)"
+echo "✓ embedded node     $EMBEDDED_VERSION  ($(du -sh "$NODE_OUT" | cut -f1))"

--- a/packaging/mac-client/embed-runtime.sh
+++ b/packaging/mac-client/embed-runtime.sh
@@ -60,6 +60,22 @@ RES="$APP/Contents/Resources"
 NODE_VERSION="${LISA_NODE_VERSION:-v22.23.2}"
 ARCHS="${LISA_EMBED_ARCHS:-arm64 x64}"
 
+# Checksums for PINNED_NODE_VERSION, committed to the repo.
+#
+# The script already verifies each tarball against nodejs.org's SHASUMS256.txt,
+# but that file comes from the same host over the same connection as the
+# tarball: anything able to serve a tampered binary can serve a sums file that
+# matches it. Node publishes a detached GPG signature for SHASUMS256.txt, and
+# checking it would mean carrying (and rotating) their release keyring in the
+# build. Pinning the hash here gets the same property more cheaply — the
+# expected value lives in version control, so changing it is a reviewed commit,
+# and this binary is signed into a notarized DMG and handed to users.
+#
+# Bumping Node: set both, from `curl https://nodejs.org/dist/<v>/SHASUMS256.txt`.
+PINNED_NODE_VERSION="v22.23.2"
+PINNED_SHA256_arm64="61130f394c1630d211dd50aecc4353d379480f36d3ac913cd85dbba1aed585c6"
+PINNED_SHA256_x64="58e99022c2ff89395576cc7fd4d98cea24bb68081475d5f88b801ee8729fb026"
+
 # ── 1. backend: dist/ + production node_modules ─────────────────────
 if [ ! -f "$REPO_ROOT/dist/cli.js" ]; then
     echo "✗ $REPO_ROOT/dist/cli.js missing — run 'npm run build' first" >&2
@@ -109,7 +125,20 @@ for arch in $ARCHS; do
         curl -fsSL "https://nodejs.org/dist/$NODE_VERSION/$tarball" -o "$tgz"
     fi
     # We are about to ship this binary to users — never skip the checksum.
-    expected="$(awk -v f="$tarball" '$2 == f { print $1 }' "$SUMS")"
+    #
+    # Prefer the value pinned in this file over the one fetched alongside the
+    # tarball. Only fall back to SHASUMS256.txt when NODE_VERSION was overridden
+    # away from the pin (a deliberate local experiment), and say so loudly:
+    # a release build must never take its expected hash from the same place as
+    # the artefact it is checking.
+    pinned_var="PINNED_SHA256_$arch"
+    expected="${!pinned_var:-}"
+    if [ "$NODE_VERSION" != "$PINNED_NODE_VERSION" ] || [ -z "$expected" ]; then
+        echo "⚠ $NODE_VERSION is not the pinned $PINNED_NODE_VERSION — falling back to" >&2
+        echo "  nodejs.org's own SHASUMS256.txt. Do NOT ship a release built this way;" >&2
+        echo "  update PINNED_NODE_VERSION / PINNED_SHA256_* instead." >&2
+        expected="$(awk -v f="$tarball" '$2 == f { print $1 }' "$SUMS")"
+    fi
     if [ -z "$expected" ]; then
         echo "✗ $tarball is not listed in SHASUMS256.txt for $NODE_VERSION" >&2
         exit 1

--- a/scripts/build-mac-apps.sh
+++ b/scripts/build-mac-apps.sh
@@ -7,7 +7,11 @@
 # Output (in dist-release/):
 #   - Lisa-Suite-v<VERSION>.dmg   disk image with Lisa.app + an /Applications
 #                                  drag target (name kept for release/link
-#                                  back-compat)
+#                                  back-compat). ~156 MB: the app embeds the
+#                                  backend and a universal Node runtime so a
+#                                  fresh Mac needs nothing installed. Set
+#                                  LISA_EMBED_ARCHS=arm64 for an Apple-Silicon-
+#                                  only build (~90 MB smaller).
 #   - Lisa-Suite-v<VERSION>.dmg.sha256
 #
 # Phases (first positional arg, default "full"):
@@ -90,12 +94,22 @@ sign_one() {
     local app="$1"
     local entitlements="$2"
     echo "→ Codesigning $app with hardened runtime…"
-    local args=(--force --deep --options runtime --timestamp
+    local args=(--force --options runtime --timestamp
                 --sign "$APPLE_SIGNING_IDENTITY")
     if [ -f "$entitlements" ]; then
         args+=(--entitlements "$entitlements")
     fi
-    codesign "${args[@]}" "$app"
+    # Inside-out, as codesign requires: the embedded Node runtime is a bare
+    # Mach-O under Resources/, which --deep does not treat as nested code, so
+    # sign it explicitly first. It needs the same entitlements the app already
+    # declares — V8 wants the allow-jit / allow-unsigned-executable-memory pair
+    # that the embedded WKWebView also wants — so the same file is reused.
+    local node="$app/Contents/Resources/node-runtime/bin/node"
+    if [ -f "$node" ]; then
+        echo "  ↳ embedded node runtime"
+        codesign "${args[@]}" "$node"
+    fi
+    codesign "${args[@]}" --deep "$app"
     codesign --verify --deep --strict --verbose=1 "$app"
 }
 
@@ -129,20 +143,18 @@ Drag Lisa.app onto Applications:
 The notch pill ("Lisa Island") is built in — turn it on from
 Lisa ▸ Settings… ▸ Show Lisa Island.
 
-Before launching the app, install + start the LISA backend:
+Nothing else to install. Lisa.app carries its own backend and its own
+Node runtime, and starts them for you the first time you open it — no
+Node, no npm, no terminal. The app then asks for an LLM key in its own
+setup screen.
 
-    # macOS, with Node 20+:
-    npm install -g @oratis/lisa
-    mkdir -p ~/.lisa
-    echo 'ANTHROPIC_API_KEY=sk-ant-...' > ~/.lisa/config.env
+Prefer the command line, or already have the CLI?
+
+    npm install -g @oratis/lisa      # or: brew install oratis/tap/lisa
     lisa serve --web
 
-Or download the standalone bundle ("lisa-mac-bundle-*.zip") from the
-same release and run:
-
-    bin/lisa serve --web
-
-The apps load http://localhost:5757 — make sure it's running.
+The app uses an already-running backend on localhost:5757 when it finds
+one, so an existing install keeps working exactly as before.
 
 Source / docs: https://github.com/oratis/LISA
 EOF

--- a/src/web/assets/client/main.css
+++ b/src/web/assets/client/main.css
@@ -3240,3 +3240,93 @@
     .chat-empty .ce-starter, .copy-btn { transition: none; }
     #log { scroll-behavior: auto; }
   }
+
+/* ── Status toast (#lisaBanner) ────────────────────────────────────
+   The safety-net message for "backend unreachable" / uncaught UI errors.
+   It used to be a wide red slab pinned at top:12px, which sat on top of
+   the Mac window's title bar AND the whole top function bar. It is now a
+   compact bottom-anchored toast: JS sets its bottom offset per call so
+   it rides just above the composer (and hugs the window edge on views
+   that have none), and it draws from the theme tokens, not hard-coded pink.
+   NB: an explicit [hidden] rule is required — the #id display below would
+   otherwise out-specify the UA's [hidden] { display: none }. */
+#lisaBanner {
+  position: fixed;
+  left: 50%;
+  bottom: 18px;
+  transform: translateX(-50%);
+  z-index: 10000;
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  max-width: min(520px, calc(100vw - 48px));
+  padding: 10px 14px;
+  border-radius: 12px;
+  background: var(--bg-card-strong);
+  border: 1px solid var(--border-strong);
+  box-shadow: 0 12px 34px rgba(0, 0, 0, 0.42);
+  color: var(--fg-2);
+  font-size: 12.5px;
+  line-height: 1.5;
+  user-select: text;
+  animation: lisaToastIn 200ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+#lisaBanner[hidden] { display: none; }
+@keyframes lisaToastIn {
+  from { opacity: 0; transform: translate(-50%, 10px); }
+  to   { opacity: 1; transform: translate(-50%, 0); }
+}
+#lisaBanner .lt-dot {
+  flex: none;
+  width: 7px;
+  height: 7px;
+  margin-top: 6px;
+  border-radius: 50%;
+  background: var(--err-color);
+  box-shadow: 0 0 0 3px var(--err-soft);
+}
+#lisaBanner .lt-body {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 7px;
+  min-width: 0;
+}
+#lisaBanner .lt-msg { color: var(--fg); }
+/* "info" = a transient, expected wait (the client is still starting the
+   backend). Calm accent + a slow pulse, so a 3-second hiccup never reads
+   as a failure. */
+#lisaBanner[data-tone="info"] {
+  border-color: var(--border-strong);
+  background: var(--bg-card-strong);
+}
+#lisaBanner[data-tone="info"] .lt-dot {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+  animation: lisaToastPulse 1.5s ease-in-out infinite;
+}
+@keyframes lisaToastPulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.3; }
+}
+#lisaBanner[data-tone="error"] {
+  border-color: rgba(255, 85, 119, 0.42);
+  background:
+    linear-gradient(0deg, var(--err-soft), var(--err-soft)),
+    var(--bg-card-strong);
+}
+#lisaBanner .lt-cmd {
+  padding: 3px 9px;
+  border-radius: 7px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-new);
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 11.5px;
+  color: var(--fg);
+  cursor: copy;
+  user-select: all;
+  transition: background 120ms ease, color 120ms ease;
+}
+#lisaBanner .lt-cmd:hover { background: var(--accent-soft); color: var(--accent); }
+#lisaBanner .lt-cmd.copied { color: var(--accent); }
+#lisaBanner .lt-cmd.copied::after { content: "  copied"; opacity: 0.65; }

--- a/src/web/assets/client/main.js
+++ b/src/web/assets/client/main.js
@@ -1,24 +1,82 @@
 // ── First-run safety net: never leave the user with a silent dead UI. Any
-// uncaught error / unreachable backend surfaces as a banner instead of nothing.
-function lisaBanner(msg) {
+// uncaught error / unreachable backend surfaces as a status toast instead of
+// nothing.
+//
+// Styled from main.css (#lisaBanner) rather than inline, so it follows the
+// active theme, and anchored to the BOTTOM: the old top:12px slab covered the
+// Mac window's title bar and the entire top function bar — the first thing a
+// user saw when the backend was down was a message covering the UI it was
+// describing.
+//   lisaBanner(msg, opts) — opts.tone: 'info' (a wait we expect to resolve)
+//   or 'error' (default); opts.cmd: a shell command shown as a copy-on-click
+//   chip under the message.
+function lisaBanner(msg, opts) {
+  var o = opts || {};
   var el = document.getElementById('lisaBanner');
   if (!el) {
     el = document.createElement('div');
     el.id = 'lisaBanner';
-    el.style.cssText = 'position:fixed;left:50%;top:12px;transform:translateX(-50%);z-index:99999;max-width:min(700px,92vw);padding:11px 16px;border-radius:12px;background:rgba(255,85,119,.14);border:1px solid rgba(255,85,119,.5);color:#ffc2cf;font:13px/1.5 -apple-system,system-ui,sans-serif;box-shadow:0 8px 30px rgba(0,0,0,.5);user-select:text';
+    el.setAttribute('role', 'status');
+    var dot = document.createElement('span');
+    dot.className = 'lt-dot';
+    var body = document.createElement('span');
+    body.className = 'lt-body';
+    var msgEl = document.createElement('span');
+    msgEl.className = 'lt-msg';
+    var cmdEl = document.createElement('code');
+    cmdEl.className = 'lt-cmd';
+    cmdEl.title = 'Click to copy';
+    cmdEl.hidden = true;
+    cmdEl.addEventListener('click', function () { lisaCopyCmd(cmdEl); });
+    body.appendChild(msgEl);
+    body.appendChild(cmdEl);
+    el.appendChild(dot);
+    el.appendChild(body);
     document.body.appendChild(el);
   }
-  el.textContent = msg;
+  el.dataset.tone = (o.tone === 'info') ? 'info' : 'error';
+  el.querySelector('.lt-msg').textContent = msg;
+  var cmd = el.querySelector('.lt-cmd');
+  cmd.textContent = o.cmd || '';
+  cmd.hidden = !o.cmd;
+  // Ride just above the composer while the chat view is up; hug the window
+  // edge on views that have none. Re-measured on every call, so a textarea
+  // that grew while the user typed never ends up covering the toast.
+  var composer = document.getElementById('form');
+  var lift = (composer && composer.offsetParent)
+    ? Math.round(composer.getBoundingClientRect().height) + 14
+    : 18;
+  el.style.bottom = lift + 'px';
   el.hidden = false;
+}
+function lisaCopyCmd(el) {
+  // clipboard API needs a secure context AND a focused document; when either is
+  // missing (http:// from the phone, an unfocused window) fall back to selecting
+  // the chip so the command is one Cmd-C away either way.
+  var selectIt = function () {
+    try {
+      var range = document.createRange();
+      range.selectNodeContents(el);
+      var sel = window.getSelection();
+      sel.removeAllRanges();
+      sel.addRange(range);
+    } catch (e) {}
+  };
+  var flash = function () {
+    el.classList.add('copied');
+    setTimeout(function () { el.classList.remove('copied'); }, 1400);
+  };
+  if (!navigator.clipboard) { selectIt(); return; }
+  navigator.clipboard.writeText(el.textContent).then(flash, selectIt);
 }
 function lisaClearBanner() { var el = document.getElementById('lisaBanner'); if (el) el.hidden = true; }
 function lisaSleep(ms) { return new Promise(function (r) { setTimeout(r, ms); }); }
 window.addEventListener('error', function (e) {
-  if (e && e.message) lisaBanner('Lisa UI error: ' + e.message + ' — reload (Cmd-R); restart the backend if it persists.');
+  if (e && e.message) lisaBanner('Interface error — reload the page to recover. (' + e.message + ')');
 });
 window.addEventListener('unhandledrejection', function (e) {
   var r = e && e.reason;
-  lisaBanner('Lisa task failed: ' + ((r && r.message) ? r.message : String(r)));
+  lisaBanner('That request failed: ' + ((r && r.message) ? r.message : String(r)));
 });
 
 // ── Interface language (UX-8) ────────────────────────────────────
@@ -1233,6 +1291,7 @@ async function startBirthStream() {
   }
 }
 
+let startupTries = 0;
 async function startupGate() {
   // Retry: the page can render a hair before the backend's API routes answer,
   // and a transient miss must not silently skip onboarding (the old bug — a
@@ -1243,10 +1302,19 @@ async function startupGate() {
     catch (e) { if (i < 5) await lisaSleep(700); }
   }
   if (!cfg) {
-    lisaBanner('Cannot reach Lisa backend on localhost:5757. Start it:  lisa serve --web  (install once: npm i -g @oratis/lisa). Retrying…');
+    // The desktop app starts the backend for us on launch, so the first few
+    // seconds of silence are normal — say so calmly, and only escalate to an
+    // error (with the manual command) once the wait stops looking routine.
+    startupTries++;
+    if (startupTries <= 2) {
+      lisaBanner('Waking Lisa up…', { tone: 'info' });
+    } else {
+      lisaBanner('Lisa is not answering yet — still retrying. You can start her backend yourself:', { cmd: 'lisa serve --web' });
+    }
     setTimeout(startupGate, 3000);
     return;
   }
+  startupTries = 0;
   lisaClearBanner();
   cfgStatus = cfg;
   cfgRenderProviders(cfg);


### PR DESCRIPTION
新用户下载 DMG 后就能直接用 —— 不需要先装 Node、npm 或跑任何终端命令；顺带把"后端起不来"时的横幅从压住标题栏的红条改成底部 toast。

## 1. Lisa.app 现在自带一整套运行时

之前 Lisa.app 只有一个 Swift 二进制：`BackendController` 去登录 shell 的 `$PATH` 上找 `lisa serve --web`，所以在用户跑过 `npm i -g @oratis/lisa` 之前这个 app 没有任何用处 —— DMG 自己的 README 也白纸黑字写着"启动前请先安装 backend"。只下载了磁盘映像的人看到的是离线启动页和一串终端命令。

新增 [`packaging/mac-client/embed-runtime.sh`](packaging/mac-client/embed-runtime.sh)，打包时把完整运行时塞进 bundle：

```
Contents/Resources/backend/{dist,node_modules,package.json}
Contents/Resources/node-runtime/bin/node
```

一台什么都没装的 Mac，第一次打开 app 就能在 localhost:5757 上拿到响应。

几个值得知道的打包决定：

- **`--omit=optional`** 砍掉 node-pty —— 依赖树里唯一的原生模块。内置后端因此保持纯 JS：不绑定任何 Node ABI，hardened runtime 下也不需要 `disable-library-validation`。PTY agent 退化成它本来在 node-pty 缺席时就会返回的 503。
- **生产依赖装在暂存目录**（按 lockfile 哈希缓存），绝不在仓库里装 —— 否则开发者跑一次 `build.sh` 就会被剪掉 devDependencies。
- **Node 二进制**对着 nodejs.org 的 `SHASUMS256.txt` 校验（这是要发给用户的可执行文件）、`strip -x`（每架构省 22MB）、lipo 成 universal。lipo 会剥掉 nodejs.org 的签名，而 arm64 拒绝执行未签名 Mach-O，所以脚本自己重签；`build-mac-apps.sh` 用 Developer ID 由内向外签 —— `--deep` 不会把 `Resources/` 下的裸 Mach-O 当作嵌套代码。现有 entitlements 已经有 V8 需要的 `allow-jit` 那一对（WKWebView 要的是同样两个）。
- **`dist/web/assets` 在 `copy-assets` 之后是指向 `src/` 的软链**，所以拷贝时解引用 —— 指到 bundle 外面的软链在用户机器上是死的，还会破坏资源封印。
- **`release-mac-apps.yml` 里原本没有 `npm ci` / `npm run build`**，CI 会打出一个空壳。已补上。

启动优先级是 `serve-command.txt` → 内置后端 → PATH 上的 `lisa`。**override 仍然排第一**：写了这个文件的人是要跑自己的源码树，偷偷换成 bundle 里的副本会让他的改动神秘失效。

### 顺带修掉"自动启动看起来没生效"

自动启动其实一直在跑（启动时，现在重新唤起 app 时也跑）。问题是后端瞬间崩掉时，app 会沉默 20 秒然后报一句 `timeout`。现在 `BackendController` 会从 `~/.lisa/backend.log` 里读出后端自己的致命错误行 —— 只匹配明确的"进程已死"特征，并留 ~2.5 秒宽限期，避免误杀慢启动 —— 离线启动页和菜单栏气泡都会显示它，并指明是哪条启动路径失败的。

## 2. 离线横幅 → 底部状态 toast

原来的兜底横幅是 `top:12px` 的宽粉条，样式写在内联 `cssText` 里。在 Mac 客户端里它正好压住窗口标题栏和整条顶部功能栏 —— 后端没起来时用户看到的第一样东西，就是一条盖住它所描述界面的消息。

- 搬进 `lisa-css.ts`（`#lisaBanner`），改用主题 token，跟随 Nebula ↔ Calm。附带一条显式 `[hidden]` 规则 —— 否则 `#id` 上的 `display: flex` 会盖过 UA 的 `[hidden] { display: none }`，`lisaClearBanner()` 会失效。
- `lisaBanner(msg, opts)` 接受 tone（`'info' | 'error'`）和一条可选的 shell 命令，渲染成点击复制的 chip。剪贴板写入需要安全上下文**且**文档处于聚焦状态，写失败时回退为选中该 chip。
- 位置每次调用时测量：聊天视图下浮在输入框上方 14px，没有输入框的视图贴窗口底边 —— 用户打字撑大 textarea 也不会盖住 toast。
- `startupGate` 前两次重试显示平静的 "Waking Lisa up…" —— 桌面端此时正常还在拉后端，t+4s 就报红是撒谎 —— 之后才升级成 error tone 并给出 `lisa serve --web`。`npm i -g @oratis/lisa` 那句安装引导去掉了：离线启动页已经有安装指引，toast 不是放这个的地方。

## 验证

- `env -i HOME=<空目录> PATH=/usr/bin:/bin`：内置 node 跑内置 dist，返回 HTTP 200 —— 这就是新用户那台干净 Mac 的处境。
- `codesign --verify --deep --strict` 通过（含嵌入的 node）。
- `npm test` 1644 passed / 0 failed；`npm run typecheck` 干净；`swift build` 干净。
- toast 在浏览器里跑过完整状态机：info → error 升级、深浅两套主题、`hidden` 真的隐藏、无输入框视图的贴底兜底。

体积：app 339MB，DMG **156MB**（原来是个空壳）。`LISA_EMBED_ARCHS=arm64` 只打 Apple Silicon 可再省 ~90MB；`LISA_SKIP_EMBED=1` 跳过嵌入，用于纯 Swift 迭代。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
