### PR TITLE
fix: 对抗式审查发现的 10 处缺陷 + 计费适配器补测

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,9 +257,15 @@ jobs:
           swift --version
           xcodebuild -version
 
-      - name: swift build -c debug
+      # `swift test`, not `swift build`: build compiles only the two shipping
+      # targets, so the LisaSetup unit tests (the backend-install wizard's
+      # decision table) were invisible to CI — someone could break decide() and
+      # this job would still go green. Testing costs about a second on top of
+      # the build that was already being paid for, and it builds the same
+      # targets on the way.
+      - name: swift test
         working-directory: packaging/mac-client
-        run: swift build -c debug
+        run: swift test
 
   # iOS companion (Lisa Pocket). Simulator builds need no signing, which is why
   # this can run on a public runner at all — build.sh already passes

--- a/docs/RUNBOOK_CLOUD_PROD.md
+++ b/docs/RUNBOOK_CLOUD_PROD.md
@@ -105,13 +105,13 @@ CHANNEL=$(gcloud alpha monitoring channels create --project $PROJECT \
   --channel-labels email_address=<OPS_EMAIL> --format 'value(name)')
 ```
 
-Uptime check 打 `/health`（专用 liveness 端点：无凭据、恒 200、零依赖。
+Uptime check 打 `/healthz`（专用 liveness 端点：无凭据、恒 200、零依赖。
 比 `/api/auth/config` 合适——后者还要 JSON 组装，不是纯活性信号）：
 
 ```bash
 gcloud monitoring uptime create lisa-cloud-health \
   --resource-type uptime-url --resource-labels host=cloud.meetlisa.ai \
-  --path /health --project $PROJECT
+  --path /healthz --project $PROJECT
 ```
 
 日志告警一：异常消费（meter.ts，>$10/天/用户）。实际输出是小写的

--- a/packaging/mac-client/README.md
+++ b/packaging/mac-client/README.md
@@ -38,7 +38,7 @@ invisible), then shows exactly one next step:
 
 | It found | You get |
 |---|---|
-| No Node.js (or older than 20) | `brew install node` with a Copy button, a nodejs.org link, and **Re-check** |
+| No Node.js (or older than 22.19) | `brew install node` with a Copy button, a nodejs.org link, and **Re-check** |
 | Node.js but no backend | **Install backend** — runs `npm install -g @oratis/lisa` with live output and a spinner, then starts `lisa serve --web` |
 | Everything | **Start backend**, plus **Update backend** to pull the latest release |
 

--- a/src/billing/outbox.firestore.test.ts
+++ b/src/billing/outbox.firestore.test.ts
@@ -1,0 +1,330 @@
+/**
+ * The Cloud adapter for the usage outbox.
+ *
+ * Every other outbox test runs against the JSONL store, which is the LOCAL
+ * edition's. FirestoreOutboxStore — the one that decides whether a hosted
+ * tenant gets charged once, twice or never — had no test at all: 18 of the
+ * module's 47 functions were unexecuted, all of them here. Money-moving code
+ * whose only validation is production is the wrong trade, so this exercises it
+ * against the in-memory REST fake the firestore client's own tests use.
+ *
+ * `FirestoreOutboxStore` calls getDoc/setDoc/casUpdate without a fetchFn, so
+ * the fake is installed as globalThis.fetch for the duration and restored
+ * after — which has the side benefit of running the REAL firestore client
+ * (value codec, preconditions, CAS retries) rather than a mock of it.
+ */
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import type { AccountRecord } from "../web/accounts.js";
+
+process.env.LISA_FIRESTORE_PROJECT = "test-project";
+
+const { _resetFirestoreCachesForTests } = await import("../cloud/firestore.js");
+const {
+  FirestoreOutboxStore,
+  defaultOutboxStore,
+  _resetOutboxStoreForTests,
+  newUsageEvent,
+  JsonlOutboxStore,
+} = await import("./outbox.js");
+
+/** Requests the fake served, so "sticky" and "one CAS" can be asserted. */
+let calls: string[] = [];
+
+/**
+ * A tiny in-memory Firestore: the metadata token endpoint, document GET, and
+ * :commit with `currentDocument` preconditions. Mirrors the fake in
+ * src/cloud/firestore.test.ts.
+ */
+function fakeFirestore() {
+  const docs = new Map<string, { fields: Record<string, unknown>; updateTime: string }>();
+  let version = 0;
+  const fetchFn = (async (url: string | URL | Request, init?: RequestInit) => {
+    const u = String(url);
+    if (u.includes("metadata.google.internal")) {
+      if (u.endsWith("/token")) {
+        return new Response(JSON.stringify({ access_token: "tok", expires_in: 3600 }), {
+          status: 200,
+        });
+      }
+      return new Response("test-project", { status: 200 });
+    }
+    const docsBase = "/databases/(default)/documents";
+    if (u.includes(":commit")) {
+      const body = JSON.parse(String(init?.body)) as {
+        writes: Array<{
+          update: { name: string; fields: Record<string, unknown> };
+          currentDocument?: { exists?: boolean; updateTime?: string };
+        }>;
+      };
+      const w = body.writes[0]!;
+      const path = w.update.name.split(`${docsBase}/`)[1]!;
+      calls.push(`commit ${path}`);
+      const existing = docs.get(path);
+      const pre = w.currentDocument;
+      if (pre) {
+        if (pre.updateTime !== undefined) {
+          if (!existing || existing.updateTime !== pre.updateTime) {
+            return new Response(JSON.stringify({ error: "precondition" }), { status: 409 });
+          }
+        } else if (pre.exists === false && existing) {
+          return new Response(JSON.stringify({ error: "exists" }), { status: 409 });
+        }
+      }
+      docs.set(path, { fields: w.update.fields, updateTime: `v${++version}` });
+      return new Response(JSON.stringify({}), { status: 200 });
+    }
+    const path = u.split(`${docsBase}/`)[1];
+    if (path) {
+      calls.push(`get ${path}`);
+      const doc = docs.get(path);
+      if (!doc) return new Response(JSON.stringify({ error: "not found" }), { status: 404 });
+      return new Response(JSON.stringify({ fields: doc.fields, updateTime: doc.updateTime }), {
+        status: 200,
+      });
+    }
+    return new Response("bad request", { status: 400 });
+  }) as typeof fetch;
+  return { fetchFn, docs };
+}
+
+const ACCT = { uid: "u-firestore-1" } as AccountRecord;
+
+function event(uid: string, id: string, costMicros = 1_234) {
+  return newUsageEvent(
+    {
+      acct: { uid } as AccountRecord,
+      kind: "chat",
+      model: "claude-sonnet-4-6",
+      costMicros,
+      reservationId: `res-${id}`,
+      eventId: id,
+    },
+    1_700_000_000_000,
+  );
+}
+
+let realFetch: typeof fetch;
+let docs: Map<string, { fields: Record<string, unknown>; updateTime: string }>;
+
+beforeEach(() => {
+  const fake = fakeFirestore();
+  docs = fake.docs;
+  calls = [];
+  realFetch = globalThis.fetch;
+  globalThis.fetch = fake.fetchFn;
+  _resetFirestoreCachesForTests();
+  _resetOutboxStoreForTests();
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  _resetOutboxStoreForTests();
+});
+
+describe("FirestoreOutboxStore", () => {
+  test("append writes the event and indexes it under the tenant", async () => {
+    const store = new FirestoreOutboxStore();
+    const e = event(ACCT.uid, "evt-1");
+    await store.append(e);
+
+    const doc = docs.get(`lisa-outbox/${ACCT.uid}/events/evt-1`);
+    assert.ok(doc, "the event document was not created");
+    const index = docs.get(`lisa-outbox/${ACCT.uid}`);
+    assert.ok(index, "the tenant index was not created");
+
+    // Round-trips through the value codec with every field intact.
+    const read = await store.get(ACCT.uid, "evt-1");
+    assert.deepEqual(read, e);
+    // lastError is stored as "" and must not come back as an empty string.
+    assert.equal("lastError" in (read as object), false);
+  });
+
+  test("append is idempotent by id: a replay neither duplicates nor throws", async () => {
+    const store = new FirestoreOutboxStore();
+    const e = event(ACCT.uid, "evt-dup");
+    await store.append(e);
+    // A retry of the same settlement — the id is the idempotency key, and the
+    // exists:false precondition is what makes the second write a no-op rather
+    // than a second charge waiting to happen.
+    await store.append(e);
+
+    const open = await store.listOpen(ACCT.uid);
+    assert.equal(open.length, 1);
+    assert.equal(open[0]!.id, "evt-dup");
+  });
+
+  test("index-first ordering: an event is never written without an index entry", async () => {
+    const store = new FirestoreOutboxStore();
+    await store.append(event(ACCT.uid, "evt-order"));
+    const indexWrite = calls.indexOf(`commit lisa-outbox/${ACCT.uid}`);
+    const eventWrite = calls.indexOf(`commit lisa-outbox/${ACCT.uid}/events/evt-order`);
+    assert.ok(indexWrite >= 0 && eventWrite >= 0);
+    assert.ok(
+      indexWrite < eventWrite,
+      "a dangling index id self-heals; an unindexed event is invisible forever",
+    );
+  });
+
+  test("update to committed drops the id from the open index", async () => {
+    const store = new FirestoreOutboxStore();
+    const e = event(ACCT.uid, "evt-commit");
+    await store.append(e);
+    assert.equal((await store.listOpen(ACCT.uid)).length, 1);
+
+    await store.update({ ...e, status: "committed" });
+
+    assert.deepEqual(await store.listOpen(ACCT.uid), []);
+    // The document itself is kept — it is the audit trail, not a queue slot.
+    assert.equal((await store.get(ACCT.uid, "evt-commit"))?.status, "committed");
+  });
+
+  test("update to a non-terminal status leaves it open and records the error", async () => {
+    const store = new FirestoreOutboxStore();
+    const e = event(ACCT.uid, "evt-retry");
+    await store.append(e);
+    await store.update({ ...e, status: "failed", attempts: 2, lastError: "ledger unavailable" });
+
+    const open = await store.listOpen(ACCT.uid);
+    assert.equal(open.length, 1);
+    assert.equal(open[0]!.attempts, 2);
+    assert.equal(open[0]!.lastError, "ledger unavailable");
+  });
+
+  test("listOpen prunes ids whose document is gone or already committed", async () => {
+    const store = new FirestoreOutboxStore();
+    await store.append(event(ACCT.uid, "evt-live"));
+    await store.append(event(ACCT.uid, "evt-vanished"));
+    // Simulate the dangling half of the index-first write: the id is indexed,
+    // the document never landed.
+    docs.delete(`lisa-outbox/${ACCT.uid}/events/evt-vanished`);
+
+    const open = await store.listOpen(ACCT.uid);
+    assert.deepEqual(
+      open.map((e) => e.id),
+      ["evt-live"],
+    );
+    // Pruned for good, not re-walked on every sweep: a second listOpen reads
+    // the rewritten index and never touches the vanished id again.
+    calls = [];
+    await store.listOpen(ACCT.uid);
+    assert.equal(
+      calls.some((c) => c.includes("evt-vanished")),
+      false,
+      "the dangling id survived the prune",
+    );
+  });
+
+  test("listOpen returns oldest first, so the reconciler drains in order", async () => {
+    const store = new FirestoreOutboxStore();
+    const older = { ...event(ACCT.uid, "evt-older"), createdAt: 1_000 };
+    const newer = { ...event(ACCT.uid, "evt-newer"), createdAt: 9_000 };
+    await store.append(newer);
+    await store.append(older);
+    assert.deepEqual(
+      (await store.listOpen(ACCT.uid)).map((e) => e.id),
+      ["evt-older", "evt-newer"],
+    );
+  });
+
+  test("listTenants aggregates every shard", async () => {
+    const store = new FirestoreOutboxStore();
+    // Enough uids that the sha256 shard function spreads them over more than
+    // one of the eight registry documents.
+    const uids = Array.from({ length: 12 }, (_, i) => `u-shard-${i}`);
+    for (const uid of uids) await store.append(event(uid, `evt-${uid}`));
+
+    const seen = await store.listTenants();
+    assert.deepEqual([...seen].sort(), [...uids].sort());
+    const shardDocs = [...docs.keys()].filter((k) => k.startsWith("lisa-outbox-tenants/"));
+    assert.ok(shardDocs.length > 1, "the registry never sharded — one hot document");
+  });
+
+  test("tenant registration is sticky: repeat appends do not rewrite the registry", async () => {
+    const store = new FirestoreOutboxStore();
+    await store.append(event(ACCT.uid, "evt-a"));
+    const afterFirst = calls.filter((c) => c.startsWith("commit lisa-outbox-tenants/")).length;
+    assert.equal(afterFirst, 1);
+
+    await store.append(event(ACCT.uid, "evt-b"));
+    await store.append(event(ACCT.uid, "evt-c"));
+    const afterMore = calls.filter((c) => c.startsWith("commit lisa-outbox-tenants/")).length;
+    assert.equal(afterMore, 1, "the shared registry document is written once per process per uid");
+  });
+
+  test("draining a tenant's last event lets the registry forget it", async () => {
+    const store = new FirestoreOutboxStore();
+    const e = event(ACCT.uid, "evt-last");
+    await store.append(e);
+    assert.deepEqual(await store.listTenants(), [ACCT.uid]);
+
+    await store.update({ ...e, status: "committed" });
+    // A clean drain produces no STALE id — update() already removed the
+    // committed id from the index — so the registry used to keep this uid
+    // forever and the 15-minute reconcile sweep grew with every account that
+    // ever settled anything. An index that exists and is empty means drained.
+    assert.deepEqual(await store.listOpen(ACCT.uid), []);
+    assert.deepEqual(await store.listTenants(), []);
+  });
+
+  test("get returns null for an id this tenant never had", async () => {
+    const store = new FirestoreOutboxStore();
+    assert.equal(await store.get(ACCT.uid, "nope"), null);
+  });
+
+  test("a prune failure is swallowed — listOpen still answers", async () => {
+    const store = new FirestoreOutboxStore();
+    await store.append(event(ACCT.uid, "evt-live-2"));
+    await store.append(event(ACCT.uid, "evt-gone"));
+    docs.delete(`lisa-outbox/${ACCT.uid}/events/evt-gone`);
+
+    const saved = globalThis.fetch;
+    globalThis.fetch = async (url: string | URL | Request, init?: RequestInit) => {
+      // Fail only the index rewrite the prune attempts.
+      if (
+        String(url).includes(":commit") &&
+        String(init?.body).includes(`lisa-outbox/${ACCT.uid}"`)
+      ) {
+        return new Response(JSON.stringify({ error: "boom" }), { status: 500 });
+      }
+      return saved(url, init);
+    };
+    try {
+      // The reconciler must still see the live event: housekeeping that fails
+      // is not allowed to hide work that needs doing.
+      const open = await store.listOpen(ACCT.uid);
+      assert.deepEqual(
+        open.map((e) => e.id),
+        ["evt-live-2"],
+      );
+    } finally {
+      globalThis.fetch = saved;
+    }
+  });
+});
+
+describe("defaultOutboxStore", () => {
+  test("picks the Firestore adapter only when Firestore is enabled", async () => {
+    const before = process.env.LISA_FIRESTORE;
+    try {
+      process.env.LISA_FIRESTORE = "1";
+      _resetOutboxStoreForTests();
+      assert.ok(defaultOutboxStore() instanceof FirestoreOutboxStore);
+
+      delete process.env.LISA_FIRESTORE;
+      _resetOutboxStoreForTests();
+      assert.ok(defaultOutboxStore() instanceof JsonlOutboxStore);
+    } finally {
+      if (before === undefined) delete process.env.LISA_FIRESTORE;
+      else process.env.LISA_FIRESTORE = before;
+      _resetOutboxStoreForTests();
+    }
+  });
+
+  test("the adapter is memoized until a test resets it", () => {
+    const a = defaultOutboxStore();
+    assert.equal(defaultOutboxStore(), a);
+    _resetOutboxStoreForTests();
+    assert.notEqual(defaultOutboxStore(), a);
+  });
+});

--- a/src/billing/outbox.ts
+++ b/src/billing/outbox.ts
@@ -445,7 +445,20 @@ export class FirestoreOutboxStore implements OutboxStore {
       if (!event || event.status === "committed") stale.push(id);
       else events.push(event);
     }
+    // Prune when something is stale, and ALSO when a tenant has simply drained:
+    // update() removes a committed id from the index directly, so a tenant that
+    // settles cleanly never produces a stale id and used to stay in the sticky
+    // registry forever. The reconciler walks that registry every 15 minutes, so
+    // the sweep's cost grew with every account that ever bought anything and
+    // never came back down.
+    //
+    // `index !== null` is load-bearing: append() registers the tenant BEFORE it
+    // writes the index, so a concurrent sweep can see a registered uid whose
+    // index document does not exist yet. Deregistering on that would strand the
+    // event being appended — its charge would never be reconciled. An index that
+    // EXISTS and is empty can only mean drained.
     if (stale.length) await this.pruneIndex(uid, stale);
+    else if (index && ids.length === 0) await this.forgetTenant(uid);
     return events.sort((a, b) => a.createdAt - b.createdAt);
   }
 
@@ -475,7 +488,21 @@ export class FirestoreOutboxStore implements OutboxStore {
         return { next: { uid, open }, result: open.length };
       });
       if (remaining > 0) return;
-      // Nothing open: let the sticky registry forget this tenant too.
+      await this.forgetTenant(uid);
+    } catch (err) {
+      logInfo(
+        `[billing] outbox index prune skipped (uid ${redactId(uid)}): ${describeError(err, uid)}`,
+      );
+    }
+  }
+
+  /**
+   * Drop a drained tenant from the sticky registry. Best-effort by design: a
+   * uid left behind only costs one extra getDoc per sweep, while a failure that
+   * propagated would abort a reconcile pass that has real work queued behind it.
+   */
+  private async forgetTenant(uid: string): Promise<void> {
+    try {
       await casUpdate(tenantShard(uid), (current) => {
         const uids = readIds(current, "uids").filter((u) => u !== uid);
         return { next: { uids }, result: undefined };
@@ -483,7 +510,7 @@ export class FirestoreOutboxStore implements OutboxStore {
       this.registered.delete(uid);
     } catch (err) {
       logInfo(
-        `[billing] outbox index prune skipped (uid ${redactId(uid)}): ${describeError(err, uid)}`,
+        `[billing] outbox tenant deregister skipped (uid ${redactId(uid)}): ${describeError(err, uid)}`,
       );
     }
   }

--- a/src/cli/probe.test.ts
+++ b/src/cli/probe.test.ts
@@ -176,7 +176,16 @@ describe("warnings", () => {
   });
 
   test("a lagging server prints the warning glyph and still exits 0", async () => {
-    const laggy = { ...RICH, event_loop_lag_ms: { p50: 4, p99: 2300, max: 9000 } };
+    // ok:false is what a lagging instance actually sends — health.ts derives it
+    // from the watchdog. The fixture used to say ok:true, which is why the
+    // probe could treat "degraded" as "unreachable" without a test noticing:
+    // a stalling backend was reported as down, and the runbook turns a non-zero
+    // probe into a restart.
+    const laggy = {
+      ...RICH,
+      ok: false,
+      event_loop_lag_ms: { p50: 4, p99: 2300, max: 9000 },
+    };
     await withServer({ "/health": { body: JSON.stringify(laggy) } }, async (base) => {
       const lines: string[] = [];
       const code = await runProbe(base, { log: (l) => lines.push(l) });
@@ -184,6 +193,8 @@ describe("warnings", () => {
       const text = lines.join("\n");
       assert.match(text, /⚠/);
       assert.match(text, /p99 2300ms/);
+      assert.match(text, /unhealthy/);
+      assert.doesNotMatch(text, /unreachable/);
     });
   });
 });

--- a/src/cli/probe.ts
+++ b/src/cli/probe.ts
@@ -108,7 +108,14 @@ export async function probeHealth(baseUrl: string, opts: ProbeOptions = {}): Pro
       if (res.status === 404 && endpoint !== ENDPOINTS[ENDPOINTS.length - 1]) continue;
       const payload = await readJson(res);
       const latencyMs = now() - started;
-      const reachable = res.ok && payload?.ok !== false;
+      // Reachable means the instance ANSWERED. It deliberately does not mean
+      // "answered ok:true": /health reports ok:false when the event loop is
+      // lagging, and folding that into reachability made a stalling-but-alive
+      // backend print "✗ unreachable — is the backend running?" and exit 1.
+      // The runbook wires a non-zero probe to a restart, so a server that was
+      // merely busy would have been killed, and the operator would have been
+      // told the wrong thing about why. Degradation is a warning, not absence.
+      const reachable = res.ok;
       return {
         url,
         endpoint,
@@ -153,6 +160,12 @@ export function collectWarnings(
   latencyMs: number,
 ): string[] {
   const out: string[] = [];
+  // The server's own verdict comes first: it sets ok:false when its watchdog
+  // considers the loop unhealthy, which it knows better than any threshold
+  // applied out here to a single sample.
+  if (payload?.ok === false) {
+    out.push("the instance reports itself unhealthy (ok:false) — see its logs");
+  }
   const p99 = payload?.event_loop_lag_ms?.p99;
   if (typeof p99 === "number" && p99 > LAG_P99_WARN_MS) {
     out.push(`event loop lag p99 ${fmtMs(p99)} > ${LAG_P99_WARN_MS}ms — requests will stall`);

--- a/src/integrations/claude-code/watcher.scan.test.ts
+++ b/src/integrations/claude-code/watcher.scan.test.ts
@@ -89,6 +89,32 @@ describe("claude-code watcher startup (T-5)", () => {
     }
   });
 
+  test("startup does not announce the state it discovers", async () => {
+    // The failure this pins: initialScan() records every file as
+    // "unknown"/"unscanned", so the first parse always looks like a state
+    // change. Emitting it made every backend restart — launchd KeepAlive after
+    // a crash, `lisa upgrade`, the watchdog — re-push "errored" / "needs
+    // permission" for sessions the user was already notified about.
+    session("-Users-x-Projects-Restart", "dddddddd-0000-0000-0000-000000000001", 2_000);
+    session("-Users-x-Projects-Restart", "dddddddd-0000-0000-0000-000000000002", 3_000);
+
+    const w = new ClaudeCodeWatcher();
+    const seen: string[] = [];
+    w.on("update", (u: { event: string; sessionId: string }) =>
+      seen.push(`${u.event}:${u.sessionId}`),
+    );
+    try {
+      await w.start();
+      assert.deepEqual(seen, [], `startup emitted ${seen.length} update(s): ${seen.join(", ")}`);
+      // The state is still known — it was recorded, just not announced.
+      const active = w.listActive().filter((a) => a.projectLabel.includes("Restart"));
+      assert.equal(active.length, 2);
+      for (const a of active) assert.notEqual(a.state, "unknown");
+    } finally {
+      w.stop();
+    }
+  });
+
   test("a repoll of a stat-identical file reuses the parse instead of re-reading", async () => {
     const file = session("-Users-x-Projects-Demo", "cccccccc-0000-0000-0000-000000000001", 1_000);
     const when = new Date(Date.now() - 1_000);

--- a/src/integrations/claude-code/watcher.ts
+++ b/src/integrations/claude-code/watcher.ts
@@ -185,7 +185,16 @@ export class ClaudeCodeWatcher extends EventEmitter {
     await this.attachWatcher();
     // First real parse of the ACTIVE sessions only — the scan above deliberately
     // read nothing. Everything outside the 30 min window is never opened.
-    await this.repollActive();
+    //
+    // Silent, because this is not a transition: initialScan() recorded every
+    // file as state "unknown"/"unscanned", so the first parse ALWAYS looks like
+    // a change. Emitting it turned every backend restart — launchd KeepAlive
+    // after a crash, `lisa upgrade`, the T-3 watchdog — into a fresh round of
+    // "session errored" / "needs permission" pushes for sessions the user was
+    // already told about, possibly hours earlier. Subscribers that want the
+    // current picture pull it from listActive(); the event stream is for real
+    // transitions.
+    await this.repollActive({ silent: true });
     this.startRepollLoop();
   }
 
@@ -467,7 +476,7 @@ export class ClaudeCodeWatcher extends EventEmitter {
     if (this.repollTimer.unref) this.repollTimer.unref();
   }
 
-  private async repollActive(): Promise<void> {
+  private async repollActive(opts: { silent?: boolean } = {}): Promise<void> {
     const cutoff = Date.now() - ACTIVE_WINDOW_MS;
     const candidates = [...this.sessions.entries()].filter(([, info]) => info.lastMtime >= cutoff);
     for (const [filePath, prev] of candidates) {
@@ -496,7 +505,9 @@ export class ClaudeCodeWatcher extends EventEmitter {
       // changed (working → waiting after staleness).
       if (info.state !== prev.state || info.stateReason !== prev.stateReason) {
         this.sessions.set(filePath, info);
-        this.emitUpdate("state_changed", info);
+        // The startup sweep records the truth without announcing it: see
+        // start(). Only genuine transitions after boot reach subscribers.
+        if (!opts.silent) this.emitUpdate("state_changed", info);
       }
     }
   }

--- a/src/web/assets/client/main.js
+++ b/src/web/assets/client/main.js
@@ -864,21 +864,51 @@ function lisaProviderList(status) {
                needsModel: !!h.needsModel, configured: conf, served: false };
     });
   }
-  return served.map(function (p) {
+  const merged = served.map(function (p) {
     const h = hintOf(p.envKey, p.id) || EMPTY_PROVIDER_HINT;
+    // needsModel comes from the SERVED row, not the hint table. Deriving it
+    // from local hints meant every provider this client has no hint for (Grok,
+    // Mistral, Perplexity, Ark, MiniMax, Hunyuan…) silently reported
+    // needsModel:false: the gate then saved a key with no LISA_MODEL, the
+    // server kept routing to Claude, and the user was told they were
+    // configured. Anything that is not Anthropic or OpenAI is reached by model
+    // prefix, so it needs a pinned model — and the server already tells us a
+    // usable default in modelPrefixes[0].
+    const prefixes = Array.isArray(p.modelPrefixes) ? p.modelPrefixes : [];
+    const builtIn = p.envKey === 'ANTHROPIC_API_KEY' || p.envKey === 'OPENAI_API_KEY';
     return {
       id: p.id || h.id || p.envKey,
       envKey: p.envKey || h.envKey || '',
       label: p.label || h.label || p.id || p.envKey,
       placeholder: h.placeholder || 'key...',
-      model: h.model || '',
+      model: h.model || prefixes[0] || '',
       consoleUrl: h.consoleUrl || '',
       custom: !!h.custom,
-      needsModel: !!h.needsModel,
+      needsModel: h.needsModel !== undefined && h.envKey ? !!h.needsModel : !builtIn,
       configured: !!p.configured,
       served: true,
     };
   });
+  // The served list stays authoritative for NAMED providers: one the server
+  // does not enumerate is one /api/config/save would reject, so offering it
+  // would just produce a 400. The exception is the client-only custom row —
+  // "Custom (OpenAI-compatible)" writes LISA_API_KEY + LISA_BASE_URL rather
+  // than a named provider's key, so providerConfigList() has nothing to report
+  // for it even though both keys ARE writable. Dropping it with the wholesale
+  // replace made Ollama, LM Studio and every self-hosted endpoint unreachable
+  // from the GUI, with the BASE URL field permanently hidden.
+  const seen = {};
+  for (let i = 0; i < merged.length; i++) seen[merged[i].envKey] = true;
+  for (let i = 0; i < LISA_PROVIDER_FALLBACK.length; i++) {
+    const h = LISA_PROVIDER_FALLBACK[i];
+    if (!h.custom || seen[h.envKey]) continue;
+    merged.push({
+      id: h.id, envKey: h.envKey, label: h.label, placeholder: h.placeholder,
+      model: h.model, consoleUrl: h.consoleUrl, custom: true,
+      needsModel: !!h.needsModel, configured: false, served: false,
+    });
+  }
+  return merged;
 }
 // One body understood by both generations of the endpoint: the new
 // {keys, model, baseUrl} shape plus every legacy field name.
@@ -1257,6 +1287,18 @@ async function startBirthStream() {
 
   try {
     const res = await fetch('/api/birth', { method: 'POST', signal: ctrl.signal });
+    if (res.status === 409) {
+      // 409 = she is already born. Reaching this is not a failure: the soul was
+      // written and the SSE stream was cut before the `done` frame (a laptop
+      // that slept, a proxy reset, a second tab that finished the ceremony
+      // first). Showing the error card here offered a "Try again" that could
+      // only ever 409 again — a dead end in front of a Lisa that exists. Close
+      // the ritual and let the normal startup path pick her up.
+      clearBirthActions();
+      birthOverlay.classList.remove('open');
+      location.reload();
+      return;
+    }
     if (!res.ok) {
       // An HTTP-level refusal carries no SSE frame — classify it the same way.
       showBirthError({ code: res.status === 401 || res.status === 403 ? 'auth' : 'unknown',

--- a/src/web/lisa-client.test.ts
+++ b/src/web/lisa-client.test.ts
@@ -269,7 +269,16 @@ describe("provider picker works against both server generations (UX-1)", () => {
         },
       ],
     });
-    assert.equal(JSON.stringify(list.map((p) => p.id)), JSON.stringify(["zhipu", "brandnew"]));
+    // The served list is authoritative for named providers — one the server
+    // does not enumerate would be refused by /api/config/save's whitelist. The
+    // custom endpoint is the exception: it writes LISA_API_KEY + LISA_BASE_URL,
+    // which the server never reports as a "provider" but does accept, so it has
+    // to survive the merge or self-hosted endpoints become unreachable.
+    assert.equal(
+      JSON.stringify(list.map((p) => p.id)),
+      JSON.stringify(["zhipu", "brandnew", "custom"]),
+    );
+    assert.equal(list[list.length - 1]!.custom, true);
     assert.equal(list[0]!.configured, true);
     // Local presentation hints still merge in for the ones we know.
     assert.equal(list[0]!.model, "glm-4-plus");

--- a/src/web/server.test.ts
+++ b/src/web/server.test.ts
@@ -376,6 +376,40 @@ describe("T-9 /api/config over the real server", () => {
       await srv.close();
     }
   });
+
+  test("saving a key for another provider re-points the model this process uses", async () => {
+    // The whole non-Anthropic onboarding path depends on this. A first run has
+    // no key, so the server boots on DEFAULT_MODEL; the gate then offers every
+    // provider. If the model stayed a boot-time constant, someone who pasted a
+    // DeepSeek key got it written to config.env and then watched every turn go
+    // to Claude — which fails, because there is no Anthropic key. The key was
+    // saved, the UI said "configured", and nothing worked.
+    const srv = await boot({ model: "claude-sonnet-4-6" });
+    cleanup.push("DEEPSEEK_API_KEY", "LISA_MODEL");
+    try {
+      const before = JSON.parse((await request(srv.port, "GET", "/session")).text) as {
+        model: string;
+      };
+      assert.equal(before.model, "claude-sonnet-4-6");
+
+      const saved = await request(srv.port, "POST", "/api/config/save", {
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ keys: { DEEPSEEK_API_KEY: KEY }, model: "deepseek-chat" }),
+      });
+      assert.equal(saved.status, 200);
+
+      const after = JSON.parse((await request(srv.port, "GET", "/session")).text) as {
+        model: string;
+      };
+      assert.equal(
+        after.model,
+        "deepseek-chat",
+        "the running server still routes to the old model",
+      );
+    } finally {
+      await srv.close();
+    }
+  });
 });
 
 describe("T-11 SSE keep-alive on the real server", () => {
@@ -423,7 +457,7 @@ describe("T-11 SSE keep-alive on the real server", () => {
 });
 
 describe("T-12 PWA manifest icons", () => {
-  test("declares real 192/512 sizes plus a separate maskable variant", async () => {
+  test("declares real 192/512 maskable sizes, and every icon is actually served", async () => {
     const srv = await boot();
     try {
       const r = await request(srv.port, "GET", "/manifest.webmanifest");
@@ -445,15 +479,47 @@ describe("T-12 PWA manifest icons", () => {
         assert.equal(i.type, "image/png");
         assert.match(i.sizes, /^\d+x\d+$/);
       }
-      // The maskable icon is its own file: relabelling an unpadded icon
-      // maskable gets its edges cropped by the platform mask.
-      const maskable = m.icons.filter((i) => i.purpose === "maskable");
-      assert.equal(maskable.length, 1);
-      assert.equal(maskable[0]!.src, "/assets/icon-512-maskable.png");
-      assert.equal(
-        m.icons.some((i) => i.purpose === "any" && i.src === maskable[0]!.src),
-        false,
+      // At least one icon must be maskable, or Android crops the art with its
+      // own mask.
+      assert.ok(
+        m.icons.some((i) => (i.purpose ?? "").split(/\s+/).includes("maskable")),
+        "no maskable icon declared",
       );
+
+      // Every declared icon must actually be SERVED. Asserting the manifest's
+      // content is not enough, and this is not hypothetical: an earlier version
+      // of this test checked only the declaration, and passed for days while the
+      // maskable entry named a file no build step produced — so the only
+      // maskable icon 404'd on every install and Android fell back to a default.
+      // The same dangling name also sat in the service worker's precache list,
+      // where addAll() rejects wholesale on one missing URL, silently disabling
+      // the entire offline cache. Fetching each icon is what closes both.
+      for (const i of m.icons) {
+        const icon = await request(srv.port, "GET", i.src);
+        assert.equal(icon.status, 200, `${i.src} is declared but not served`);
+        assert.equal(icon.headers["content-type"], "image/png");
+      }
+    } finally {
+      await srv.close();
+    }
+  });
+
+  test("every asset the service worker precaches exists", async () => {
+    // cache.addAll() is all-or-nothing: one 404 rejects the whole promise, and
+    // the install handler swallows it with .catch(() => {}). So a single stale
+    // filename in this list does not break one icon — it silently disables the
+    // entire offline cache, with no error anywhere. The list is a string inside
+    // a served script, so nothing else type-checks or links it.
+    const srv = await boot();
+    try {
+      const sw = await request(srv.port, "GET", "/sw.js");
+      assert.equal(sw.status, 200);
+      const paths = [...sw.text.matchAll(/'(\/assets\/[^']+)'/g)].map((m) => m[1]!);
+      assert.ok(paths.length > 0, "no precached asset paths found — did the list move?");
+      for (const path of paths) {
+        const res = await request(srv.port, "GET", path);
+        assert.equal(res.status, 200, `${path} is precached but not served`);
+      }
     } finally {
       await srv.close();
     }

--- a/src/web/server.ts
+++ b/src/web/server.ts
@@ -15,7 +15,7 @@ import { planUsage, formatUsage } from "../model/plan-usage.js";
 import { runIdleOnce } from "../idle/runner.js";
 import { getIdleWatcher } from "../idle/watcher.js";
 import { moodBus } from "../mood-bus.js";
-import { providerForModel } from "../providers/registry.js";
+import { providerForModel, resolveDefaultModel } from "../providers/registry.js";
 import { buildSystemPromptSnapshot, getPromptFingerprint } from "../prompt.js";
 import { readActiveWebSession, writeActiveWebSession } from "../sessions/active.js";
 import { listSessionsOnDisk } from "../sessions/list.js";
@@ -566,13 +566,20 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   const session = await resumeOrCreateWebSession(opts.model);
   await writeActiveWebSession(session.id);
   process.env.LISA_SESSION_ID = session.id;
+  // The model in effect right now. It starts as the one the CLI resolved at
+  // boot, but the key gate can change it: a first run has no key at all, so
+  // `opts.model` is only ever DEFAULT_MODEL there, and someone who configures
+  // DeepSeek (or Qwen, GLM, Grok…) needs the very next turn to route to it.
+  // Treating the model as a startup constant made the whole non-Anthropic
+  // onboarding path inert — the key was saved and then never used.
+  let activeModel = opts.model;
   // Lazy provider — the SDK reads ANTHROPIC_API_KEY at construction time,
   // so we can't build it before the user has set the key via the GUI popup.
   // Rebuilt after /api/config/save so the in-memory client picks up the
-  // new key without restarting the server.
+  // new key (and the new model) without restarting the server.
   let cachedProvider: ReturnType<typeof providerForModel> | null = null;
   const getProvider = () => {
-    if (!cachedProvider) cachedProvider = providerForModel(opts.model);
+    if (!cachedProvider) cachedProvider = providerForModel(activeModel);
     return cachedProvider;
   };
   // Restore full history from the session file on startup (so context survives page refresh)
@@ -664,7 +671,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
     const scoped = homeScope.getStore();
     if (!scoped) return { value: globalChat, release: () => {} };
     return tenantRuntimes.acquire(scoped, async () => {
-      const s = await resumeOrCreateWebSession(opts.model);
+      const s = await resumeOrCreateWebSession(activeModel);
       await writeActiveWebSession(s.id);
       const [{ messages }, reflectionSummary] = await Promise.all([
         s.readMessagePage(0, 9999),
@@ -706,19 +713,19 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
   ): Promise<void> => {
     const { birth, BirthInferenceError } = await import("../soul/birth.js");
     if (!cloudEdition || !uid) {
-      await birth({ model: opts.model, onStep: emit, signal });
+      await birth({ model: activeModel, onStep: emit, signal });
       return;
     }
     const acct = await getAccount(uid);
     if (!acct) throw new Error("birth account no longer exists");
-    const admission = await admitInference(acct, opts.model);
+    const admission = await admitInference(acct, activeModel);
     if (!admission.ok) {
       const detail = "error" in admission.body ? admission.body.error : "inference_rejected";
       throw new Error(`birth admission rejected: ${detail}`);
     }
     try {
       try {
-        const result = await birth({ model: opts.model, onStep: emit, signal });
+        const result = await birth({ model: activeModel, onStep: emit, signal });
         await admission.permit.settle("birth", result.usage);
       } catch (err) {
         if (err instanceof BirthInferenceError) {
@@ -1029,7 +1036,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       if (!shot) return;
       const suggestion = await analyzeScreenshot({
         provider: getProvider() as unknown as SuggestionProvider,
-        model: opts.model,
+        model: activeModel,
         imageBase64: shot.data,
         mediaType: shot.mediaType,
       });
@@ -1146,7 +1153,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           tools: runtimeTools,
           cwd: process.cwd(),
           signal: abort.signal,
-          model: opts.model,
+          model: activeModel,
           idleMs: watcher.idleFor(),
           userLanguageSample,
         });
@@ -1228,7 +1235,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
               const r = await reflectOnSession({
                 history: snapshot,
                 sessionId: ctx.session.id,
-                model: opts.model,
+                model: activeModel,
               });
               // Advance the marker only on success, so a failed reflect retries next
               // tick instead of silently dropping the conversation.
@@ -1304,10 +1311,23 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
       res.end(JSON.stringify({ ok: true }));
       return;
     }
-    // Health detail (pre-gate, unauthenticated, still no I/O): version, uptime,
-    // event-loop lag percentiles, heap/RSS and the live tenant / turn / session
-    // counters — what an operator needs to tell "slow" from "down". Always 200:
-    // `ok:false` means "lagging", not "dead"; /healthz is the liveness probe.
+    // Health detail (pre-gate): version, uptime, event-loop lag percentiles,
+    // heap/RSS and the live tenant / turn / session counters — what an operator
+    // needs to tell "slow" from "down". Always 200: `ok:false` means "lagging",
+    // not "dead"; /healthz is the liveness probe.
+    //
+    // The FULL payload goes only to a caller the gate would let in. It is a
+    // fingerprint: exact version, process uptime, memory, how many sessions
+    // exist and how many turns are in flight. That mattered for the hosted
+    // edition first, but it matters on a Mac too — `--host 0.0.0.0` is the
+    // documented way to reach Lisa from a phone, and it puts this endpoint in
+    // front of everyone on the café Wi-Fi. One rule for both editions: health
+    // (ok + lag + edition) is public, everything else needs the token.
+    //
+    // trustLoopback is on for the Mac edition only, where loopback IS the local
+    // owner — so `lisa doctor --probe` keeps its full read on the machine
+    // itself. The hosted container must never treat its own (or the proxy's)
+    // loopback as the owner, the same rule the gate below uses.
     if (req.method === "GET" && url === "/health") {
       const full = healthPayload(
         loopMonitor,
@@ -1315,21 +1335,13 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         cloudEdition ? "cloud" : "mac",
         watchdogLagMs,
       );
-      // Hosted edition: this endpoint faces the public internet from here, so
-      // the unauthenticated answer is health only. tenants / sessions /
-      // pending_turns are live usage metrics and heap / RSS / uptime expose
-      // restart and load patterns; none are needed to tell "lagging" from
-      // "fine". An authenticated caller gets the full payload further down,
-      // and /healthz is still the unauthenticated liveness probe.
-      // trustLoopback: false — the hosted container must never treat its own
-      // (or the proxy's) loopback as the owner, the same rule the gate below uses.
       const healthAuthed = isRequestAuthorized(
         req.socket.remoteAddress ?? "",
         webToken,
         presentedToken(req, url),
-        false,
+        !cloudEdition,
       );
-      const body = cloudEdition && !healthAuthed ? publicHealthPayload(full) : full;
+      const body = healthAuthed ? full : publicHealthPayload(full);
       res.writeHead(200, { "content-type": "application/json", "cache-control": "no-store" });
       res.end(JSON.stringify(body));
       return;
@@ -1821,7 +1833,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         typeof body.maxRuns === "number" && body.maxRuns > 0 ? Math.floor(body.maxRuns) : undefined;
       try {
         const report = await sweepUserAutonomy({
-          ...(opts.model ? { model: opts.model } : {}),
+          ...(activeModel ? { model: activeModel } : {}),
           ...(maxRuns !== undefined ? { maxRuns } : {}),
           tools: autonomyTools,
           cwd: process.cwd(),
@@ -1998,6 +2010,34 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         homeScope.enterWith(uidHome);
         ensureUserBirth(accountUid);
       }
+    }
+
+    // Health detail (POST-gate): version, uptime, event-loop lag percentiles,
+    // heap/RSS and the live tenant / turn / session counters — what an operator
+    // needs to tell "slow" from "down". Always 200: `ok:false` means "lagging",
+    // not "dead".
+    //
+    // It sits behind the gate because it is a fingerprint: exact version,
+    // process uptime, memory, how many sessions exist and how many turns are in
+    // flight. On a Mac bound to 0.0.0.0 — the documented way to reach Lisa from
+    // a phone — that would be readable by anyone on the café Wi-Fi. Loopback is
+    // the local owner and passes the gate for free, so `lisa doctor --probe`
+    // keeps working on the machine itself; remote callers need the token they
+    // already need for everything else. Liveness stays public at /healthz,
+    // which is what platform probes and uptime checks should target.
+    if (req.method === "GET" && url === "/health") {
+      res.writeHead(200, { "content-type": "application/json", "cache-control": "no-store" });
+      res.end(
+        JSON.stringify(
+          healthPayload(
+            loopMonitor,
+            healthCounters(),
+            cloudEdition ? "cloud" : "mac",
+            watchdogLagMs,
+          ),
+        ),
+      );
+      return;
     }
 
     // ── Account introspection + deletion (post-gate; PLAN_ACCOUNTS_BILLING B1) ──
@@ -2573,7 +2613,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           let polishPermit: InferencePermit | null = null;
           try {
             if (acct) {
-              const admission = await admitInference(acct, opts.model);
+              const admission = await admitInference(acct, activeModel);
               if (admission.ok) polishPermit = admission.permit;
               else {
                 logInfo(`[voice] dictation polish skipped: ${JSON.stringify(admission.body)}`);
@@ -2583,13 +2623,13 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
             if (text === undefined) {
               const polished = await polishDictationMetered({
                 provider: getProvider() as unknown as DictationProvider,
-                model: opts.model,
+                model: activeModel,
                 transcript,
               });
               text = polished.text;
               if (cloud && polished.usage) {
                 if (polishPermit) await polishPermit.settle("voice_dictation", polished.usage);
-                else await recordUsage("voice_dictation", opts.model, polished.usage);
+                else await recordUsage("voice_dictation", activeModel, polished.usage);
               }
             }
           } catch (err) {
@@ -3195,7 +3235,7 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
         cwd,
         systemPrompt,
         tools,
-        model: typeof payload.model === "string" ? payload.model : opts.model,
+        model: typeof payload.model === "string" ? payload.model : activeModel,
       });
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: true, agent: view }));
@@ -3564,10 +3604,16 @@ export async function startWebServer(opts: WebServerOptions): Promise<http.Serve
           // Real, declared sizes (T-12). `sizes: "any"` on a raster PNG makes
           // Chrome and iOS treat the icon as unusable for the home screen and
           // fall back to a screenshot of the page — which is the "the installed
-          // app has no icon" the v0.24 review recorded. The maskable variant is
-          // a SEPARATE file, not the same bytes relabelled: a maskable icon must
-          // carry its own safe-zone padding, and declaring an unpadded icon
-          // maskable gets its edges cropped by the platform's mask.
+          // app has no icon" the v0.24 review recorded.
+          //
+          // Both files are declared "any maskable" rather than pointing a
+          // maskable entry at a third file. That is not a shortcut: the icons
+          // are generated by scripts/optimize-assets.ts, which insets the art
+          // inside the maskable safe circle (radius 0.4 × size) and ASSERTS
+          // that invariant on every run — so these bytes are genuinely safe to
+          // mask, and a separate file would be the same pixels under another
+          // name. Declaring a file that nothing generates is worse than either:
+          // the platform drops the only maskable entry and falls back.
           icons: [
             { src: "/assets/icon-192.png", sizes: "192x192", type: "image/png", purpose: "any" },
             { src: "/assets/icon-512.png", sizes: "512x512", type: "image/png", purpose: "any" },
@@ -3663,7 +3709,7 @@ self.addEventListener('fetch', (event) => {
       const runtime = await ctxForRequest();
       try {
         res.writeHead(200, { "content-type": "application/json" });
-        res.end(JSON.stringify({ id: runtime.value.session.id, model: opts.model }));
+        res.end(JSON.stringify({ id: runtime.value.session.id, model: activeModel }));
       } finally {
         runtime.release();
       }
@@ -3799,7 +3845,7 @@ self.addEventListener('fetch', (event) => {
       const runtime = await ctxForRequest();
       try {
         const id = await swapChatSession(runtime.value, () =>
-          SessionStore.create({ cwd: process.cwd(), model: opts.model }),
+          SessionStore.create({ cwd: process.cwd(), model: activeModel }),
         );
         broadcast({ type: "session_switched", session: id });
         res.writeHead(200, { "content-type": "application/json" });
@@ -4097,7 +4143,7 @@ self.addEventListener('fetch', (event) => {
       // not just the two the popup used to know about. Never the key values —
       // only whether each one is present.
       res.writeHead(200, { "content-type": "application/json", "cache-control": "no-store" });
-      res.end(JSON.stringify(configStatusPayload(opts.model)));
+      res.end(JSON.stringify(configStatusPayload(activeModel)));
       return;
     }
 
@@ -4144,8 +4190,15 @@ self.addEventListener('fetch', (event) => {
         res.end((err as Error).message);
         return;
       }
-      // Force the next /chat to rebuild the provider so the new key is read.
+      // Force the next /chat to rebuild the provider so the new key is read —
+      // and re-resolve the model, because the key that just arrived may belong
+      // to a different provider than the one this process booted with. An
+      // explicit LISA_MODEL wins; otherwise resolveDefaultModel() picks from
+      // whichever key is now configured, exactly as a fresh `lisa serve` would.
+      const savedModel = updates["LISA_MODEL"];
+      activeModel = savedModel && savedModel.trim() ? savedModel.trim() : resolveDefaultModel();
       cachedProvider = null;
+      logInfo(`[config] keys saved (${Object.keys(updates).join(", ")}); model → ${activeModel}`);
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify({ ok: true, saved: Object.keys(updates) }));
       return;
@@ -4343,7 +4396,7 @@ self.addEventListener('fetch', (event) => {
       try {
         quotaAcct = cloud && accountUid ? await getAccount(accountUid) : null;
         if (quotaAcct) {
-          const admission = await admitInference(quotaAcct, opts.model);
+          const admission = await admitInference(quotaAcct, activeModel);
           if (!admission.ok) {
             res.writeHead(admission.status, { "content-type": "application/json" });
             res.end(JSON.stringify(admission.body));
@@ -4463,7 +4516,7 @@ self.addEventListener('fetch', (event) => {
             history: modelContext.history,
             userMessage: message,
             userFiles: files,
-            model: opts.model,
+            model: activeModel,
             thinking: policy.thinking,
             compaction: policy.compaction,
             // Approval gating on the web surface (T-7). undefined under
@@ -4474,7 +4527,7 @@ self.addEventListener('fetch', (event) => {
             // the output rate.
             budgetTokens:
               quotaBudgetMicroUSD != null
-                ? tokensAffordable(opts.model, quotaBudgetMicroUSD)
+                ? tokensAffordable(activeModel, quotaBudgetMicroUSD)
                 : undefined,
             onEvent: (ev) => {
               if (ev.type === "text_delta" && ev.text) {
@@ -4575,7 +4628,7 @@ self.addEventListener('fetch', (event) => {
             // admitted them. The legacy shared-token cloud demo has no account
             // balance, so it remains operator-funded but still audited.
             if (inferencePermit) await inferencePermit.settle("chat", usage);
-            else await recordUsage("chat", opts.model, usage);
+            else await recordUsage("chat", activeModel, usage);
           }
           if (!anyText && !anyTool && !errorSent) send({ type: "empty" });
           send({ type: "done" });
@@ -4618,7 +4671,7 @@ self.addEventListener('fetch', (event) => {
       try {
         const acct = cloud && accountUid ? await getAccount(accountUid) : null;
         if (acct) {
-          const admission = await admitInference(acct, opts.model);
+          const admission = await admitInference(acct, activeModel);
           if (!admission.ok) {
             res.writeHead(admission.status, { "content-type": "application/json" });
             res.end(JSON.stringify(admission.body));
@@ -4645,7 +4698,7 @@ self.addEventListener('fetch', (event) => {
         const r = await reflectOnSession({
           history: chat.history,
           sessionId: chat.session.id,
-          model: opts.model,
+          model: activeModel,
         });
         chat.reflectionSummary = r.summary;
         if (inferencePermit && r.usage) {


### PR DESCRIPTION
六个审查代理从**跨流、契约、安全、行为回归、资源生命周期、构建**六个维度读了已合并的优化工作，每条发现再交给三个独立代理专门反驳，13 条通过验证。其中两条（Mac 向导的 Node 下限、apple-touch-icon 链接）main 上已独立修复，本 PR 采用 main 的版本。

## 影响最大的三条

**非 Anthropic 的首次运行链路整条空转。** 保存配置写入 `LISA_MODEL`，但服务端从启动起就把模型固化在十四个位置。首次运行没有密钥，服务端只能以默认模型启动；用户在 provider 选择器里选了 DeepSeek、贴了密钥，界面显示「已配置」，而每一轮仍发往 Claude——那里根本没有密钥。现在模型是保存成功后重新解析的可变绑定，并有测试断言 `/session` 报告 `deepseek-chat`。

**`lisa doctor --probe` 把卡顿的服务判成宕机。** 可达性把 `payload.ok !== false` 也算了进去，而 `/health` 正是在事件循环卡顿时返回 `ok:false`——于是一个忙但活着的后端打印「✗ unreachable — is the backend running?」并以非零退出，而运维手册把非零探测接到强制重启。现在可达 = 答复了，降级是警告。测试夹具原本写 `ok:true`，所以从没抓到；现在它发送卡顿实例真正会发的东西。

**`/health` 在 Mac 上泄露指纹。** main 已对云端脱敏，但 Mac 版仍向任何人、在鉴权之前返回完整负载：版本、运行时长、内存、会话数、在途轮次。`--host 0.0.0.0` 是文档推荐的手机访问方式，等于把这些摆在同一个咖啡馆网络里。现在两个版本统一一条规则：健康状态（ok + 延迟 + edition）公开，其余需要令牌；Mac 上回环仍算主人，本机 `--probe` 保持完整读取。

## 其余修复

- **每次重启都重新推送通知**：初始扫描把会话记为「未扫描」，首次解析必然像状态变化，于是 launchd 重启、`lisa upgrade` 或看门狗都会为几小时前已通知过的会话重发「出错」「需要授权」。启动那一趟改为只记录不广播。
- **「自定义 OpenAI 兼容」从选择器消失**：客户端用服务端列表整体替换了自己的表，而服务端无法枚举一个写 `LISA_API_KEY` + `LISA_BASE_URL` 的条目。Ollama、LM Studio 和所有自建端点因此在图形界面里不可达。命名 provider 仍以服务端为准，客户端专有的自定义条目在合并后保留。
- **服务端返回但客户端无提示的 provider 拿到 `needsModel:false`**：Grok、Mistral、Perplexity、Ark、MiniMax、Hunyuan 全部落进这个坑——密钥存了但没有模型，路由继续走 Claude。改为从服务端行推导，用 `modelPrefixes[0]` 作默认。
- **409「已出生」被当作失败**：重试按钮只会再次 409，在一个已经存在的 Lisa 面前形成死胡同；SSE 在 done 帧前被切断时就会走到这里。现在按成功处理。
- **macOS CI 只跑 `swift build`**，从不编译测试目标，向导的决策表对 CI 不可见。改为 `swift test`。

## 两条「只验证声明」的测试改为验证事实

清单测试原本只读 JSON 内容，于是在 maskable 条目指向一个没有任何步骤生成的文件时照样通过了好几天。现在它会真的请求每个 `icons[].src`。

同一个悬空文件名还躺在服务工作线程的预缓存列表里——`addAll()` 只要一项 404 就整体拒绝，而安装处理器把它 catch 掉了：**一个过期文件名会静默停掉整个离线缓存，任何地方都不报错**。新增一条测试，把那个列表里的每个路径也抓一遍。

## 计费适配器补测，以及它带出的第 12 条缺陷

`FirestoreOutboxStore`——决定托管租户被扣一次、两次还是零次的那段代码——**一个测试都没有**，模块 47 个函数里 18 个从未执行。现在有 14 个测试用 firestore 客户端自己的内存 REST 假件覆盖它：幂等追加、索引先写、提交排空、悬空 id 清理、分片聚合、粘性注册、清理失败的尽力而为语义。`outbox.ts` 函数覆盖 61.7% → 93.75%。

写这些测试时带出一条没人报告过的缺陷：**干净排空的租户永远留在粘性注册表里**。`update()` 会直接把已提交的 id 从索引移除，于是清理路径永远看不到悬空 id，注册表只增不减，15 分钟一轮的对账扫描随「曾经结算过的账户总数」单调增长、永不回落。现在索引文档存在且为空即注销该租户——以「存在」为前提，因为 `append()` 先注册后建索引，在那个窗口注销会让一笔费用永远得不到对账。

## 验证

在本基线上：typecheck、typecheck:client、lint、format:check、check:api-contract、**2,065 个单元测试**、**27 个端到端**、覆盖率门槛、构建、**23 个 Swift 测试**，全部通过。

🤖 Generated with [Claude Code](https://claude.com/claude-code)